### PR TITLE
Online status without color

### DIFF
--- a/ios/Podfile.lock
+++ b/ios/Podfile.lock
@@ -77,9 +77,6 @@ PODS:
     - Flutter
   - flutter_secure_storage (6.0.0):
     - Flutter
-  - FMDB (2.7.5):
-    - FMDB/standard (= 2.7.5)
-  - FMDB/standard (2.7.5)
   - GoogleDataTransport (9.3.0):
     - GoogleUtilities/Environment (~> 7.7)
     - nanopb (< 2.30910.0, >= 2.30908.0)
@@ -124,7 +121,7 @@ PODS:
     - Flutter
   - sqflite (0.0.3):
     - Flutter
-    - FMDB (>= 2.7.5)
+    - FlutterMacOS
   - stockfish (1.4.0):
     - Flutter
   - system_info_plus (0.0.1):
@@ -150,7 +147,7 @@ DEPENDENCIES:
   - share_plus (from `.symlinks/plugins/share_plus/ios`)
   - shared_preferences_foundation (from `.symlinks/plugins/shared_preferences_foundation/darwin`)
   - soundpool (from `.symlinks/plugins/soundpool/ios`)
-  - sqflite (from `.symlinks/plugins/sqflite/ios`)
+  - sqflite (from `.symlinks/plugins/sqflite/darwin`)
   - stockfish (from `.symlinks/plugins/stockfish/ios`)
   - system_info_plus (from `.symlinks/plugins/system_info_plus/ios`)
   - url_launcher_ios (from `.symlinks/plugins/url_launcher_ios/ios`)
@@ -167,7 +164,6 @@ SPEC REPOS:
     - FirebaseInstallations
     - FirebaseMessaging
     - FirebaseSessions
-    - FMDB
     - GoogleDataTransport
     - GoogleUtilities
     - nanopb
@@ -207,7 +203,7 @@ EXTERNAL SOURCES:
   soundpool:
     :path: ".symlinks/plugins/soundpool/ios"
   sqflite:
-    :path: ".symlinks/plugins/sqflite/ios"
+    :path: ".symlinks/plugins/sqflite/darwin"
   stockfish:
     :path: ".symlinks/plugins/stockfish/ios"
   system_info_plus:
@@ -237,7 +233,6 @@ SPEC CHECKSUMS:
   flutter_appauth: 0863b1f33110b410213e736aead4a6727303f509
   flutter_native_splash: 52501b97d1c0a5f898d687f1646226c1f93c56ef
   flutter_secure_storage: 23fc622d89d073675f2eaa109381aefbcf5a49be
-  FMDB: 2ce00b547f966261cd18927a3ddb07cb6f3db82a
   GoogleDataTransport: 57c22343ab29bc686febbf7cbb13bad167c2d8fe
   GoogleUtilities: 0759d1a57ebb953965c2dfe0ba4c82e95ccc2e34
   nanopb: d4d75c12cd1316f4a64e3c6963f879ecd4b5e0d5
@@ -249,7 +244,7 @@ SPEC CHECKSUMS:
   share_plus: c3fef564749587fc939ef86ffb283ceac0baf9f5
   shared_preferences_foundation: b4c3b4cddf1c21f02770737f147a3f5da9d39695
   soundpool: c7f4422ca206e77f8900ed3c4ee6a6ff5a0e38a9
-  sqflite: 50a33e1d72bd59ee092a519a35d107502757ebed
+  sqflite: 673a0e54cc04b7d6dba8d24fb8095b31c3a99eec
   stockfish: 614d240ac2cd05a462dad552c7b5937bb14604fd
   system_info_plus: 5393c8da281d899950d751713575fbf91c7709aa
   url_launcher_ios: bbd758c6e7f9fd7b5b1d4cde34d2b95fcce5e812

--- a/lib/src/model/game/game_controller.dart
+++ b/lib/src/model/game/game_controller.dart
@@ -82,8 +82,6 @@ class GameController extends _$GameController {
 
         PlayableGame game = fullEvent.game;
 
-        _socketEventVersion = fullEvent.socketEventVersion;
-
         if (fullEvent.game.messages != null) {
           chatNotifier.setMessages(fullEvent.game.messages!);
         }
@@ -95,6 +93,8 @@ class GameController extends _$GameController {
             return game;
           });
         }
+
+        _socketEventVersion = fullEvent.socketEventVersion;
 
         return GameState(
           gameFullId: gameFullId,

--- a/lib/src/view/game/game_player.dart
+++ b/lib/src/view/game/game_player.dart
@@ -59,23 +59,19 @@ class GamePlayer extends StatelessWidget {
         Row(
           mainAxisAlignment: MainAxisAlignment.start,
           children: [
-            if (player.user?.isPatron == true)
+            Icon(
+              player.onGame == true ? Icons.cloud : Icons.cloud_off,
+              color: player.onGame == true ? LichessColors.green : null,
+              size: 14,
+            ),
+            const SizedBox(width: 5),
+            if (player.user?.isPatron == true) ...[
               Icon(
                 LichessIcons.patron,
-                size: 14,
-                color:
-                    player.onGame == true ? LichessColors.green : Colors.grey,
-              )
-            else
-              Icon(
-                player.onGame == true
-                    ? CupertinoIcons.circle_fill
-                    : CupertinoIcons.circle,
-                size: 14,
-                color:
-                    player.onGame == true ? LichessColors.green : Colors.grey,
+                size: playerFontSize,
               ),
-            const SizedBox(width: 5),
+              const SizedBox(width: 5),
+            ],
             if (player.user?.title != null) ...[
               Text(
                 player.user!.title!,

--- a/lib/src/view/user/user_screen.dart
+++ b/lib/src/view/user/user_screen.dart
@@ -30,13 +30,20 @@ class UserScreen extends ConsumerWidget {
   }
 
   Widget _buildAndroid(BuildContext context, WidgetRef ref) {
-    final asyncUser = ref.watch(userProvider(id: user.id));
+    final asyncUser = ref.watch(userAndStatusProvider(id: user.id));
+    final updatedLightUser = asyncUser.maybeWhen(
+      data: (data) => data.$1.lightUser.copyWith(isOnline: data.$2.online),
+      orElse: () => null,
+    );
     return Scaffold(
       appBar: AppBar(
-        title: UserFullNameWidget(user: user),
+        title: UserFullNameWidget(
+          user: updatedLightUser ?? user,
+          shouldShowOnline: updatedLightUser != null,
+        ),
       ),
       body: asyncUser.when(
-        data: (user) => _UserProfileListView(user),
+        data: (data) => _UserProfileListView(data.$1),
         loading: () => const Center(child: CircularProgressIndicator()),
         error: (error, _) {
           if (error is NotFoundException) {
@@ -57,14 +64,21 @@ class UserScreen extends ConsumerWidget {
   }
 
   Widget _buildIos(BuildContext context, WidgetRef ref) {
-    final asyncUser = ref.watch(userProvider(id: user.id));
+    final asyncUser = ref.watch(userAndStatusProvider(id: user.id));
+    final updatedLightUser = asyncUser.maybeWhen(
+      data: (data) => data.$1.lightUser.copyWith(isOnline: data.$2.online),
+      orElse: () => null,
+    );
     return CupertinoPageScaffold(
       navigationBar: CupertinoNavigationBar(
-        middle: UserFullNameWidget(user: user),
+        middle: UserFullNameWidget(
+          user: updatedLightUser ?? user,
+          shouldShowOnline: updatedLightUser != null,
+        ),
       ),
       child: asyncUser.when(
-        data: (user) => SafeArea(
-          child: _UserProfileListView(user),
+        data: (data) => SafeArea(
+          child: _UserProfileListView(data.$1),
         ),
         loading: () =>
             const Center(child: CircularProgressIndicator.adaptive()),

--- a/lib/src/widgets/user_full_name.dart
+++ b/lib/src/widgets/user_full_name.dart
@@ -1,5 +1,4 @@
 import 'package:cached_network_image/cached_network_image.dart';
-import 'package:flutter/cupertino.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:lichess_mobile/src/constants.dart';
@@ -17,6 +16,7 @@ class UserFullNameWidget extends ConsumerWidget {
     this.aiLevel,
     this.rating,
     this.provisional,
+    this.shouldShowOnline = false,
     this.style,
     super.key,
   });
@@ -26,6 +26,7 @@ class UserFullNameWidget extends ConsumerWidget {
     required this.aiLevel,
     this.rating,
     this.provisional,
+    this.shouldShowOnline = false,
     this.style,
     super.key,
   });
@@ -39,6 +40,9 @@ class UserFullNameWidget extends ConsumerWidget {
   /// Whether the rating is provisional.
   final bool? provisional;
   final TextStyle? style;
+
+  /// Whether to show the online status.
+  final bool? shouldShowOnline;
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
@@ -60,6 +64,16 @@ class UserFullNameWidget extends ConsumerWidget {
     return Row(
       mainAxisSize: MainAxisSize.min,
       children: [
+        if (user != null && shouldShowOnline == true)
+          Padding(
+            padding: const EdgeInsets.only(right: 5),
+            child: Icon(
+              user?.isOnline == true ? Icons.cloud : Icons.cloud_off,
+              size: style?.fontSize ??
+                  DefaultTextStyle.of(context).style.fontSize,
+              color: user?.isOnline == true ? LichessColors.good : null,
+            ),
+          ),
         if (user?.isPatron == true)
           Padding(
             padding: const EdgeInsets.only(right: 5),

--- a/lib/src/widgets/user_full_name.dart
+++ b/lib/src/widgets/user_full_name.dart
@@ -65,8 +65,9 @@ class UserFullNameWidget extends ConsumerWidget {
             padding: const EdgeInsets.only(right: 5),
             child: Icon(
               LichessIcons.patron,
-              size: DefaultTextStyle.of(context).style.fontSize,
-              color: DefaultTextStyle.of(context).style.color,
+              size: style?.fontSize ??
+                  DefaultTextStyle.of(context).style.fontSize,
+              color: style?.color ?? DefaultTextStyle.of(context).style.color,
             ),
           ),
         if (user?.title != null) ...[

--- a/lib/src/widgets/user_list_tile.dart
+++ b/lib/src/widgets/user_list_tile.dart
@@ -2,6 +2,7 @@ import 'package:cached_network_image/cached_network_image.dart';
 import 'package:fast_immutable_collections/fast_immutable_collections.dart';
 import 'package:flutter/cupertino.dart';
 import 'package:flutter/foundation.dart';
+import 'package:flutter/material.dart';
 import 'package:lichess_mobile/src/constants.dart';
 import 'package:lichess_mobile/src/model/common/perf.dart';
 import 'package:lichess_mobile/src/model/user/user.dart';
@@ -66,14 +67,18 @@ class UserListTile extends StatelessWidget {
       padding: defaultTargetPlatform == TargetPlatform.iOS
           ? Styles.bodyPadding
           : null,
-      leading: _OnlineOrPatron(
-        patron: isPatron,
-        online: isOnline,
+      leading: Icon(
+        isOnline == true ? Icons.cloud : Icons.cloud_off,
+        color: isOnline == true ? LichessColors.good : null,
       ),
       title: Padding(
         padding: const EdgeInsets.only(right: 5.0),
         child: Row(
           children: [
+            if (isPatron == true) ...[
+              const Icon(LichessIcons.patron),
+              const SizedBox(width: 5),
+            ],
             if (title != null) ...[
               Text(
                 title!,
@@ -139,33 +144,5 @@ class _UserRating extends StatelessWidget {
         Text(rating),
       ],
     );
-  }
-}
-
-class _OnlineOrPatron extends StatelessWidget {
-  const _OnlineOrPatron({
-    required this.patron,
-    required this.online,
-  });
-
-  final bool? patron;
-  final bool? online;
-
-  @override
-  Widget build(BuildContext context) {
-    if (patron != null) {
-      return Icon(
-        LichessIcons.patron,
-        color:
-            online != null && online! ? LichessColors.good : LichessColors.grey,
-      );
-    } else {
-      return Icon(
-        CupertinoIcons.circle_fill,
-        size: 20,
-        color:
-            online != null && online! ? LichessColors.good : LichessColors.grey,
-      );
-    }
   }
 }


### PR DESCRIPTION
Closes #408 

- Replaced the green dots by cloud and cloud off icons to differentiate without color that players are online or offline.

See it:
<details><summary>In a game screen</summary>
<p>
![Simulator Screenshot - iPhone 15 - 2024-01-30 at 12 14 24](https://github.com/lichess-org/mobile/assets/423393/cf16a854-e252-45bd-bb63-d65e54b68d7f)

</p>
</details> 

<details><summary>In a players list screen</summary>
<p>

![Simulator Screenshot - iPhone 15 - 2024-01-30 at 12 14 04](https://github.com/lichess-org/mobile/assets/423393/65828674-f724-4143-8b5c-df6d762de050)

</p>
</details>
