### PR TITLE
puzzle(-streak) analysis in analysisboard

### DIFF
--- a/lib/src/model/puzzle/puzzle_controller.dart
+++ b/lib/src/model/puzzle/puzzle_controller.dart
@@ -6,6 +6,7 @@ import 'package:dartchess/dartchess.dart';
 import 'package:fast_immutable_collections/fast_immutable_collections.dart';
 import 'package:freezed_annotation/freezed_annotation.dart';
 import 'package:http/http.dart' as http;
+import 'package:lichess_mobile/src/constants.dart';
 import 'package:lichess_mobile/src/model/common/chess.dart';
 import 'package:lichess_mobile/src/model/common/http.dart';
 import 'package:lichess_mobile/src/model/common/node.dart';
@@ -462,6 +463,24 @@ class PuzzleController extends _$PuzzleController {
     } else {
       ref.read(evaluationServiceProvider).disposeEngine();
     }
+  }
+
+  String makePgn() {
+    final initPosition = _gameTree.nodeAt(state.initialPath).position;
+    var currentPosition = initPosition;
+    final pgnMoves = state.puzzle.puzzle.solution.fold<List<String>>([],
+        (List<String> acc, move) {
+      final moveObj = Move.fromUci(move);
+      if (moveObj != null) {
+        final String san;
+        (currentPosition, san) = currentPosition.makeSan(moveObj);
+        return acc..add(san);
+      }
+      return acc;
+    });
+    final pgn =
+        '[FEN "${initPosition.fen}"][Site "$kLichessHost/training/${state.puzzle.puzzle.id}"]${pgnMoves.join(' ')}';
+    return pgn;
   }
 
   void _startEngineEval() {

--- a/lib/src/model/puzzle/puzzle_theme.dart
+++ b/lib/src/model/puzzle/puzzle_theme.dart
@@ -193,8 +193,8 @@ IList<PuzzleThemeCategory> puzzleThemeCategories(
       l10n.strings.puzzleLengths,
       [
         PuzzleThemeKey.oneMove,
-        PuzzleThemeKey.long,
         PuzzleThemeKey.short,
+        PuzzleThemeKey.long,
         PuzzleThemeKey.veryLong,
       ],
     ),

--- a/lib/src/view/puzzle/puzzle_screen.dart
+++ b/lib/src/view/puzzle/puzzle_screen.dart
@@ -575,7 +575,9 @@ class _BottomBar extends ConsumerWidget {
           },
         ),
         BottomSheetAction(
-          makeLabel: (context) => const Text('Puzzle Source Game'),
+          makeLabel: (context) => Text(
+            context.l10n.puzzleFromGameLink(puzzleState.puzzle.game.id.value),
+          ),
           onPressed: (_) {
             ref
                 .withClient(

--- a/lib/src/view/puzzle/puzzle_screen.dart
+++ b/lib/src/view/puzzle/puzzle_screen.dart
@@ -8,8 +8,10 @@ import 'package:lichess_mobile/src/constants.dart';
 import 'package:lichess_mobile/src/model/analysis/analysis_controller.dart';
 import 'package:lichess_mobile/src/model/auth/auth_session.dart';
 import 'package:lichess_mobile/src/model/common/chess.dart';
+import 'package:lichess_mobile/src/model/common/http.dart';
 import 'package:lichess_mobile/src/model/common/id.dart';
 import 'package:lichess_mobile/src/model/engine/evaluation_service.dart';
+import 'package:lichess_mobile/src/model/game/game_repository.dart';
 import 'package:lichess_mobile/src/model/puzzle/puzzle_angle.dart';
 import 'package:lichess_mobile/src/model/puzzle/puzzle_controller.dart';
 import 'package:lichess_mobile/src/model/puzzle/puzzle_difficulty.dart';
@@ -29,6 +31,7 @@ import 'package:lichess_mobile/src/utils/share.dart';
 import 'package:lichess_mobile/src/view/account/rating_pref_aware.dart';
 import 'package:lichess_mobile/src/view/analysis/analysis_screen.dart';
 import 'package:lichess_mobile/src/view/engine/engine_gauge.dart';
+import 'package:lichess_mobile/src/view/game/archived_game_screen.dart';
 import 'package:lichess_mobile/src/view/puzzle/puzzle_settings_screen.dart';
 import 'package:lichess_mobile/src/view/settings/toggle_sound_button.dart';
 import 'package:lichess_mobile/src/widgets/adaptive_action_sheet.dart';
@@ -569,6 +572,25 @@ class _BottomBar extends ConsumerWidget {
                 ),
               ),
             );
+          },
+        ),
+        BottomSheetAction(
+          makeLabel: (context) => const Text('Puzzle Source Game'),
+          onPressed: (_) {
+            ref
+                .withClient(
+              (client) =>
+                  GameRepository(client).getGame(puzzleState.puzzle.game.id),
+            )
+                .then((game) {
+              pushPlatformRoute(
+                context,
+                builder: (context) => ArchivedGameScreen(
+                  gameData: game.data,
+                  orientation: puzzleState.pov,
+                ),
+              );
+            });
           },
         ),
       ],

--- a/lib/src/view/puzzle/puzzle_screen.dart
+++ b/lib/src/view/puzzle/puzzle_screen.dart
@@ -5,7 +5,9 @@ import 'package:flutter/cupertino.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:lichess_mobile/src/constants.dart';
+import 'package:lichess_mobile/src/model/analysis/analysis_controller.dart';
 import 'package:lichess_mobile/src/model/auth/auth_session.dart';
+import 'package:lichess_mobile/src/model/common/chess.dart';
 import 'package:lichess_mobile/src/model/common/id.dart';
 import 'package:lichess_mobile/src/model/engine/evaluation_service.dart';
 import 'package:lichess_mobile/src/model/puzzle/puzzle_angle.dart';
@@ -25,9 +27,11 @@ import 'package:lichess_mobile/src/utils/l10n_context.dart';
 import 'package:lichess_mobile/src/utils/navigation.dart';
 import 'package:lichess_mobile/src/utils/share.dart';
 import 'package:lichess_mobile/src/view/account/rating_pref_aware.dart';
+import 'package:lichess_mobile/src/view/analysis/analysis_screen.dart';
 import 'package:lichess_mobile/src/view/engine/engine_gauge.dart';
 import 'package:lichess_mobile/src/view/puzzle/puzzle_settings_screen.dart';
 import 'package:lichess_mobile/src/view/settings/toggle_sound_button.dart';
+import 'package:lichess_mobile/src/widgets/adaptive_action_sheet.dart';
 import 'package:lichess_mobile/src/widgets/adaptive_choice_picker.dart';
 import 'package:lichess_mobile/src/widgets/board_table.dart';
 import 'package:lichess_mobile/src/widgets/bottom_bar_button.dart';
@@ -463,17 +467,11 @@ class _BottomBar extends ConsumerWidget {
               if (puzzleState.mode == PuzzleMode.view)
                 Expanded(
                   child: BottomBarButton(
+                    label: context.l10n.menu,
                     onTap: () {
-                      launchShareDialog(
-                        context,
-                        text:
-                            '$kLichessHost/training/${puzzleState.puzzle.puzzle.id}',
-                      );
+                      _showPuzzleMenu(context, ref);
                     },
-                    label: 'Share this puzzle',
-                    icon: Theme.of(context).platform == TargetPlatform.iOS
-                        ? CupertinoIcons.share
-                        : Icons.share,
+                    icon: Icons.menu,
                   ),
                 ),
               if (puzzleState.mode == PuzzleMode.view)
@@ -537,6 +535,43 @@ class _BottomBar extends ConsumerWidget {
           ),
         ),
       ),
+    );
+  }
+
+  Future<void> _showPuzzleMenu(BuildContext context, WidgetRef ref) {
+    final puzzleState = ref.watch(ctrlProvider);
+    return showAdaptiveActionSheet(
+      context: context,
+      actions: [
+        BottomSheetAction(
+          makeLabel: (context) => const Text('Share this puzzle'),
+          onPressed: (context) {
+            launchShareDialog(
+              context,
+              text: '$kLichessHost/training/${puzzleState.puzzle.puzzle.id}',
+            );
+          },
+        ),
+        BottomSheetAction(
+          makeLabel: (context) => Text(context.l10n.analysis),
+          onPressed: (context) {
+            pushPlatformRoute(
+              context,
+              builder: (context) => AnalysisScreen(
+                title: context.l10n.analysis,
+                options: AnalysisOptions(
+                  isLocalEvaluationAllowed: true,
+                  variant: Variant.standard,
+                  pgn: ref.read(ctrlProvider.notifier).makePgn(),
+                  orientation: puzzleState.pov,
+                  id: standaloneAnalysisId,
+                  initialMoveCursor: 0,
+                ),
+              ),
+            );
+          },
+        ),
+      ],
     );
   }
 

--- a/lib/src/view/puzzle/streak_screen.dart
+++ b/lib/src/view/puzzle/streak_screen.dart
@@ -4,7 +4,9 @@ import 'package:flutter/cupertino.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:lichess_mobile/src/constants.dart';
+import 'package:lichess_mobile/src/model/analysis/analysis_controller.dart';
 import 'package:lichess_mobile/src/model/auth/auth_session.dart';
+import 'package:lichess_mobile/src/model/common/chess.dart';
 import 'package:lichess_mobile/src/model/puzzle/puzzle_angle.dart';
 import 'package:lichess_mobile/src/model/puzzle/puzzle_controller.dart';
 import 'package:lichess_mobile/src/model/puzzle/puzzle_providers.dart';
@@ -16,7 +18,9 @@ import 'package:lichess_mobile/src/styles/styles.dart';
 import 'package:lichess_mobile/src/utils/chessground_compat.dart';
 import 'package:lichess_mobile/src/utils/immersive_mode.dart';
 import 'package:lichess_mobile/src/utils/l10n_context.dart';
+import 'package:lichess_mobile/src/utils/navigation.dart';
 import 'package:lichess_mobile/src/utils/share.dart';
+import 'package:lichess_mobile/src/view/analysis/analysis_screen.dart';
 import 'package:lichess_mobile/src/view/settings/toggle_sound_button.dart';
 import 'package:lichess_mobile/src/widgets/board_table.dart';
 import 'package:lichess_mobile/src/widgets/bottom_bar_button.dart';
@@ -306,6 +310,29 @@ class _BottomBar extends ConsumerWidget {
                     icon: Theme.of(context).platform == TargetPlatform.iOS
                         ? CupertinoIcons.share
                         : Icons.share,
+                  ),
+                ),
+              if (puzzleState.streak!.finished)
+                Expanded(
+                  child: BottomBarButton(
+                    onTap: () {
+                      pushPlatformRoute(
+                        context,
+                        builder: (context) => AnalysisScreen(
+                          title: context.l10n.analysis,
+                          options: AnalysisOptions(
+                            isLocalEvaluationAllowed: true,
+                            variant: Variant.standard,
+                            pgn: ref.read(ctrlProvider.notifier).makePgn(),
+                            orientation: puzzleState.pov,
+                            id: standaloneAnalysisId,
+                            initialMoveCursor: 0,
+                          ),
+                        ),
+                      );
+                    },
+                    label: context.l10n.analysis,
+                    icon: Icons.biotech,
                   ),
                 ),
               if (puzzleState.streak!.finished)


### PR DESCRIPTION
Implements #595: Allows the user to analyze the last puzzle (the one they failed) of the streak or normal puzzles on the analysis board. For streak, there is a button in the bottom bar. For normal puzzles I merged it together with the share puzzle to a menu, because we should not have two separate buttons for analysis (evaluation bar and analysis board) in the same button bar.

When the user presses to go to the analysis board the initial position corresponds to the starting position of the puzzle and the moves of the solution are there. 
