### PR TITLE
Clear engine suggestion arrows after reaching checkmate or stalemate

### DIFF
--- a/lib/src/model/common/eval.dart
+++ b/lib/src/model/common/eval.dart
@@ -72,7 +72,10 @@ class ClientEval with _$ClientEval implements Eval {
   }
 
   IList<Move?> get bestMoves {
-    return pvs.map((e) => Move.fromUci(e.moves.first)).toIList();
+    return pvs
+        .where((e) => e.moves.isNotEmpty)
+        .map((e) => Move.fromUci(e.moves.first))
+        .toIList();
   }
 
   @override

--- a/lib/src/model/engine/uci_protocol.dart
+++ b/lib/src/model/engine/uci_protocol.dart
@@ -99,9 +99,9 @@ class UCIProtocol {
         _stopRequested != true &&
         parts.first == 'info') {
       int depth = 0;
-      int? nodes;
+      int nodes = 0;
       int multiPv = 1;
-      int? elapsedMs;
+      int elapsedMs = 0;
       String? evalType;
       bool isMate = false;
       int? povEv;
@@ -130,16 +130,10 @@ class UCIProtocol {
         }
       }
 
-      // Sometimes we get #0. Let's just skip it.
-      if (isMate && povEv == 0) return;
-
       // Track max pv index to determine when pv prints are done.
       if (_expectedPvs < multiPv) _expectedPvs = multiPv;
 
-      if (depth < minDepth ||
-          nodes == null ||
-          elapsedMs == null ||
-          povEv == null) return;
+      if ((depth < minDepth && moves.isNotEmpty) || povEv == null) return;
 
       final pivot = _work!.threatMode == true ? 0 : 1;
       final ev = _work!.ply % 2 == pivot ? -povEv : povEv;


### PR DESCRIPTION
# Summary

This ensures that we emit an evaluation from `UCIProtocol` once checkmate or stalemate has been reached, addressing https://github.com/lichess-org/mobile/issues/717.

Stockfish sends the message `info depth 0 score mate 0` when checkmate is reached and `info depth 0 score cp 0` when stalemate is reached. Before this change, these messages were being filtered out (by an explicit check for checkmate and because `nodes` and `time` were missing for stalemate), so no evaluation was emitted. This led to the analysis board retaining a stale list of "best moves" and suggesting nonsense.

An alternative approach would be to allow for the stale "best moves" list, and just hide the arrows if the game is over. I prefer the approach taken in this PR, however, because it respects Stockfish as the source of truth for the suggestions.

This assumes that there are no cases in which it is important to filter out a message from Stockfish because it did not include `nodes` or `time`. If such cases do exist, please let me know.

# Repro steps

- Go to Tools > Analysis board
- Click Start
- Play Fool's Mate (1. f3 e6 2. g4 Qh4#)

# Screenshots

## Before

<img src="https://github.com/lichess-org/mobile/assets/20631761/bf693283-5ca0-4ad5-8c82-b7ea06f54c39" width="300">

## After

<img src="https://github.com/lichess-org/mobile/assets/20631761/123b7276-d0ff-4a59-a54e-19b93b98c2f8" width="300">
