### PR TITLE
update min fide elo

### DIFF
--- a/lib/src/view/account/edit_profile_screen.dart
+++ b/lib/src/view/account/edit_profile_screen.dart
@@ -208,8 +208,8 @@ class _EditProfileFormState extends ConsumerState<_EditProfileForm> {
               text: widget.user.profile?.fideRating?.toString(),
             ),
             validator: (value) {
-              if (value != null && (value < 1000 || value > 3000)) {
-                return 'Rating must be between 1000 and 3000';
+              if (value != null && (value < 1400 || value > 3000)) {
+                return 'Rating must be between 1400 and 3000';
               }
               return null;
             },


### PR DESCRIPTION
Updates the minimum FIDE Elo, which was recently changed. On the server side this change is already implemented and entering a number between 1000 and 1400 lead to strange behavior.
The corresponding lila PR: https://github.com/lichess-org/lila/pull/14779