### PR TITLE
improve visibility of mainline in treeview

### DIFF
--- a/lib/src/view/analysis/tree_view.dart
+++ b/lib/src/view/analysis/tree_view.dart
@@ -292,7 +292,7 @@ class InlineMove extends ConsumerWidget {
             color: _textColor(context, 0.6, branch.nags?.firstOrNull),
           )
         : baseTextStyle.copyWith(
-            color: _textColor(context, 0.6, branch.nags?.firstOrNull),
+            color: _textColor(context, 1, branch.nags?.firstOrNull),
             fontWeight: FontWeight.w600,
           );
 


### PR DESCRIPTION
Change the color of the mainline, so that it is more visible and the notation looks better organized:


<details>
<summary>Old</summary>

![old](https://github.com/lichess-org/mobile/assets/78898963/f445fdc6-1ac1-4562-a160-41621e171532)
</details>

<details>
<summary>New</summary>

![new](https://github.com/lichess-org/mobile/assets/78898963/c06db35b-ce64-47d6-ac8f-e19a0fcf4e5b)
</details>

