### PR TITLE
fix text being cut off in stormNewRun and stormEndRun translations

### DIFF
--- a/lib/src/view/puzzle/storm_screen.dart
+++ b/lib/src/view/puzzle/storm_screen.dart
@@ -634,7 +634,7 @@ class _BottomBar extends ConsumerWidget {
                 ),
               BottomBarButton(
                 icon: Icons.delete,
-                label: context.l10n.stormNewRun.split(' ').take(2).join(' '),
+                label: context.l10n.stormNewRun.split('(').first.trimRight(),
                 showLabel: true,
                 onTap: () {
                   stormState.clock.reset();
@@ -644,7 +644,7 @@ class _BottomBar extends ConsumerWidget {
               if (stormState.mode == StormMode.running)
                 BottomBarButton(
                   icon: LichessIcons.flag,
-                  label: context.l10n.stormEndRun.split(' ').take(2).join(' '),
+                  label: context.l10n.stormEndRun.split('(').first.trimRight(),
                   showLabel: true,
                   onTap: stormState.puzzleIndex >= 1
                       ? () {


### PR DESCRIPTION
In English, these strings are something like "End run (hotkey: ...)" and "New run (hotkey: ...)". The previous logic discarded the text in parenthesis by simply keeping the first two words.

However, in some languages we may have more than two words (e.g. in German it's "Beende den Run"). With this change, we keep everything until the '(' character, which should be more robust.

If the string for some reason does not contain '(' at all, split('(') will return a list containing the string itself, so that will work too.