### PR TITLE
Attempt to fix secure storage crash after app reinstall on Android

### DIFF
--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -14,7 +14,8 @@
         android:label="Lichess"
         android:name="${applicationName}"
         android:icon="@mipmap/ic_launcher"
-        android:roundIcon="@mipmap/ic_launcher_round">
+        android:roundIcon="@mipmap/ic_launcher_round"
+        android:fullBackupContent="@xml/backup_rules">
 
     <meta-data
       android:name="com.google.firebase.messaging.default_notification_icon"

--- a/android/app/src/main/kotlin/org/lichess/mobileV2/MainActivity.kt
+++ b/android/app/src/main/kotlin/org/lichess/mobileV2/MainActivity.kt
@@ -1,5 +1,7 @@
 package org.lichess.mobileV2
 
+import android.app.ActivityManager
+import android.content.Context
 import android.graphics.Rect
 import androidx.core.view.ViewCompat
 import androidx.annotation.NonNull
@@ -8,17 +10,28 @@ import io.flutter.embedding.engine.FlutterEngine
 import io.flutter.plugin.common.MethodChannel
 
 class MainActivity: FlutterActivity() {
-  private val CHANNEL = "mobile.lichess.org/gestures_exclusion"
+  private val exclusionChannel = "mobile.lichess.org/gestures_exclusion"
+  private val storageChannel = "mobile.lichess.org/storage"
 
   override fun configureFlutterEngine(@NonNull flutterEngine: FlutterEngine) {
     super.configureFlutterEngine(flutterEngine)
-    MethodChannel(flutterEngine.dartExecutor.binaryMessenger, CHANNEL).setMethodCallHandler {
+    MethodChannel(flutterEngine.dartExecutor.binaryMessenger, exclusionChannel).setMethodCallHandler {
       call, result ->
       if (call.method == "setSystemGestureExclusionRects") {
         val arguments = call.arguments as List<Map<String, Int>>
         val decodedRects = decodeExclusionRects(arguments)
         ViewCompat.setSystemGestureExclusionRects(activity.window.decorView, decodedRects)
         result.success(null)
+      } else {
+        result.notImplemented()
+      }
+    }
+
+    MethodChannel(flutterEngine.dartExecutor.binaryMessenger, storageChannel).setMethodCallHandler {
+      call, result ->
+      if (call.method == "clearApplicationUserData") {
+        val activityManager = context.getSystemService(Context.ACTIVITY_SERVICE) as ActivityManager
+        result.success(activityManager.clearApplicationUserData())
       } else {
         result.notImplemented()
       }

--- a/android/app/src/main/res/xml/backup_rules.xml
+++ b/android/app/src/main/res/xml/backup_rules.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="utf-8"?>
+<full-backup-content>
+  <include domain="sharedpref" path="."/>
+  <exclude domain="sharedpref" path="lichess_secure_storage.xml"/>
+</full-backup-content>

--- a/android/app/src/main/res/xml/backup_rules.xml
+++ b/android/app/src/main/res/xml/backup_rules.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <full-backup-content>
   <include domain="sharedpref" path="."/>
-  <exclude domain="sharedpref" path="lichess_secure_storage.xml"/>
+  <exclude domain="sharedpref" path="org.lichess.mobile.secure.xml"/>
 </full-backup-content>

--- a/lib/src/app.dart
+++ b/lib/src/app.dart
@@ -21,6 +21,7 @@ import 'package:lichess_mobile/src/model/settings/general_preferences.dart';
 import 'package:lichess_mobile/src/navigation.dart';
 import 'package:lichess_mobile/src/notification_service.dart';
 import 'package:lichess_mobile/src/styles/styles.dart';
+import 'package:lichess_mobile/src/utils/android.dart';
 import 'package:lichess_mobile/src/utils/connectivity.dart';
 import 'package:lichess_mobile/src/utils/navigation.dart';
 import 'package:lichess_mobile/src/utils/screen.dart';
@@ -34,7 +35,7 @@ class LoadingAppScreen extends ConsumerWidget {
     ref.listen<AsyncValue<AppInitializationData>>(
       appInitializationProvider,
       (_, state) {
-        if (state.hasValue) {
+        if (state.hasValue || state.hasError) {
           FlutterNativeSplash.remove();
         }
       },
@@ -48,7 +49,37 @@ class LoadingAppScreen extends ConsumerWidget {
             debugPrint(
               'SEVERE: [App] could not initialize app; $err\n$st',
             );
-            return const SizedBox.shrink();
+            // We should really do everything we can to avoid this screen
+            // but in last resort, let's show an error message and invite the
+            // user to clear app data.
+            // TODO implement it on iOS
+            return Theme.of(context).platform == TargetPlatform.android
+                ? MaterialApp(
+                    home: Scaffold(
+                      body: Column(
+                        mainAxisSize: MainAxisSize.max,
+                        mainAxisAlignment: MainAxisAlignment.center,
+                        children: [
+                          const Padding(
+                            padding: EdgeInsets.all(16.0),
+                            child: Text(
+                              "Something went wrong :'(\n\nIf the problem persists, you can try to clear the storage and restart the application.\n\nSorry for the inconvenience.",
+                              textAlign: TextAlign.center,
+                              style: TextStyle(fontSize: 18.0),
+                            ),
+                          ),
+                          const SizedBox(height: 16.0),
+                          ElevatedButton(
+                            onPressed: () {
+                              AndroidStorage.instance.clearUserData();
+                            },
+                            child: const Text('Clear storage'),
+                          ),
+                        ],
+                      ),
+                    ),
+                  )
+                : const SizedBox.shrink();
           },
         );
   }

--- a/lib/src/app.dart
+++ b/lib/src/app.dart
@@ -9,7 +9,7 @@ import 'package:flutter_native_splash/flutter_native_splash.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:lichess_mobile/l10n/l10n.dart';
 import 'package:lichess_mobile/main.dart';
-import 'package:lichess_mobile/src/app_dependencies.dart';
+import 'package:lichess_mobile/src/app_initialization.dart';
 import 'package:lichess_mobile/src/constants.dart';
 import 'package:lichess_mobile/src/model/account/account_repository.dart';
 import 'package:lichess_mobile/src/model/common/id.dart';
@@ -31,8 +31,8 @@ class LoadingAppScreen extends ConsumerWidget {
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
-    ref.listen<AsyncValue<AppDependencies>>(
-      appDependenciesProvider,
+    ref.listen<AsyncValue<AppInitializationData>>(
+      appInitializationProvider,
       (_, state) {
         if (state.hasValue) {
           FlutterNativeSplash.remove();
@@ -40,18 +40,17 @@ class LoadingAppScreen extends ConsumerWidget {
       },
     );
 
-    final appDependencies = ref.watch(appDependenciesProvider);
-    return appDependencies.when(
-      data: (_) => const Application(),
-      // loading screen is handled by the native splash screen
-      loading: () => const SizedBox.shrink(),
-      error: (err, st) {
-        debugPrint(
-          'SEVERE: [App] could not load app dependencies; $err\n$st',
+    return ref.watch(appInitializationProvider).when(
+          data: (_) => const Application(),
+          // loading screen is handled by the native splash screen
+          loading: () => const SizedBox.shrink(),
+          error: (err, st) {
+            debugPrint(
+              'SEVERE: [App] could not initialize app; $err\n$st',
+            );
+            return const SizedBox.shrink();
+          },
         );
-        return const SizedBox.shrink();
-      },
-    );
   }
 }
 

--- a/lib/src/db/database.dart
+++ b/lib/src/db/database.dart
@@ -1,4 +1,4 @@
-import 'package:lichess_mobile/src/app_dependencies.dart';
+import 'package:lichess_mobile/src/app_initialization.dart';
 import 'package:riverpod_annotation/riverpod_annotation.dart';
 import 'package:sqflite/sqflite.dart';
 
@@ -15,9 +15,9 @@ const kStorageAnonId = '**anonymous**';
 
 @Riverpod(keepAlive: true)
 Database database(DatabaseRef ref) {
-  // requireValue is possible because appDependenciesProvider is loaded before
+  // requireValue is possible because appInitializationProvider is loaded before
   // anything. See: lib/src/app.dart
-  final db = ref.read(appDependenciesProvider).requireValue.database;
+  final db = ref.read(appInitializationProvider).requireValue.database;
   ref.onDispose(db.close);
   return db;
 }

--- a/lib/src/db/secure_storage.dart
+++ b/lib/src/db/secure_storage.dart
@@ -5,8 +5,7 @@ part 'secure_storage.g.dart';
 
 AndroidOptions _getAndroidOptions() => const AndroidOptions(
       encryptedSharedPreferences: true,
-      sharedPreferencesName: 'lichess_secure_storage',
-      preferencesKeyPrefix: 'lichess.secure.',
+      sharedPreferencesName: 'org.lichess.mobile.secure',
     );
 
 @Riverpod(keepAlive: true)

--- a/lib/src/db/secure_storage.dart
+++ b/lib/src/db/secure_storage.dart
@@ -3,7 +3,13 @@ import 'package:riverpod_annotation/riverpod_annotation.dart';
 
 part 'secure_storage.g.dart';
 
+AndroidOptions _getAndroidOptions() => const AndroidOptions(
+      encryptedSharedPreferences: true,
+      sharedPreferencesName: 'lichess_secure_storage',
+      preferencesKeyPrefix: 'lichess.secure.',
+    );
+
 @Riverpod(keepAlive: true)
 FlutterSecureStorage secureStorage(SecureStorageRef ref) {
-  return const FlutterSecureStorage();
+  return FlutterSecureStorage(aOptions: _getAndroidOptions());
 }

--- a/lib/src/db/shared_preferences.dart
+++ b/lib/src/db/shared_preferences.dart
@@ -1,4 +1,4 @@
-import 'package:lichess_mobile/src/app_dependencies.dart';
+import 'package:lichess_mobile/src/app_initialization.dart';
 import 'package:riverpod_annotation/riverpod_annotation.dart';
 import 'package:shared_preferences/shared_preferences.dart';
 
@@ -6,7 +6,7 @@ part 'shared_preferences.g.dart';
 
 @Riverpod(keepAlive: true)
 SharedPreferences sharedPreferences(SharedPreferencesRef ref) {
-  // requireValue is possible because appDependenciesProvider is loaded before
+  // requireValue is possible because appInitializationProvider is loaded before
   // anything. See: lib/src/app.dart
-  return ref.read(appDependenciesProvider).requireValue.sharedPreferences;
+  return ref.read(appInitializationProvider).requireValue.sharedPreferences;
 }

--- a/lib/src/model/auth/auth_session.dart
+++ b/lib/src/model/auth/auth_session.dart
@@ -1,5 +1,5 @@
 import 'package:freezed_annotation/freezed_annotation.dart';
-import 'package:lichess_mobile/src/app_dependencies.dart';
+import 'package:lichess_mobile/src/app_initialization.dart';
 import 'package:lichess_mobile/src/model/user/user.dart';
 import 'package:riverpod_annotation/riverpod_annotation.dart';
 
@@ -12,10 +12,10 @@ part 'auth_session.g.dart';
 class AuthSession extends _$AuthSession {
   @override
   AuthSessionState? build() {
-    // requireValue is possible because appDependenciesProvider is loaded before
+    // requireValue is possible because appInitializationProvider is loaded before
     // anything. See: lib/src/app.dart
     return ref.watch(
-      appDependenciesProvider.select((data) => data.requireValue.userSession),
+      appInitializationProvider.select((data) => data.requireValue.userSession),
     );
   }
 

--- a/lib/src/model/common/service/sound_service.dart
+++ b/lib/src/model/common/service/sound_service.dart
@@ -1,7 +1,7 @@
 import 'package:fast_immutable_collections/fast_immutable_collections.dart';
 import 'package:flutter/foundation.dart';
 import 'package:flutter/services.dart' show rootBundle;
-import 'package:lichess_mobile/src/app_dependencies.dart';
+import 'package:lichess_mobile/src/app_initialization.dart';
 import 'package:lichess_mobile/src/model/settings/general_preferences.dart';
 import 'package:lichess_mobile/src/model/settings/sound_theme.dart';
 import 'package:riverpod_annotation/riverpod_annotation.dart';
@@ -25,9 +25,9 @@ typedef SoundMap = IMap<Sound, int>;
 
 @Riverpod(keepAlive: true)
 SoundService soundService(SoundServiceRef ref) {
-  // requireValue is possible because appDependenciesProvider is loaded before
+  // requireValue is possible because appInitializationProvider is loaded before
   // anything. See: lib/src/app.dart
-  final deps = ref.read(appDependenciesProvider).requireValue;
+  final deps = ref.read(appInitializationProvider).requireValue;
   final (pool, sounds) = deps.soundPool;
   return SoundService(pool, sounds, ref);
 }

--- a/lib/src/model/common/socket.dart
+++ b/lib/src/model/common/socket.dart
@@ -7,7 +7,7 @@ import 'package:device_info_plus/device_info_plus.dart';
 import 'package:flutter/foundation.dart';
 import 'package:flutter/widgets.dart';
 import 'package:freezed_annotation/freezed_annotation.dart';
-import 'package:lichess_mobile/src/app_dependencies.dart';
+import 'package:lichess_mobile/src/app_initialization.dart';
 import 'package:lichess_mobile/src/constants.dart';
 import 'package:lichess_mobile/src/model/auth/auth_session.dart';
 import 'package:lichess_mobile/src/model/auth/bearer.dart';
@@ -594,9 +594,9 @@ SocketPool socketPool(SocketPoolRef ref) {
 /// Socket Random Identifier.
 @Riverpod(keepAlive: true)
 String sri(SriRef ref) {
-  // requireValue is possible because appDependenciesProvider is loaded before
+  // requireValue is possible because appInitializationProvider is loaded before
   // anything. See: lib/src/app.dart
-  return ref.read(appDependenciesProvider).requireValue.sri;
+  return ref.read(appInitializationProvider).requireValue.sri;
 }
 
 /// Average lag computed from WebSocket ping/pong protocol.

--- a/lib/src/model/engine/evaluation_service.dart
+++ b/lib/src/model/engine/evaluation_service.dart
@@ -6,7 +6,7 @@ import 'package:dartchess/dartchess.dart';
 import 'package:fast_immutable_collections/fast_immutable_collections.dart';
 import 'package:flutter/foundation.dart';
 import 'package:freezed_annotation/freezed_annotation.dart';
-import 'package:lichess_mobile/src/app_dependencies.dart';
+import 'package:lichess_mobile/src/app_initialization.dart';
 import 'package:lichess_mobile/src/model/common/chess.dart';
 import 'package:lichess_mobile/src/model/common/eval.dart';
 import 'package:lichess_mobile/src/model/common/uci.dart';
@@ -172,10 +172,10 @@ class EvaluationService {
 
 @Riverpod(keepAlive: true)
 EvaluationService evaluationService(EvaluationServiceRef ref) {
-  // requireValue is possible because appDependenciesProvider is loaded before
+  // requireValue is possible because appInitializationProvider is loaded before
   // anything. See: lib/src/app.dart
   final maxMemory =
-      ref.read(appDependenciesProvider).requireValue.engineMaxMemoryInMb;
+      ref.read(appInitializationProvider).requireValue.engineMaxMemoryInMb;
 
   final service = EvaluationService(ref, maxMemory: maxMemory);
   ref.onDispose(() {

--- a/lib/src/utils/android.dart
+++ b/lib/src/utils/android.dart
@@ -1,6 +1,8 @@
 import 'dart:io';
 
 import 'package:device_info_plus/device_info_plus.dart';
+import 'package:flutter/foundation.dart';
+import 'package:flutter/services.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 
 final androidVersionProvider =
@@ -11,3 +13,27 @@ final androidVersionProvider =
   final info = await DeviceInfoPlugin().androidInfo;
   return info.version;
 });
+
+class AndroidStorage {
+  static const _channel = MethodChannel('mobile.lichess.org/storage');
+
+  const AndroidStorage._();
+
+  static const instance = AndroidStorage._();
+
+  /// Clear all user data from the app.
+  Future<bool> clearUserData() async {
+    if (Platform.isAndroid) {
+      try {
+        final result =
+            await _channel.invokeMethod<bool>('clearApplicationUserData');
+        return result ?? false;
+      } on PlatformException catch (e) {
+        debugPrint('Failed to clear user data: ${e.message}');
+        return false;
+      }
+    }
+
+    throw UnimplementedError('This method is only available on Android');
+  }
+}

--- a/lib/src/utils/device_info.dart
+++ b/lib/src/utils/device_info.dart
@@ -1,12 +1,12 @@
 import 'package:device_info_plus/device_info_plus.dart';
-import 'package:lichess_mobile/src/app_dependencies.dart';
+import 'package:lichess_mobile/src/app_initialization.dart';
 import 'package:riverpod_annotation/riverpod_annotation.dart';
 
 part 'device_info.g.dart';
 
 @Riverpod(keepAlive: true)
 BaseDeviceInfo deviceInfo(DeviceInfoRef ref) {
-  // requireValue is possible because appDependenciesProvider is loaded before
+  // requireValue is possible because appInitializationProvider is loaded before
   // anything. See: lib/src/app.dart
-  return ref.read(appDependenciesProvider).requireValue.deviceInfo;
+  return ref.read(appInitializationProvider).requireValue.deviceInfo;
 }

--- a/lib/src/utils/package_info.dart
+++ b/lib/src/utils/package_info.dart
@@ -1,4 +1,4 @@
-import 'package:lichess_mobile/src/app_dependencies.dart';
+import 'package:lichess_mobile/src/app_initialization.dart';
 import 'package:package_info_plus/package_info_plus.dart';
 import 'package:riverpod_annotation/riverpod_annotation.dart';
 
@@ -6,7 +6,7 @@ part 'package_info.g.dart';
 
 @Riverpod(keepAlive: true)
 PackageInfo packageInfo(PackageInfoRef ref) {
-  // requireValue is possible because appDependenciesProvider is loaded before
+  // requireValue is possible because appInitializationProvider is loaded before
   // anything. See: lib/src/app.dart
-  return ref.read(appDependenciesProvider).requireValue.packageInfo;
+  return ref.read(appInitializationProvider).requireValue.packageInfo;
 }

--- a/test/test_app.dart
+++ b/test/test_app.dart
@@ -9,7 +9,7 @@ import 'package:http/http.dart' as http;
 import 'package:http/testing.dart';
 import 'package:intl/intl.dart';
 import 'package:lichess_mobile/l10n/l10n.dart';
-import 'package:lichess_mobile/src/app_dependencies.dart';
+import 'package:lichess_mobile/src/app_initialization.dart';
 import 'package:lichess_mobile/src/crashlytics.dart';
 import 'package:lichess_mobile/src/db/shared_preferences.dart';
 import 'package:lichess_mobile/src/model/account/account_preferences.dart';
@@ -121,8 +121,8 @@ Future<Widget> buildTestApp(
       // ignore: scoped_providers_should_specify_dependencies
       gameStorageProvider.overrideWithValue(MockGameStorage()),
       // ignore: scoped_providers_should_specify_dependencies
-      appDependenciesProvider.overrideWith((ref) {
-        return AppDependencies(
+      appInitializationProvider.overrideWith((ref) {
+        return AppInitializationData(
           packageInfo: PackageInfo(
             appName: 'lichess_mobile_test',
             version: 'test',

--- a/test/test_container.dart
+++ b/test/test_container.dart
@@ -7,7 +7,7 @@ import 'package:flutter_test/flutter_test.dart';
 import 'package:http/http.dart' as http;
 import 'package:http/testing.dart';
 import 'package:intl/intl.dart';
-import 'package:lichess_mobile/src/app_dependencies.dart';
+import 'package:lichess_mobile/src/app_initialization.dart';
 import 'package:lichess_mobile/src/crashlytics.dart';
 import 'package:lichess_mobile/src/db/shared_preferences.dart';
 import 'package:lichess_mobile/src/model/auth/auth_session.dart';
@@ -94,8 +94,8 @@ Future<ProviderContainer> makeContainer({
       soundServiceProvider.overrideWithValue(FakeSoundService()),
       sharedPreferencesProvider.overrideWithValue(sharedPreferences),
       sessionStorageProvider.overrideWithValue(FakeSessionStorage()),
-      appDependenciesProvider.overrideWith((ref) {
-        return AppDependencies(
+      appInitializationProvider.overrideWith((ref) {
+        return AppInitializationData(
           packageInfo: PackageInfo(
             appName: 'lichess_mobile_test',
             version: 'test',


### PR DESCRIPTION
Related issue: #736 

Changes in this PR:
- configure flutter secure storage with `EncryptedSharedPreferences`
- exclude secure storage from app backup
- catch exception when reading secure data fails in app initialisation
- add an error screen inviting the user to clear app data when it fails to load (as last resort)
