### PR TITLE
Challenge from a Position with Fen

### DIFF
--- a/lib/src/model/challenge/challenge.dart
+++ b/lib/src/model/challenge/challenge.dart
@@ -104,8 +104,9 @@ class ChallengeRequest
         if (clock != null)
           'clock.increment': clock!.increment.inSeconds.toString(),
         if (days != null) 'days': days.toString(),
-        'rated': rated.toString(),
+        'rated': variant == Variant.fromPosition ? 'false' : rated.toString(),
         'variant': variant.name,
+        if (variant == Variant.fromPosition) 'fen': initialFen,
         if (sideChoice != SideChoice.random) 'color': sideChoice.name,
       };
 }


### PR DESCRIPTION
implements #797
closes #803
Adds the possibility to challenge another player with a fen:
Behavior with an invalid fen: 

https://github.com/lichess-org/mobile/assets/78898963/a156e151-48af-4638-bc00-7548ea156520

Behavior with a valid fen:

https://github.com/lichess-org/mobile/assets/78898963/57f585cc-be6b-4182-b3d7-d968cbf16af4

Some remarks:
- From position games can not be rated, so the button is disabled
- The last position used to challenge is not stored (in my opinion this is not necessary)
- Assumes that the fen checker is the same as employed on the serverside, otherwise it might lead to strange behavior.
- Was not tested on iOS
