### PR TITLE
Fix Storm Dashboard for Other Users

### DIFF
--- a/lib/src/model/puzzle/puzzle_providers.dart
+++ b/lib/src/model/puzzle/puzzle_providers.dart
@@ -101,11 +101,12 @@ Future<IList<PuzzleHistoryEntry>?> puzzleRecentActivity(
 }
 
 @riverpod
-Future<StormDashboard?> stormDashboard(StormDashboardRef ref) async {
-  final session = ref.watch(authSessionProvider);
-  if (session == null) return null;
+Future<StormDashboard?> stormDashboard(
+  StormDashboardRef ref, {
+  required UserId id,
+}) async {
   return ref.withClientCacheFor(
-    (client) => PuzzleRepository(client).stormDashboard(session.user.id),
+    (client) => PuzzleRepository(client).stormDashboard(id),
     const Duration(minutes: 30),
   );
 }

--- a/lib/src/model/puzzle/puzzle_providers.dart
+++ b/lib/src/model/puzzle/puzzle_providers.dart
@@ -105,9 +105,8 @@ Future<StormDashboard?> stormDashboard(
   StormDashboardRef ref, {
   required UserId id,
 }) async {
-  return ref.withClientCacheFor(
+  return ref.withClient(
     (client) => PuzzleRepository(client).stormDashboard(id),
-    const Duration(minutes: 30),
   );
 }
 

--- a/lib/src/view/puzzle/storm_dashboard.dart
+++ b/lib/src/view/puzzle/storm_dashboard.dart
@@ -3,6 +3,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:intl/intl.dart';
 import 'package:lichess_mobile/src/model/puzzle/puzzle_providers.dart';
+import 'package:lichess_mobile/src/model/user/user.dart';
 import 'package:lichess_mobile/src/styles/lichess_colors.dart';
 import 'package:lichess_mobile/src/styles/lichess_icons.dart';
 import 'package:lichess_mobile/src/styles/styles.dart';
@@ -10,45 +11,66 @@ import 'package:lichess_mobile/src/utils/l10n_context.dart';
 import 'package:lichess_mobile/src/widgets/list.dart';
 import 'package:lichess_mobile/src/widgets/shimmer.dart';
 import 'package:lichess_mobile/src/widgets/stat_card.dart';
+import 'package:lichess_mobile/src/widgets/user_full_name.dart';
 
 class StormDashboardModal extends StatelessWidget {
-  const StormDashboardModal({super.key});
+  const StormDashboardModal({super.key, required this.user});
 
+  final LightUser user;
   @override
   Widget build(BuildContext context) {
     return Theme.of(context).platform == TargetPlatform.iOS
         ? CupertinoPageScaffold(
             navigationBar: CupertinoNavigationBar(
-              middle: Row(
-                mainAxisSize: MainAxisSize.min,
-                children: [
-                  const Icon(LichessIcons.storm, size: 20),
-                  const SizedBox(width: 8.0),
-                  Text(context.l10n.stormHighscores),
-                ],
-              ),
+              middle: _Title(user: user),
             ),
-            child: _Body(),
+            child: _Body(user: user),
           )
         : Scaffold(
-            body: _Body(),
             appBar: AppBar(
-              title: Row(
-                children: [
-                  const Icon(LichessIcons.storm, size: 20),
-                  const SizedBox(width: 8.0),
-                  Text(context.l10n.stormHighscores),
-                ],
-              ),
+              titleSpacing: 0,
+              title: _Title(user: user),
             ),
+            body: _Body(user: user),
           );
   }
 }
 
+class _Title extends StatelessWidget {
+  const _Title({required this.user});
+
+  final LightUser user;
+
+  @override
+  Widget build(BuildContext context) {
+    return Row(
+      children: [
+        Flexible(
+          child: UserFullNameWidget(user: user),
+        ),
+        Flexible(
+          child: Row(
+            children: [
+              const SizedBox(width: 8.0),
+              const Icon(LichessIcons.storm, size: 20),
+              const SizedBox(width: 8.0),
+              Text(context.l10n.stormHighscores),
+            ],
+          ),
+        ),
+      ],
+    );
+  }
+}
+
 class _Body extends ConsumerWidget {
+  const _Body({required this.user});
+
+  final LightUser user;
+
   @override
   Widget build(BuildContext context, WidgetRef ref) {
-    final stormDashboard = ref.watch(stormDashboardProvider);
+    final stormDashboard = ref.watch(stormDashboardProvider(id: user.id));
     return stormDashboard.when(
       data: (data) {
         if (data == null) {

--- a/lib/src/view/puzzle/storm_dashboard.dart
+++ b/lib/src/view/puzzle/storm_dashboard.dart
@@ -11,55 +11,40 @@ import 'package:lichess_mobile/src/utils/l10n_context.dart';
 import 'package:lichess_mobile/src/widgets/list.dart';
 import 'package:lichess_mobile/src/widgets/shimmer.dart';
 import 'package:lichess_mobile/src/widgets/stat_card.dart';
-import 'package:lichess_mobile/src/widgets/user_full_name.dart';
 
 class StormDashboardModal extends StatelessWidget {
   const StormDashboardModal({super.key, required this.user});
 
   final LightUser user;
+
   @override
   Widget build(BuildContext context) {
     return Theme.of(context).platform == TargetPlatform.iOS
         ? CupertinoPageScaffold(
             navigationBar: CupertinoNavigationBar(
-              middle: _Title(user: user),
+              middle: Row(
+                mainAxisSize: MainAxisSize.min,
+                children: [
+                  const Icon(LichessIcons.storm, size: 20),
+                  const SizedBox(width: 8.0),
+                  Text(context.l10n.stormHighscores),
+                ],
+              ),
             ),
             child: _Body(user: user),
           )
         : Scaffold(
-            appBar: AppBar(
-              titleSpacing: 0,
-              title: _Title(user: user),
-            ),
             body: _Body(user: user),
+            appBar: AppBar(
+              title: Row(
+                children: [
+                  const Icon(LichessIcons.storm, size: 20),
+                  const SizedBox(width: 8.0),
+                  Text(context.l10n.stormHighscores),
+                ],
+              ),
+            ),
           );
-  }
-}
-
-class _Title extends StatelessWidget {
-  const _Title({required this.user});
-
-  final LightUser user;
-
-  @override
-  Widget build(BuildContext context) {
-    return Row(
-      children: [
-        Flexible(
-          child: UserFullNameWidget(user: user),
-        ),
-        Flexible(
-          child: Row(
-            children: [
-              const SizedBox(width: 8.0),
-              const Icon(LichessIcons.storm, size: 20),
-              const SizedBox(width: 8.0),
-              Text(context.l10n.stormHighscores),
-            ],
-          ),
-        ),
-      ],
-    );
   }
 }
 

--- a/lib/src/view/puzzle/storm_screen.dart
+++ b/lib/src/view/puzzle/storm_screen.dart
@@ -877,14 +877,14 @@ class _StormDashboardButton extends ConsumerWidget {
         case TargetPlatform.iOS:
           return CupertinoIconButton(
             padding: EdgeInsets.zero,
-            onPressed: () => _showDashboard(context),
+            onPressed: () => _showDashboard(context, session),
             semanticsLabel: 'Storm History',
             icon: const Icon(Icons.history),
           );
         case TargetPlatform.android:
           return IconButton(
             tooltip: 'Storm History',
-            onPressed: () => _showDashboard(context),
+            onPressed: () => _showDashboard(context, session),
             icon: const Icon(Icons.history),
           );
         default:
@@ -895,10 +895,11 @@ class _StormDashboardButton extends ConsumerWidget {
     return const SizedBox.shrink();
   }
 
-  void _showDashboard(BuildContext context) => pushPlatformRoute(
+  void _showDashboard(BuildContext context, AuthSessionState session) =>
+      pushPlatformRoute(
         context,
         rootNavigator: true,
         fullscreenDialog: true,
-        builder: (_) => const StormDashboardModal(),
+        builder: (_) => StormDashboardModal(user: session.user),
       );
 }

--- a/lib/src/view/user/perf_cards.dart
+++ b/lib/src/view/user/perf_cards.dart
@@ -124,7 +124,7 @@ class PerfCards extends StatelessWidget {
       builder: (context) {
         switch (perf) {
           case Perf.storm:
-            return const StormDashboardModal();
+            return StormDashboardModal(user: user.lightUser);
           default:
             return PerfStatsScreen(
               user: user,

--- a/lib/src/view/user/perf_stats_screen.dart
+++ b/lib/src/view/user/perf_stats_screen.dart
@@ -56,7 +56,7 @@ class PerfStatsScreen extends StatelessWidget {
     return Scaffold(
       appBar: AppBar(
         titleSpacing: 0,
-        title: _Title(user: user, perf: perf),
+        title: _Title(perf: perf),
       ),
       body: _Body(user: user, perf: perf),
     );
@@ -65,7 +65,7 @@ class PerfStatsScreen extends StatelessWidget {
   Widget _iosBuilder(BuildContext context) {
     return CupertinoPageScaffold(
       navigationBar: CupertinoNavigationBar(
-        middle: _Title(user: user, perf: perf),
+        middle: _Title(perf: perf),
       ),
       child: _Body(user: user, perf: perf),
     );
@@ -73,23 +73,18 @@ class PerfStatsScreen extends StatelessWidget {
 }
 
 class _Title extends StatelessWidget {
-  const _Title({required this.user, required this.perf});
+  const _Title({required this.perf});
 
-  final User user;
   final Perf perf;
 
   @override
   Widget build(BuildContext context) {
     return Row(
       children: [
-        Flexible(
-          child: UserFullNameWidget(user: user.lightUser),
-        ),
-        Flexible(
-          child: Text(
-            ' ${context.l10n.perfStatPerfStats(perf.title)}',
-            overflow: TextOverflow.ellipsis,
-          ),
+        Icon(perf.icon),
+        Text(
+          ' ${context.l10n.perfStatPerfStats(perf.title)}',
+          overflow: TextOverflow.ellipsis,
         ),
       ],
     );


### PR DESCRIPTION
This PR resolves the issue of displaying other users storm highscores. At the moment users would either be directed to their own highscore screen or encounter an error if not logged in. 
Now it should correctly display the highscores of other users. Also, I have included the user's name in the screen title, as it's now possible to view highscores of other users.
<details>
<summary>Preview</summary>

![image](https://github.com/lichess-org/mobile/assets/78898963/37f1f340-9979-4656-99c1-a49ea030f3c8)
</details>
I can not test it for iOS but I copied the code from perf_stats_screen.

One question remaining is whether we really should implement caching for the storm dashboard. Currently, if a user views their history, plays, beats their daily highscore and then revisits their history, the updated highscore isn't displayed.