### PR TITLE
add multidex as an android dependency

### DIFF
--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -86,4 +86,5 @@ flutter {
 
 dependencies {
     implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:$kotlin_version"
+    implementation 'com.android.support:multidex:2.0.1'
 }


### PR DESCRIPTION
Add `com.android.support:multidex` into `android/app/build.gradle` to support multidex

Closes: #525 