### PR TITLE
only show next correct move when viewing puzzle solution

### DIFF
--- a/lib/src/model/puzzle/puzzle_controller.dart
+++ b/lib/src/model/puzzle/puzzle_controller.dart
@@ -181,7 +181,9 @@ class PuzzleController extends _$PuzzleController {
       mode: PuzzleMode.view,
     );
 
-    _goToNextNode();
+    Timer(const Duration(milliseconds: 800), () {
+      _goToNextNode();
+    });
   }
 
   void skipMove() {

--- a/lib/src/model/puzzle/puzzle_controller.dart
+++ b/lib/src/model/puzzle/puzzle_controller.dart
@@ -106,6 +106,7 @@ class PuzzleController extends _$PuzzleController {
       resultSent: false,
       isChangingDifficulty: false,
       isLocalEvalEnabled: false,
+      viewedSolutionRecently: false,
       streak: streak,
       nextPuzzleStreakFetchError: false,
       nextPuzzleStreakFetchIsRetrying: false,
@@ -179,10 +180,17 @@ class PuzzleController extends _$PuzzleController {
 
     state = state.copyWith(
       mode: PuzzleMode.view,
+      viewedSolutionRecently: true,
     );
 
     Timer(const Duration(milliseconds: 800), () {
       _goToNextNode();
+    });
+
+    Timer(const Duration(seconds: 3), () {
+      state = state.copyWith(
+        viewedSolutionRecently: false,
+      );
     });
   }
 
@@ -553,6 +561,7 @@ class PuzzleState with _$PuzzleState {
     required bool isLocalEvalEnabled,
     required bool resultSent,
     required bool isChangingDifficulty,
+    required bool viewedSolutionRecently,
     PuzzleContext? nextContext,
     PuzzleStreak? streak,
     // if the automatic attempt to fetch the next puzzle in the streak fails

--- a/lib/src/model/puzzle/puzzle_controller.dart
+++ b/lib/src/model/puzzle/puzzle_controller.dart
@@ -160,11 +160,17 @@ class PuzzleController extends _$PuzzleController {
   void userNext() {
     _viewSolutionTimer?.cancel();
     _goToNextNode(replaying: true);
+    state = state.copyWith(
+      viewedSolutionRecently: false,
+    );
   }
 
   void userPrevious() {
     _viewSolutionTimer?.cancel();
     _goToPreviousNode(replaying: true);
+    state = state.copyWith(
+      viewedSolutionRecently: false,
+    );
   }
 
   void viewSolution() {
@@ -180,17 +186,17 @@ class PuzzleController extends _$PuzzleController {
 
     state = state.copyWith(
       mode: PuzzleMode.view,
-      viewedSolutionRecently: true,
     );
 
     Timer(const Duration(milliseconds: 800), () {
       _goToNextNode();
-    });
 
-    Timer(const Duration(seconds: 3), () {
-      state = state.copyWith(
-        viewedSolutionRecently: false,
-      );
+      if (state.canGoNext) {
+        state = state.copyWith(viewedSolutionRecently: true);
+        Timer(const Duration(seconds: 5), () {
+          state = state.copyWith(viewedSolutionRecently: false);
+        });
+      }
     });
   }
 

--- a/lib/src/model/puzzle/puzzle_controller.dart
+++ b/lib/src/model/puzzle/puzzle_controller.dart
@@ -181,14 +181,7 @@ class PuzzleController extends _$PuzzleController {
       mode: PuzzleMode.view,
     );
 
-    _viewSolutionTimer =
-        Timer.periodic(const Duration(milliseconds: 800), (timer) {
-      if (state.canGoNext) {
-        _goToNextNode();
-      } else {
-        timer.cancel();
-      }
-    });
+    _goToNextNode();
   }
 
   void skipMove() {

--- a/lib/src/view/puzzle/puzzle_screen.dart
+++ b/lib/src/view/puzzle/puzzle_screen.dart
@@ -502,6 +502,7 @@ class _BottomBar extends ConsumerWidget {
                       label: context.l10n.next,
                       icon: CupertinoIcons.chevron_forward,
                       showTooltip: false,
+                      blink: puzzleState.viewedSolutionRecently,
                     ),
                   ),
                 ),

--- a/lib/src/widgets/bottom_bar_button.dart
+++ b/lib/src/widgets/bottom_bar_button.dart
@@ -66,16 +66,15 @@ class BottomBarButton extends StatelessWidget {
                   mainAxisAlignment: MainAxisAlignment.center,
                   crossAxisAlignment: CrossAxisAlignment.center,
                   children: [
-                    if (blink) ...[
+                    if (blink)
                       _BlinkIcon(
                         icon: icon,
                         color: highlighted
                             ? primary
                             : Theme.of(context).iconTheme.color ?? Colors.black,
-                      ),
-                    ] else ...[
+                      )
+                    else
                       Icon(icon, color: highlighted ? primary : null),
-                    ],
                     if (showLabel)
                       Padding(
                         padding: const EdgeInsets.symmetric(horizontal: 8.0),

--- a/lib/src/widgets/bottom_bar_button.dart
+++ b/lib/src/widgets/bottom_bar_button.dart
@@ -11,6 +11,7 @@ class BottomBarButton extends StatelessWidget {
     this.highlighted = false,
     this.showLabel = false,
     this.showTooltip = true,
+    this.blink = false,
     this.tooltip,
     super.key,
   });
@@ -23,6 +24,7 @@ class BottomBarButton extends StatelessWidget {
   final bool highlighted;
   final bool showLabel;
   final bool showTooltip;
+  final bool blink;
 
   /// In case we want to override the tooltip message. If null, the [label] will
   /// be used.
@@ -64,10 +66,16 @@ class BottomBarButton extends StatelessWidget {
                   mainAxisAlignment: MainAxisAlignment.center,
                   crossAxisAlignment: CrossAxisAlignment.center,
                   children: [
-                    Icon(
-                      icon,
-                      color: highlighted ? primary : null,
-                    ),
+                    if (blink) ...[
+                      _BlinkIcon(
+                        icon: icon,
+                        color: highlighted
+                            ? primary
+                            : Theme.of(context).iconTheme.color ?? Colors.black,
+                      ),
+                    ] else ...[
+                      Icon(icon, color: highlighted ? primary : null),
+                    ],
                     if (showLabel)
                       Padding(
                         padding: const EdgeInsets.symmetric(horizontal: 8.0),
@@ -111,6 +119,66 @@ class BottomBarButton extends StatelessWidget {
           ),
         ),
       ),
+    );
+  }
+}
+
+class _BlinkIcon extends StatefulWidget {
+  const _BlinkIcon({
+    required this.icon,
+    required this.color,
+  });
+
+  final IconData icon;
+  final Color color;
+
+  @override
+  _BlinkIconState createState() => _BlinkIconState();
+}
+
+class _BlinkIconState extends State<_BlinkIcon>
+    with SingleTickerProviderStateMixin {
+  late AnimationController _controller;
+  late Animation<Color?> _colorAnimation;
+
+  @override
+  void initState() {
+    super.initState();
+
+    _controller = AnimationController(
+      duration: const Duration(milliseconds: 500),
+      vsync: this,
+    );
+
+    _colorAnimation =
+        ColorTween(begin: widget.color, end: null).animate(_controller)
+          ..addStatusListener((status) {
+            if (_controller.status == AnimationStatus.completed) {
+              _controller.reverse();
+            } else if (_controller.status == AnimationStatus.dismissed) {
+              _controller.forward();
+            }
+          });
+
+    _controller.forward();
+  }
+
+  @override
+  void dispose() {
+    _controller.dispose();
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return AnimatedBuilder(
+      animation: _colorAnimation,
+      builder: (context, child) {
+        return Icon(
+          widget.icon,
+          color: _colorAnimation.value ?? Colors.transparent,
+        );
+      },
     );
   }
 }

--- a/test/view/puzzle/puzzle_screen_test.dart
+++ b/test/view/puzzle/puzzle_screen_test.dart
@@ -415,11 +415,11 @@ void main() {
         await tester.tap(find.byIcon(Icons.help));
 
         // wait for solution replay animation to finish
-        await tester.pump(const Duration(seconds: 3));
+        await tester.pump(const Duration(milliseconds: 150));
         await tester.pumpAndSettle();
 
         expect(find.byKey(const Key('h4-blackRook')), findsOneWidget);
-        expect(find.byKey(const Key('h8-whiteQueen')), findsNothing);
+        expect(find.byKey(const Key('h8-whiteQueen')), findsOneWidget);
         expect(
           find.text('Puzzle complete!'),
           findsOneWidget,

--- a/test/view/puzzle/puzzle_screen_test.dart
+++ b/test/view/puzzle/puzzle_screen_test.dart
@@ -14,6 +14,7 @@ import 'package:lichess_mobile/src/model/puzzle/puzzle_batch_storage.dart';
 import 'package:lichess_mobile/src/model/puzzle/puzzle_storage.dart';
 import 'package:lichess_mobile/src/model/puzzle/puzzle_theme.dart';
 import 'package:lichess_mobile/src/view/puzzle/puzzle_screen.dart';
+import 'package:lichess_mobile/src/widgets/bottom_bar_button.dart';
 import 'package:mocktail/mocktail.dart';
 
 import '../../test_app.dart';
@@ -424,6 +425,14 @@ void main() {
           find.text('Puzzle complete!'),
           findsOneWidget,
         );
+
+        final nextMoveBtnEnabled = find.byWidgetPredicate(
+          (widget) =>
+              widget is BottomBarButton &&
+              widget.icon == CupertinoIcons.chevron_forward &&
+              widget.enabled,
+        );
+        expect(nextMoveBtnEnabled, findsOneWidget);
 
         expect(find.byIcon(CupertinoIcons.play_arrow_solid), findsOneWidget);
 

--- a/test/view/puzzle/puzzle_screen_test.dart
+++ b/test/view/puzzle/puzzle_screen_test.dart
@@ -415,7 +415,7 @@ void main() {
         await tester.tap(find.byIcon(Icons.help));
 
         // wait for solution replay animation to finish
-        await tester.pump(const Duration(milliseconds: 150));
+        await tester.pump(const Duration(seconds: 1));
         await tester.pumpAndSettle();
 
         expect(find.byKey(const Key('h4-blackRook')), findsOneWidget);


### PR DESCRIPTION
close #761 
This alters the "show solution button" to only show the next move in the solution, which is in line with both the website and the old app. 