### PR TITLE
Add a list of broadcasts to the watch tab

### DIFF
--- a/lib/src/model/broadcast/broadcast.dart
+++ b/lib/src/model/broadcast/broadcast.dart
@@ -1,0 +1,18 @@
+import 'package:freezed_annotation/freezed_annotation.dart';
+
+part 'broadcast.freezed.dart';
+
+@freezed
+class Broadcast with _$Broadcast {
+  const factory Broadcast({
+    required Tour tour,
+  }) = _Broadcast;
+}
+
+@freezed
+class Tour with _$Tour {
+  const factory Tour({
+    required String name,
+    required String description,
+  }) = _Tour;
+}

--- a/lib/src/model/broadcast/broadcast_repository.dart
+++ b/lib/src/model/broadcast/broadcast_repository.dart
@@ -1,0 +1,31 @@
+import 'package:deep_pick/deep_pick.dart';
+import 'package:fast_immutable_collections/fast_immutable_collections.dart';
+import 'package:http/http.dart' as http;
+import 'package:lichess_mobile/src/model/broadcast/broadcast.dart';
+import 'package:lichess_mobile/src/model/common/http.dart';
+
+class BroadcastRepository {
+  BroadcastRepository(this.client);
+
+  final http.Client client;
+
+  Future<IList<Broadcast>> getBroadcasts() {
+    return client.readNdJsonList(
+      Uri(path: '/api/broadcast'),
+      headers: {'Accept': 'application/x-ndjson'},
+      mapper: _makeBroadcastFromJson,
+    );
+  }
+}
+
+Broadcast _makeBroadcastFromJson(Map<String, dynamic> json) =>
+    _broadcastFromPick(pick(json).required());
+
+Broadcast _broadcastFromPick(RequiredPick pick) {
+  return Broadcast(
+    tour: Tour(
+      name: pick('tour', 'name').asStringOrThrow(),
+      description: pick('tour', 'description').asStringOrThrow(),
+    ),
+  );
+}

--- a/lib/src/model/broadcast/broadcast_repository_providers.dart
+++ b/lib/src/model/broadcast/broadcast_repository_providers.dart
@@ -1,0 +1,13 @@
+import 'package:fast_immutable_collections/fast_immutable_collections.dart';
+import 'package:lichess_mobile/src/model/broadcast/broadcast.dart';
+import 'package:lichess_mobile/src/model/broadcast/broadcast_repository.dart';
+import 'package:lichess_mobile/src/model/common/http.dart';
+import 'package:riverpod_annotation/riverpod_annotation.dart';
+
+part 'broadcast_repository_providers.g.dart';
+
+@riverpod
+Future<IList<Broadcast>> broadcasts(BroadcastsRef ref) async {
+  return ref
+      .withClient((client) => BroadcastRepository(client).getBroadcasts());
+}

--- a/lib/src/view/watch/broadcast_tile.dart
+++ b/lib/src/view/watch/broadcast_tile.dart
@@ -1,0 +1,29 @@
+import 'package:flutter/material.dart';
+import 'package:lichess_mobile/src/model/broadcast/broadcast.dart';
+import 'package:lichess_mobile/src/widgets/list.dart';
+
+class BroadcastTile extends StatelessWidget {
+  const BroadcastTile({required this.broadcast, this.showSubtitle = false});
+
+  final Broadcast broadcast;
+  final bool showSubtitle;
+
+  @override
+  Widget build(BuildContext context) {
+    return PlatformListTile(
+      onTap: () => {},
+      title: Padding(
+        padding: const EdgeInsets.only(right: 5.0),
+        child: Row(
+          children: [
+            Flexible(
+              child: Text(broadcast.tour.name, overflow: TextOverflow.ellipsis),
+            ),
+          ],
+        ),
+      ),
+      subtitle: Text(broadcast.tour.description),
+      isThreeLine: showSubtitle,
+    );
+  }
+}


### PR DESCRIPTION
This pull request only add a list of broadcasts with their names and their descriptions. I don't plan working further on the broadcast feature.
![broadcast](https://github.com/lichess-org/mobile/assets/120588494/878053a6-bafb-41c0-b572-95c2100fec97)