### PR TITLE
Remove Dependency Info Block

### DIFF
--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -84,6 +84,11 @@ android {
             applicationIdSuffix ".debug"
         }
     }
+
+    dependenciesInfo {        # The Dependency Info Block is an encrypted proprietary blob from Google
+        includeInApk false    # Remove this blob from APK files that are shared on GitHub
+        includeInBundle true  # Ok to include it in AAB files as they are only used by Google Play
+    }
 }
 
 flutter {


### PR DESCRIPTION
The [Dependency Info Block](https://developer.android.com/build/dependencies#dependency-info-play) is an encrypted proprietary blob from Google that is added to every APK and AAB file by default, and that is [not reproducible](https://issuetracker.google.com/issues/268071369).

As discussed in #743, this pull request [removes](https://developer.android.com/reference/tools/gradle-api/8.4/com/android/build/api/dsl/DependenciesInfo) this blob from APK files by adding the following in [build.gradle](android/app/build.gradle):

```java
android {
    …

    dependenciesInfo {
        includeInApk false    # APK files
        includeInBundle true  # AAB files
    }
}
```

This pull request does not remove the Dependency Info Block from AAB files because, at the moment, those files are not shared with anyone else than the Google Play. If AAB files are to be published to other stores in the future (such as [Accrescent](https://accrescent.app/)), it might be worth it to remove the Dependency Info Block from them as well.