### PR TITLE
Clickable AcplChart 

### DIFF
--- a/lib/src/model/analysis/analysis_controller.dart
+++ b/lib/src/model/analysis/analysis_controller.dart
@@ -184,6 +184,31 @@ class AnalysisController extends _$AnalysisController {
     );
   }
 
+  void jumpToNthNode(int n) {
+    UciPath path = _root.mainlinePath;
+    while (!path.penultimate.isEmpty) {
+      path = path.penultimate;
+    }
+    Node? node = _root.nodeAt(path);
+    int count = 0;
+
+    while (node != null && count < n) {
+      if (node.children.isNotEmpty) {
+        path = path + node.children.first.id;
+        node = _root.nodeAt(path);
+        count++;
+      } else {
+        break;
+      }
+    }
+
+    if (node != null) {
+      _setPath(
+        path,
+      );
+    }
+  }
+
   void toggleBoard() {
     state = state.copyWith(pov: state.pov.opposite);
   }

--- a/lib/src/view/analysis/analysis_screen.dart
+++ b/lib/src/view/analysis/analysis_screen.dart
@@ -1073,7 +1073,7 @@ class AcplChart extends ConsumerWidget {
               lineBarsData: [
                 LineChartBarData(
                   spots: spots,
-                  isCurved: true,
+                  isCurved: false,
                   barWidth: 1,
                   color: mainLineColor,
                   aboveBarData: BarAreaData(

--- a/lib/src/view/analysis/analysis_screen.dart
+++ b/lib/src/view/analysis/analysis_screen.dart
@@ -1043,7 +1043,31 @@ class AcplChart extends ConsumerWidget {
           padding: const EdgeInsets.all(16.0),
           child: LineChart(
             LineChartData(
-              lineTouchData: const LineTouchData(enabled: false),
+              lineTouchData: LineTouchData(
+                enabled: false,
+                touchCallback:
+                    (FlTouchEvent event, LineTouchResponse? touchResponse) {
+                  if (event is FlTapUpEvent) {
+                    final touchX = event.localPosition.dx;
+                    final chartWidth = context.size!.width -
+                        32; // Insets on both sides of the chart of 16
+                    final minX = spots.first.x;
+                    final maxX = spots.last.x;
+                    final touchXDataValue =
+                        minX + (touchX / chartWidth) * (maxX - minX);
+                    final closestSpot = spots.reduce(
+                      (a, b) => (a.x - touchXDataValue).abs() <
+                              (b.x - touchXDataValue).abs()
+                          ? a
+                          : b,
+                    );
+                    final closestNodeIndex = closestSpot.x.round();
+                    ref
+                        .read(analysisControllerProvider(options).notifier)
+                        .jumpToNthNode(closestNodeIndex);
+                  }
+                },
+              ),
               minY: -1.0,
               maxY: 1.0,
               lineBarsData: [


### PR DESCRIPTION
Fixes #471

I've modified the graph such that it is clickable. It solely depends on the x-value of the touch input. Maybe there is more sophisticated method that involves the distance on the y -axis that works better. 
However I observed that the website implementation also considers only the x-value.

Also I changed the graph type to be non-curved. The current curved representation sometimes leads to the maximum not being on a move itself.

To illustrate the difference, please refer to the following videos:
<details>
<summary>isCurved: true</summary>

https://github.com/lichess-org/mobile/assets/78898963/de35e001-213c-4b22-b543-cf5fd30b8361
</details>
<details>
<summary>isCurved: false</summary>

https://github.com/lichess-org/mobile/assets/78898963/0fc200ca-3e25-40f1-ad83-c1a9acd154b6
</details>

While implementing these changes, I noticed a small "bug." If one promotes a line other than the game to the mainline, the graph still jumps around when pressing it. I'm uncertain about what the intended behavior in this scenario should be. On the website the same "bug" exists. Probably we can just ignore that.