### PR TITLE
feat: scale arrows in analysis based on winning chances

### DIFF
--- a/pubspec.lock
+++ b/pubspec.lock
@@ -186,10 +186,10 @@ packages:
     dependency: "direct main"
     description:
       name: chessground
-      sha256: "134a6eb0f0eaf9dbd67f32cbf30aa9921401d98797c2274fefafa815f18f54b5"
+      sha256: "2c2a4de4161a77bb87919f27eff56cb08724a8a240da62d59f56f403ab3a9e27"
       url: "https://pub.dev"
     source: hosted
-    version: "3.1.0"
+    version: "3.1.1"
   ci:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -10,7 +10,7 @@ environment:
 dependencies:
   async: ^2.10.0
   cached_network_image: ^3.2.2
-  chessground: ^3.1.0
+  chessground: ^3.1.1
   collection: ^1.17.0
   connectivity_plus: ^6.0.2
   cronet_http: ^1.3.1


### PR DESCRIPTION
# Notes

- Not sure if we still need the different opacities now...? The old app does not have them, but I think it looks nice. The Web UI seems to use a different opacity for the best move, and the same opacity for all other moves
- Scaling logic could probably be adjusted in the feature based on user feedback, but I think the result looks pretty close to the old app and the web UI already.

# Screenshots

## Current version:

![](https://github.com/lichess-org/mobile/assets/13141438/83f713f7-943d-4d24-92af-801a4ff7ccb9)

## This  PR:

![](https://github.com/lichess-org/mobile/assets/13141438/4be0f333-969b-495c-94ce-0e96c7b7b3f4)

## Old App for comparison (Shows different moves because the two screenshots above are from a debug build):

![](https://github.com/lichess-org/mobile/assets/13141438/95546460-0715-4d50-bef9-63c8eedde350)


