### PR TITLE
feat: hide move list in zen mode

### DIFF
--- a/lib/src/view/game/game_body.dart
+++ b/lib/src/view/game/game_body.dart
@@ -287,6 +287,7 @@ class GameBody extends ConsumerWidget {
                       onSelectMove: (moveIndex) {
                         ref.read(ctrlProvider.notifier).cursorAt(moveIndex);
                       },
+                      zenMode: gameState.isZenModeActive,
                     ),
                   ),
                 ),

--- a/lib/src/widgets/board_table.dart
+++ b/lib/src/widgets/board_table.dart
@@ -43,6 +43,7 @@ class BoardTable extends ConsumerStatefulWidget {
     this.showMoveListPlaceholder = false,
     this.showEngineGaugePlaceholder = false,
     this.boardKey,
+    this.zenMode = false,
     super.key,
   }) : assert(
           moves == null || currentMoveIndex != null,
@@ -90,6 +91,9 @@ class BoardTable extends ConsumerStatefulWidget {
 
   /// Whether to show the engine gauge placeholder.
   final bool showEngineGaugePlaceholder;
+
+  /// If true, the move list will be hidden
+  final bool zenMode;
 
   @override
   ConsumerState<BoardTable> createState() => _BoardTableState();
@@ -242,7 +246,7 @@ class _BoardTableState extends ConsumerState<BoardTable> {
                         mainAxisAlignment: MainAxisAlignment.spaceAround,
                         children: [
                           Flexible(child: widget.topTable),
-                          if (slicedMoves != null)
+                          if (!widget.zenMode && slicedMoves != null)
                             Expanded(
                               child: Padding(
                                 padding: const EdgeInsets.all(16.0),
@@ -274,7 +278,8 @@ class _BoardTableState extends ConsumerState<BoardTable> {
                 mainAxisSize: MainAxisSize.max,
                 mainAxisAlignment: MainAxisAlignment.center,
                 children: [
-                  if (slicedMoves != null &&
+                  if (!widget.zenMode &&
+                      slicedMoves != null &&
                       verticalSpaceLeftBoardOnPortrait >= 130)
                     MoveList(
                       type: MoveListType.inline,


### PR DESCRIPTION
This is consistent with both the old app and the Web UI