### PR TITLE
correct capitalization

### DIFF
--- a/lib/src/utils/string.dart
+++ b/lib/src/utils/string.dart
@@ -10,6 +10,6 @@ String genRandomString(int len) {
 
 extension StringExtension on String {
   String capitalize() {
-    return '${this[0].toUpperCase()}${substring(1).toLowerCase()}';
+    return '${this[0].toUpperCase()}${substring(1)}';
   }
 }


### PR DESCRIPTION
In the german version the translation of “Blunders” to “Grobe Patzer” had a minor bug in the analysis screen. The word “Patzer” was written in lowercase. I have modified the capitalize method to ensure that only the first letter of string is capitalized. Now "grobe Patzer" is correctly capitalized to "Grobe Patzer". For other languages this should not make a difference.