### PR TITLE
Country name Turkey officially changed to Turkiye

### DIFF
--- a/lib/src/view/user/countries.dart
+++ b/lib/src/view/user/countries.dart
@@ -236,7 +236,7 @@ const Map<String, String> countries = {
   'TM': 'Turkmenistan',
   'TN': 'Tunisia',
   'TO': 'Tonga',
-  'TR': 'Turkey',
+  'TR': 'Turkiye',
   'TT': 'Trinidad and Tobago',
   'TV': 'Tuvalu',
   'TW': 'Taiwan',


### PR DESCRIPTION
Country named Turkey before officially changed its name to Turkiye.

Some related news and sources for confirmation:

    https://www.un.org/en/about-us/member-states/turkiye
    https://turkiye.un.org/en/184798-turkeys-name-changed-t%C3%BCrkiye
    https://www.theguardian.com/world/2022/jun/03/turkey-changes-name-to-turkiye-as-other-name-is-for-the-birds

