### PR TITLE
Fix deprecated warnings for some colorSchemes properties

### DIFF
--- a/lib/src/view/engine/engine_gauge.dart
+++ b/lib/src/view/engine/engine_gauge.dart
@@ -52,8 +52,8 @@ class EngineGauge extends ConsumerWidget {
       Theme.of(context).platform == TargetPlatform.iOS
           ? _kEvalGaugeBackgroundColor
           : brightness == Brightness.dark
-              ? lighten(Theme.of(context).colorScheme.background, .07)
-              : lighten(Theme.of(context).colorScheme.onBackground, .17);
+              ? lighten(Theme.of(context).colorScheme.surface, .07)
+              : lighten(Theme.of(context).colorScheme.onSurface, .17);
 
   static Color valueColor(BuildContext context, Brightness brightness) =>
       Theme.of(context).platform == TargetPlatform.iOS
@@ -61,8 +61,8 @@ class EngineGauge extends ConsumerWidget {
               ? _kEvalGaugeValueColorDarkBg
               : _kEvalGaugeValueColorLightBg
           : brightness == Brightness.dark
-              ? darken(Theme.of(context).colorScheme.onBackground, .03)
-              : darken(Theme.of(context).colorScheme.background, .01);
+              ? darken(Theme.of(context).colorScheme.onSurface, .03)
+              : darken(Theme.of(context).colorScheme.surface, .01);
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {

--- a/lib/src/view/play/time_control_modal.dart
+++ b/lib/src/view/play/time_control_modal.dart
@@ -183,7 +183,7 @@ class _ChoiceChip extends StatelessWidget {
         color: Theme.of(context).platform == TargetPlatform.iOS
             ? CupertinoColors.secondarySystemGroupedBackground
                 .resolveFrom(context)
-            : Theme.of(context).colorScheme.surfaceVariant,
+            : Theme.of(context).colorScheme.tertiary.withOpacity(0.15),
         borderRadius: const BorderRadius.all(Radius.circular(5.0)),
         border: selected
             ? Border.fromBorderSide(

--- a/lib/src/view/puzzle/puzzle_dashboard_widget.dart
+++ b/lib/src/view/puzzle/puzzle_dashboard_widget.dart
@@ -143,8 +143,7 @@ class PuzzleChart extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    final radarColor =
-        Theme.of(context).colorScheme.onBackground.withOpacity(0.5);
+    final radarColor = Theme.of(context).colorScheme.onSurface.withOpacity(0.5);
     final chartColor = Theme.of(context).colorScheme.tertiary;
     return RadarChart(
       RadarChartData(

--- a/lib/src/widgets/board_table.dart
+++ b/lib/src/widgets/board_table.dart
@@ -120,7 +120,7 @@ class BoardTable extends ConsumerWidget {
                         color: Theme.of(context).platform == TargetPlatform.iOS
                             ? CupertinoColors.secondarySystemBackground
                                 .resolveFrom(context)
-                            : Theme.of(context).colorScheme.background,
+                            : Theme.of(context).colorScheme.surface,
                         borderRadius:
                             const BorderRadius.all(Radius.circular(10.0)),
                       ),

--- a/lib/src/widgets/feedback.dart
+++ b/lib/src/widgets/feedback.dart
@@ -23,7 +23,7 @@ class ConnectivityBanner extends ConsumerWidget {
           height: 45,
           color: theme.platform == TargetPlatform.iOS
               ? cupertinoTheme.barBackgroundColor
-              : theme.colorScheme.surfaceVariant,
+              : theme.colorScheme.tertiary.withOpacity(0.15),
           child: Padding(
             padding: const EdgeInsets.symmetric(horizontal: 8.0),
             child: Row(


### PR DESCRIPTION
I fixed the deprecated warnings that appear when running `flutter analyze`. The `background` and `onBackground` were easily replaced with `surface` and `onSurface` without any visible changes. The suggested replacement for `surfaceVariant` did not work; the best I could come up with is `tertiary.withOpacity(0.15)`, and it looks similar to before now.
It changes the color of the tiles with the timecontrols.

I tested it with light, dark, and system colors and different themes, and it looks pretty good.


| New                                            | Old                                            |
|------------------------------------------------|------------------------------------------------|
| ![Image 1](https://github.com/lichess-org/mobile/assets/78898963/41b772cb-2145-4ed8-ba44-d095cdd91cd8) | ![Image 3](https://github.com/lichess-org/mobile/assets/78898963/f1f6b569-e9a6-4bdb-811b-efd89cb827a5) |
| ![Image 2](https://github.com/lichess-org/mobile/assets/78898963/441c5f4f-c6b6-41c2-a46c-35053834d504) | ![Image 4](https://github.com/lichess-org/mobile/assets/78898963/ccd1b2df-3f3e-4a71-b3af-63b85de340fe) |


