### PR TITLE
Fixed incorrectly positioned annotation when performing an alternative castling move on the analysis screen.

### DIFF
--- a/lib/src/view/analysis/analysis_screen.dart
+++ b/lib/src/view/analysis/analysis_screen.dart
@@ -284,6 +284,8 @@ class _Board extends ConsumerWidget {
 
     final bestMoves = evalBestMoves ?? currentNode.eval?.bestMoves;
 
+    final sanMove = currentNode.sanMove;
+
     return cg.Board(
       size: boardSize,
       onMove: (move, {isDrop, isPremove}) =>
@@ -314,8 +316,13 @@ class _Board extends ConsumerWidget {
                     ),
               )
             : null,
-        annotations: currentNode.sanMove != null && annotation != null
-            ? IMap({currentNode.sanMove!.move.cg.to: annotation})
+        annotations: sanMove != null && annotation != null
+            ? altCastles.containsKey(sanMove.move.uci)
+                ? IMap({
+                    Move.fromUci(altCastles[sanMove.move.uci]!)!.cg.to:
+                        annotation,
+                  })
+                : IMap({sanMove.move.cg.to: annotation})
             : null,
       ),
       settings: cg.BoardSettings(


### PR DESCRIPTION

Closes https://github.com/lichess-org/mobile/issues/543

Fixed incorrectly positioned annotation when performing an alternative castling move on the analysis screen.

| before | after | lichess.org |
|---------|---------|---------|
| ![Screenshot_1708587191](https://github.com/lichess-org/mobile/assets/49310621/c126970e-3b09-4b78-8278-993acea36f07) | ![Screenshot_1708587219](https://github.com/lichess-org/mobile/assets/49310621/13c82617-ecb6-4fd3-bb4b-4b8e20c076d9) | <img width="643" alt="Screenshot 2024-02-22 at 10 36 54" src="https://github.com/lichess-org/mobile/assets/49310621/8e00747b-63c9-4196-b29a-cc91daea369f"> |