### PR TITLE
Extend translation comments based on crowdin feedback

### DIFF
--- a/docs/internationalisation.md
+++ b/docs/internationalisation.md
@@ -71,3 +71,7 @@ described above, they can be used like the other translations, however a `mobile
 > Such messages are mostly edge cases in the sense they should be rarely seen and people would understand that something
 > went wrong and could not load without understanding the actual meaning of the error message.
 
+> **Note**
+> Do not translate names such as "Puzzle Storm" and "Puzzle Streak". If such names appear in a translation string,
+> add a comment that they should not be translated.
+

--- a/translation/source/mobile.xml
+++ b/translation/source/mobile.xml
@@ -33,7 +33,7 @@
   <string name="cancelTakebackOffer" comment="Menu action that cancels a previous takeback offer">Cancel takeback offer</string>
   <string name="cancelDrawOffer" comment="Menu action that cancels a previous draw offer">Cancel draw offer</string>
   <string name="waitingForOpponentToJoin" comment="This is after the user has created a game and is waiting for an opponent to join.">Waiting for opponent to join...</string>
-  <string name="blindfoldMode" comment="This button toggles blindfold mode">Blindfold</string>
+  <string name="blindfoldMode" comment="This button toggles blindfold mode. This mean the user can only see the board, but not the pieces.">Blindfold</string>
   <string name="liveStreamers" comment="This is shown as a heading in the streamer screen">Live streamers</string>
   <string name="customGameJoinAGame" comment="This is shown in the custom game screen. Will open the game lobby.">Join a game</string>
   <string name="correspondenceClearSavedMove" comment="This is shown in the correspondence game screen. Will clear the saved move.">Clear saved move</string>

--- a/translation/source/mobile.xml
+++ b/translation/source/mobile.xml
@@ -2,7 +2,7 @@
 <resources>
   <string name="homeTab" comment="The tab in bottom navigation bar. Must be very short (10 characters max) to avoid ugly text shifting issues." maxLength="10">Home</string>
   <string name="puzzlesTab" comment="The tab in bottom navigation bar. Must be very short (10 characters max) to avoid ugly text shifting issues." maxLength="10">Puzzles</string>
-  <string name="toolsTab" comment="The tab in bottom navigation bar. Must be very short (10 characters max) to avoid ugly text shifting issues." maxLength="10">Tools</string>
+  <string name="toolsTab" comment="The tab in bottom navigation bar. Must be very short (10 characters max) to avoid ugly text shifting issues. Currently this includes the analysis board, the chess clock, and importing a position by PGN/FEN" maxLength="10">Tools</string>
   <string name="watchTab" comment="The tab in bottom navigation bar. Must be very short (10 characters max) to avoid ugly text shifting issues." maxLength="10">Watch</string>
   <string name="settingsTab" comment="The tab in bottom navigation bar. Must be very short (10 characters max) to avoid ugly text shifting issues." maxLength="10">Settings</string>
   <string name="mustBeLoggedIn" comment="This is shown when the user tries to access a feature that requires login.">You must be logged in to view this page.</string>

--- a/translation/source/mobile.xml
+++ b/translation/source/mobile.xml
@@ -19,8 +19,8 @@
   <string name="playersMatchingSearchTerm" comment="This is shown when searching for a player. %s is the string that user entered in the search bar">Players with "%s"</string>
   <string name="noSearchResults" comment="This is shown when the search did not return any results.">No results</string>
   <string name="areYouSure" comment="This is shown in confirmation dialogs.">Are you sure?</string>
-  <string name="puzzleStreakAbortWarning" comment="Shown as a subtitle in the confirmation dialog for aborting puzzle streak.">You will lose your current streak and your score will be saved.</string>
-  <string name="puzzleStormNothingToShow" comment="Shown when the user has not played any puzzle storm runs yet">Nothing to show. Play some runs of storm</string>
+  <string name="puzzleStreakAbortWarning" comment="Shown as a subtitle in the confirmation dialog for aborting puzzle streak. Prefer to not translate Puzzle Streak">You will lose your current streak and your score will be saved.</string>
+  <string name="puzzleStormNothingToShow" comment="Shown when the user has not played any puzzle storm runs yet. Prefer to not translate Puzzle Storm.">Nothing to show. Play some runs of Puzzle Storm.</string>
   <string name="sharePuzzle" comment="This is shown in the puzzle screen. When pressed, the user can share the puzzle.">Share this puzzle</string>
   <string name="shareGameURL" comment="Menu action that shares the URL of the current game">Share game URL</string>
   <string name="shareGamePGN" comment="Menu action that shares the PGN of a game">Share PGN</string>


### PR DESCRIPTION
This adresses most of the feedback I've seen on crowdin about the new mobile-only texts