### PR TITLE
Make it possible to install Play Store and debug builds on the same device

### DIFF
--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -80,6 +80,9 @@ android {
             )
             signingConfig signingConfigs.release
         }
+        debug {
+            applicationIdSuffix ".debug"
+        }
     }
 }
 

--- a/android/app/src/debug/AndroidManifest.xml
+++ b/android/app/src/debug/AndroidManifest.xml
@@ -1,9 +1,11 @@
-<manifest xmlns:android="http://schemas.android.com/apk/res/android">
+<manifest xmlns:android="http://schemas.android.com/apk/res/android"
+     xmlns:tools="http://schemas.android.com/tools">
     <!-- The INTERNET permission is required for development. Specifically,
          the Flutter tool needs it to communicate with the running application
          to allow setting breakpoints, to provide hot reload, etc.
     -->
     <uses-permission android:name="android.permission.INTERNET"/>
-   <application
-        android:usesCleartextTraffic="true"/>
+   <application tools:replace="android:label"
+        android:usesCleartextTraffic="true"
+        android:label="Lichess beta - DEBUG"/>
 </manifest>

--- a/android/app/src/debug/AndroidManifest.xml
+++ b/android/app/src/debug/AndroidManifest.xml
@@ -7,5 +7,5 @@
     <uses-permission android:name="android.permission.INTERNET"/>
    <application tools:replace="android:label"
         android:usesCleartextTraffic="true"
-        android:label="Lichess beta - DEBUG"/>
+        android:label="Lichess - DEBUG"/>
 </manifest>

--- a/android/app/src/debug/google-services.json
+++ b/android/app/src/debug/google-services.json
@@ -1,0 +1,46 @@
+{
+  "project_info": {
+    "project_number": "974101866555",
+    "project_id": "lichessv2",
+    "storage_bucket": "lichessv2.appspot.com"
+  },
+  "client": [
+    {
+      "client_info": {
+        "mobilesdk_app_id": "1:974101866555:android:91f3475b526b436bb8541e",
+        "android_client_info": {
+          "package_name": "org.lichess.mobileV2.debug"
+        }
+      },
+      "oauth_client": [
+        {
+          "client_id": "974101866555-om4jq3npgepplk0fihrldnhuso1gm7k0.apps.googleusercontent.com",
+          "client_type": 3
+        }
+      ],
+      "api_key": [
+        {
+          "current_key": "AIzaSyDQI6NZ5CM8xpuq9jfM0-D4Tq6fYfsaSh0"
+        }
+      ],
+      "services": {
+        "appinvite_service": {
+          "other_platform_oauth_client": [
+            {
+              "client_id": "974101866555-om4jq3npgepplk0fihrldnhuso1gm7k0.apps.googleusercontent.com",
+              "client_type": 3
+            },
+            {
+              "client_id": "974101866555-8ag66ua0p0pn1ab7u982i58a9iubhbod.apps.googleusercontent.com",
+              "client_type": 2,
+              "ios_info": {
+                "bundle_id": "org.lichess.mobileV2"
+              }
+            }
+          ]
+        }
+      }
+    }
+  ],
+  "configuration_version": "1"
+}


### PR DESCRIPTION
# Summary

- Change the application ID of the debug build on Android from `org.lichess.mobileV2` to `org.lichess.mobileV2.debug`, so it is possible to have both installed at the same time
- Rename the app from "Lichess beta" to "Lichess - DEBUG", so it is easy to tell which version is which

The Android emulator performs poorly on my computer, so I have been using my personal phone to test changes. With this change, I will no longer have to uninstall the production app from the Play Store in order to develop.

# Testing

Initial testing:
- Installed "Lichess beta" from the Play Store
- Installed the debug build via `flutter run --dart-define=LICHESS_HOST=lichess.dev --dart-define=LICHESS_WS_HOST=socket.lichess.dev`
- Verified that both builds are installed
- Verified that the debug build is named "Lichess - DEBUG"
- Verified that the debug build can still sign into lichess.dev (to ensure OAuth still works)

After additional request:
- Built and installed the release build
- Verified that the release build is still named "Lichess"