### PR TITLE
Fix CI

### DIFF
--- a/lib/src/view/puzzle/puzzle_tab_screen.dart
+++ b/lib/src/view/puzzle/puzzle_tab_screen.dart
@@ -65,9 +65,9 @@ class _PuzzleTabScreenState extends ConsumerState<PuzzleTabScreen> {
       ],
     );
 
-    return PopScope(
+    return PopScope<Object?>(
       canPop: false,
-      onPopInvoked: (bool didPop) {
+      onPopInvokedWithResult: (bool didPop, Object? result) {
         if (!didPop) {
           ref.read(currentBottomTabProvider.notifier).state = BottomTab.home;
         }

--- a/lib/src/view/puzzle/storm_screen.dart
+++ b/lib/src/view/puzzle/storm_screen.dart
@@ -141,9 +141,9 @@ class _Body extends ConsumerWidget {
       }
     });
 
-    final content = PopScope(
+    final content = PopScope<Object?>(
       canPop: stormState.mode != StormMode.running,
-      onPopInvoked: (bool didPop) async {
+      onPopInvokedWithResult: (bool didPop, Object? result) async {
         if (didPop) {
           return;
         }

--- a/lib/src/view/puzzle/streak_screen.dart
+++ b/lib/src/view/puzzle/streak_screen.dart
@@ -229,9 +229,9 @@ class _Body extends ConsumerWidget {
       ],
     );
 
-    return PopScope(
+    return PopScope<Object?>(
       canPop: puzzleState.streak!.index == 0 || puzzleState.streak!.finished,
-      onPopInvoked: (bool didPop) async {
+      onPopInvokedWithResult: (bool didPop, Object? result) async {
         if (didPop) {
           return;
         }

--- a/lib/src/view/settings/settings_screen.dart
+++ b/lib/src/view/settings/settings_screen.dart
@@ -45,9 +45,9 @@ class SettingsScreen extends ConsumerWidget {
   }
 
   Widget _androidBuilder(BuildContext context, WidgetRef ref) {
-    return PopScope(
+    return PopScope<Object?>(
       canPop: false,
-      onPopInvoked: (bool didPop) {
+      onPopInvokedWithResult: (bool didPop, Object? result) {
         if (!didPop) {
           ref.read(currentBottomTabProvider.notifier).state = BottomTab.home;
         }

--- a/lib/src/view/tools/tools_tab_screen.dart
+++ b/lib/src/view/tools/tools_tab_screen.dart
@@ -23,9 +23,9 @@ class ToolsTabScreen extends ConsumerWidget {
   }
 
   Widget _androidBuilder(BuildContext context, WidgetRef ref) {
-    return PopScope(
+    return PopScope<Object?>(
       canPop: false,
-      onPopInvoked: (bool didPop) {
+      onPopInvokedWithResult: (bool didPop, Object? result) {
         if (!didPop) {
           ref.read(currentBottomTabProvider.notifier).state = BottomTab.home;
         }

--- a/lib/src/view/watch/watch_tab_screen.dart
+++ b/lib/src/view/watch/watch_tab_screen.dart
@@ -84,9 +84,9 @@ class _WatchScreenState extends ConsumerState<WatchTabScreen> {
   }
 
   Widget _buildAndroid(BuildContext context, WidgetRef ref) {
-    return PopScope(
+    return PopScope<Object?>(
       canPop: false,
-      onPopInvoked: (bool didPop) {
+      onPopInvokedWithResult: (bool didPop, Object? result) {
         if (!didPop) {
           ref.read(currentBottomTabProvider.notifier).state = BottomTab.home;
         }

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -785,18 +785,18 @@ packages:
     dependency: transitive
     description:
       name: leak_tracker
-      sha256: "7f0df31977cb2c0b88585095d168e689669a2cc9b97c309665e3386f3e9d341a"
+      sha256: "3f87a60e8c63aecc975dda1ceedbc8f24de75f09e4856ea27daf8958f2f0ce05"
       url: "https://pub.dev"
     source: hosted
-    version: "10.0.4"
+    version: "10.0.5"
   leak_tracker_flutter_testing:
     dependency: transitive
     description:
       name: leak_tracker_flutter_testing
-      sha256: "06e98f569d004c1315b991ded39924b21af84cf14cc94791b8aea337d25b57f8"
+      sha256: "932549fb305594d82d7183ecd9fa93463e9914e1b67cacc34bc40906594a1806"
       url: "https://pub.dev"
     source: hosted
-    version: "3.0.3"
+    version: "3.0.5"
   leak_tracker_testing:
     dependency: transitive
     description:
@@ -841,18 +841,18 @@ packages:
     dependency: "direct main"
     description:
       name: material_color_utilities
-      sha256: "0e0a020085b65b6083975e499759762399b4475f766c21668c4ecca34ea74e5a"
+      sha256: f7142bb1154231d7ea5f96bc7bde4bda2a0945d2806bb11670e30b850d56bdec
       url: "https://pub.dev"
     source: hosted
-    version: "0.8.0"
+    version: "0.11.1"
   meta:
     dependency: "direct main"
     description:
       name: meta
-      sha256: "7687075e408b093f36e6bbf6c91878cc0d4cd10f409506f7bc996f68220b9136"
+      sha256: "25dfcaf170a0190f47ca6355bdd4552cb8924b430512ff0cafb8db9bd41fe33b"
       url: "https://pub.dev"
     source: hosted
-    version: "1.12.0"
+    version: "1.14.0"
   mime:
     dependency: transitive
     description:
@@ -1336,10 +1336,10 @@ packages:
     dependency: transitive
     description:
       name: test_api
-      sha256: "9955ae474176f7ac8ee4e989dadfb411a58c30415bcfb648fa04b2b8a03afa7f"
+      sha256: "2419f20b0c8677b2d67c8ac4d1ac7372d862dc6c460cdbb052b40155408cd794"
       url: "https://pub.dev"
     source: hosted
-    version: "0.7.0"
+    version: "0.7.1"
   timeago:
     dependency: "direct main"
     description:
@@ -1464,10 +1464,10 @@ packages:
     dependency: transitive
     description:
       name: vm_service
-      sha256: "3923c89304b715fb1eb6423f017651664a03bf5f4b29983627c4da791f74a4ec"
+      sha256: "7475cb4dd713d57b6f7464c0e13f06da0d535d8b2067e188962a59bac2cf280b"
       url: "https://pub.dev"
     source: hosted
-    version: "14.2.1"
+    version: "14.2.2"
   wakelock_plus:
     dependency: "direct main"
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -46,7 +46,7 @@ dependencies:
   json_annotation: ^4.7.0
   linkify: ^5.0.0
   logging: ^1.1.0
-  material_color_utilities: ^0.8.0
+  material_color_utilities: ^0.11.1
   meta: ^1.8.0
   package_info_plus: ^8.0.0
   path: ^1.8.2


### PR DESCRIPTION
Add the fix from @Mauritz8 in #744 and replace the [deprecated](https://docs.flutter.dev/release/breaking-changes/popscope-with-result) `onPopInvoked` with `onPopInvokedWithResult`.