### PR TITLE
localize numbers

### DIFF
--- a/lib/src/utils/string.dart
+++ b/lib/src/utils/string.dart
@@ -1,5 +1,6 @@
 import 'dart:convert';
 import 'dart:math';
+import 'package:intl/intl.dart';
 
 final _random = Random.secure();
 
@@ -11,5 +12,14 @@ String genRandomString(int len) {
 extension StringExtension on String {
   String capitalize() {
     return '${this[0].toUpperCase()}${substring(1).toLowerCase()}';
+  }
+}
+
+extension NumberLocalizationExtension on String {
+  String localizeNumbers() {
+    return replaceAllMapped(
+      RegExp(r'\d+(\.\d+)?'),
+      (m) => NumberFormat().format(double.parse(m.group(0)!)),
+    );
   }
 }

--- a/lib/src/view/puzzle/puzzle_dashboard_widget.dart
+++ b/lib/src/view/puzzle/puzzle_dashboard_widget.dart
@@ -39,7 +39,7 @@ class PuzzleDashboardWidget extends ConsumerWidget {
                     .replaceAll(RegExp(r'\d+'), '')
                     .trim()
                     .capitalize(),
-                value: data.global.nb.toString(),
+                value: data.global.nb.toString().localizeNumbers(),
               ),
               StatCard(
                 context.l10n.puzzleSolved.capitalize(),

--- a/lib/src/view/puzzle/puzzle_feedback_widget.dart
+++ b/lib/src/view/puzzle/puzzle_feedback_widget.dart
@@ -8,6 +8,7 @@ import 'package:lichess_mobile/src/model/settings/board_preferences.dart';
 import 'package:lichess_mobile/src/model/settings/brightness.dart';
 import 'package:lichess_mobile/src/styles/lichess_colors.dart';
 import 'package:lichess_mobile/src/utils/l10n_context.dart';
+import 'package:lichess_mobile/src/utils/string.dart';
 
 class PuzzleFeedbackWidget extends ConsumerWidget {
   const PuzzleFeedbackWidget({
@@ -37,8 +38,9 @@ class PuzzleFeedbackWidget extends ConsumerWidget {
       case PuzzleMode.view:
         final puzzleRating =
             context.l10n.puzzleRatingX(puzzle.puzzle.rating.toString());
-        final playedXTimes =
-            context.l10n.puzzlePlayedXTimes(puzzle.puzzle.plays);
+        final playedXTimes = context.l10n
+            .puzzlePlayedXTimes(puzzle.puzzle.plays)
+            .localizeNumbers();
         return _FeedbackTile(
           leading: state.result == PuzzleResult.win
               ? const Icon(Icons.check, size: 36, color: LichessColors.good)

--- a/lib/src/view/puzzle/puzzle_tab_screen.dart
+++ b/lib/src/view/puzzle/puzzle_tab_screen.dart
@@ -21,6 +21,7 @@ import 'package:lichess_mobile/src/utils/connectivity.dart';
 import 'package:lichess_mobile/src/utils/l10n_context.dart';
 import 'package:lichess_mobile/src/utils/layout.dart';
 import 'package:lichess_mobile/src/utils/navigation.dart';
+import 'package:lichess_mobile/src/utils/string.dart';
 import 'package:lichess_mobile/src/view/puzzle/history_boards.dart';
 import 'package:lichess_mobile/src/view/puzzle/puzzle_dashboard_widget.dart';
 import 'package:lichess_mobile/src/view/puzzle/puzzle_history_screen.dart';
@@ -449,7 +450,9 @@ class _DailyPuzzle extends ConsumerWidget {
                 style: Styles.boardPreviewTitle,
               ),
               Text(
-                context.l10n.puzzlePlayedXTimes(data.puzzle.plays),
+                context.l10n
+                    .puzzlePlayedXTimes(data.puzzle.plays)
+                    .localizeNumbers(),
               ),
             ],
           ),
@@ -522,7 +525,9 @@ class _OfflinePuzzlePreview extends ConsumerWidget {
                 style: Styles.boardPreviewTitle,
               ),
               Text(
-                context.l10n.puzzlePlayedXTimes(data?.puzzle.puzzle.plays ?? 0),
+                context.l10n
+                    .puzzlePlayedXTimes(data?.puzzle.puzzle.plays ?? 0)
+                    .localizeNumbers(),
               ),
             ],
           ),

--- a/lib/src/view/user/perf_stats_screen.dart
+++ b/lib/src/view/user/perf_stats_screen.dart
@@ -17,6 +17,7 @@ import 'package:lichess_mobile/src/styles/styles.dart';
 import 'package:lichess_mobile/src/utils/duration.dart';
 import 'package:lichess_mobile/src/utils/l10n_context.dart';
 import 'package:lichess_mobile/src/utils/navigation.dart';
+import 'package:lichess_mobile/src/utils/string.dart';
 import 'package:lichess_mobile/src/view/game/archived_game_screen.dart';
 import 'package:lichess_mobile/src/widgets/feedback.dart';
 import 'package:lichess_mobile/src/widgets/list.dart';
@@ -209,10 +210,13 @@ class _Body extends ConsumerWidget {
                   textBaseline: TextBaseline.alphabetic,
                   children: [
                     Text(
-                      '${context.l10n.perfStatTotalGames} ',
+                      '${context.l10n.perfStatTotalGames} '.localizeNumbers(),
                       style: Styles.sectionTitle,
                     ),
-                    Text(data.totalGames.toString(), style: _mainValueStyle),
+                    Text(
+                      data.totalGames.toString().localizeNumbers(),
+                      style: _mainValueStyle,
+                    ),
                   ],
                 ),
               ),
@@ -463,7 +467,7 @@ class _PercentageValueWidget extends StatelessWidget {
       mainAxisAlignment: MainAxisAlignment.center,
       children: [
         Text(
-          value.toString(),
+          value.toString().localizeNumbers(),
           style: const TextStyle(fontSize: _defaultValueFontSize),
         ),
         Text(


### PR DESCRIPTION
closes #504
I added localizations to integers that are likely to be larger than 1000 (number of games played and also the number of times a puzzle has been played), except ratings. It could be easily extended to more numbers. 
Tested for German, French, and English.