### PR TITLE
fix: change puzzle dashboard graph size on tablet, to prevent overflow

### DIFF
--- a/lib/src/view/puzzle/dashboard_screen.dart
+++ b/lib/src/view/puzzle/dashboard_screen.dart
@@ -10,6 +10,7 @@ import 'package:lichess_mobile/src/model/puzzle/puzzle_providers.dart';
 import 'package:lichess_mobile/src/model/puzzle/puzzle_theme.dart';
 import 'package:lichess_mobile/src/styles/styles.dart';
 import 'package:lichess_mobile/src/utils/l10n_context.dart';
+import 'package:lichess_mobile/src/utils/screen.dart';
 import 'package:lichess_mobile/src/utils/string.dart';
 import 'package:lichess_mobile/src/widgets/adaptive_choice_picker.dart';
 import 'package:lichess_mobile/src/widgets/buttons.dart';
@@ -115,7 +116,10 @@ class PuzzleDashboardWidget extends ConsumerWidget {
               Padding(
                 padding: const EdgeInsets.all(10.0),
                 child: AspectRatio(
-                  aspectRatio: 1.2,
+                  aspectRatio:
+                      MediaQuery.sizeOf(context).width > FormFactor.desktop
+                          ? 2.8
+                          : 1.2,
                   child: PuzzleChart(chartData),
                 ),
               ),


### PR DESCRIPTION
I used the desktop formfactor because it only affects tablets in landscape mode.

before:
![Screenshot from 2024-07-26 08-29-03](https://github.com/user-attachments/assets/6d1f7bea-57d2-41cb-9d5e-93c0515e7a99)

after:
![image_2024-07-26_083555014](https://github.com/user-attachments/assets/8f97a5a3-a124-4585-b1c9-2fe58b091a11)
