### PR TITLE
Set puzzle themes text style

### DIFF
--- a/lib/src/ui/puzzle/puzzle_dashboard_screen.dart
+++ b/lib/src/ui/puzzle/puzzle_dashboard_screen.dart
@@ -141,7 +141,10 @@ class _Body extends ConsumerWidget {
         padding: Styles.bodySectionBottomPadding,
         child: CardButton(
           icon: const Icon(LichessIcons.target, size: 44),
-          title: Text(context.l10n.puzzlePuzzleThemes),
+          title: Text(
+            context.l10n.puzzlePuzzleThemes,
+            style: Styles.sectionTitle,
+          ),
           subtitle: const Text('Play puzzles from a specific theme.'),
           onTap: () {
             pushPlatformRoute(


### PR DESCRIPTION
Makes sure the "Puzzle themes" text is bolded/styled like in the other buttons.

| Before | After |
| --- | --- |
| ![image](https://github.com/lichess-org/mobile/assets/10077686/fec2d293-229a-405b-bf40-2eb91291c5d6) | ![image](https://github.com/lichess-org/mobile/assets/10077686/c6e5a3e2-b132-409b-a2bd-83526238e8db) |