### PR TITLE
Refactor TimeIncrement.display Method and Fix Edge Case #823

### DIFF
--- a/lib/src/model/common/time_increment.dart
+++ b/lib/src/model/common/time_increment.dart
@@ -32,26 +32,12 @@ class TimeIncrement {
   bool get isInfinite => time == 0 && increment == 0;
 
   String get display {
-    String displayTime = '';
-    switch (time) {
-      case 0:
-        if (increment == 0) {
-          displayTime = '∞';
-        } else {
-          displayTime = '0+$increment';
-        }
-      case 45:
-        displayTime = '¾+$increment';
-      case 30:
-        displayTime = '½+$increment';
-      case 15:
-        displayTime = '¼+$increment';
-      default:
-        displayTime = '${(time / 60).floor()}+$increment';
+    if (isInfinite) {
+      return '∞';
+    } else {
+      return '${clockLabelInMinutes(time)}+$increment';
     }
-    return displayTime;
-  }
-
+}
   @override
   bool operator ==(Object other) =>
       identical(this, other) ||

--- a/lib/src/model/common/time_increment.dart
+++ b/lib/src/model/common/time_increment.dart
@@ -37,7 +37,8 @@ class TimeIncrement {
     } else {
       return '${clockLabelInMinutes(time)}+$increment';
     }
-}
+  }
+
   @override
   bool operator ==(Object other) =>
       identical(this, other) ||

--- a/test/model/common/time_increment_test.dart
+++ b/test/model/common/time_increment_test.dart
@@ -10,7 +10,6 @@ void main() {
     });
 
     test('JSON Serialization', () {
-
       final json = const TimeIncrement(300, 5).toJson();
       expect(json['time'], 300);
       expect(json['increment'], 5);
@@ -31,8 +30,9 @@ void main() {
     });
 
     test('Estimated Duration', () {
-      expect(const TimeIncrement(300, 5).estimatedDuration, const Duration(seconds: 300 + 5 * 40));
-      expect(const TimeIncrement(0, 0).estimatedDuration,Duration.zero);
+      expect(const TimeIncrement(300, 5).estimatedDuration,
+          const Duration(seconds: 300 + 5 * 40));
+      expect(const TimeIncrement(0, 0).estimatedDuration, Duration.zero);
     });
 
     test('Equality and HashCode', () {

--- a/test/model/common/time_increment_test.dart
+++ b/test/model/common/time_increment_test.dart
@@ -1,0 +1,58 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:lichess_mobile/src/model/common/time_increment.dart';
+
+void main() {
+  group('TimeIncrement Tests', () {
+    test('Initialization', () {
+      const timeIncrement = TimeIncrement(300, 5);
+      expect(timeIncrement.time, 300);
+      expect(timeIncrement.increment, 5);
+    });
+
+    test('JSON Serialization', () {
+
+      final json = const TimeIncrement(300, 5).toJson();
+      expect(json['time'], 300);
+      expect(json['increment'], 5);
+
+      final newTimeIncrement = TimeIncrement.fromJson(json);
+      expect(newTimeIncrement.time, 300);
+      expect(newTimeIncrement.increment, 5);
+    });
+
+    test('Display Strings', () {
+      expect(const TimeIncrement(0, 0).display, '∞');
+      expect(const TimeIncrement(0, 5).display, '0+5');
+      expect(const TimeIncrement(45, 5).display, '¾+5');
+      expect(const TimeIncrement(30, 5).display, '½+5');
+      expect(const TimeIncrement(15, 5).display, '¼+5');
+      expect(const TimeIncrement(90, 5).display, '1.5+5');
+      expect(const TimeIncrement(600, 5).display, '10+5');
+    });
+
+    test('Estimated Duration', () {
+      expect(const TimeIncrement(300, 5).estimatedDuration, const Duration(seconds: 300 + 5 * 40));
+      expect(const TimeIncrement(0, 0).estimatedDuration,Duration.zero);
+    });
+
+    test('Equality and HashCode', () {
+      const timeIncrement1 = TimeIncrement(300, 5);
+      const timeIncrement2 = TimeIncrement(300, 5);
+      const timeIncrement3 = TimeIncrement(600, 10);
+
+      expect(timeIncrement1, timeIncrement2);
+      expect(timeIncrement1.hashCode, timeIncrement2.hashCode);
+      expect(timeIncrement1, isNot(timeIncrement3));
+    });
+
+    test('clockLabelInMinutes Function', () {
+      expect(clockLabelInMinutes(0), '0');
+      expect(clockLabelInMinutes(45), '¾');
+      expect(clockLabelInMinutes(30), '½');
+      expect(clockLabelInMinutes(15), '¼');
+      expect(clockLabelInMinutes(60), '1');
+      expect(clockLabelInMinutes(90), '1.5');
+      expect(clockLabelInMinutes(600), '10');
+    });
+  });
+}


### PR DESCRIPTION
### Description:
closes #823 
This pull request refactors the `TimeIncrement.display` method to utilize the `clockLabelInMinutes` function for better readability and maintainability. Additionally, it addresses an edge case noted in issue #823, where non-integer minute values were not displayed correctly. This ensures the correct display of time increments such as `1.5+5`.

### Changes Made:
1. **Refactored `TimeIncrement.display` Method:**
   - The `display` method now leverages the `clockLabelInMinutes` function to convert time in seconds to a more readable minute format.
   - This change simplifies the logic and ensures consistent formatting for various time values.

2. **Fixed Edge Case:**
   - The issue where a time of `90+5` seconds was incorrectly displayed as `1+5` instead of `1.5+5` has been resolved.

3. **Added Unit Tests:**
   - Created a new test file `time_increment_test.dart` to cover the functionality of the `TimeIncrement` class.
   - Tests include initialization, JSON serialization, display string formatting, estimated duration calculation, equality checks, and the `clockLabelInMinutes` function.

### Files Modified:
- **lib/src/model/common/time_increment.dart:**
- **test/model/common/time_increment_test.dart:**


### Testing:
- Verified that all unit tests pass successfully, confirming the correctness of the display method and the `clockLabelInMinutes` function.
