### PR TITLE
display the leaderboard for logged in users

### DIFF
--- a/lib/src/view/user/player_screen.dart
+++ b/lib/src/view/user/player_screen.dart
@@ -11,7 +11,6 @@ import 'package:lichess_mobile/src/utils/l10n_context.dart';
 import 'package:lichess_mobile/src/utils/navigation.dart';
 import 'package:lichess_mobile/src/view/account/rating_pref_aware.dart';
 import 'package:lichess_mobile/src/view/relation/following_screen.dart';
-import 'package:lichess_mobile/src/view/user/leaderboard_screen.dart';
 import 'package:lichess_mobile/src/view/user/leaderboard_widget.dart';
 import 'package:lichess_mobile/src/view/user/search_screen.dart';
 import 'package:lichess_mobile/src/view/user/user_screen.dart';
@@ -72,23 +71,7 @@ class _Body extends ConsumerWidget {
             child: const _SearchButton(),
           ),
           if (session != null) _OnlineFriendsWidget(),
-          if (session == null)
-            RatingPrefAware(child: LeaderboardWidget())
-          else
-            Align(
-              alignment: Alignment.centerLeft,
-              child: Padding(
-                padding: Styles.bodySectionPadding,
-                child: NoPaddingTextButton(
-                  onPressed: () => pushPlatformRoute(
-                    context,
-                    title: context.l10n.leaderboard,
-                    builder: (_) => const LeaderboardScreen(),
-                  ),
-                  child: Text(context.l10n.leaderboard),
-                ),
-              ),
-            ),
+          RatingPrefAware(child: LeaderboardWidget()),
         ],
       ),
     );


### PR DESCRIPTION
At the moment the leaderboard is not displayed in the player screen for users that are logged in.

<details>
<summary>Before</summary>

![before](https://github.com/lichess-org/mobile/assets/78898963/ce24f77b-70b9-4d05-b355-2bd86d11a5ef)
</details>

<details>
<summary>After</summary>

![after](https://github.com/lichess-org/mobile/assets/78898963/4afbfa13-1aaa-47b0-868e-47f02eada4d9)

</details>

feel free to ignore this pull request if this was intended