### PR TITLE
Focus detector and immersive mode improvements

### DIFF
--- a/lib/src/navigation.dart
+++ b/lib/src/navigation.dart
@@ -81,6 +81,9 @@ final RouteObserver<PageRoute<void>> rootNavPageRouteObserver =
 final RouteObserver<PageRoute<void>> homeRouteObserver =
     RouteObserver<PageRoute<void>>();
 
+final RouteObserver<PageRoute<void>> watchRouteObserver =
+    RouteObserver<PageRoute<void>>();
+
 final tabsProvider = Provider<List<_Tab>>((ref) {
   final l10n = ref.watch(l10nProvider);
 
@@ -181,9 +184,7 @@ class BottomNavScaffold extends ConsumerWidget {
       case 0:
         return _MaterialTabView(
           navigatorKey: homeNavigatorKey,
-          navigatorObservers: [
-            homeRouteObserver,
-          ],
+          navigatorObservers: [homeRouteObserver],
           builder: (context) => const HomeTabScreen(),
         );
       case 1:
@@ -200,6 +201,7 @@ class BottomNavScaffold extends ConsumerWidget {
         return _MaterialTabView(
           navigatorKey: watchNavigatorKey,
           builder: (context) => const WatchTabScreen(),
+          navigatorObservers: [watchRouteObserver],
         );
       default:
         assert(false, 'Unexpected tab');
@@ -213,9 +215,7 @@ class BottomNavScaffold extends ConsumerWidget {
         return CupertinoTabView(
           defaultTitle: context.l10n.play,
           navigatorKey: homeNavigatorKey,
-          navigatorObservers: [
-            homeRouteObserver,
-          ],
+          navigatorObservers: [homeRouteObserver],
           builder: (context) => const HomeTabScreen(),
         );
       case 1:
@@ -235,6 +235,7 @@ class BottomNavScaffold extends ConsumerWidget {
           defaultTitle: context.l10n.watch,
           navigatorKey: watchNavigatorKey,
           builder: (context) => const WatchTabScreen(),
+          navigatorObservers: [watchRouteObserver],
         );
       default:
         assert(false, 'Unexpected tab');

--- a/lib/src/navigation.dart
+++ b/lib/src/navigation.dart
@@ -78,12 +78,6 @@ final watchScrollController = ScrollController(debugLabel: 'WatchScroll');
 final RouteObserver<PageRoute<void>> rootNavPageRouteObserver =
     RouteObserver<PageRoute<void>>();
 
-final RouteObserver<PageRoute<void>> homeRouteObserver =
-    RouteObserver<PageRoute<void>>();
-
-final RouteObserver<PageRoute<void>> watchRouteObserver =
-    RouteObserver<PageRoute<void>>();
-
 final tabsProvider = Provider<List<_Tab>>((ref) {
   final l10n = ref.watch(l10nProvider);
 
@@ -184,7 +178,6 @@ class BottomNavScaffold extends ConsumerWidget {
       case 0:
         return _MaterialTabView(
           navigatorKey: homeNavigatorKey,
-          navigatorObservers: [homeRouteObserver],
           builder: (context) => const HomeTabScreen(),
         );
       case 1:
@@ -201,7 +194,6 @@ class BottomNavScaffold extends ConsumerWidget {
         return _MaterialTabView(
           navigatorKey: watchNavigatorKey,
           builder: (context) => const WatchTabScreen(),
-          navigatorObservers: [watchRouteObserver],
         );
       default:
         assert(false, 'Unexpected tab');
@@ -215,7 +207,6 @@ class BottomNavScaffold extends ConsumerWidget {
         return CupertinoTabView(
           defaultTitle: context.l10n.play,
           navigatorKey: homeNavigatorKey,
-          navigatorObservers: [homeRouteObserver],
           builder: (context) => const HomeTabScreen(),
         );
       case 1:
@@ -235,7 +226,6 @@ class BottomNavScaffold extends ConsumerWidget {
           defaultTitle: context.l10n.watch,
           navigatorKey: watchNavigatorKey,
           builder: (context) => const WatchTabScreen(),
-          navigatorObservers: [watchRouteObserver],
         );
       default:
         assert(false, 'Unexpected tab');

--- a/lib/src/utils/focus_detector.dart
+++ b/lib/src/utils/focus_detector.dart
@@ -1,0 +1,176 @@
+import 'package:flutter/widgets.dart';
+import 'package:visibility_detector/visibility_detector.dart';
+
+// code taken and adapted from
+// https://github.com/EdsonBueno/focus_detector
+
+/// Fires callbacks every time the widget appears or disappears from the screen.
+class FocusDetector extends StatefulWidget {
+  const FocusDetector({
+    required this.child,
+    this.onFocusGained,
+    this.onFocusRegained,
+    this.onFocusLost,
+    this.onVisibilityGained,
+    this.onVisibilityRegained,
+    this.onVisibilityLost,
+    this.onForegroundGained,
+    this.onForegroundLost,
+    super.key,
+  });
+
+  /// Called when the widget becomes visible or enters foreground while visible.
+  final VoidCallback? onFocusGained;
+
+  /// Called when the widget gains focus again (same as onFocusGained but does
+  /// not fires the first time).
+  final VoidCallback? onFocusRegained;
+
+  /// Called when the widget becomes invisible or enters background while visible.
+  final VoidCallback? onFocusLost;
+
+  /// Called when the widget becomes visible.
+  final VoidCallback? onVisibilityGained;
+
+  /// Called when the widget become visible again (same as onVisibilityGained but
+  /// does not fires the first time).
+  final VoidCallback? onVisibilityRegained;
+
+  /// Called when the widget becomes invisible.
+  final VoidCallback? onVisibilityLost;
+
+  /// Called when the app entered the foreground while the widget is visible.
+  final VoidCallback? onForegroundGained;
+
+  /// Called when the app is sent to background while the widget was visible.
+  final VoidCallback? onForegroundLost;
+
+  /// The widget below this widget in the tree.
+  final Widget child;
+
+  @override
+  _FocusDetectorState createState() => _FocusDetectorState();
+}
+
+class _FocusDetectorState extends State<FocusDetector>
+    with WidgetsBindingObserver {
+  final _visibilityDetectorKey = UniqueKey();
+
+  /// Counter to keep track of the visibility changes.
+  int _visibilityCounter = 0;
+
+  /// Whether this widget is currently visible within the app.
+  bool _isWidgetVisible = false;
+
+  /// Whether the app is in the foreground.
+  bool _isAppInForeground = true;
+
+  @override
+  void initState() {
+    WidgetsBinding.instance.addObserver(this);
+    super.initState();
+  }
+
+  @override
+  void didChangeAppLifecycleState(AppLifecycleState state) {
+    _notifyPlaneTransition(state);
+  }
+
+  /// Notifies app's transitions to/from the foreground.
+  void _notifyPlaneTransition(AppLifecycleState state) {
+    if (!_isWidgetVisible) {
+      return;
+    }
+
+    final isAppResumed = state == AppLifecycleState.resumed;
+    final wasResumed = _isAppInForeground;
+    if (isAppResumed && !wasResumed) {
+      _isAppInForeground = true;
+      _notifyFocusGain();
+      _notifyForegroundGain();
+      return;
+    }
+
+    final isAppPaused = state == AppLifecycleState.paused;
+    if (isAppPaused && wasResumed) {
+      _isAppInForeground = false;
+      _notifyFocusLoss();
+      _notifyForegroundLoss();
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) => VisibilityDetector(
+        key: _visibilityDetectorKey,
+        onVisibilityChanged: (visibilityInfo) {
+          final visibleFraction = visibilityInfo.visibleFraction;
+          _notifyVisibilityStatusChange(visibleFraction);
+        },
+        child: widget.child,
+      );
+
+  /// Notifies changes in the widget's visibility.
+  void _notifyVisibilityStatusChange(double newVisibleFraction) {
+    if (!_isAppInForeground) {
+      return;
+    }
+
+    final wasFullyVisible = _isWidgetVisible;
+    final isFullyVisible = newVisibleFraction == 1;
+    if (!wasFullyVisible && isFullyVisible) {
+      _isWidgetVisible = true;
+      _notifyFocusGain();
+      _notifyVisibilityGain();
+      _visibilityCounter++;
+    }
+
+    final isFullyInvisible = newVisibleFraction == 0;
+    if (wasFullyVisible && isFullyInvisible) {
+      _isWidgetVisible = false;
+      _notifyFocusLoss();
+      _notifyVisibilityLoss();
+    }
+  }
+
+  void _notifyFocusGain() {
+    widget.onFocusGained?.call();
+    if (_visibilityCounter > 0) {
+      widget.onFocusRegained?.call();
+    }
+  }
+
+  void _notifyFocusLoss() {
+    widget.onFocusLost?.call();
+  }
+
+  void _notifyVisibilityGain() {
+    widget.onVisibilityGained?.call();
+    if (_visibilityCounter > 0) {
+      widget.onVisibilityRegained?.call();
+    }
+  }
+
+  void _notifyVisibilityLoss() {
+    widget.onVisibilityLost?.call();
+  }
+
+  void _notifyForegroundGain() {
+    final onForegroundGained = widget.onForegroundGained;
+    if (onForegroundGained != null) {
+      onForegroundGained();
+    }
+  }
+
+  void _notifyForegroundLoss() {
+    final onForegroundLost = widget.onForegroundLost;
+    if (onForegroundLost != null) {
+      onForegroundLost();
+    }
+  }
+
+  @override
+  void dispose() {
+    WidgetsBinding.instance.removeObserver(this);
+    super.dispose();
+  }
+}

--- a/lib/src/utils/immersive_mode.dart
+++ b/lib/src/utils/immersive_mode.dart
@@ -1,11 +1,29 @@
 import 'package:device_info_plus/device_info_plus.dart';
 import 'package:flutter/foundation.dart';
 import 'package:flutter/services.dart';
+import 'package:flutter/widgets.dart';
+import 'package:lichess_mobile/src/utils/focus_detector.dart';
 import 'package:wakelock_plus/wakelock_plus.dart';
 
 final _deviceInfoPlugin = DeviceInfoPlugin();
 
 final immersiveModeService = ImmersiveModeService();
+
+/// A widget that enables immersive mode when focused.
+class ImmersiveModeWidget extends StatelessWidget {
+  const ImmersiveModeWidget({required this.child, super.key});
+
+  final Widget child;
+
+  @override
+  Widget build(BuildContext context) {
+    return FocusDetector(
+      onVisibilityGained: () => immersiveModeService.enable(),
+      onVisibilityLost: () => immersiveModeService.disable(),
+      child: child,
+    );
+  }
+}
 
 /// Immersive mode is a way to hide the system UI (status bar and navigation bar)
 /// on Android 10 and above, and to force the device to stay awake.
@@ -14,6 +32,10 @@ final immersiveModeService = ImmersiveModeService();
 /// They conflict with board game gestures, and we must set immersive mode
 /// to disable them.
 class ImmersiveModeService {
+  /// Enable immersive mode.
+  ///
+  /// This hides the system UI (status bar and navigation bar) and forces the
+  /// device to stay awake.
   Future<void> enable() async {
     WakelockPlus.enable();
     if (defaultTargetPlatform == TargetPlatform.android) {
@@ -24,6 +46,10 @@ class ImmersiveModeService {
     }
   }
 
+  /// Disable immersive mode.
+  ///
+  /// This shows the system UI (status bar and navigation bar) and allows the
+  /// device to sleep.
   Future<void> disable() async {
     WakelockPlus.disable();
     if (defaultTargetPlatform == TargetPlatform.android) {

--- a/lib/src/utils/immersive_mode.dart
+++ b/lib/src/utils/immersive_mode.dart
@@ -1,48 +1,21 @@
 import 'package:device_info_plus/device_info_plus.dart';
 import 'package:flutter/foundation.dart';
-import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 import 'package:wakelock_plus/wakelock_plus.dart';
 
 final _deviceInfoPlugin = DeviceInfoPlugin();
 
-/// State mixin that sets immersive mode for board screens.
-///
-/// Mixin user must subscribe to the [NavigatorObserver] and call `super`.
-///
+final immersiveModeService = ImmersiveModeService();
+
 /// Immersive mode is a way to hide the system UI (status bar and navigation bar)
 /// on Android 10 and above, and to force the device to stay awake.
 ///
 /// Navigation gestures start with Android 10 (API 29).
 /// They conflict with board game gestures, and we must set immersive mode
 /// to disable them.
-mixin ImmersiveMode<T extends StatefulWidget> on State<T>
-    implements RouteAware {
-  @override
-  void didPopNext() {
-    _setImmersiveMode();
+class ImmersiveModeService {
+  Future<void> enable() async {
     WakelockPlus.enable();
-  }
-
-  @override
-  void didPush() {
-    _setImmersiveMode();
-    WakelockPlus.enable();
-  }
-
-  @override
-  void didPop() {
-    _disableImmersiveMode();
-    WakelockPlus.disable();
-  }
-
-  @override
-  void didPushNext() {
-    _disableImmersiveMode();
-    WakelockPlus.disable();
-  }
-
-  Future<void> _setImmersiveMode() async {
     if (defaultTargetPlatform == TargetPlatform.android) {
       final androidInfo = await _deviceInfoPlugin.androidInfo;
       if (androidInfo.version.sdkInt >= 29) {
@@ -51,7 +24,8 @@ mixin ImmersiveMode<T extends StatefulWidget> on State<T>
     }
   }
 
-  Future<void> _disableImmersiveMode() async {
+  Future<void> disable() async {
+    WakelockPlus.disable();
     if (defaultTargetPlatform == TargetPlatform.android) {
       final androidInfo = await _deviceInfoPlugin.androidInfo;
       if (androidInfo.version.sdkInt >= 29) {

--- a/lib/src/view/game/game_body.dart
+++ b/lib/src/view/game/game_body.dart
@@ -17,6 +17,8 @@ import 'package:lichess_mobile/src/model/game/game_preferences.dart';
 import 'package:lichess_mobile/src/model/game/playable_game.dart';
 import 'package:lichess_mobile/src/model/settings/board_preferences.dart';
 import 'package:lichess_mobile/src/utils/chessground_compat.dart';
+import 'package:lichess_mobile/src/utils/focus_detector.dart';
+import 'package:lichess_mobile/src/utils/immersive_mode.dart';
 import 'package:lichess_mobile/src/utils/l10n_context.dart';
 import 'package:lichess_mobile/src/utils/navigation.dart';
 import 'package:lichess_mobile/src/view/analysis/analysis_screen.dart';
@@ -29,6 +31,7 @@ import 'package:lichess_mobile/src/widgets/buttons.dart';
 import 'package:lichess_mobile/src/widgets/countdown_clock.dart';
 import 'package:lichess_mobile/src/widgets/user_full_name.dart';
 import 'package:lichess_mobile/src/widgets/yes_no_dialog.dart';
+import 'package:wakelock_plus/wakelock_plus.dart';
 
 import 'game_common_widgets.dart';
 import 'game_loading_board.dart';
@@ -40,6 +43,11 @@ import 'game_screen_providers.dart';
 ///
 /// This widget is responsible for displaying the board, the clocks, the players,
 /// and the bottom bar.
+///
+/// It also listens to the game state and shows dialogs when necessary.
+///
+/// Handles the immersive mode through focus detection, and the pop scope to
+/// prevent the user from going back to the previous screen.
 class GameBody extends ConsumerWidget {
   const GameBody({
     required this.id,
@@ -197,84 +205,97 @@ class GameBody extends ConsumerWidget {
         final bottomPlayer = youAre == Side.white ? white : black;
         final isBoardTurned = ref.watch(isBoardTurnedProvider);
 
-        return PopScope(
-          canPop: gameState.game.meta.speed == Speed.correspondence ||
-              !gameState.game.playable,
-          child: Column(
-            children: [
-              Expanded(
-                child: SafeArea(
-                  bottom: false,
-                  child: BoardTable(
-                    boardSettingsOverrides: BoardSettingsOverrides(
-                      autoQueenPromotion: gameState.canAutoQueen,
-                      autoQueenPromotionOnPremove:
-                          gameState.canAutoQueenOnPremove,
-                      blindfoldMode: blindfoldMode,
+        return FocusDetector(
+          onVisibilityGained: () {
+            _enableImmersiveMode(gameState.game);
+          },
+          onVisibilityLost: () {
+            immersiveModeService.disable();
+          },
+          child: PopScope(
+            canPop: gameState.game.meta.speed == Speed.correspondence ||
+                !gameState.game.playable,
+            child: Column(
+              children: [
+                Expanded(
+                  child: SafeArea(
+                    bottom: false,
+                    child: BoardTable(
+                      boardSettingsOverrides: BoardSettingsOverrides(
+                        autoQueenPromotion: gameState.canAutoQueen,
+                        autoQueenPromotionOnPremove:
+                            gameState.canAutoQueenOnPremove,
+                        blindfoldMode: blindfoldMode,
+                      ),
+                      onMove: (move, {isDrop, isPremove}) {
+                        ref.read(ctrlProvider.notifier).onUserMove(
+                              Move.fromUci(move.uci)!,
+                              isPremove: isPremove,
+                              isDrop: isDrop,
+                            );
+                      },
+                      onPremove: gameState.canPremove
+                          ? (move) {
+                              ref.read(ctrlProvider.notifier).setPremove(move);
+                            }
+                          : null,
+                      boardData: cg.BoardData(
+                        interactableSide:
+                            gameState.game.playable && !gameState.isReplaying
+                                ? youAre == Side.white
+                                    ? cg.InteractableSide.white
+                                    : cg.InteractableSide.black
+                                : cg.InteractableSide.none,
+                        orientation:
+                            isBoardTurned ? youAre.opposite.cg : youAre.cg,
+                        fen: position.fen,
+                        lastMove:
+                            gameState.game.moveAt(gameState.stepCursor)?.cg,
+                        isCheck: position.isCheck,
+                        sideToMove: sideToMove.cg,
+                        validMoves: algebraicLegalMoves(position),
+                        premove: gameState.premove,
+                      ),
+                      topTable: topPlayer,
+                      bottomTable: gameState.canShowClaimWinCountdown &&
+                              gameState.opponentLeftCountdown != null
+                          ? _ClaimWinCountdown(
+                              duration: gameState.opponentLeftCountdown!,
+                            )
+                          : bottomPlayer,
+                      moves: gameState.game.steps
+                          .skip(1)
+                          .map((e) => e.sanMove!.san)
+                          .toList(growable: false),
+                      currentMoveIndex: gameState.stepCursor,
+                      onSelectMove: (moveIndex) {
+                        ref.read(ctrlProvider.notifier).cursorAt(moveIndex);
+                      },
                     ),
-                    onMove: (move, {isDrop, isPremove}) {
-                      ref.read(ctrlProvider.notifier).onUserMove(
-                            Move.fromUci(move.uci)!,
-                            isPremove: isPremove,
-                            isDrop: isDrop,
-                          );
-                    },
-                    onPremove: gameState.canPremove
-                        ? (move) {
-                            ref.read(ctrlProvider.notifier).setPremove(move);
-                          }
-                        : null,
-                    boardData: cg.BoardData(
-                      interactableSide:
-                          gameState.game.playable && !gameState.isReplaying
-                              ? youAre == Side.white
-                                  ? cg.InteractableSide.white
-                                  : cg.InteractableSide.black
-                              : cg.InteractableSide.none,
-                      orientation:
-                          isBoardTurned ? youAre.opposite.cg : youAre.cg,
-                      fen: position.fen,
-                      lastMove: gameState.game.moveAt(gameState.stepCursor)?.cg,
-                      isCheck: position.isCheck,
-                      sideToMove: sideToMove.cg,
-                      validMoves: algebraicLegalMoves(position),
-                      premove: gameState.premove,
-                    ),
-                    topTable: topPlayer,
-                    bottomTable: gameState.canShowClaimWinCountdown &&
-                            gameState.opponentLeftCountdown != null
-                        ? _ClaimWinCountdown(
-                            duration: gameState.opponentLeftCountdown!,
-                          )
-                        : bottomPlayer,
-                    moves: gameState.game.steps
-                        .skip(1)
-                        .map((e) => e.sanMove!.san)
-                        .toList(growable: false),
-                    currentMoveIndex: gameState.stepCursor,
-                    onSelectMove: (moveIndex) {
-                      ref.read(ctrlProvider.notifier).cursorAt(moveIndex);
-                    },
                   ),
                 ),
-              ),
-              _GameBottomBar(
-                id: id,
-                gameState: gameState,
-                onLoadGameCallback: onLoadGameCallback,
-                onNewOpponentCallback: onNewOpponentCallback,
-              ),
-            ],
+                _GameBottomBar(
+                  id: id,
+                  gameState: gameState,
+                  onLoadGameCallback: onLoadGameCallback,
+                  onNewOpponentCallback: onNewOpponentCallback,
+                ),
+              ],
+            ),
           ),
         );
       },
-      loading: () => PopScope(canPop: true, child: loadingBoardWidget),
+      loading: () => FocusDetector(
+        child: PopScope(canPop: true, child: loadingBoardWidget),
+      ),
       error: (e, s) {
         debugPrint(
           'SEVERE: [GameBody] could not load game data; $e\n$s',
         );
-        return const PopScope(
-          child: LoadGameError(),
+        return const FocusDetector(
+          child: PopScope(
+            child: LoadGameError(),
+          ),
         );
       },
     );
@@ -306,6 +327,16 @@ class GameBody extends ConsumerWidget {
           }
         });
       }
+
+      // true when the game was loaded, playable, and just finished
+      if (prev?.valueOrNull?.game.playable == true &&
+          state.requireValue.game.playable == false) {
+        immersiveModeService.disable();
+      }
+      // true when the game was not loaded: handles rematches
+      else if (prev?.hasValue != true) {
+        _enableImmersiveMode(state.requireValue.game);
+      }
     }
 
     if (prev?.hasValue == true && state.hasValue) {
@@ -326,6 +357,16 @@ class GameBody extends ConsumerWidget {
         Navigator.of(context).popUntil((route) => route is! PopupRoute);
         onLoadGameCallback(state.requireValue.redirectGameId!);
       }
+    }
+  }
+
+  void _enableImmersiveMode(PlayableGame game) {
+    // Enable immersive mode when the game is in real time and playable.
+    if (game.meta.speed != Speed.correspondence && game.playable) {
+      immersiveModeService.enable();
+    } else if (game.playable) {
+      // Correspondence: just enable the wakelock when the game is playable.
+      WakelockPlus.enable();
     }
   }
 }

--- a/lib/src/view/game/lobby_screen.dart
+++ b/lib/src/view/game/lobby_screen.dart
@@ -6,8 +6,6 @@ import 'package:lichess_mobile/src/model/common/id.dart';
 import 'package:lichess_mobile/src/model/lobby/create_game_service.dart';
 import 'package:lichess_mobile/src/model/lobby/game_seek.dart';
 import 'package:lichess_mobile/src/navigation.dart';
-import 'package:lichess_mobile/src/utils/focus_detector.dart';
-import 'package:lichess_mobile/src/utils/immersive_mode.dart';
 import 'package:lichess_mobile/src/view/game/game_body.dart';
 import 'package:lichess_mobile/src/view/game/game_common_widgets.dart';
 import 'package:lichess_mobile/src/view/game/game_loading_board.dart';
@@ -79,78 +77,74 @@ class _LobbyScreenState extends ConsumerState<LobbyScreen> with RouteAware {
     final gameIdAsync =
         ref.watch(_lobbyGameProvider(widget.seek)).unwrapPrevious();
 
-    return FocusDetector(
-      onVisibilityGained: () => immersiveModeService.enable(),
-      onVisibilityLost: () => immersiveModeService.disable(),
-      child: gameIdAsync.when(
-        data: (data) {
-          final (gameId, fromRematch: isRematch) = data;
-          final body = GameBody(
-            id: gameId,
-            loadingBoardWidget: isRematch
-                ? const StandaloneGameLoadingBoard()
-                : LobbyGameLoadingBoard(widget.seek),
-            whiteClockKey: _whiteClockKey,
-            blackClockKey: _blackClockKey,
-            onLoadGameCallback: (id) {
-              ref.read(_lobbyGameProvider(widget.seek).notifier).rematch(id);
-            },
-            onNewOpponentCallback: (_) {
-              ref.invalidate(_lobbyGameProvider(widget.seek));
-            },
-          );
-          return PlatformWidget(
-            androidBuilder: (context) => Scaffold(
-              resizeToAvoidBottomInset: false,
-              appBar: GameAppBar(id: gameId),
-              body: body,
-            ),
-            iosBuilder: (context) => CupertinoPageScaffold(
-              resizeToAvoidBottomInset: false,
-              navigationBar: GameCupertinoNavBar(id: gameId),
-              child: body,
-            ),
-          );
-        },
-        loading: () => PlatformWidget(
+    return gameIdAsync.when(
+      data: (data) {
+        final (gameId, fromRematch: isRematch) = data;
+        final body = GameBody(
+          id: gameId,
+          loadingBoardWidget: isRematch
+              ? const StandaloneGameLoadingBoard()
+              : LobbyGameLoadingBoard(widget.seek),
+          whiteClockKey: _whiteClockKey,
+          blackClockKey: _blackClockKey,
+          onLoadGameCallback: (id) {
+            ref.read(_lobbyGameProvider(widget.seek).notifier).rematch(id);
+          },
+          onNewOpponentCallback: (_) {
+            ref.invalidate(_lobbyGameProvider(widget.seek));
+          },
+        );
+        return PlatformWidget(
+          androidBuilder: (context) => Scaffold(
+            resizeToAvoidBottomInset: false,
+            appBar: GameAppBar(id: gameId),
+            body: body,
+          ),
+          iosBuilder: (context) => CupertinoPageScaffold(
+            resizeToAvoidBottomInset: false,
+            navigationBar: GameCupertinoNavBar(id: gameId),
+            child: body,
+          ),
+        );
+      },
+      loading: () => PlatformWidget(
+        androidBuilder: (context) => Scaffold(
+          resizeToAvoidBottomInset: false,
+          appBar: GameAppBar(seek: widget.seek),
+          body: PopScope(
+            canPop: false,
+            child: LobbyGameLoadingBoard(widget.seek),
+          ),
+        ),
+        iosBuilder: (context) => CupertinoPageScaffold(
+          resizeToAvoidBottomInset: false,
+          navigationBar: GameCupertinoNavBar(seek: widget.seek),
+          child: PopScope(
+            canPop: false,
+            child: LobbyGameLoadingBoard(widget.seek),
+          ),
+        ),
+      ),
+      error: (e, s) {
+        debugPrint(
+          'SEVERE: [LobbyGameScreen] could not create game; $e\n$s',
+        );
+        const body = PopScope(
+          child: LoadGameError(),
+        );
+        return PlatformWidget(
           androidBuilder: (context) => Scaffold(
             resizeToAvoidBottomInset: false,
             appBar: GameAppBar(seek: widget.seek),
-            body: PopScope(
-              canPop: false,
-              child: LobbyGameLoadingBoard(widget.seek),
-            ),
+            body: body,
           ),
           iosBuilder: (context) => CupertinoPageScaffold(
             resizeToAvoidBottomInset: false,
             navigationBar: GameCupertinoNavBar(seek: widget.seek),
-            child: PopScope(
-              canPop: false,
-              child: LobbyGameLoadingBoard(widget.seek),
-            ),
+            child: body,
           ),
-        ),
-        error: (e, s) {
-          debugPrint(
-            'SEVERE: [LobbyGameScreen] could not create game; $e\n$s',
-          );
-          const body = PopScope(
-            child: LoadGameError(),
-          );
-          return PlatformWidget(
-            androidBuilder: (context) => Scaffold(
-              resizeToAvoidBottomInset: false,
-              appBar: GameAppBar(seek: widget.seek),
-              body: body,
-            ),
-            iosBuilder: (context) => CupertinoPageScaffold(
-              resizeToAvoidBottomInset: false,
-              navigationBar: GameCupertinoNavBar(seek: widget.seek),
-              child: body,
-            ),
-          );
-        },
-      ),
+        );
+      },
     );
   }
 }

--- a/lib/src/view/game/standalone_game_screen.dart
+++ b/lib/src/view/game/standalone_game_screen.dart
@@ -7,8 +7,6 @@ import 'package:lichess_mobile/src/model/common/id.dart';
 import 'package:lichess_mobile/src/model/game/playable_game.dart';
 import 'package:lichess_mobile/src/model/lobby/game_seek.dart';
 import 'package:lichess_mobile/src/model/lobby/game_setup.dart';
-import 'package:lichess_mobile/src/utils/focus_detector.dart';
-import 'package:lichess_mobile/src/utils/immersive_mode.dart';
 import 'package:lichess_mobile/src/utils/navigation.dart';
 import 'package:lichess_mobile/src/view/game/game_loading_board.dart';
 import 'package:lichess_mobile/src/view/game/lobby_screen.dart';
@@ -60,45 +58,41 @@ class _StandaloneGameScreenState extends ConsumerState<StandaloneGameScreen> {
 
   @override
   Widget build(BuildContext context) {
-    return FocusDetector(
-      onVisibilityGained: () => immersiveModeService.enable(),
-      onVisibilityLost: () => immersiveModeService.disable(),
-      child: PlatformWidget(
-        androidBuilder: (context) => Scaffold(
-          resizeToAvoidBottomInset: false,
-          appBar: GameAppBar(id: _gameId),
-          body: GameBody(
-            id: _gameId,
-            loadingBoardWidget: widget.params.id == _gameId
-                ? StandaloneGameLoadingBoard(
-                    fen: widget.params.fen,
-                    orientation: widget.params.orientation,
-                    lastMove: widget.params.lastMove,
-                  )
-                : const StandaloneGameLoadingBoard(),
-            whiteClockKey: _whiteClockKey,
-            blackClockKey: _blackClockKey,
-            onLoadGameCallback: _loadGame,
-            onNewOpponentCallback: _onNewOpponent,
-          ),
+    return PlatformWidget(
+      androidBuilder: (context) => Scaffold(
+        resizeToAvoidBottomInset: false,
+        appBar: GameAppBar(id: _gameId),
+        body: GameBody(
+          id: _gameId,
+          loadingBoardWidget: widget.params.id == _gameId
+              ? StandaloneGameLoadingBoard(
+                  fen: widget.params.fen,
+                  orientation: widget.params.orientation,
+                  lastMove: widget.params.lastMove,
+                )
+              : const StandaloneGameLoadingBoard(),
+          whiteClockKey: _whiteClockKey,
+          blackClockKey: _blackClockKey,
+          onLoadGameCallback: _loadGame,
+          onNewOpponentCallback: _onNewOpponent,
         ),
-        iosBuilder: (context) => CupertinoPageScaffold(
-          resizeToAvoidBottomInset: false,
-          navigationBar: GameCupertinoNavBar(id: _gameId),
-          child: GameBody(
-            id: _gameId,
-            loadingBoardWidget: widget.params.id == _gameId
-                ? StandaloneGameLoadingBoard(
-                    fen: widget.params.fen,
-                    orientation: widget.params.orientation,
-                    lastMove: widget.params.lastMove,
-                  )
-                : const StandaloneGameLoadingBoard(),
-            whiteClockKey: _whiteClockKey,
-            blackClockKey: _blackClockKey,
-            onLoadGameCallback: _loadGame,
-            onNewOpponentCallback: _onNewOpponent,
-          ),
+      ),
+      iosBuilder: (context) => CupertinoPageScaffold(
+        resizeToAvoidBottomInset: false,
+        navigationBar: GameCupertinoNavBar(id: _gameId),
+        child: GameBody(
+          id: _gameId,
+          loadingBoardWidget: widget.params.id == _gameId
+              ? StandaloneGameLoadingBoard(
+                  fen: widget.params.fen,
+                  orientation: widget.params.orientation,
+                  lastMove: widget.params.lastMove,
+                )
+              : const StandaloneGameLoadingBoard(),
+          whiteClockKey: _whiteClockKey,
+          blackClockKey: _blackClockKey,
+          onLoadGameCallback: _loadGame,
+          onNewOpponentCallback: _onNewOpponent,
         ),
       ),
     );

--- a/lib/src/view/game/standalone_game_screen.dart
+++ b/lib/src/view/game/standalone_game_screen.dart
@@ -7,6 +7,7 @@ import 'package:lichess_mobile/src/model/common/id.dart';
 import 'package:lichess_mobile/src/model/game/playable_game.dart';
 import 'package:lichess_mobile/src/model/lobby/game_seek.dart';
 import 'package:lichess_mobile/src/model/lobby/game_setup.dart';
+import 'package:lichess_mobile/src/utils/focus_detector.dart';
 import 'package:lichess_mobile/src/utils/immersive_mode.dart';
 import 'package:lichess_mobile/src/utils/navigation.dart';
 import 'package:lichess_mobile/src/view/game/game_loading_board.dart';
@@ -45,8 +46,7 @@ class StandaloneGameScreen extends ConsumerStatefulWidget {
       _StandaloneGameScreenState();
 }
 
-class _StandaloneGameScreenState extends ConsumerState<StandaloneGameScreen>
-    with ImmersiveMode {
+class _StandaloneGameScreenState extends ConsumerState<StandaloneGameScreen> {
   final _whiteClockKey = GlobalKey(debugLabel: 'whiteClockOnGameScreen');
   final _blackClockKey = GlobalKey(debugLabel: 'blackClockOnGameScreen');
 
@@ -60,41 +60,45 @@ class _StandaloneGameScreenState extends ConsumerState<StandaloneGameScreen>
 
   @override
   Widget build(BuildContext context) {
-    return PlatformWidget(
-      androidBuilder: (context) => Scaffold(
-        resizeToAvoidBottomInset: false,
-        appBar: GameAppBar(id: _gameId),
-        body: GameBody(
-          id: _gameId,
-          loadingBoardWidget: widget.params.id == _gameId
-              ? StandaloneGameLoadingBoard(
-                  fen: widget.params.fen,
-                  orientation: widget.params.orientation,
-                  lastMove: widget.params.lastMove,
-                )
-              : const StandaloneGameLoadingBoard(),
-          whiteClockKey: _whiteClockKey,
-          blackClockKey: _blackClockKey,
-          onLoadGameCallback: _loadGame,
-          onNewOpponentCallback: _onNewOpponent,
+    return FocusDetector(
+      onVisibilityGained: () => immersiveModeService.enable(),
+      onVisibilityLost: () => immersiveModeService.disable(),
+      child: PlatformWidget(
+        androidBuilder: (context) => Scaffold(
+          resizeToAvoidBottomInset: false,
+          appBar: GameAppBar(id: _gameId),
+          body: GameBody(
+            id: _gameId,
+            loadingBoardWidget: widget.params.id == _gameId
+                ? StandaloneGameLoadingBoard(
+                    fen: widget.params.fen,
+                    orientation: widget.params.orientation,
+                    lastMove: widget.params.lastMove,
+                  )
+                : const StandaloneGameLoadingBoard(),
+            whiteClockKey: _whiteClockKey,
+            blackClockKey: _blackClockKey,
+            onLoadGameCallback: _loadGame,
+            onNewOpponentCallback: _onNewOpponent,
+          ),
         ),
-      ),
-      iosBuilder: (context) => CupertinoPageScaffold(
-        resizeToAvoidBottomInset: false,
-        navigationBar: GameCupertinoNavBar(id: _gameId),
-        child: GameBody(
-          id: _gameId,
-          loadingBoardWidget: widget.params.id == _gameId
-              ? StandaloneGameLoadingBoard(
-                  fen: widget.params.fen,
-                  orientation: widget.params.orientation,
-                  lastMove: widget.params.lastMove,
-                )
-              : const StandaloneGameLoadingBoard(),
-          whiteClockKey: _whiteClockKey,
-          blackClockKey: _blackClockKey,
-          onLoadGameCallback: _loadGame,
-          onNewOpponentCallback: _onNewOpponent,
+        iosBuilder: (context) => CupertinoPageScaffold(
+          resizeToAvoidBottomInset: false,
+          navigationBar: GameCupertinoNavBar(id: _gameId),
+          child: GameBody(
+            id: _gameId,
+            loadingBoardWidget: widget.params.id == _gameId
+                ? StandaloneGameLoadingBoard(
+                    fen: widget.params.fen,
+                    orientation: widget.params.orientation,
+                    lastMove: widget.params.lastMove,
+                  )
+                : const StandaloneGameLoadingBoard(),
+            whiteClockKey: _whiteClockKey,
+            blackClockKey: _blackClockKey,
+            onLoadGameCallback: _loadGame,
+            onNewOpponentCallback: _onNewOpponent,
+          ),
         ),
       ),
     );

--- a/lib/src/view/home/home_tab_screen.dart
+++ b/lib/src/view/home/home_tab_screen.dart
@@ -35,8 +35,6 @@ import 'package:lichess_mobile/src/widgets/feedback.dart';
 import 'package:lichess_mobile/src/widgets/platform.dart';
 import 'package:lichess_mobile/src/widgets/user_full_name.dart';
 
-final isHomeRootProvider = StateProvider<bool>((ref) => true);
-
 class HomeTabScreen extends ConsumerStatefulWidget {
   const HomeTabScreen({super.key});
 
@@ -44,7 +42,7 @@ class HomeTabScreen extends ConsumerStatefulWidget {
   ConsumerState<HomeTabScreen> createState() => _HomeScreenState();
 }
 
-class _HomeScreenState extends ConsumerState<HomeTabScreen> with RouteAware {
+class _HomeScreenState extends ConsumerState<HomeTabScreen> {
   final _androidRefreshKey = GlobalKey<RefreshIndicatorState>();
 
   bool wasOnline = true;
@@ -70,33 +68,6 @@ class _HomeScreenState extends ConsumerState<HomeTabScreen> with RouteAware {
       androidBuilder: _androidBuilder,
       iosBuilder: _iosBuilder,
     );
-  }
-
-  @override
-  void didChangeDependencies() {
-    super.didChangeDependencies();
-    final route = ModalRoute.of(context);
-    if (route != null && route is PageRoute) {
-      homeRouteObserver.subscribe(this, route);
-    }
-  }
-
-  @override
-  void dispose() {
-    homeRouteObserver.unsubscribe(this);
-    super.dispose();
-  }
-
-  @override
-  void didPushNext() {
-    ref.read(isHomeRootProvider.notifier).state = false;
-    super.didPushNext();
-  }
-
-  @override
-  void didPopNext() {
-    ref.read(isHomeRootProvider.notifier).state = true;
-    super.didPopNext();
   }
 
   Widget _androidBuilder(BuildContext context) {

--- a/lib/src/view/puzzle/puzzle_screen.dart
+++ b/lib/src/view/puzzle/puzzle_screen.dart
@@ -20,6 +20,7 @@ import 'package:lichess_mobile/src/navigation.dart';
 import 'package:lichess_mobile/src/styles/styles.dart';
 import 'package:lichess_mobile/src/utils/chessground_compat.dart';
 import 'package:lichess_mobile/src/utils/connectivity.dart';
+import 'package:lichess_mobile/src/utils/focus_detector.dart';
 import 'package:lichess_mobile/src/utils/immersive_mode.dart';
 import 'package:lichess_mobile/src/utils/l10n_context.dart';
 import 'package:lichess_mobile/src/utils/navigation.dart';
@@ -52,8 +53,7 @@ class PuzzleScreen extends ConsumerStatefulWidget {
   ConsumerState<PuzzleScreen> createState() => _PuzzleScreenState();
 }
 
-class _PuzzleScreenState extends ConsumerState<PuzzleScreen>
-    with RouteAware, ImmersiveMode {
+class _PuzzleScreenState extends ConsumerState<PuzzleScreen> with RouteAware {
   @override
   void didChangeDependencies() {
     super.didChangeDependencies();
@@ -79,9 +79,13 @@ class _PuzzleScreenState extends ConsumerState<PuzzleScreen>
 
   @override
   Widget build(BuildContext context) {
-    return PlatformWidget(
-      androidBuilder: _androidBuilder,
-      iosBuilder: _iosBuilder,
+    return FocusDetector(
+      onVisibilityGained: () => immersiveModeService.enable(),
+      onVisibilityLost: () => immersiveModeService.disable(),
+      child: PlatformWidget(
+        androidBuilder: _androidBuilder,
+        iosBuilder: _iosBuilder,
+      ),
     );
   }
 

--- a/lib/src/view/puzzle/puzzle_screen.dart
+++ b/lib/src/view/puzzle/puzzle_screen.dart
@@ -20,7 +20,6 @@ import 'package:lichess_mobile/src/navigation.dart';
 import 'package:lichess_mobile/src/styles/styles.dart';
 import 'package:lichess_mobile/src/utils/chessground_compat.dart';
 import 'package:lichess_mobile/src/utils/connectivity.dart';
-import 'package:lichess_mobile/src/utils/focus_detector.dart';
 import 'package:lichess_mobile/src/utils/immersive_mode.dart';
 import 'package:lichess_mobile/src/utils/l10n_context.dart';
 import 'package:lichess_mobile/src/utils/navigation.dart';
@@ -79,9 +78,7 @@ class _PuzzleScreenState extends ConsumerState<PuzzleScreen> with RouteAware {
 
   @override
   Widget build(BuildContext context) {
-    return FocusDetector(
-      onVisibilityGained: () => immersiveModeService.enable(),
-      onVisibilityLost: () => immersiveModeService.disable(),
+    return ImmersiveModeWidget(
       child: PlatformWidget(
         androidBuilder: _androidBuilder,
         iosBuilder: _iosBuilder,

--- a/lib/src/view/puzzle/storm_screen.dart
+++ b/lib/src/view/puzzle/storm_screen.dart
@@ -13,11 +13,11 @@ import 'package:lichess_mobile/src/model/puzzle/storm.dart';
 import 'package:lichess_mobile/src/model/puzzle/storm_controller.dart';
 import 'package:lichess_mobile/src/model/settings/board_preferences.dart';
 import 'package:lichess_mobile/src/model/settings/brightness.dart';
-import 'package:lichess_mobile/src/navigation.dart';
 import 'package:lichess_mobile/src/styles/lichess_colors.dart';
 import 'package:lichess_mobile/src/styles/lichess_icons.dart';
 import 'package:lichess_mobile/src/styles/styles.dart';
 import 'package:lichess_mobile/src/utils/chessground_compat.dart';
+import 'package:lichess_mobile/src/utils/focus_detector.dart';
 import 'package:lichess_mobile/src/utils/immersive_mode.dart';
 import 'package:lichess_mobile/src/utils/l10n_context.dart';
 import 'package:lichess_mobile/src/utils/navigation.dart';
@@ -34,34 +34,18 @@ import 'package:lichess_mobile/src/widgets/yes_no_dialog.dart';
 
 import 'history_boards.dart';
 
-class StormScreen extends StatefulWidget {
+class StormScreen extends StatelessWidget {
   const StormScreen({super.key});
 
   @override
-  State<StormScreen> createState() => _StormScreenState();
-}
-
-class _StormScreenState extends State<StormScreen> with ImmersiveMode {
-  @override
-  void didChangeDependencies() {
-    super.didChangeDependencies();
-    final route = ModalRoute.of(context);
-    if (route != null && route is PageRoute) {
-      rootNavPageRouteObserver.subscribe(this, route);
-    }
-  }
-
-  @override
-  void dispose() {
-    rootNavPageRouteObserver.unsubscribe(this);
-    super.dispose();
-  }
-
-  @override
   Widget build(BuildContext context) {
-    return PlatformWidget(
-      androidBuilder: _androidBuilder,
-      iosBuilder: _iosBuilder,
+    return FocusDetector(
+      onVisibilityGained: () => immersiveModeService.enable(),
+      onVisibilityLost: () => immersiveModeService.disable(),
+      child: PlatformWidget(
+        androidBuilder: _androidBuilder,
+        iosBuilder: _iosBuilder,
+      ),
     );
   }
 

--- a/lib/src/view/puzzle/storm_screen.dart
+++ b/lib/src/view/puzzle/storm_screen.dart
@@ -17,7 +17,6 @@ import 'package:lichess_mobile/src/styles/lichess_colors.dart';
 import 'package:lichess_mobile/src/styles/lichess_icons.dart';
 import 'package:lichess_mobile/src/styles/styles.dart';
 import 'package:lichess_mobile/src/utils/chessground_compat.dart';
-import 'package:lichess_mobile/src/utils/focus_detector.dart';
 import 'package:lichess_mobile/src/utils/immersive_mode.dart';
 import 'package:lichess_mobile/src/utils/l10n_context.dart';
 import 'package:lichess_mobile/src/utils/navigation.dart';
@@ -39,9 +38,7 @@ class StormScreen extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    return FocusDetector(
-      onVisibilityGained: () => immersiveModeService.enable(),
-      onVisibilityLost: () => immersiveModeService.disable(),
+    return ImmersiveModeWidget(
       child: PlatformWidget(
         androidBuilder: _androidBuilder,
         iosBuilder: _iosBuilder,

--- a/lib/src/view/puzzle/streak_screen.dart
+++ b/lib/src/view/puzzle/streak_screen.dart
@@ -11,11 +11,11 @@ import 'package:lichess_mobile/src/model/puzzle/puzzle_providers.dart';
 import 'package:lichess_mobile/src/model/puzzle/puzzle_service.dart';
 import 'package:lichess_mobile/src/model/puzzle/puzzle_streak.dart';
 import 'package:lichess_mobile/src/model/puzzle/puzzle_theme.dart';
-import 'package:lichess_mobile/src/navigation.dart';
 import 'package:lichess_mobile/src/styles/lichess_colors.dart';
 import 'package:lichess_mobile/src/styles/lichess_icons.dart';
 import 'package:lichess_mobile/src/styles/styles.dart';
 import 'package:lichess_mobile/src/utils/chessground_compat.dart';
+import 'package:lichess_mobile/src/utils/focus_detector.dart';
 import 'package:lichess_mobile/src/utils/immersive_mode.dart';
 import 'package:lichess_mobile/src/utils/l10n_context.dart';
 import 'package:lichess_mobile/src/view/settings/toggle_sound_button.dart';
@@ -28,34 +28,18 @@ import 'package:share_plus/share_plus.dart';
 
 import 'puzzle_feedback_widget.dart';
 
-class StreakScreen extends StatefulWidget {
+class StreakScreen extends StatelessWidget {
   const StreakScreen({super.key});
 
   @override
-  State<StreakScreen> createState() => _StreakScreenState();
-}
-
-class _StreakScreenState extends State<StreakScreen> with ImmersiveMode {
-  @override
-  void didChangeDependencies() {
-    super.didChangeDependencies();
-    final route = ModalRoute.of(context);
-    if (route != null && route is PageRoute) {
-      rootNavPageRouteObserver.subscribe(this, route);
-    }
-  }
-
-  @override
-  void dispose() {
-    rootNavPageRouteObserver.unsubscribe(this);
-    super.dispose();
-  }
-
-  @override
   Widget build(BuildContext context) {
-    return PlatformWidget(
-      androidBuilder: _androidBuilder,
-      iosBuilder: _iosBuilder,
+    return FocusDetector(
+      onVisibilityGained: () => immersiveModeService.enable(),
+      onVisibilityLost: () => immersiveModeService.disable(),
+      child: PlatformWidget(
+        androidBuilder: _androidBuilder,
+        iosBuilder: _iosBuilder,
+      ),
     );
   }
 

--- a/lib/src/view/puzzle/streak_screen.dart
+++ b/lib/src/view/puzzle/streak_screen.dart
@@ -15,7 +15,6 @@ import 'package:lichess_mobile/src/styles/lichess_colors.dart';
 import 'package:lichess_mobile/src/styles/lichess_icons.dart';
 import 'package:lichess_mobile/src/styles/styles.dart';
 import 'package:lichess_mobile/src/utils/chessground_compat.dart';
-import 'package:lichess_mobile/src/utils/focus_detector.dart';
 import 'package:lichess_mobile/src/utils/immersive_mode.dart';
 import 'package:lichess_mobile/src/utils/l10n_context.dart';
 import 'package:lichess_mobile/src/view/settings/toggle_sound_button.dart';
@@ -33,9 +32,7 @@ class StreakScreen extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    return FocusDetector(
-      onVisibilityGained: () => immersiveModeService.enable(),
-      onVisibilityLost: () => immersiveModeService.disable(),
+    return ImmersiveModeWidget(
       child: PlatformWidget(
         androidBuilder: _androidBuilder,
         iosBuilder: _iosBuilder,

--- a/lib/src/view/relation/relation_screen.dart
+++ b/lib/src/view/relation/relation_screen.dart
@@ -4,7 +4,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:lichess_mobile/src/model/relation/relation_ctrl.dart';
 import 'package:lichess_mobile/src/model/user/user.dart';
-import 'package:lichess_mobile/src/navigation.dart';
+import 'package:lichess_mobile/src/utils/focus_detector.dart';
 import 'package:lichess_mobile/src/utils/l10n_context.dart';
 import 'package:lichess_mobile/src/utils/navigation.dart';
 import 'package:lichess_mobile/src/view/relation/following_screen.dart';
@@ -22,13 +22,22 @@ class RelationScreen extends ConsumerStatefulWidget {
   ConsumerState<RelationScreen> createState() => _RelationScreenState();
 }
 
-class _RelationScreenState extends ConsumerState<RelationScreen>
-    with RouteAware {
+class _RelationScreenState extends ConsumerState<RelationScreen> {
   @override
   Widget build(BuildContext context) {
-    return PlatformWidget(
-      androidBuilder: _androidBuilder,
-      iosBuilder: _iosBuilder,
+    return FocusDetector(
+      onFocusRegained: () {
+        ref.read(relationCtrlProvider.notifier).startWatchingFriends();
+      },
+      onFocusLost: () {
+        if (context.mounted) {
+          ref.read(relationCtrlProvider.notifier).stopWatchingFriends();
+        }
+      },
+      child: PlatformWidget(
+        androidBuilder: _androidBuilder,
+        iosBuilder: _iosBuilder,
+      ),
     );
   }
 
@@ -46,33 +55,6 @@ class _RelationScreenState extends ConsumerState<RelationScreen>
       navigationBar: const CupertinoNavigationBar(),
       child: _Body(),
     );
-  }
-
-  @override
-  void didChangeDependencies() {
-    super.didChangeDependencies();
-    final route = ModalRoute.of(context);
-    if (route != null && route is PageRoute) {
-      homeRouteObserver.subscribe(this, route);
-    }
-  }
-
-  @override
-  void dispose() {
-    homeRouteObserver.unsubscribe(this);
-    super.dispose();
-  }
-
-  @override
-  void didPushNext() {
-    ref.read(relationCtrlProvider.notifier).stopWatchingFriends();
-    super.didPushNext();
-  }
-
-  @override
-  void didPopNext() {
-    ref.read(relationCtrlProvider.notifier).startWatchingFriends();
-    super.didPopNext();
   }
 }
 

--- a/lib/src/view/watch/watch_tab_screen.dart
+++ b/lib/src/view/watch/watch_tab_screen.dart
@@ -190,7 +190,6 @@ class _WatchTvWidget extends ConsumerWidget {
           headerTrailing: NoPaddingTextButton(
             onPressed: () => pushPlatformRoute(
               context,
-              rootNavigator: true,
               builder: (context) => const LiveTvChannelsScreen(),
             ).then((_) => _refreshData(ref)),
             child: Text(

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -1453,7 +1453,7 @@ packages:
     source: hosted
     version: "2.1.4"
   visibility_detector:
-    dependency: transitive
+    dependency: "direct main"
     description:
       name: visibility_detector
       sha256: "15c54a459ec2c17b4705450483f3d5a2858e733aee893dcee9d75fd04814940d"

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -66,6 +66,7 @@ dependencies:
   system_info_plus: ^0.0.5
   timeago: ^3.6.0
   url_launcher: ^6.1.9
+  visibility_detector: ^0.3.3
   wakelock_plus: ^1.1.1
   web_socket_channel: ^2.4.0
 

--- a/test/test_app.dart
+++ b/test/test_app.dart
@@ -23,6 +23,7 @@ import 'package:package_info_plus/package_info_plus.dart';
 import 'package:shared_preferences/shared_preferences.dart';
 import 'package:soundpool/soundpool.dart';
 import 'package:sqflite/sqflite.dart';
+import 'package:visibility_detector/visibility_detector.dart';
 
 import './fake_crashlytics.dart';
 import './model/auth/fake_auth_repository.dart';
@@ -46,6 +47,8 @@ Future<Widget> buildTestApp(
   AuthSessionState? userSession,
 }) async {
   await tester.binding.setSurfaceSize(kTestSurfaceSize);
+
+  VisibilityDetectorController.instance.updateInterval = Duration.zero;
 
   SharedPreferences.setMockInitialValues({});
 


### PR DESCRIPTION
So far we've been relying on `RouterObserver` and `RouteAware` widgets to react to screen changes but this solution had flaws. 

In this PR we're replacing it with a `FocusDetector` based solution, much more robust.

- Immersive mode should now behave properly (allowing android back swipe gesture on screens pushed above a board screen)
- No more issues with root navigator vs navigator to detect screen changes
- Future proof with coming deep links when we need to ensure a websocket connection is created again when a hidden screen gets visibility back