### PR TITLE
fix #2323: Adjust visibility of plus button on iPad Pro [HomeTabScreen]

### DIFF
--- a/lib/src/view/home/home_tab_screen.dart
+++ b/lib/src/view/home/home_tab_screen.dart
@@ -115,7 +115,8 @@ class _HomeScreenState extends ConsumerState<HomeTabScreen> with RouteAware {
               mainAxisSize: MainAxisSize.min,
               children: [
                 const _PlayerScreenButton(),
-                if (isHandset) ...[
+                // if (isHandset)
+                  ...[
                   const SizedBox(width: 6.0),
                   AppBarIconButton(
                     semanticsLabel: context.l10n.createAGame,


### PR DESCRIPTION
Hi @veloce,

I just reproduced this issue #687 on the iPad Pro 6th generation. It looks like the plus button is not displaying on the iPad mainly because of this check `(home_tab_screen.dart)`:

```
if (isHandset)
    ...[
        const SizedBox(width: 6.0),
        AppBarIconButton()
    ]
```
The visibility is controlled by `isHandset()`. I want to clarify whether this is an intended handset check. If we remove that condition, the button will be visible on any device, which should resolve the issue.

I'll go ahead and make a PR. If that's fine with you, please merge it.