### PR TITLE
Remove Inapplicable Correspondence Statistics 

### DIFF
--- a/lib/src/view/user/perf_stats_screen.dart
+++ b/lib/src/view/user/perf_stats_screen.dart
@@ -171,13 +171,14 @@ class _Body extends ConsumerWidget {
                 child: _ProgressionWidget(data.progress),
               ),
               StatCardRow([
-                StatCard(
-                  context.l10n.rank,
-                  value: data.rank == null
-                      ? '?'
-                      : NumberFormat.decimalPattern(Intl.getCurrentLocale())
-                          .format(data.rank),
-                ),
+                if (data.rank != null)
+                  StatCard(
+                    context.l10n.rank,
+                    value: data.rank == null
+                        ? '?'
+                        : NumberFormat.decimalPattern(Intl.getCurrentLocale())
+                            .format(data.rank),
+                  ),
                 StatCard(
                   context.l10n
                       .perfStatRatingDeviation('')

--- a/lib/src/view/user/perf_stats_screen.dart
+++ b/lib/src/view/user/perf_stats_screen.dart
@@ -141,7 +141,7 @@ class _Body extends ConsumerWidget {
                         ),
                       ],
                     ),
-                    if (data.percentile != null)
+                    if (data.percentile != null && data.percentile! > 0.0)
                       Text(
                         (loggedInUser != null &&
                                 loggedInUser.user.id == user.id)


### PR DESCRIPTION
closes #566

currently the UserPerfStats has two problems

1. displays [USERNAME] is better than 0.00% of [`perfType`] players. when` perf.percentile == 0.0`
2. displays ? in Rank Card for perfs with no leaderboard (i.e. correspondance)

proposed fix

1. display AreBetterThanPercentOfPerfTypePlayers when `perf.percentile > 0.0`.
2. remove rank `StatCard` for correspondence perf.

**maintainer input needed**
when removing rank stat card visually going from 2×2 grid layout to 1 then 2×1  isn't pleasing is it okay if we leave it as is or should we remove rows all together (for correspondence )  to display progress, rating deviation ,highest Elo and lowest Elo on a single row
in short

the original is

| Progress    |            |
| ----------- | ---------- |
| rank        | deviation  |
| highest elo | lowest elo |

<table>
<tr><th>Layout 1 </th><th>Layout 2</th></tr>
<tr><td>

| Progress    |            |
| ----------- | ---------- |
| deviation   |            |
| highest elo | lowest elo |

</td><td>

| Progress    |
| ----------- |
| deviation   |
| highest elo |
| lowest elo  |

</td></tr> </table>
