### PR TITLE
offline mode improvements

### DIFF
--- a/lib/src/navigation.dart
+++ b/lib/src/navigation.dart
@@ -161,7 +161,11 @@ class BottomNavScaffold extends ConsumerWidget {
   /// scrollable to the top.
   /// Otherwise, switch to the tapped tab.
   void _onItemTapped(
-      BuildContext context, WidgetRef ref, int index, bool isOnline) {
+    BuildContext context,
+    WidgetRef ref,
+    int index,
+    bool isOnline,
+  ) {
     final curTab = ref.read(currentBottomTabProvider);
     final tappedTab = BottomTab.values[index];
 

--- a/lib/src/view/home/home_tab_screen.dart
+++ b/lib/src/view/home/home_tab_screen.dart
@@ -93,7 +93,7 @@ class _HomeScreenState extends ConsumerState<HomeTabScreen> {
           const _SearchButton(),
           const _SettingsButton(),
           if (session != null)
-            const _RelationButton()
+            _RelationButton(wasOnline)
           else
             const SignInWidget(),
         ],
@@ -137,7 +137,7 @@ class _HomeScreenState extends ConsumerState<HomeTabScreen> {
               children: [
                 const _SearchButton(),
                 const _SettingsButton(),
-                if (session != null) const _RelationButton(),
+                if (session != null) _RelationButton(wasOnline),
               ],
             ),
           ),
@@ -749,20 +749,33 @@ class _GamePreview<T> extends StatelessWidget {
 }
 
 class _RelationButton extends ConsumerWidget {
-  const _RelationButton();
+  const _RelationButton(this.wasOnline);
+
+  final bool wasOnline;
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
     return AppBarIconButton(
-      icon: const Icon(Icons.people),
+      icon: Icon(
+        Icons.people,
+        color: !wasOnline ? Colors.grey : null,
+      ),
       semanticsLabel: context.l10n.friends,
       onPressed: () {
-        pushPlatformRoute(
-          context,
-          title: context.l10n.friends,
-          builder: (_) => const RelationScreen(),
-          fullscreenDialog: true,
-        );
+        if (!wasOnline) {
+          showPlatformSnackbar(
+            context,
+            'Cannot load friend list without internet connectivity',
+            type: SnackBarType.error,
+          );
+        } else {
+          pushPlatformRoute(
+            context,
+            title: context.l10n.friends,
+            builder: (_) => const RelationScreen(),
+            fullscreenDialog: true,
+          );
+        }
       },
     );
   }

--- a/lib/src/view/home/home_tab_screen.dart
+++ b/lib/src/view/home/home_tab_screen.dart
@@ -765,7 +765,7 @@ class _RelationButton extends ConsumerWidget {
         if (!wasOnline) {
           showPlatformSnackbar(
             context,
-            'Cannot load friend list without internet connectivity',
+            'Not available in offline mode',
             type: SnackBarType.error,
           );
         } else {


### PR DESCRIPTION
Closes: #462 

# Recap
In puzzle tab:
- [x] ~~_remove error messages for dashboard and history that could not load_~~ : cannot reproduce the error message, even offline, the history and dashboards are displayed

In play tab:

- [x] disable friends button

In the bottom navigation bar:
- [x] disable the "watch" button
- [x] show a toast: "Not available in offline mode" if the watch button is tapped