### PR TITLE
Navigate the puzzle with back and forward buttons

### DIFF
--- a/lib/src/model/puzzle/puzzle_controller.dart
+++ b/lib/src/model/puzzle/puzzle_controller.dart
@@ -563,9 +563,9 @@ class PuzzleState with _$PuzzleState {
 
   Position get position => node.position;
   String get fen => node.position.fen;
-  bool get canGoNext => mode == PuzzleMode.view && node.children.isNotEmpty;
-  bool get canGoBack =>
-      mode == PuzzleMode.view && currentPath.size > initialPath.size;
+  bool get canPlayMove => mode == PuzzleMode.view || node.children.isNotEmpty;
+  bool get canGoNext => node.children.isNotEmpty;
+  bool get canGoBack => currentPath.size > initialPath.size;
 
   IMap<String, ISet<String>> get validMoves => algebraicLegalMoves(position);
 }

--- a/lib/src/model/puzzle/puzzle_controller.dart
+++ b/lib/src/model/puzzle/puzzle_controller.dart
@@ -583,7 +583,7 @@ class PuzzleState with _$PuzzleState {
 
   Position get position => node.position;
   String get fen => node.position.fen;
-  bool get canPlayMove => mode == PuzzleMode.view || node.children.isNotEmpty;
+  bool get canPlayMove => mode == PuzzleMode.play && node.children.isEmpty;
   bool get canGoNext => node.children.isNotEmpty;
   bool get canGoBack => currentPath.size > 0;
 

--- a/lib/src/model/puzzle/puzzle_controller.dart
+++ b/lib/src/model/puzzle/puzzle_controller.dart
@@ -151,6 +151,7 @@ class PuzzleController extends _$PuzzleController {
         _onFailOrWin(PuzzleResult.lose);
         if (initialStreak == null) {
           await Future<void>.delayed(const Duration(milliseconds: 500));
+          _gameTree.deleteAt(state.currentPath);
           _setPath(state.currentPath.penultimate);
         }
       }
@@ -584,7 +585,7 @@ class PuzzleState with _$PuzzleState {
   String get fen => node.position.fen;
   bool get canPlayMove => mode == PuzzleMode.view || node.children.isNotEmpty;
   bool get canGoNext => node.children.isNotEmpty;
-  bool get canGoBack => currentPath.size > initialPath.size;
+  bool get canGoBack => currentPath.size > 0;
 
   IMap<String, ISet<String>> get validMoves => algebraicLegalMoves(position);
 }

--- a/lib/src/view/puzzle/puzzle_screen.dart
+++ b/lib/src/view/puzzle/puzzle_screen.dart
@@ -324,9 +324,11 @@ class _Body extends ConsumerWidget {
                       ? cg.InteractableSide.none
                       : puzzleState.mode == PuzzleMode.view
                           ? cg.InteractableSide.both
-                          : puzzleState.pov == Side.white
-                              ? cg.InteractableSide.white
-                              : cg.InteractableSide.black,
+                          : puzzleState.canPlayMove
+                              ? cg.InteractableSide.none
+                              : puzzleState.pov == Side.white
+                                  ? cg.InteractableSide.white
+                                  : cg.InteractableSide.black,
                   fen: puzzleState.fen,
                   isCheck: puzzleState.position.isCheck,
                   lastMove: puzzleState.lastMove?.cg,
@@ -446,9 +448,11 @@ class _BottomBar extends ConsumerWidget {
               if (initialPuzzleContext.userId != null &&
                   !isDailyPuzzle &&
                   puzzleState.mode != PuzzleMode.view)
-                _DifficultySelector(
-                  initialPuzzleContext: initialPuzzleContext,
-                  ctrlProvider: ctrlProvider,
+                Expanded(
+                  child: _DifficultySelector(
+                    initialPuzzleContext: initialPuzzleContext,
+                    ctrlProvider: ctrlProvider,
+                  ),
                 ),
               if (puzzleState.mode != PuzzleMode.view)
                 BottomBarButton(
@@ -486,38 +490,34 @@ class _BottomBar extends ConsumerWidget {
                     highlighted: puzzleState.isLocalEvalEnabled,
                   ),
                 ),
-              if (puzzleState.mode == PuzzleMode.view)
-                Expanded(
-                  child: RepeatButton(
-                    triggerDelays: _repeatTriggerDelays,
-                    onLongPress:
+              Expanded(
+                child: RepeatButton(
+                  triggerDelays: _repeatTriggerDelays,
+                  onLongPress:
+                      puzzleState.canGoBack ? () => _moveBackward(ref) : null,
+                  child: BottomBarButton(
+                    onTap:
                         puzzleState.canGoBack ? () => _moveBackward(ref) : null,
-                    child: BottomBarButton(
-                      onTap: puzzleState.canGoBack
-                          ? () => _moveBackward(ref)
-                          : null,
-                      label: 'Previous',
-                      icon: CupertinoIcons.chevron_back,
-                      showTooltip: false,
-                    ),
+                    label: 'Previous',
+                    icon: CupertinoIcons.chevron_back,
+                    showTooltip: false,
                   ),
                 ),
-              if (puzzleState.mode == PuzzleMode.view)
-                Expanded(
-                  child: RepeatButton(
-                    triggerDelays: _repeatTriggerDelays,
-                    onLongPress:
+              ),
+              Expanded(
+                child: RepeatButton(
+                  triggerDelays: _repeatTriggerDelays,
+                  onLongPress:
+                      puzzleState.canGoNext ? () => _moveForward(ref) : null,
+                  child: BottomBarButton(
+                    onTap:
                         puzzleState.canGoNext ? () => _moveForward(ref) : null,
-                    child: BottomBarButton(
-                      onTap: puzzleState.canGoNext
-                          ? () => _moveForward(ref)
-                          : null,
-                      label: context.l10n.next,
-                      icon: CupertinoIcons.chevron_forward,
-                      showTooltip: false,
-                    ),
+                    label: context.l10n.next,
+                    icon: CupertinoIcons.chevron_forward,
+                    showTooltip: false,
                   ),
                 ),
+              ),
               if (puzzleState.mode == PuzzleMode.view)
                 Expanded(
                   child: BottomBarButton(

--- a/lib/src/view/puzzle/puzzle_screen.dart
+++ b/lib/src/view/puzzle/puzzle_screen.dart
@@ -492,30 +492,38 @@ class _BottomBar extends ConsumerWidget {
                   ),
                 ),
               Expanded(
-                child: RepeatButton(
-                  triggerDelays: _repeatTriggerDelays,
-                  onLongPress:
-                      puzzleState.canGoBack ? () => _moveBackward(ref) : null,
-                  child: BottomBarButton(
-                    onTap:
+                child: Semantics(
+                  label: 'Previous Button',
+                  child: RepeatButton(
+                    triggerDelays: _repeatTriggerDelays,
+                    onLongPress:
                         puzzleState.canGoBack ? () => _moveBackward(ref) : null,
-                    label: 'Previous',
-                    icon: CupertinoIcons.chevron_back,
-                    showTooltip: false,
+                    child: BottomBarButton(
+                      onTap: puzzleState.canGoBack
+                          ? () => _moveBackward(ref)
+                          : null,
+                      label: 'Previous',
+                      icon: CupertinoIcons.chevron_back,
+                      showTooltip: false,
+                    ),
                   ),
                 ),
               ),
               Expanded(
-                child: RepeatButton(
-                  triggerDelays: _repeatTriggerDelays,
-                  onLongPress:
-                      puzzleState.canGoNext ? () => _moveForward(ref) : null,
-                  child: BottomBarButton(
-                    onTap:
+                child: Semantics(
+                  label: 'Next Button',
+                  child: RepeatButton(
+                    triggerDelays: _repeatTriggerDelays,
+                    onLongPress:
                         puzzleState.canGoNext ? () => _moveForward(ref) : null,
-                    label: context.l10n.next,
-                    icon: CupertinoIcons.chevron_forward,
-                    showTooltip: false,
+                    child: BottomBarButton(
+                      onTap: puzzleState.canGoNext
+                          ? () => _moveForward(ref)
+                          : null,
+                      label: context.l10n.next,
+                      icon: CupertinoIcons.chevron_forward,
+                      showTooltip: false,
+                    ),
                   ),
                 ),
               ),

--- a/lib/src/view/puzzle/puzzle_screen.dart
+++ b/lib/src/view/puzzle/puzzle_screen.dart
@@ -332,10 +332,10 @@ class _Body extends ConsumerWidget {
                       : puzzleState.mode == PuzzleMode.view
                           ? cg.InteractableSide.both
                           : puzzleState.canPlayMove
-                              ? cg.InteractableSide.none
-                              : puzzleState.pov == Side.white
+                              ? puzzleState.pov == Side.white
                                   ? cg.InteractableSide.white
-                                  : cg.InteractableSide.black,
+                                  : cg.InteractableSide.black
+                              : cg.InteractableSide.none,
                   fen: puzzleState.fen,
                   isCheck: puzzleState.position.isCheck,
                   lastMove: puzzleState.lastMove?.cg,


### PR DESCRIPTION
Implements a request from discord to navigate the puzzles. It is possible to go back and see the previous moves, including the introductory move.
I am not entirely happy with the buttons, at the moment the navigating buttons do not have a tooltip while the show solution and the difficulty selector have it. I figured this is the best way though, as there is no translation for previous.