### PR TITLE
Change index for analysis that doesn't start from chess initial position

### DIFF
--- a/lib/src/model/analysis/analysis_controller.dart
+++ b/lib/src/model/analysis/analysis_controller.dart
@@ -109,7 +109,8 @@ class AnalysisController extends _$AnalysisController {
       onVisitNode: (root, branch, isMainline) {
         if (isMainline &&
             options.initialMoveCursor != null &&
-            branch.position.ply <= options.initialMoveCursor!) {
+            branch.position.ply <=
+                root.position.ply + options.initialMoveCursor!) {
           path = path + branch.id;
           lastMove = branch.sanMove.move;
         }

--- a/lib/src/view/analysis/analysis_screen.dart
+++ b/lib/src/view/analysis/analysis_screen.dart
@@ -1248,6 +1248,11 @@ class AcplChart extends ConsumerWidget {
           .select((value) => value.acplChartData),
     );
 
+    final rootPly = ref.watch(
+      analysisControllerProvider(pgn, options)
+          .select((value) => value.root.position.ply),
+    );
+
     final currentNode = ref.watch(
       analysisControllerProvider(pgn, options)
           .select((value) => value.currentNode),
@@ -1327,7 +1332,7 @@ class AcplChart extends ConsumerWidget {
                 verticalLines: [
                   if (isOnMainline)
                     VerticalLine(
-                      x: (currentNode.position.ply - 1).toDouble(),
+                      x: (currentNode.position.ply - 1 - rootPly).toDouble(),
                       color: mainLineColor,
                       strokeWidth: 1.0,
                     ),


### PR DESCRIPTION
For a game that doesn't start from move 1 the ACPL chart and the analysis screen current move will be offset by the index of the first move of the game.