### PR TITLE
wrap around tos violation

### DIFF
--- a/lib/src/view/user/user_profile.dart
+++ b/lib/src/view/user/user_profile.dart
@@ -58,11 +58,13 @@ class UserProfile extends ConsumerWidget {
                   const SizedBox(
                     width: 5,
                   ),
-                  Text(
-                    context.l10n.thisAccountViolatedTos,
-                    style: const TextStyle(
-                      color: LichessColors.error,
-                      fontWeight: FontWeight.bold,
+                  Flexible(
+                    child: Text(
+                      context.l10n.thisAccountViolatedTos,
+                      style: const TextStyle(
+                        color: LichessColors.error,
+                        fontWeight: FontWeight.bold,
+                      ),
                     ),
                   ),
                 ],


### PR DESCRIPTION
fixes bug reported on discord that for certain languages not the complete text was displayed on accounts that violated tos.