### PR TITLE
Remove kTabletThreshold constant 

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -15,12 +15,12 @@ import 'package:lichess_mobile/src/model/common/id.dart';
 import 'package:lichess_mobile/src/model/correspondence/correspondence_game_storage.dart';
 import 'package:lichess_mobile/src/model/correspondence/offline_correspondence_game.dart';
 import 'package:lichess_mobile/src/model/game/playable_game.dart';
+import 'package:lichess_mobile/src/utils/layout.dart';
 import 'package:path/path.dart' as path;
 import 'package:sqflite/sqflite.dart';
 
 import 'firebase_options.dart';
 import 'src/app.dart';
-import 'src/constants.dart';
 
 Future<void> main() async {
   final widgetsBinding = WidgetsFlutterBinding.ensureInitialized();
@@ -54,7 +54,7 @@ Future<void> main() async {
   if (defaultTargetPlatform == TargetPlatform.android) {
     final view = widgetsBinding.platformDispatcher.views.first;
     final data = MediaQueryData.fromView(view);
-    if (data.size.shortestSide < kTabletThreshold) {
+    if (data.size.shortestSide < FormFactor.tablet) {
       await SystemChrome.setPreferredOrientations(
         [DeviceOrientation.portraitUp],
       );

--- a/lib/src/constants.dart
+++ b/lib/src/constants.dart
@@ -32,8 +32,6 @@ const kProvisionalDeviation = 110;
 const kClueLessDeviation = 230;
 
 // UI
-// TODO use [FormFactor] instead of [kTabletThreshold]
-const kTabletThreshold = 600;
 const kCardTextScaleFactor = 1.64;
 const kMaxClockTextScaleFactor = 1.94;
 const kEmptyWidget = SizedBox.shrink();

--- a/lib/src/view/analysis/analysis_screen.dart
+++ b/lib/src/view/analysis/analysis_screen.dart
@@ -22,6 +22,7 @@ import 'package:lichess_mobile/src/styles/lichess_icons.dart';
 import 'package:lichess_mobile/src/styles/styles.dart';
 import 'package:lichess_mobile/src/utils/chessground_compat.dart';
 import 'package:lichess_mobile/src/utils/l10n_context.dart';
+import 'package:lichess_mobile/src/utils/layout.dart';
 import 'package:lichess_mobile/src/utils/string.dart';
 import 'package:lichess_mobile/src/view/engine/engine_gauge.dart';
 import 'package:lichess_mobile/src/widgets/adaptive_action_sheet.dart';
@@ -164,7 +165,7 @@ class _Body extends ConsumerWidget {
               builder: (context, constraints) {
                 final aspectRatio = constraints.biggest.aspectRatio;
                 final defaultBoardSize = constraints.biggest.shortestSide;
-                final isTablet = defaultBoardSize > kTabletThreshold;
+                final isTablet = getScreenType(context) == ScreenType.tablet;
                 final remainingHeight =
                     constraints.maxHeight - defaultBoardSize;
                 final isSmallScreen =

--- a/lib/src/view/puzzle/history_boards.dart
+++ b/lib/src/view/puzzle/history_boards.dart
@@ -2,7 +2,6 @@ import 'package:fast_immutable_collections/fast_immutable_collections.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_layout_grid/flutter_layout_grid.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
-import 'package:lichess_mobile/src/constants.dart';
 import 'package:lichess_mobile/src/model/auth/auth_session.dart';
 import 'package:lichess_mobile/src/model/puzzle/puzzle.dart';
 import 'package:lichess_mobile/src/model/puzzle/puzzle_angle.dart';
@@ -11,6 +10,7 @@ import 'package:lichess_mobile/src/model/puzzle/puzzle_service.dart';
 import 'package:lichess_mobile/src/model/puzzle/puzzle_theme.dart';
 import 'package:lichess_mobile/src/styles/lichess_colors.dart';
 import 'package:lichess_mobile/src/utils/chessground_compat.dart';
+import 'package:lichess_mobile/src/utils/layout.dart';
 import 'package:lichess_mobile/src/utils/navigation.dart';
 import 'package:lichess_mobile/src/view/account/rating_pref_aware.dart';
 import 'package:lichess_mobile/src/view/puzzle/puzzle_screen.dart';
@@ -34,7 +34,7 @@ class _PuzzleHistoryState extends ConsumerState<PuzzleHistoryBoards> {
   Widget build(BuildContext context) {
     return LayoutBuilder(
       builder: (context, constraints) {
-        final crossAxisCount = constraints.maxWidth > kTabletThreshold ? 4 : 2;
+        final crossAxisCount = constraints.maxWidth > FormFactor.tablet ? 4 : 2;
         const columnGap = 12.0;
         final boardWidth =
             (constraints.maxWidth - (columnGap * crossAxisCount - columnGap)) /

--- a/lib/src/view/puzzle/puzzle_history_screen.dart
+++ b/lib/src/view/puzzle/puzzle_history_screen.dart
@@ -3,7 +3,6 @@ import 'package:flutter/cupertino.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:intl/intl.dart';
-import 'package:lichess_mobile/src/constants.dart';
 import 'package:lichess_mobile/src/model/auth/auth_session.dart';
 import 'package:lichess_mobile/src/model/puzzle/puzzle.dart';
 import 'package:lichess_mobile/src/model/puzzle/puzzle_activity.dart';
@@ -15,6 +14,7 @@ import 'package:lichess_mobile/src/styles/lichess_colors.dart';
 import 'package:lichess_mobile/src/styles/styles.dart';
 import 'package:lichess_mobile/src/utils/chessground_compat.dart' as cg;
 import 'package:lichess_mobile/src/utils/l10n_context.dart';
+import 'package:lichess_mobile/src/utils/layout.dart';
 import 'package:lichess_mobile/src/utils/navigation.dart';
 import 'package:lichess_mobile/src/view/account/rating_pref_aware.dart';
 import 'package:lichess_mobile/src/view/puzzle/puzzle_screen.dart';
@@ -99,7 +99,7 @@ class _BodyState extends ConsumerState<_Body> {
           );
         }
         final crossAxisCount =
-            MediaQuery.sizeOf(context).width > kTabletThreshold ? 4 : 2;
+            MediaQuery.sizeOf(context).width > FormFactor.tablet ? 4 : 2;
         final columnsGap = _kPuzzlePadding * crossAxisCount + _kPuzzlePadding;
         final boardWidth =
             (MediaQuery.sizeOf(context).width - columnsGap) / crossAxisCount;

--- a/lib/src/widgets/board_table.dart
+++ b/lib/src/widgets/board_table.dart
@@ -7,6 +7,7 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:lichess_mobile/src/constants.dart';
 import 'package:lichess_mobile/src/model/settings/board_preferences.dart';
 import 'package:lichess_mobile/src/styles/styles.dart';
+import 'package:lichess_mobile/src/utils/layout.dart';
 import 'package:lichess_mobile/src/utils/rate_limit.dart';
 import 'package:lichess_mobile/src/view/engine/engine_gauge.dart';
 
@@ -89,7 +90,7 @@ class BoardTable extends ConsumerWidget {
         final aspectRatio = constraints.biggest.aspectRatio;
         final defaultBoardSize = constraints.biggest.shortestSide;
 
-        final isTablet = defaultBoardSize > kTabletThreshold;
+        final isTablet = getScreenType(context) == ScreenType.tablet;
         final boardSize = isTablet
             ? defaultBoardSize - kTabletBoardTableSidePadding * 2
             : defaultBoardSize;


### PR DESCRIPTION
Closes #426
replacing `kTabletThreshold` with `FormFactor.tablet` and `getScreenType(context)`
It updates the following files:

-   lib/main.dart
-   lib/src/constants.dart
-   lib/src/view/analysis/analysis_screen.dart
-   lib/src/view/puzzle/history_boards.dart
-   lib/src/view/puzzle/puzzle_history_screen.dart
-   lib/src/widgets/board_table.dart