### PR TITLE
fix incorrect move sounds during analysis

### DIFF
--- a/lib/src/model/analysis/analysis_controller.dart
+++ b/lib/src/model/analysis/analysis_controller.dart
@@ -383,9 +383,9 @@ class AnalysisController extends _$AnalysisController {
         ? _root.view
         : state.root;
 
+    final isForward = path.size > state.currentPath.size;
     if (currentNode is Branch) {
       if (!replaying) {
-        final isForward = path.size > state.currentPath.size;
         if (isForward) {
           final isCheck = currentNode.sanMove.isCheck;
           if (currentNode.sanMove.isCapture) {
@@ -396,7 +396,7 @@ class AnalysisController extends _$AnalysisController {
             ref.read(moveFeedbackServiceProvider).moveFeedback(check: isCheck);
           }
         }
-      } else {
+      } else if (isForward) {
         final soundService = ref.read(soundServiceProvider);
         if (currentNode.sanMove.isCapture) {
           soundService.play(Sound.capture);


### PR DESCRIPTION
fixes #870 

sounds should now be played correctly when user goes to previous or next move on analysis board. The issue was that only associated move of current node (after the requested change) was considered when determining which sound to play. Now the associated move of current node is used when user moves forward through the tree and associated move of previous node (before the requested change) is used when backtracking.

This also fixes move sound not playing when reverting first move of the game. Now the normal move sound is played whenever current node is not a Branch. I am not sure about this, so I am looking for some feedback if this is undesired behavior.