### PR TITLE
Parse pgn without moves

### DIFF
--- a/lib/src/view/analysis/analysis_position_choice_screen.dart
+++ b/lib/src/view/analysis/analysis_position_choice_screen.dart
@@ -148,9 +148,10 @@ class _BodyState extends State<_Body> {
       final rule = Rule.fromPgn(game.headers['Variant']);
 
       final mainlineMoves = game.moves.mainline();
-      //if there is a first move, require it to be valid
-      if (mainlineMoves.isNotEmpty &&
-          (initialPosition.parseSan(mainlineMoves.first.san) == null)) {
+      //if there is a first move, require it to be valid, otherwise require a FEN
+      if ((mainlineMoves.isNotEmpty &&
+              (initialPosition.parseSan(mainlineMoves.first.san) == null)) ||
+          (mainlineMoves.isEmpty && game.headers['FEN'] == null)) {
         return null;
       }
 

--- a/lib/src/view/analysis/analysis_position_choice_screen.dart
+++ b/lib/src/view/analysis/analysis_position_choice_screen.dart
@@ -147,16 +147,18 @@ class _BodyState extends State<_Body> {
       final initialPosition = PgnGame.startingPosition(game.headers);
       final rule = Rule.fromPgn(game.headers['Variant']);
 
-      // require at least 1 valid move
-      if (game.moves.mainline().isEmpty) return null;
-      final move = initialPosition.parseSan(game.moves.mainline().first.san);
-      if (move == null) return null;
+      final mainlineMoves = game.moves.mainline();
+      //if there is a first move, require it to be valid
+      if (mainlineMoves.isNotEmpty &&
+          (initialPosition.parseSan(mainlineMoves.first.san) == null)) {
+        return null;
+      }
 
       return AnalysisOptions(
         isLocalEvaluationAllowed: true,
         variant: rule != null ? Variant.fromRule(rule) : Variant.standard,
         pgn: textInput!,
-        initialMoveCursor: 1,
+        initialMoveCursor: mainlineMoves.isEmpty ? 0 : 1,
         orientation: Side.white,
         id: standaloneAnalysisId,
       );


### PR DESCRIPTION
The user will now be able to import a PGN file even if it does not contain any moves. This functionality is already present in the old app and on the website. For instance:
```
[Variant "From Position"]
[FEN "r1bqkb1r/pppp1ppp/2n2n2/4p2Q/2B1P3/8/PPPP1PPP/RNB1K1NR w KQkq - 0 1"]
```

This position can now be analysed. One advantage of this over plain FEN is that PGN headers can also be imported. 
I let the previous behaviour unchanged: If moves are present, at least the first move must be legal for the PGN analysable.
If there are no moves, there has to be a FEN header for it to be analysable.
