### PR TITLE
Fix 0+1 shown as ultrabullet in time control selector

### DIFF
--- a/ios/Runner/Info.plist
+++ b/ios/Runner/Info.plist
@@ -101,8 +101,6 @@
 		<string>$(FLUTTER_BUILD_NUMBER)</string>
 		<key>ITSAppUsesNonExemptEncryption</key>
 		<false/>
-		<key>FLTEnableImpeller</key>
-		<false />
 		<key>LSRequiresIPhoneOS</key>
 		<true/>
 		<key>UIApplicationSupportsIndirectInputEvents</key>

--- a/lib/src/model/common/speed.dart
+++ b/lib/src/model/common/speed.dart
@@ -19,7 +19,7 @@ enum Speed {
   final IconData icon;
 
   factory Speed.fromTimeIncrement(TimeIncrement t) {
-    switch (t.duration.inSeconds) {
+    switch (t.estimatedDuration.inSeconds) {
       case >= 1 && <= 29:
         return Speed.ultraBullet;
       case >= 30 && <= 179:

--- a/lib/src/model/common/time_increment.dart
+++ b/lib/src/model/common/time_increment.dart
@@ -25,7 +25,9 @@ class TimeIncrement {
         'increment': increment,
       };
 
-  Duration get duration => Duration(seconds: time);
+  /// Returns the estimated duration of the game, with increment * 40 added to
+  /// the initial time.
+  Duration get estimatedDuration => Duration(seconds: time + increment * 40);
 
   Speed get speed => Speed.fromTimeIncrement(this);
 

--- a/lib/src/view/play/time_control_modal.dart
+++ b/lib/src/view/play/time_control_modal.dart
@@ -39,19 +39,6 @@ class TimeControlModal extends ConsumerWidget {
               timeControlPref,
               choices: const [
                 TimeIncrement(0, 1),
-                TimeIncrement(15, 0),
-              ],
-              title: const _SectionTitle(
-                title: 'Ultrabullet',
-                icon: LichessIcons.ultrabullet,
-              ),
-              onSelected: onSelected,
-            ),
-            const SizedBox(height: 20.0),
-            _SectionChoices(
-              timeControlPref,
-              choices: const [
-                TimeIncrement(30, 0),
                 TimeIncrement(60, 0),
                 TimeIncrement(60, 1),
                 TimeIncrement(120, 1),


### PR DESCRIPTION
Fix the logic used to determine speed from a time control. Now increments are taken into account and 0+1 is now correctly shown as "bullet".

Remove the ultrabullet section from the fast pairing time control modal because ultrabullet has only one option possible.

Closes #259 