### PR TITLE
fix: add start game sound

### DIFF
--- a/lib/src/model/game/game_controller.dart
+++ b/lib/src/model/game/game_controller.dart
@@ -103,6 +103,10 @@ class GameController extends _$GameController {
 
         _socketEventVersion = fullEvent.socketEventVersion;
 
+        if (game.status == GameStatus.started && game.steps.length == 1) {
+          ref.read(soundServiceProvider).play(Sound.dong);
+        }
+
         return GameState(
           gameFullId: gameFullId,
           game: game,


### PR DESCRIPTION
fixes #890

Checks if the game just started in the first `'full'` game event handler and plays the start game sound. 

Since the first `'full'` event is always handled here, and we always receive a `'full'` event when connecting to a new game, this seemed like an appropriate place for playing the starting sound. 