### PR TITLE
Settings: Board theme screen had incorrect title

### DIFF
--- a/lib/src/view/settings/board_theme_screen.dart
+++ b/lib/src/view/settings/board_theme_screen.dart
@@ -21,7 +21,7 @@ class BoardThemeScreen extends StatelessWidget {
 
   Widget _androidBuilder(BuildContext context) {
     return Scaffold(
-      appBar: AppBar(title: Text(context.l10n.background)),
+      appBar: AppBar(title: Text(context.l10n.boardTheme)),
       body: _Body(),
     );
   }


### PR DESCRIPTION
Before: 
![image](https://github.com/lichess-org/mobile/assets/8635304/247987dd-2883-4c1f-8e23-9c83d443d168)
After:
![image](https://github.com/lichess-org/mobile/assets/8635304/cc3d5cd1-a5b8-43b7-9222-74463ee3f022)
