### PR TITLE
Dependabot: add updates for Github Action workflows

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -10,3 +10,11 @@ updates:
     directory: "/" # Location of package manifests
     schedule:
       interval: "weekly"
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    groups:
+       ci-dependencies:
+          patterns:
+            - "*" # Match all CI dependencies to one PR.


### PR DESCRIPTION
Groups all CI action version updates to one PR. Follow same weekly schedule as Dart/Pub updates.