### PR TITLE
Fix Bugs in Profile Screen

### DIFF
--- a/lib/src/model/user/profile.dart
+++ b/lib/src/model/user/profile.dart
@@ -74,7 +74,10 @@ class SocialLink with _$SocialLink {
   const SocialLink._();
 
   static SocialLink? fromUrl(String url) {
-    final uri = Uri.tryParse(url);
+    final updatedUrl = url.startsWith('http://') || url.startsWith('https://')
+        ? url
+        : 'https://$url';
+    final uri = Uri.tryParse(updatedUrl);
     if (uri == null) return null;
     final host = uri.host.replaceAll(RegExp(r'www\.'), '');
     final site =

--- a/lib/src/model/user/profile.dart
+++ b/lib/src/model/user/profile.dart
@@ -47,7 +47,8 @@ class Profile with _$Profile {
       uscfRating: pick('uscfRating').asIntOrNull(),
       ecfRating: pick('ecfRating').asIntOrNull(),
       links: rawLinks
-          ?.map((e) {
+          ?.where((e) => e.trim().isNotEmpty)
+          .map((e) {
             final link = SocialLink.fromUrl(e);
             if (link == null) {
               final uri = Uri.tryParse(e);

--- a/lib/src/view/account/edit_profile_screen.dart
+++ b/lib/src/view/account/edit_profile_screen.dart
@@ -356,7 +356,7 @@ class _EditProfileFormState extends ConsumerState<_EditProfileForm> {
                 textInputAction: textInputAction,
                 controller: controller,
                 onChanged: (value) {
-                  field.didChange(value);
+                  field.didChange(value.trim());
                 },
               ),
               if (description != null) ...[

--- a/lib/src/view/user/user_profile.dart
+++ b/lib/src/view/user/user_profile.dart
@@ -99,9 +99,8 @@ class UserProfile extends ConsumerWidget {
               text: user.profile!.bio!.replaceAll('\n', ' '),
               options: const LinkifyOptions(
                 defaultToHttps: true,
-                looseUrl: true,
               ),
-              maxLines: 10,
+              maxLines: bioMaxLines,
               style: bioStyle,
               overflow: TextOverflow.ellipsis,
               linkStyle: Theme.of(context)

--- a/lib/src/view/user/user_profile.dart
+++ b/lib/src/view/user/user_profile.dart
@@ -97,9 +97,6 @@ class UserProfile extends ConsumerWidget {
                 UserTagLinkifier(),
               ],
               text: user.profile!.bio!.replaceAll('\n', ' '),
-              options: const LinkifyOptions(
-                defaultToHttps: true,
-              ),
               maxLines: bioMaxLines,
               style: bioStyle,
               overflow: TextOverflow.ellipsis,

--- a/lib/src/view/user/user_profile.dart
+++ b/lib/src/view/user/user_profile.dart
@@ -27,12 +27,12 @@ const _userNameStyle = TextStyle(fontSize: 20, fontWeight: FontWeight.w500);
 class UserProfile extends ConsumerWidget {
   const UserProfile({
     required this.user,
-    this.bioMaxLines,
+    this.bioMaxLines = 10,
   });
 
   final User user;
 
-  final int? bioMaxLines;
+  final int bioMaxLines;
   static const bioStyle = TextStyle(fontStyle: FontStyle.italic);
 
   @override
@@ -96,8 +96,12 @@ class UserProfile extends ConsumerWidget {
                 EmailLinkifier(),
                 UserTagLinkifier(),
               ],
-              text: user.profile!.bio!,
-              maxLines: bioMaxLines,
+              text: user.profile!.bio!.replaceAll('\n', ' '),
+              options: const LinkifyOptions(
+                defaultToHttps: true,
+                looseUrl: true,
+              ),
+              maxLines: 10,
               style: bioStyle,
               overflow: TextOverflow.ellipsis,
               linkStyle: Theme.of(context)


### PR DESCRIPTION
Fixes some nasty bugs in the profile screen:

- Currently, social media links without https or http couldn't be parsed due to the URI standard 
- I removed empty links
- All profile text was displayed on a single line and consequently often cut off. I set the maximum to ten lines.  Also it replaces all new lines with a space as its done on the website.
- An error message with no explanation appeared when entering whitespace strings in profile editing. This fix trims leading and trailing whitespace to prevent the error. 


<details>
<summary>before</summary>

![before](https://github.com/lichess-org/mobile/assets/78898963/0630e5eb-4191-4ae3-ba5f-b75ee7ae38ee)
</details>

<details>
<summary>after</summary>

![after](https://github.com/lichess-org/mobile/assets/78898963/f62279ca-b6aa-44f9-b61f-a34d9ba62a2f)
</details>
