### PR TITLE
allow http on android devices/emulators

### DIFF
--- a/android/app/src/debug/AndroidManifest.xml
+++ b/android/app/src/debug/AndroidManifest.xml
@@ -5,4 +5,6 @@
          to allow setting breakpoints, to provide hot reload, etc.
     -->
     <uses-permission android:name="android.permission.INTERNET"/>
+   <application
+        android:usesCleartextTraffic="true"/>
 </manifest>

--- a/lib/src/features/auth/data/auth_repository.dart
+++ b/lib/src/features/auth/data/auth_repository.dart
@@ -56,6 +56,7 @@ class AuthRepository {
           await _appAuth.authorizeAndExchangeCode(AuthorizationTokenRequest(
         kLichessClientId,
         redirectUri,
+        allowInsecureConnections: true,
         serviceConfiguration: const AuthorizationServiceConfiguration(
             authorizationEndpoint: '$kLichessHost/oauth',
             tokenEndpoint: '$kLichessHost/api/token'),


### PR DESCRIPTION
In concert with the following command (which must be run after the emulator/device has started): adb reverse tcp:9663 tcp:9663

Avoid 10.0.2.x networking as it will confuse CORS.  Use localhost:9663

If Chrome instacrashes, it is likely you need to disable vulkan in  emulator settings.  Will add docs for all this pending discussion of where they should go.