### PR TITLE
fix: twice as slow text update frequency

### DIFF
--- a/lib/src/view/game/game_loading_board.dart
+++ b/lib/src/view/game/game_loading_board.dart
@@ -271,7 +271,7 @@ class _AnimatedLobbyNumberState extends State<_AnimatedLobbyNumber> {
         end: value,
       ),
       curve: Curves.linear,
-      duration: const Duration(seconds: 3),
+      duration: const Duration(seconds: 6),
       builder: (context, int value, _) {
         return Text(widget.labelBuilder(value), style: _lobbyNumbersStyle);
       },


### PR DESCRIPTION
close #738. I'm not sure what the sweet spot is for the duration, and it is quite hard to test in a realistic setting, but making it half as fast seems resonable. 