### PR TITLE
Skip intelliJ files in .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -27,3 +27,9 @@ doc/api/
 *.js.map
 
 .DS_Store
+
+# IntelliJ related
+*.iml
+*.ipr
+*.iws
+.idea/


### PR DESCRIPTION
We need to skip intelliJ generated files in .gitignore.