### PR TITLE
feat: coordinate trainer

### DIFF
--- a/lib/src/constants.dart
+++ b/lib/src/constants.dart
@@ -1,3 +1,5 @@
+import 'package:chessground/chessground.dart' as cg;
+import 'package:dartchess/dartchess.dart' as dc;
 import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 
@@ -53,6 +55,12 @@ const kInitialFen = 'rnbqkbnr/pppppppp/8/8/8/8/PPPPPPPP/RNBQKBNR w KQkq - 0 1';
 const kTabletBoardTableSidePadding = 16.0;
 const kBottomBarHeight = 56.0;
 const kMaterialPopupMenuMaxWidth = 500.0;
+
+const cg.ChessboardState kEmptyBoardState = cg.ChessboardState(
+  fen: kEmptyFen,
+  interactableSide: cg.InteractableSide.none,
+  orientation: dc.Side.white,
+);
 
 /// The threshold to detect screens with a small remaining height left board.
 const kSmallRemainingHeightLeftBoardThreshold = 160;

--- a/lib/src/model/analysis/analysis_controller.dart
+++ b/lib/src/model/analysis/analysis_controller.dart
@@ -1,5 +1,6 @@
 import 'dart:async';
 
+import 'package:chessground/chessground.dart' as cg;
 import 'package:collection/collection.dart';
 import 'package:dartchess/dartchess.dart';
 import 'package:fast_immutable_collections/fast_immutable_collections.dart';
@@ -18,6 +19,7 @@ import 'package:lichess_mobile/src/model/common/uci.dart';
 import 'package:lichess_mobile/src/model/engine/evaluation_service.dart';
 import 'package:lichess_mobile/src/model/engine/work.dart';
 import 'package:lichess_mobile/src/model/game/player.dart';
+import 'package:lichess_mobile/src/utils/chessground_compat.dart';
 import 'package:lichess_mobile/src/utils/rate_limit.dart';
 import 'package:lichess_mobile/src/view/engine/engine_gauge.dart';
 import 'package:riverpod_annotation/riverpod_annotation.dart';
@@ -656,8 +658,8 @@ class AnalysisState with _$AnalysisState {
     IList<PgnComment>? pgnRootComments,
   }) = _AnalysisState;
 
-  IMap<String, ISet<String>> get validMoves =>
-      algebraicLegalMoves(currentNode.position);
+  IMap<cg.SquareId, ISet<cg.SquareId>> get validMoves =>
+      algebraicLegalMovesAsSquareIds(currentNode.position);
 
   /// Whether the user can request server analysis.
   ///

--- a/lib/src/model/puzzle/puzzle_controller.dart
+++ b/lib/src/model/puzzle/puzzle_controller.dart
@@ -1,6 +1,7 @@
 import 'dart:async';
 
 import 'package:async/async.dart';
+import 'package:chessground/chessground.dart' as cg;
 import 'package:collection/collection.dart';
 import 'package:dartchess/dartchess.dart';
 import 'package:fast_immutable_collections/fast_immutable_collections.dart';
@@ -22,6 +23,7 @@ import 'package:lichess_mobile/src/model/puzzle/puzzle_service.dart';
 import 'package:lichess_mobile/src/model/puzzle/puzzle_session.dart';
 import 'package:lichess_mobile/src/model/puzzle/puzzle_streak.dart';
 import 'package:lichess_mobile/src/model/puzzle/puzzle_theme.dart';
+import 'package:lichess_mobile/src/utils/chessground_compat.dart';
 import 'package:lichess_mobile/src/utils/rate_limit.dart';
 import 'package:result_extensions/result_extensions.dart';
 import 'package:riverpod_annotation/riverpod_annotation.dart';
@@ -592,5 +594,6 @@ class PuzzleState with _$PuzzleState {
   bool get canGoBack =>
       mode == PuzzleMode.view && currentPath.size > initialPath.size;
 
-  IMap<String, ISet<String>> get validMoves => algebraicLegalMoves(position);
+  IMap<cg.SquareId, ISet<cg.SquareId>> get validMoves =>
+      algebraicLegalMovesAsSquareIds(position);
 }

--- a/lib/src/model/puzzle/storm_controller.dart
+++ b/lib/src/model/puzzle/storm_controller.dart
@@ -12,6 +12,7 @@ import 'package:lichess_mobile/src/model/auth/auth_session.dart';
 import 'package:lichess_mobile/src/model/common/http.dart';
 import 'package:lichess_mobile/src/model/common/service/move_feedback.dart';
 import 'package:lichess_mobile/src/model/common/service/sound_service.dart';
+import 'package:lichess_mobile/src/utils/chessground_compat.dart';
 import 'package:result_extensions/result_extensions.dart';
 import 'package:riverpod_annotation/riverpod_annotation.dart';
 
@@ -345,7 +346,8 @@ class StormState with _$StormState {
 
   bool get isOver => moveIndex >= puzzle.solution.length - 1;
 
-  IMap<String, ISet<String>> get validMoves => algebraicLegalMoves(position);
+  IMap<cg.SquareId, ISet<cg.SquareId>> get validMoves =>
+      algebraicLegalMovesAsSquareIds(position);
 }
 
 enum StormMode { initial, running, ended }

--- a/lib/src/model/settings/board_preferences.dart
+++ b/lib/src/model/settings/board_preferences.dart
@@ -168,56 +168,56 @@ enum BoardTheme {
 
   const BoardTheme(this.label);
 
-  BoardColorScheme get colors {
+  ChessboardColorScheme get colors {
     switch (this) {
       case BoardTheme.system:
-        return getBoardColorScheme() ?? BoardColorScheme.brown;
+        return getBoardColorScheme() ?? ChessboardColorScheme.brown;
       case BoardTheme.blue:
-        return BoardColorScheme.blue;
+        return ChessboardColorScheme.blue;
       case BoardTheme.blue2:
-        return BoardColorScheme.blue2;
+        return ChessboardColorScheme.blue2;
       case BoardTheme.blue3:
-        return BoardColorScheme.blue3;
+        return ChessboardColorScheme.blue3;
       case BoardTheme.blueMarble:
-        return BoardColorScheme.blueMarble;
+        return ChessboardColorScheme.blueMarble;
       case BoardTheme.canvas:
-        return BoardColorScheme.canvas;
+        return ChessboardColorScheme.canvas;
       case BoardTheme.wood:
-        return BoardColorScheme.wood;
+        return ChessboardColorScheme.wood;
       case BoardTheme.wood2:
-        return BoardColorScheme.wood2;
+        return ChessboardColorScheme.wood2;
       case BoardTheme.wood3:
-        return BoardColorScheme.wood3;
+        return ChessboardColorScheme.wood3;
       case BoardTheme.wood4:
-        return BoardColorScheme.wood4;
+        return ChessboardColorScheme.wood4;
       case BoardTheme.maple:
-        return BoardColorScheme.maple;
+        return ChessboardColorScheme.maple;
       case BoardTheme.maple2:
-        return BoardColorScheme.maple2;
+        return ChessboardColorScheme.maple2;
       case BoardTheme.brown:
-        return BoardColorScheme.brown;
+        return ChessboardColorScheme.brown;
       case BoardTheme.leather:
-        return BoardColorScheme.leather;
+        return ChessboardColorScheme.leather;
       case BoardTheme.green:
-        return BoardColorScheme.green;
+        return ChessboardColorScheme.green;
       case BoardTheme.marble:
-        return BoardColorScheme.marble;
+        return ChessboardColorScheme.marble;
       case BoardTheme.greenPlastic:
-        return BoardColorScheme.greenPlastic;
+        return ChessboardColorScheme.greenPlastic;
       case BoardTheme.grey:
-        return BoardColorScheme.grey;
+        return ChessboardColorScheme.grey;
       case BoardTheme.metal:
-        return BoardColorScheme.metal;
+        return ChessboardColorScheme.metal;
       case BoardTheme.olive:
-        return BoardColorScheme.olive;
+        return ChessboardColorScheme.olive;
       case BoardTheme.newspaper:
-        return BoardColorScheme.newspaper;
+        return ChessboardColorScheme.newspaper;
       case BoardTheme.purpleDiag:
-        return BoardColorScheme.purpleDiag;
+        return ChessboardColorScheme.purpleDiag;
       case BoardTheme.pinkPyramid:
-        return BoardColorScheme.pinkPyramid;
+        return ChessboardColorScheme.pinkPyramid;
       case BoardTheme.horsey:
-        return BoardColorScheme.horsey;
+        return ChessboardColorScheme.horsey;
     }
   }
 

--- a/lib/src/utils/chessground_compat.dart
+++ b/lib/src/utils/chessground_compat.dart
@@ -1,41 +1,34 @@
 import 'package:chessground/chessground.dart' as chessground;
 import 'package:dartchess/dartchess.dart';
+import 'package:fast_immutable_collections/fast_immutable_collections.dart';
 
-extension ChessgroundSideCompat on Side {
-  chessground.Side get cg =>
-      this == Side.white ? chessground.Side.white : chessground.Side.black;
+IMap<chessground.SquareId, ISet<chessground.SquareId>>
+    algebraicLegalMovesAsSquareIds(
+  Position pos, {
+  bool isChess960 = false,
+}) {
+  return algebraicLegalMoves(pos, isChess960: isChess960).map(
+    (square, moves) => MapEntry(
+      chessground.SquareId(square),
+      moves.map((e) => chessground.SquareId(e)).toISet(),
+    ),
+  );
 }
 
 extension ChessgroundMoveCompat on Move {
   chessground.Move get cg {
     // !! Chessground doesn't support drop moves yet
     if (this is DropMove) {
-      return chessground.Move(from: toAlgebraic(to), to: toAlgebraic(to));
+      return chessground.Move(
+        from: chessground.SquareId(toAlgebraic(to)),
+        to: chessground.SquareId(toAlgebraic(to)),
+      );
     }
 
     return chessground.Move(
-      from: toAlgebraic((this as NormalMove).from),
-      to: toAlgebraic(to),
-      promotion: (this as NormalMove).promotion?.cg,
+      from: chessground.SquareId(toAlgebraic((this as NormalMove).from)),
+      to: chessground.SquareId(toAlgebraic(to)),
+      promotion: (this as NormalMove).promotion,
     );
-  }
-}
-
-extension ChessgroundRoleCompat on Role {
-  chessground.Role get cg {
-    switch (this) {
-      case Role.pawn:
-        return chessground.Role.pawn;
-      case Role.knight:
-        return chessground.Role.knight;
-      case Role.bishop:
-        return chessground.Role.bishop;
-      case Role.rook:
-        return chessground.Role.rook;
-      case Role.king:
-        return chessground.Role.king;
-      case Role.queen:
-        return chessground.Role.queen;
-    }
   }
 }

--- a/lib/src/utils/color_palette.dart
+++ b/lib/src/utils/color_palette.dart
@@ -1,11 +1,12 @@
 import 'dart:ui';
 
 import 'package:chessground/chessground.dart';
+import 'package:dartchess/dartchess.dart';
 import 'package:material_color_utilities/material_color_utilities.dart';
 
 CorePalette? _corePalette;
 
-BoardColorScheme? _boardColorScheme;
+ChessboardColorScheme? _boardColorScheme;
 
 /// Set the system core palette if available (android 12+ only).
 ///
@@ -17,19 +18,19 @@ void setCorePalette(CorePalette? palette) {
     final darkSquare = Color(palette.secondary.get(60));
     final lightSquare = Color(palette.primary.get(95));
 
-    _boardColorScheme = BoardColorScheme(
+    _boardColorScheme = ChessboardColorScheme(
       darkSquare: darkSquare,
       lightSquare: lightSquare,
-      background: SolidColorBackground(
+      background: SolidColorChessboardBackground(
         lightSquare: lightSquare,
         darkSquare: darkSquare,
       ),
-      whiteCoordBackground: SolidColorBackground(
+      whiteCoordBackground: SolidColorChessboardBackground(
         lightSquare: lightSquare,
         darkSquare: darkSquare,
         coordinates: true,
       ),
-      blackCoordBackground: SolidColorBackground(
+      blackCoordBackground: SolidColorChessboardBackground(
         lightSquare: lightSquare,
         darkSquare: darkSquare,
         coordinates: true,
@@ -53,6 +54,6 @@ CorePalette? getCorePalette() {
 }
 
 /// Get the board colors based on the core palette, if available (android 12+).
-BoardColorScheme? getBoardColorScheme() {
+ChessboardColorScheme? getBoardColorScheme() {
   return _boardColorScheme;
 }

--- a/lib/src/view/analysis/analysis_screen.dart
+++ b/lib/src/view/analysis/analysis_screen.dart
@@ -424,7 +424,7 @@ class _BoardState extends ConsumerState<_Board> {
                   cg.PieceShape(
                     color: color,
                     orig: move.cg.to,
-                    role: promRole.cg,
+                    role: promRole,
                   ),
               ];
             case DropMove(role: final role, to: _):
@@ -432,7 +432,7 @@ class _BoardState extends ConsumerState<_Board> {
                 cg.PieceShape(
                   color: color,
                   orig: move.cg.to,
-                  role: role.cg,
+                  role: role,
                 ),
               ];
           }
@@ -472,12 +472,12 @@ class _BoardState extends ConsumerState<_Board> {
         ? _computeBestMoveShapes(bestMoves)
         : ISet();
 
-    return cg.Board(
+    return cg.Chessboard(
       size: widget.boardSize,
       onMove: (move, {isDrop, isPremove}) =>
           ref.read(ctrlProvider.notifier).onUserMove(Move.fromUci(move.uci)!),
-      data: cg.BoardData(
-        orientation: analysisState.pov.cg,
+      state: cg.ChessboardState(
+        orientation: analysisState.pov,
         interactableSide: analysisState.position.isGameOver
             ? cg.InteractableSide.none
             : analysisState.position.turn == Side.white
@@ -486,7 +486,7 @@ class _BoardState extends ConsumerState<_Board> {
         fen: analysisState.position.fen,
         isCheck: boardPrefs.boardHighlights && analysisState.position.isCheck,
         lastMove: analysisState.lastMove?.cg,
-        sideToMove: analysisState.position.turn.cg,
+        sideToMove: analysisState.position.turn,
         validMoves: analysisState.validMoves,
         shapes: userShapes.union(bestMoveShapes),
         annotations:
@@ -499,7 +499,7 @@ class _BoardState extends ConsumerState<_Board> {
                     : IMap({sanMove.move.cg.to: annotation})
                 : null,
       ),
-      settings: cg.BoardSettings(
+      settings: cg.ChessboardSettings(
         pieceAssets: boardPrefs.pieceSet.assets,
         colorScheme: boardPrefs.boardTheme.colors,
         showValidMoves: boardPrefs.showLegalMoves,

--- a/lib/src/view/broadcast/broadcast_screen.dart
+++ b/lib/src/view/broadcast/broadcast_screen.dart
@@ -1,4 +1,3 @@
-import 'package:chessground/chessground.dart';
 import 'package:dartchess/dartchess.dart' as dartchess;
 import 'package:fast_immutable_collections/fast_immutable_collections.dart';
 import 'package:flutter/cupertino.dart';
@@ -132,10 +131,10 @@ class BroadcastPreview extends StatelessWidget {
             }
 
             final game = games![index];
-            final playingSide = dartchess.Setup.parseFen(game.fen).turn.cg;
+            final playingSide = dartchess.Setup.parseFen(game.fen).turn;
 
             return BoardThumbnail(
-              orientation: Side.white,
+              orientation: dartchess.Side.white,
               fen: game.fen,
               lastMove: game.lastMove?.cg,
               size: boardWidth,
@@ -143,14 +142,14 @@ class BroadcastPreview extends StatelessWidget {
                 width: boardWidth,
                 player: game.players[1],
                 gameStatus: game.status,
-                side: Side.black,
+                side: dartchess.Side.black,
                 playingSide: playingSide,
               ),
               footer: _PlayerWidget(
                 width: boardWidth,
                 player: game.players[0],
                 gameStatus: game.status,
-                side: Side.white,
+                side: dartchess.Side.white,
                 playingSide: playingSide,
               ),
             );
@@ -180,14 +179,14 @@ class _PlayerWidget extends StatelessWidget {
           federation: null,
         ),
         gameStatus = '*',
-        side = Side.white,
-        playingSide = Side.white,
+        side = dartchess.Side.white,
+        playingSide = dartchess.Side.white,
         _displayShimmerPlaceholder = true;
 
   final BroadcastPlayer player;
   final String gameStatus;
-  final Side side;
-  final Side playingSide;
+  final dartchess.Side side;
+  final dartchess.Side playingSide;
   final double width;
 
   final bool _displayShimmerPlaceholder;
@@ -257,10 +256,10 @@ class _PlayerWidget extends StatelessWidget {
                   (gameStatus == '½-½')
                       ? '½'
                       : (gameStatus == '1-0')
-                          ? side == Side.white
+                          ? side == dartchess.Side.white
                               ? '1'
                               : '0'
-                          : side == Side.black
+                          : side == dartchess.Side.black
                               ? '1'
                               : '0',
                   style:

--- a/lib/src/view/correspondence/offline_correspondence_game_screen.dart
+++ b/lib/src/view/correspondence/offline_correspondence_game_screen.dart
@@ -232,18 +232,18 @@ class _BodyState extends ConsumerState<_Body> {
               onMove: (move, {isDrop, isPremove}) {
                 onUserMove(Move.fromUci(move.uci)!);
               },
-              boardData: cg.BoardData(
+              boardState: cg.ChessboardState(
                 interactableSide: game.playable && !isReplaying
                     ? youAre == Side.white
                         ? cg.InteractableSide.white
                         : cg.InteractableSide.black
                     : cg.InteractableSide.none,
-                orientation: isBoardTurned ? youAre.opposite.cg : youAre.cg,
+                orientation: isBoardTurned ? youAre.opposite : youAre,
                 fen: position.fen,
                 lastMove: game.moveAt(stepCursor)?.cg,
                 isCheck: position.isCheck,
-                sideToMove: sideToMove.cg,
-                validMoves: algebraicLegalMoves(position),
+                sideToMove: sideToMove,
+                validMoves: algebraicLegalMovesAsSquareIds(position),
               ),
               topTable: topPlayer,
               bottomTable: bottomPlayer,

--- a/lib/src/view/game/archived_game_screen.dart
+++ b/lib/src/view/game/archived_game_screen.dart
@@ -153,9 +153,9 @@ class _BoardBody extends ConsumerWidget {
     final topPlayer = orientation == Side.white ? black : white;
     final bottomPlayer = orientation == Side.white ? white : black;
     final loadingBoard = BoardTable(
-      boardData: cg.BoardData(
+      boardState: cg.ChessboardState(
         interactableSide: cg.InteractableSide.none,
-        orientation: (isBoardTurned ? orientation.opposite : orientation).cg,
+        orientation: (isBoardTurned ? orientation.opposite : orientation),
         fen: gameData.lastFen ?? kInitialBoardFEN,
       ),
       topTable: topPlayer,
@@ -196,13 +196,12 @@ class _BoardBody extends ConsumerWidget {
         final position = game.positionAt(cursor);
 
         return BoardTable(
-          boardData: cg.BoardData(
+          boardState: cg.ChessboardState(
             interactableSide: cg.InteractableSide.none,
-            orientation:
-                (isBoardTurned ? orientation.opposite : orientation).cg,
+            orientation: (isBoardTurned ? orientation.opposite : orientation),
             fen: position.fen,
             lastMove: game.moveAt(cursor)?.cg,
-            sideToMove: position.turn.cg,
+            sideToMove: position.turn,
             isCheck: position.isCheck,
           ),
           topTable: topPlayer,

--- a/lib/src/view/game/game_body.dart
+++ b/lib/src/view/game/game_body.dart
@@ -252,22 +252,21 @@ class GameBody extends ConsumerWidget {
                               ref.read(ctrlProvider.notifier).setPremove(move);
                             }
                           : null,
-                      boardData: cg.BoardData(
+                      boardState: cg.ChessboardState(
                         interactableSide:
                             gameState.game.playable && !gameState.isReplaying
                                 ? youAre == Side.white
                                     ? cg.InteractableSide.white
                                     : cg.InteractableSide.black
                                 : cg.InteractableSide.none,
-                        orientation:
-                            isBoardTurned ? youAre.opposite.cg : youAre.cg,
+                        orientation: isBoardTurned ? youAre.opposite : youAre,
                         fen: position.fen,
                         lastMove:
                             gameState.game.moveAt(gameState.stepCursor)?.cg,
                         isCheck: boardPreferences.boardHighlights &&
                             position.isCheck,
-                        sideToMove: position.turn.cg,
-                        validMoves: algebraicLegalMoves(position),
+                        sideToMove: position.turn,
+                        validMoves: algebraicLegalMovesAsSquareIds(position),
                         premove: gameState.premove,
                       ),
                       topTable: topPlayer,

--- a/lib/src/view/game/game_list_tile.dart
+++ b/lib/src/view/game/game_list_tile.dart
@@ -133,7 +133,7 @@ class _ContextMenu extends ConsumerWidget {
                               size: constraints.maxWidth -
                                   (constraints.maxWidth / 1.618),
                               fen: game.lastFen!,
-                              orientation: mySide.cg,
+                              orientation: mySide,
                               lastMove: game.lastMove?.cg,
                             ),
                           Expanded(

--- a/lib/src/view/game/game_loading_board.dart
+++ b/lib/src/view/game/game_loading_board.dart
@@ -29,11 +29,7 @@ class LobbyScreenLoadingContent extends StatelessWidget {
           child: SafeArea(
             bottom: false,
             child: BoardTable(
-              boardData: const cg.BoardData(
-                interactableSide: cg.InteractableSide.none,
-                orientation: cg.Side.white,
-                fen: kEmptyFen,
-              ),
+              boardState: kEmptyBoardState,
               topTable: const SizedBox.shrink(),
               bottomTable: const SizedBox.shrink(),
               showMoveListPlaceholder: true,
@@ -112,11 +108,7 @@ class ChallengeLoadingContent extends StatelessWidget {
           child: SafeArea(
             bottom: false,
             child: BoardTable(
-              boardData: const cg.BoardData(
-                interactableSide: cg.InteractableSide.none,
-                orientation: cg.Side.white,
-                fen: kEmptyFen,
-              ),
+              boardState: kEmptyBoardState,
               topTable: const SizedBox.shrink(),
               bottomTable: const SizedBox.shrink(),
               showMoveListPlaceholder: true,
@@ -192,9 +184,9 @@ class StandaloneGameLoadingBoard extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     return BoardTable(
-      boardData: cg.BoardData(
+      boardState: cg.ChessboardState(
         interactableSide: cg.InteractableSide.none,
-        orientation: orientation?.cg ?? cg.Side.white,
+        orientation: orientation ?? Side.white,
         fen: fen ?? kEmptyFen,
         lastMove: lastMove?.cg,
       ),
@@ -218,9 +210,9 @@ class LoadGameError extends StatelessWidget {
           child: SafeArea(
             bottom: false,
             child: BoardTable(
-              boardData: const cg.BoardData(
+              boardState: const cg.ChessboardState(
                 interactableSide: cg.InteractableSide.none,
-                orientation: cg.Side.white,
+                orientation: Side.white,
                 fen: kEmptyFen,
               ),
               topTable: const SizedBox.shrink(),
@@ -263,9 +255,9 @@ class ChallengeDeclinedBoard extends StatelessWidget {
           child: SafeArea(
             bottom: false,
             child: BoardTable(
-              boardData: const cg.BoardData(
+              boardState: const cg.ChessboardState(
                 interactableSide: cg.InteractableSide.none,
-                orientation: cg.Side.white,
+                orientation: Side.white,
                 fen: kEmptyFen,
               ),
               topTable: const SizedBox.shrink(),

--- a/lib/src/view/game/offline_correspondence_games_screen.dart
+++ b/lib/src/view/game/offline_correspondence_games_screen.dart
@@ -77,7 +77,7 @@ class OfflineCorrespondenceGamePreview extends ConsumerWidget {
   @override
   Widget build(BuildContext context, WidgetRef ref) {
     return SmallBoardPreview(
-      orientation: game.orientation.cg,
+      orientation: game.orientation,
       lastMove: game.lastMove?.cg,
       fen: game.lastPosition.fen,
       description: Column(

--- a/lib/src/view/home/home_tab_screen.dart
+++ b/lib/src/view/home/home_tab_screen.dart
@@ -744,7 +744,7 @@ class _GamePreviewCarouselItem extends StatelessWidget {
   Widget build(BuildContext context) {
     return BoardCarouselItem(
       fen: game.fen,
-      orientation: game.orientation.cg,
+      orientation: game.orientation,
       lastMove: game.lastMove?.cg,
       description: Align(
         alignment: Alignment.centerLeft,

--- a/lib/src/view/play/challenge_screen.dart
+++ b/lib/src/view/play/challenge_screen.dart
@@ -1,6 +1,5 @@
 import 'dart:async';
 
-import 'package:chessground/chessground.dart' as cg;
 import 'package:dartchess/dartchess.dart';
 import 'package:flutter/cupertino.dart';
 import 'package:flutter/material.dart';
@@ -323,8 +322,8 @@ class _ChallengeBodyState extends ConsumerState<_ChallengeBody> {
                 expand: preferences.variant == Variant.fromPosition,
                 child: SmallBoardPreview(
                   orientation: preferences.sideChoice == SideChoice.black
-                      ? cg.Side.black
-                      : cg.Side.white,
+                      ? Side.black
+                      : Side.white,
                   fen: fromPositionFenInput ?? kEmptyFen,
                   description: AdaptiveTextField(
                     maxLines: 5,

--- a/lib/src/view/play/ongoing_games_screen.dart
+++ b/lib/src/view/play/ongoing_games_screen.dart
@@ -69,7 +69,7 @@ class OngoingGamePreview extends ConsumerWidget {
   @override
   Widget build(BuildContext context, WidgetRef ref) {
     return SmallBoardPreview(
-      orientation: game.orientation.cg,
+      orientation: game.orientation,
       lastMove: game.lastMove?.cg,
       fen: game.fen,
       description: Column(

--- a/lib/src/view/puzzle/puzzle_feedback_widget.dart
+++ b/lib/src/view/puzzle/puzzle_feedback_widget.dart
@@ -1,4 +1,3 @@
-import 'package:chessground/chessground.dart' as cg;
 import 'package:dartchess/dartchess.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
@@ -30,9 +29,7 @@ class PuzzleFeedbackWidget extends ConsumerWidget {
         ref.watch(boardPreferencesProvider.select((state) => state.boardTheme));
     final brightness = ref.watch(currentBrightnessProvider);
 
-    final piece = state.pov == Side.white
-        ? cg.PieceKind.whiteKing
-        : cg.PieceKind.blackKing;
+    final piece = state.pov == Side.white ? kWhiteKingKind : kBlackKingKind;
     final asset = pieceSet.assets[piece]!;
 
     switch (state.mode) {

--- a/lib/src/view/puzzle/puzzle_history_screen.dart
+++ b/lib/src/view/puzzle/puzzle_history_screen.dart
@@ -75,7 +75,7 @@ class PuzzleHistoryPreview extends ConsumerWidget {
                 ),
               );
             },
-            orientation: side.cg,
+            orientation: side,
             fen: fen,
             lastMove: lastMove.cg,
             footer: Padding(
@@ -241,7 +241,7 @@ class _HistoryBoard extends ConsumerWidget {
             ),
           );
         },
-        orientation: turn.cg,
+        orientation: turn,
         fen: fen,
         lastMove: lastMove.cg,
         footer: Padding(

--- a/lib/src/view/puzzle/puzzle_screen.dart
+++ b/lib/src/view/puzzle/puzzle_screen.dart
@@ -175,11 +175,7 @@ class _LoadNextPuzzle extends ConsumerWidget {
             child: BoardTable(
               topTable: kEmptyWidget,
               bottomTable: kEmptyWidget,
-              boardData: cg.BoardData(
-                fen: kEmptyFen,
-                interactableSide: cg.InteractableSide.none,
-                orientation: cg.Side.white,
-              ),
+              boardState: kEmptyBoardState,
               errorMessage: 'No more puzzles. Go online to get more.',
             ),
           );
@@ -198,11 +194,7 @@ class _LoadNextPuzzle extends ConsumerWidget {
           child: BoardTable(
             topTable: kEmptyWidget,
             bottomTable: kEmptyWidget,
-            boardData: const cg.BoardData(
-              fen: kEmptyFen,
-              interactableSide: cg.InteractableSide.none,
-              orientation: cg.Side.white,
-            ),
+            boardState: kEmptyBoardState,
             errorMessage: e.toString(),
           ),
         );
@@ -238,10 +230,10 @@ class _LoadPuzzleFromId extends ConsumerWidget {
             child: SafeArea(
               bottom: false,
               child: BoardTable(
-                boardData: cg.BoardData(
+                boardState: cg.ChessboardState(
                   fen: kEmptyFen,
                   interactableSide: cg.InteractableSide.none,
-                  orientation: cg.Side.white,
+                  orientation: Side.white,
                 ),
                 topTable: kEmptyWidget,
                 bottomTable: kEmptyWidget,
@@ -261,11 +253,7 @@ class _LoadPuzzleFromId extends ConsumerWidget {
               child: SafeArea(
                 bottom: false,
                 child: BoardTable(
-                  boardData: const cg.BoardData(
-                    fen: kEmptyFen,
-                    interactableSide: cg.InteractableSide.none,
-                    orientation: cg.Side.white,
-                  ),
+                  boardState: kEmptyBoardState,
                   topTable: kEmptyWidget,
                   bottomTable: kEmptyWidget,
                   errorMessage: e.toString(),
@@ -311,8 +299,8 @@ class _Body extends ConsumerWidget {
                     .read(ctrlProvider.notifier)
                     .onUserMove(Move.fromUci(move.uci)!);
               },
-              boardData: cg.BoardData(
-                orientation: puzzleState.pov.cg,
+              boardState: cg.ChessboardState(
+                orientation: puzzleState.pov,
                 interactableSide: puzzleState.mode == PuzzleMode.load ||
                         puzzleState.position.isGameOver
                     ? cg.InteractableSide.none
@@ -325,7 +313,7 @@ class _Body extends ConsumerWidget {
                 isCheck: boardPreferences.boardHighlights &&
                     puzzleState.position.isCheck,
                 lastMove: puzzleState.lastMove?.cg,
-                sideToMove: puzzleState.position.turn.cg,
+                sideToMove: puzzleState.position.turn,
                 validMoves: puzzleState.validMoves,
                 shapes: puzzleState.isEngineEnabled && evalBestMove != null
                     ? ISet([

--- a/lib/src/view/puzzle/puzzle_tab_screen.dart
+++ b/lib/src/view/puzzle/puzzle_tab_screen.dart
@@ -448,7 +448,7 @@ class _DailyPuzzle extends ConsumerWidget {
       data: (data) {
         final preview = PuzzlePreview.fromPuzzle(data);
         return SmallBoardPreview(
-          orientation: preview.orientation.cg,
+          orientation: preview.orientation,
           fen: preview.initialFen,
           lastMove: preview.initialMove.cg,
           description: Column(
@@ -496,7 +496,7 @@ class _DailyPuzzle extends ConsumerWidget {
         );
       },
       loading: () => SmallBoardPreview(
-        orientation: Side.white.cg,
+        orientation: Side.white,
         fen: kEmptyFen,
         description: Column(
           crossAxisAlignment: CrossAxisAlignment.start,
@@ -530,7 +530,7 @@ class _OfflinePuzzlePreview extends ConsumerWidget {
         final preview =
             data != null ? PuzzlePreview.fromPuzzle(data.puzzle) : null;
         return SmallBoardPreview(
-          orientation: preview?.orientation.cg ?? Side.white.cg,
+          orientation: preview?.orientation ?? Side.white,
           fen: preview?.initialFen ?? kEmptyFen,
           lastMove: preview?.initialMove.cg,
           description: Column(

--- a/lib/src/view/puzzle/storm_screen.dart
+++ b/lib/src/view/puzzle/storm_screen.dart
@@ -101,11 +101,7 @@ class _Load extends ConsumerWidget {
           child: BoardTable(
             topTable: kEmptyWidget,
             bottomTable: kEmptyWidget,
-            boardData: const cg.BoardData(
-              fen: kEmptyFen,
-              interactableSide: cg.InteractableSide.none,
-              orientation: cg.Side.white,
-            ),
+            boardState: kEmptyBoardState,
             errorMessage: e.toString(),
           ),
         );
@@ -176,8 +172,8 @@ class _Body extends ConsumerWidget {
                       .onUserMove(Move.fromUci(move.uci)!),
                   onPremove: (move) =>
                       ref.read(ctrlProvider.notifier).setPremove(move),
-                  boardData: cg.BoardData(
-                    orientation: stormState.pov.cg,
+                  boardState: cg.ChessboardState(
+                    orientation: stormState.pov,
                     interactableSide: !stormState.firstMovePlayed ||
                             stormState.mode == StormMode.ended ||
                             stormState.position.isGameOver
@@ -189,7 +185,7 @@ class _Body extends ConsumerWidget {
                     isCheck: boardPreferences.boardHighlights &&
                         stormState.position.isCheck,
                     lastMove: stormState.lastMove?.cg,
-                    sideToMove: stormState.position.turn.cg,
+                    sideToMove: stormState.position.turn,
                     validMoves: stormState.validMoves,
                     premove: stormState.premove,
                   ),

--- a/lib/src/view/puzzle/streak_screen.dart
+++ b/lib/src/view/puzzle/streak_screen.dart
@@ -102,11 +102,7 @@ class _Load extends ConsumerWidget {
           child: BoardTable(
             topTable: kEmptyWidget,
             bottomTable: kEmptyWidget,
-            boardData: const cg.BoardData(
-              fen: kEmptyFen,
-              interactableSide: cg.InteractableSide.none,
-              orientation: cg.Side.white,
-            ),
+            boardState: kEmptyBoardState,
             errorMessage: e.toString(),
           ),
         );
@@ -154,8 +150,8 @@ class _Body extends ConsumerWidget {
                       .read(ctrlProvider.notifier)
                       .onUserMove(Move.fromUci(move.uci)!);
                 },
-                boardData: cg.BoardData(
-                  orientation: puzzleState.pov.cg,
+                boardState: cg.ChessboardState(
+                  orientation: puzzleState.pov,
                   interactableSide: puzzleState.mode == PuzzleMode.load ||
                           puzzleState.position.isGameOver
                       ? cg.InteractableSide.none
@@ -167,7 +163,7 @@ class _Body extends ConsumerWidget {
                   fen: puzzleState.fen,
                   isCheck: puzzleState.position.isCheck,
                   lastMove: puzzleState.lastMove?.cg,
-                  sideToMove: puzzleState.position.turn.cg,
+                  sideToMove: puzzleState.position.turn,
                   validMoves: puzzleState.validMoves,
                 ),
                 topTable: Center(

--- a/lib/src/view/settings/piece_set_screen.dart
+++ b/lib/src/view/settings/piece_set_screen.dart
@@ -1,4 +1,5 @@
 import 'package:chessground/chessground.dart';
+import 'package:dartchess/dartchess.dart';
 import 'package:flutter/cupertino.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
@@ -40,12 +41,12 @@ class _Body extends ConsumerWidget {
 
     List<AssetImage> getPieceImages(PieceSet set) {
       return [
-        set.assets[PieceKind.whiteKing]!,
-        set.assets[PieceKind.blackQueen]!,
-        set.assets[PieceKind.whiteRook]!,
-        set.assets[PieceKind.blackBishop]!,
-        set.assets[PieceKind.whiteKnight]!,
-        set.assets[PieceKind.blackPawn]!,
+        set.assets[kWhiteKingKind]!,
+        set.assets[kBlackQueenKind]!,
+        set.assets[kWhiteRookKind]!,
+        set.assets[kBlackBishopKind]!,
+        set.assets[kWhiteKnightKind]!,
+        set.assets[kBlackPawnKind]!,
       ];
     }
 

--- a/lib/src/view/watch/live_tv_channels_screen.dart
+++ b/lib/src/view/watch/live_tv_channels_screen.dart
@@ -84,7 +84,7 @@ class _Body extends ConsumerWidget {
                   ),
                 );
               },
-              orientation: game.orientation.cg,
+              orientation: game.orientation,
               fen: game.fen ?? kEmptyFen,
               lastMove: game.lastMove?.cg,
               description: Column(

--- a/lib/src/view/watch/tv_screen.dart
+++ b/lib/src/view/watch/tv_screen.dart
@@ -122,11 +122,11 @@ class _Body extends ConsumerWidget {
                     gameState.game.positionAt(gameState.stepCursor);
                 final sideToMove = position.turn;
 
-                final boardData = cg.BoardData(
+                final boardData = cg.ChessboardState(
                   interactableSide: cg.InteractableSide.none,
-                  orientation: gameState.orientation.cg,
+                  orientation: gameState.orientation,
                   fen: position.fen,
-                  sideToMove: sideToMove.cg,
+                  sideToMove: sideToMove,
                   lastMove: game.moveAt(gameState.stepCursor)?.cg,
                   isCheck: boardPreferences.boardHighlights && position.isCheck,
                 );
@@ -153,7 +153,7 @@ class _Body extends ConsumerWidget {
                   materialDiff: game.lastMaterialDiffAt(Side.white),
                 );
                 return BoardTable(
-                  boardData: boardData,
+                  boardState: boardData,
                   boardSettingsOverrides: const BoardSettingsOverrides(
                     animationDuration: Duration.zero,
                   ),
@@ -173,11 +173,7 @@ class _Body extends ConsumerWidget {
               loading: () => const BoardTable(
                 topTable: kEmptyWidget,
                 bottomTable: kEmptyWidget,
-                boardData: cg.BoardData(
-                  interactableSide: cg.InteractableSide.none,
-                  orientation: cg.Side.white,
-                  fen: kEmptyFen,
-                ),
+                boardState: kEmptyBoardState,
                 showMoveListPlaceholder: true,
               ),
               error: (err, stackTrace) {
@@ -187,11 +183,7 @@ class _Body extends ConsumerWidget {
                 return const BoardTable(
                   topTable: kEmptyWidget,
                   bottomTable: kEmptyWidget,
-                  boardData: cg.BoardData(
-                    fen: kEmptyFen,
-                    interactableSide: cg.InteractableSide.none,
-                    orientation: cg.Side.white,
-                  ),
+                  boardState: kEmptyBoardState,
                   errorMessage: 'Could not load TV stream.',
                   showMoveListPlaceholder: true,
                 );

--- a/lib/src/widgets/board_carousel_item.dart
+++ b/lib/src/widgets/board_carousel_item.dart
@@ -1,4 +1,5 @@
 import 'package:chessground/chessground.dart';
+import 'package:dartchess/dartchess.dart' as dc;
 import 'package:flutter/gestures.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/rendering.dart';
@@ -21,7 +22,7 @@ class BoardCarouselItem extends ConsumerWidget {
   });
 
   /// Side by which the board is oriented.
-  final Side orientation;
+  final dc.Side orientation;
 
   /// FEN string describing the position of the board.
   final String fen;
@@ -79,15 +80,15 @@ class BoardCarouselItem extends ConsumerWidget {
                   },
                   child: SizedBox(
                     height: boardSize,
-                    child: Board(
+                    child: Chessboard(
                       size: boardSize,
-                      data: BoardData(
+                      state: ChessboardState(
                         interactableSide: InteractableSide.none,
                         fen: fen,
                         orientation: orientation,
                         lastMove: lastMove,
                       ),
-                      settings: BoardSettings(
+                      settings: ChessboardSettings(
                         enableCoordinates: false,
                         borderRadius: const BorderRadius.only(
                           topLeft: Radius.circular(10.0),

--- a/lib/src/widgets/board_preview.dart
+++ b/lib/src/widgets/board_preview.dart
@@ -1,4 +1,5 @@
 import 'package:chessground/chessground.dart';
+import 'package:dartchess/dartchess.dart' as dc;
 import 'package:flutter/cupertino.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
@@ -18,7 +19,7 @@ class SmallBoardPreview extends ConsumerStatefulWidget {
   });
 
   /// Side by which the board is oriented.
-  final Side orientation;
+  final dc.Side orientation;
 
   /// FEN string describing the position of the board.
   final String fen;
@@ -64,15 +65,15 @@ class _SmallBoardPreviewState extends ConsumerState<SmallBoardPreview> {
               height: boardSize,
               child: Row(
                 children: [
-                  Board(
+                  Chessboard(
                     size: boardSize,
-                    data: BoardData(
+                    state: ChessboardState(
                       interactableSide: InteractableSide.none,
                       fen: widget.fen,
                       orientation: widget.orientation,
                       lastMove: widget.lastMove,
                     ),
-                    settings: BoardSettings(
+                    settings: ChessboardSettings(
                       enableCoordinates: false,
                       borderRadius:
                           const BorderRadius.all(Radius.circular(4.0)),

--- a/lib/src/widgets/board_table.dart
+++ b/lib/src/widgets/board_table.dart
@@ -31,7 +31,7 @@ class BoardTable extends ConsumerStatefulWidget {
   const BoardTable({
     this.onMove,
     this.onPremove,
-    required this.boardData,
+    required this.boardState,
     this.boardSettingsOverrides,
     required this.topTable,
     required this.bottomTable,
@@ -54,7 +54,7 @@ class BoardTable extends ConsumerStatefulWidget {
   final void Function(Move, {bool? isDrop, bool? isPremove})? onMove;
   final void Function(Move?)? onPremove;
 
-  final BoardData boardData;
+  final ChessboardState boardState;
 
   final BoardSettingsOverrides? boardSettingsOverrides;
 
@@ -146,7 +146,7 @@ class _BoardTableState extends ConsumerState<BoardTable> {
               )
             : null;
 
-        final defaultSettings = BoardSettings(
+        final defaultSettings = ChessboardSettings(
           pieceAssets: boardPrefs.pieceSet.assets,
           colorScheme: boardPrefs.boardTheme.colors,
           showValidMoves: boardPrefs.showLegalMoves,
@@ -169,11 +169,11 @@ class _BoardTableState extends ConsumerState<BoardTable> {
             ? widget.boardSettingsOverrides!.merge(defaultSettings)
             : defaultSettings;
 
-        final board = Board(
+        final board = Chessboard(
           key: widget.boardKey,
           size: boardSize,
-          data: widget.boardData.copyWith(
-            shapes: userShapes.union(widget.boardData.shapes ?? ISet()),
+          state: widget.boardState.copyWith(
+            shapes: userShapes.union(widget.boardState.shapes ?? ISet()),
           ),
           settings: settings,
           onMove: widget.onMove,
@@ -364,7 +364,7 @@ class BoardSettingsOverrides {
   final bool? autoQueenPromotionOnPremove;
   final bool? blindfoldMode;
 
-  BoardSettings merge(BoardSettings settings) {
+  ChessboardSettings merge(ChessboardSettings settings) {
     return settings.copyWith(
       animationDuration: animationDuration,
       autoQueenPromotion: autoQueenPromotion,

--- a/lib/src/widgets/board_thumbnail.dart
+++ b/lib/src/widgets/board_thumbnail.dart
@@ -1,4 +1,5 @@
 import 'package:chessground/chessground.dart';
+import 'package:dartchess/dartchess.dart' as dc;
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:lichess_mobile/src/constants.dart';
@@ -20,7 +21,7 @@ class BoardThumbnail extends ConsumerStatefulWidget {
     required this.size,
     this.header,
     this.footer,
-  })  : orientation = Side.white,
+  })  : orientation = dc.Side.white,
         fen = kInitialFen,
         lastMove = null,
         onTap = null;
@@ -29,7 +30,7 @@ class BoardThumbnail extends ConsumerStatefulWidget {
   final double size;
 
   /// Side by which the board is oriented.
-  final Side orientation;
+  final dc.Side orientation;
 
   /// FEN string describing the position of the board.
   final String fen;
@@ -66,15 +67,15 @@ class _BoardThumbnailState extends ConsumerState<BoardThumbnail> {
   Widget build(BuildContext context) {
     final boardPrefs = ref.watch(boardPreferencesProvider);
 
-    final board = Board(
+    final board = Chessboard(
       size: widget.size,
-      data: BoardData(
+      state: ChessboardState(
         interactableSide: InteractableSide.none,
         fen: widget.fen,
         orientation: widget.orientation,
         lastMove: widget.lastMove,
       ),
-      settings: BoardSettings(
+      settings: ChessboardSettings(
         enableCoordinates: false,
         borderRadius: const BorderRadius.all(Radius.circular(4.0)),
         boxShadow: boardShadows,

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -185,11 +185,12 @@ packages:
   chessground:
     dependency: "direct main"
     description:
-      name: chessground
-      sha256: "44b2f20c8df56d7f42c5d10c68dc8b79f766db65f9f1b4cca45c4d30579d4e57"
-      url: "https://pub.dev"
-    source: hosted
-    version: "3.2.0"
+      path: "."
+      ref: "22db3bafaf25b62357affcaac310df40a1efa426"
+      resolved-ref: "22db3bafaf25b62357affcaac310df40a1efa426"
+      url: "https://github.com/lichess-org/flutter-chessground"
+    source: git
+    version: "4.0.0"
   ci:
     dependency: transitive
     description:
@@ -982,10 +983,10 @@ packages:
     dependency: transitive
     description:
       name: path_provider_android
-      sha256: "30c5aa827a6ae95ce2853cdc5fe3971daaac00f6f081c419c013f7f57bff2f5e"
+      sha256: e84c8a53fe1510ef4582f118c7b4bdf15b03002b51d7c2b66983c65843d61193
       url: "https://pub.dev"
     source: hosted
-    version: "2.2.7"
+    version: "2.2.8"
   path_provider_foundation:
     dependency: transitive
     description:
@@ -1166,10 +1167,10 @@ packages:
     dependency: transitive
     description:
       name: shared_preferences_android
-      sha256: "93d0ec9dd902d85f326068e6a899487d1f65ffcd5798721a95330b26c8131577"
+      sha256: "3d4571b3c5eb58ce52a419d86e655493d0bc3020672da79f72fa0c16ca3a8ec1"
       url: "https://pub.dev"
     source: hosted
-    version: "2.2.3"
+    version: "2.2.4"
   shared_preferences_foundation:
     dependency: transitive
     description:
@@ -1307,10 +1308,10 @@ packages:
     dependency: transitive
     description:
       name: sqlite3
-      sha256: "6d17989c0b06a5870b2190d391925186f944cb943e5262d0d3f778fcfca3bc6e"
+      sha256: fde692580bee3379374af1f624eb3e113ab2865ecb161dbe2d8ac2de9735dbdb
       url: "https://pub.dev"
     source: hosted
-    version: "2.4.4"
+    version: "2.4.5"
   stack_trace:
     dependency: transitive
     description:
@@ -1428,10 +1429,10 @@ packages:
     dependency: transitive
     description:
       name: url_launcher_android
-      sha256: "95d8027db36a0e52caf55680f91e33ea6aa12a3ce608c90b06f4e429a21067ac"
+      sha256: c24484594a8dea685610569ab0f2547de9c7a1907500a9bc5e37e4c9a3cbfb23
       url: "https://pub.dev"
     source: hosted
-    version: "6.3.5"
+    version: "6.3.6"
   url_launcher_ios:
     dependency: transitive
     description:
@@ -1540,10 +1541,10 @@ packages:
     dependency: "direct main"
     description:
       name: wakelock_plus
-      sha256: "14758533319a462ffb5aa3b7ddb198e59b29ac3b02da14173a1715d65d4e6e68"
+      sha256: "4fa83a128b4127619e385f686b4f080a5d2de46cff8e8c94eccac5fcf76550e5"
       url: "https://pub.dev"
     source: hosted
-    version: "1.2.5"
+    version: "1.2.7"
   wakelock_plus_platform_interface:
     dependency: transitive
     description:
@@ -1596,10 +1597,10 @@ packages:
     dependency: transitive
     description:
       name: win32_registry
-      sha256: "10589e0d7f4e053f2c61023a31c9ce01146656a70b7b7f0828c0b46d7da2a9bb"
+      sha256: "723b7f851e5724c55409bb3d5a32b203b3afe8587eaf5dafb93a5fed8ecda0d6"
       url: "https://pub.dev"
     source: hosted
-    version: "1.1.3"
+    version: "1.1.4"
   xdg_directories:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -10,7 +10,11 @@ environment:
 dependencies:
   async: ^2.10.0
   cached_network_image: ^3.2.2
-  chessground: ^3.2.0
+  # TODO use ^4.0.0 once available
+  chessground:
+    git:
+      url: https://github.com/lichess-org/flutter-chessground
+      ref: 22db3bafaf25b62357affcaac310df40a1efa426
   collection: ^1.17.0
   connectivity_plus: ^6.0.2
   cronet_http: ^1.3.1

--- a/test/test_utils.dart
+++ b/test/test_utils.dart
@@ -1,6 +1,7 @@
 import 'dart:convert';
 
 import 'package:chessground/chessground.dart' as cg;
+import 'package:dartchess/dartchess.dart' as dc;
 import 'package:flutter/cupertino.dart';
 import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
@@ -67,10 +68,10 @@ Future<void> meetsTapTargetGuideline(WidgetTester tester) async {
 Offset squareOffset(
   cg.SquareId id,
   Rect boardRect, {
-  cg.Side orientation = cg.Side.white,
+  dc.Side orientation = dc.Side.white,
 }) {
   final squareSize = boardRect.width / 8;
-  final o = cg.Coord.fromSquareId(id).offset(orientation, squareSize);
+  final o = id.coord.offset(orientation, squareSize);
   return Offset(
     o.dx + boardRect.left + squareSize / 2,
     o.dy + boardRect.top + squareSize / 2,
@@ -82,11 +83,15 @@ Future<void> playMove(
   Rect boardRect,
   String from,
   String to, {
-  cg.Side orientation = cg.Side.white,
+  dc.Side orientation = dc.Side.white,
 }) async {
-  await tester.tapAt(squareOffset(from, boardRect, orientation: orientation));
+  await tester.tapAt(
+    squareOffset(cg.SquareId(from), boardRect, orientation: orientation),
+  );
   await tester.pump();
-  await tester.tapAt(squareOffset(to, boardRect, orientation: orientation));
+  await tester.tapAt(
+    squareOffset(cg.SquareId(to), boardRect, orientation: orientation),
+  );
   await tester.pump();
 }
 

--- a/test/view/analysis/analysis_screen_test.dart
+++ b/test/view/analysis/analysis_screen_test.dart
@@ -45,7 +45,7 @@ void main() {
 
       await tester.pumpWidget(app);
 
-      expect(find.byType(cg.Board), findsOneWidget);
+      expect(find.byType(cg.Chessboard), findsOneWidget);
       expect(find.byType(cg.PieceWidget), findsNWidgets(25));
       final currentMove = find.widgetWithText(InlineMove, 'Qe1#');
       expect(currentMove, findsOneWidget);

--- a/test/view/game/archived_game_screen_test.dart
+++ b/test/view/game/archived_game_screen_test.dart
@@ -47,7 +47,7 @@ void main() {
         await tester.pumpWidget(app);
 
         // data shown immediately
-        expect(find.byType(cg.Board), findsOneWidget);
+        expect(find.byType(cg.Chessboard), findsOneWidget);
         expect(find.byType(cg.PieceWidget), findsNWidgets(25));
         expect(find.widgetWithText(GamePlayer, 'veloce'), findsOneWidget);
         expect(
@@ -57,7 +57,10 @@ void main() {
 
         // cannot interact with board
         expect(
-          tester.widget<cg.Board>(find.byType(cg.Board)).data.interactableSide,
+          tester
+              .widget<cg.Chessboard>(find.byType(cg.Chessboard))
+              .state
+              .interactableSide,
           cg.InteractableSide.none,
         );
 
@@ -78,7 +81,7 @@ void main() {
         await tester.pumpAndSettle();
 
         // same info still displayed
-        expect(find.byType(cg.Board), findsOneWidget);
+        expect(find.byType(cg.Chessboard), findsOneWidget);
         expect(find.byType(cg.PieceWidget), findsNWidgets(25));
         expect(find.widgetWithText(GamePlayer, 'veloce'), findsOneWidget);
         expect(

--- a/test/view/puzzle/puzzle_screen_test.dart
+++ b/test/view/puzzle/puzzle_screen_test.dart
@@ -98,7 +98,7 @@ void main() {
         // wait for the puzzle to load
         await tester.pump(const Duration(milliseconds: 200));
 
-        expect(find.byType(cg.Board), findsOneWidget);
+        expect(find.byType(cg.Chessboard), findsOneWidget);
         expect(find.text('Your turn'), findsOneWidget);
       },
     );
@@ -127,13 +127,13 @@ void main() {
 
       await tester.pumpWidget(app);
 
-      expect(find.byType(cg.Board), findsNothing);
+      expect(find.byType(cg.Chessboard), findsNothing);
       expect(find.text('Your turn'), findsNothing);
 
       // wait for the puzzle to load
       await tester.pump(const Duration(milliseconds: 200));
 
-      expect(find.byType(cg.Board), findsOneWidget);
+      expect(find.byType(cg.Chessboard), findsOneWidget);
       expect(find.text('Your turn'), findsOneWidget);
     });
 
@@ -189,16 +189,16 @@ void main() {
         // wait for the puzzle to load
         await tester.pump(const Duration(milliseconds: 200));
 
-        expect(find.byType(cg.Board), findsOneWidget);
+        expect(find.byType(cg.Chessboard), findsOneWidget);
         expect(find.text('Your turn'), findsOneWidget);
 
         // before the first move is played, puzzle is not interactable
-        expect(find.byKey(const Key('g4-blackRook')), findsOneWidget);
-        await tester.tap(find.byKey(const Key('g4-blackRook')));
+        expect(find.byKey(const Key('g4-blackrook')), findsOneWidget);
+        await tester.tap(find.byKey(const Key('g4-blackrook')));
         await tester.pump();
         expect(find.byKey(const Key('g4-selected')), findsNothing);
 
-        const orientation = cg.Side.black;
+        const orientation = Side.black;
 
         // await for first move to be played
         await tester.pump(const Duration(milliseconds: 1500));
@@ -208,25 +208,25 @@ void main() {
         // in play mode we see the solution button
         expect(find.byIcon(Icons.help), findsOneWidget);
 
-        expect(find.byKey(const Key('g4-blackRook')), findsOneWidget);
-        expect(find.byKey(const Key('h8-whiteQueen')), findsOneWidget);
+        expect(find.byKey(const Key('g4-blackrook')), findsOneWidget);
+        expect(find.byKey(const Key('h8-whitequeen')), findsOneWidget);
 
-        final boardRect = tester.getRect(find.byType(cg.Board));
+        final boardRect = tester.getRect(find.byType(cg.Chessboard));
 
         await playMove(tester, boardRect, 'g4', 'h4', orientation: orientation);
 
-        expect(find.byKey(const Key('h4-blackRook')), findsOneWidget);
+        expect(find.byKey(const Key('h4-blackrook')), findsOneWidget);
         expect(find.text('Best move!'), findsOneWidget);
 
         // wait for line reply and move animation
         await tester.pump(const Duration(milliseconds: 500));
         await tester.pumpAndSettle();
 
-        expect(find.byKey(const Key('h4-whiteQueen')), findsOneWidget);
+        expect(find.byKey(const Key('h4-whitequeen')), findsOneWidget);
 
         await playMove(tester, boardRect, 'b4', 'h4', orientation: orientation);
 
-        expect(find.byKey(const Key('h4-blackRook')), findsOneWidget);
+        expect(find.byKey(const Key('h4-blackrook')), findsOneWidget);
         expect(find.text('Success!'), findsOneWidget);
 
         // wait for move animation
@@ -305,17 +305,17 @@ void main() {
         // wait for the puzzle to load
         await tester.pump(const Duration(milliseconds: 200));
 
-        expect(find.byType(cg.Board), findsOneWidget);
+        expect(find.byType(cg.Chessboard), findsOneWidget);
         expect(find.text('Your turn'), findsOneWidget);
 
-        const orientation = cg.Side.black;
+        const orientation = Side.black;
 
         // await for first move to be played
         await tester.pump(const Duration(milliseconds: 1500));
 
-        expect(find.byKey(const Key('g4-blackRook')), findsOneWidget);
+        expect(find.byKey(const Key('g4-blackrook')), findsOneWidget);
 
-        final boardRect = tester.getRect(find.byType(cg.Board));
+        final boardRect = tester.getRect(find.byType(cg.Chessboard));
 
         await playMove(tester, boardRect, 'g4', 'f4', orientation: orientation);
 
@@ -329,11 +329,11 @@ void main() {
         await tester.pumpAndSettle();
 
         // can still play the puzzle
-        expect(find.byKey(const Key('g4-blackRook')), findsOneWidget);
+        expect(find.byKey(const Key('g4-blackrook')), findsOneWidget);
 
         await playMove(tester, boardRect, 'g4', 'h4', orientation: orientation);
 
-        expect(find.byKey(const Key('h4-blackRook')), findsOneWidget);
+        expect(find.byKey(const Key('h4-blackrook')), findsOneWidget);
         expect(find.text('Best move!'), findsOneWidget);
 
         // wait for line reply and move animation
@@ -342,7 +342,7 @@ void main() {
 
         await playMove(tester, boardRect, 'b4', 'h4', orientation: orientation);
 
-        expect(find.byKey(const Key('h4-blackRook')), findsOneWidget);
+        expect(find.byKey(const Key('h4-blackrook')), findsOneWidget);
         expect(
           find.text('Puzzle complete!'),
           findsOneWidget,
@@ -418,13 +418,13 @@ void main() {
         // wait for the puzzle to load
         await tester.pump(const Duration(milliseconds: 200));
 
-        expect(find.byType(cg.Board), findsOneWidget);
+        expect(find.byType(cg.Chessboard), findsOneWidget);
         expect(find.text('Your turn'), findsOneWidget);
 
         // await for first move to be played and view solution button to appear
         await tester.pump(const Duration(seconds: 5));
 
-        expect(find.byKey(const Key('g4-blackRook')), findsOneWidget);
+        expect(find.byKey(const Key('g4-blackrook')), findsOneWidget);
 
         expect(find.byIcon(Icons.help), findsOneWidget);
         await tester.tap(find.byIcon(Icons.help));
@@ -433,8 +433,8 @@ void main() {
         await tester.pump(const Duration(seconds: 1));
         await tester.pumpAndSettle();
 
-        expect(find.byKey(const Key('h4-blackRook')), findsOneWidget);
-        expect(find.byKey(const Key('h8-whiteQueen')), findsOneWidget);
+        expect(find.byKey(const Key('h4-blackrook')), findsOneWidget);
+        expect(find.byKey(const Key('h8-whitequeen')), findsOneWidget);
         expect(
           find.text('Puzzle complete!'),
           findsOneWidget,

--- a/test/view/puzzle/storm_screen_test.dart
+++ b/test/view/puzzle/storm_screen_test.dart
@@ -1,4 +1,5 @@
 import 'package:chessground/chessground.dart' as cg;
+import 'package:dartchess/dartchess.dart';
 import 'package:fast_immutable_collections/fast_immutable_collections.dart';
 import 'package:flutter/foundation.dart';
 import 'package:flutter_test/flutter_test.dart';
@@ -60,7 +61,7 @@ void main() {
 
         await tester.pumpWidget(app);
 
-        expect(find.byType(cg.Board), findsOneWidget);
+        expect(find.byType(cg.Chessboard), findsOneWidget);
         expect(
           find.text('You play the white pieces in all puzzles'),
           findsWidgets,
@@ -85,43 +86,43 @@ void main() {
         await tester.pumpWidget(app);
 
         // before the first move is played, puzzle is not interactable
-        expect(find.byKey(const Key('h5-whiteRook')), findsOneWidget);
-        await tester.tap(find.byKey(const Key('h5-whiteRook')));
+        expect(find.byKey(const Key('h5-whiterook')), findsOneWidget);
+        await tester.tap(find.byKey(const Key('h5-whiterook')));
         await tester.pump();
         expect(find.byKey(const Key('h5-selected')), findsNothing);
 
         // wait for first move to be played
         await tester.pump(const Duration(seconds: 1));
 
-        expect(find.byKey(const Key('g8-blackKing')), findsOneWidget);
+        expect(find.byKey(const Key('g8-blackking')), findsOneWidget);
 
-        final boardRect = tester.getRect(find.byType(cg.Board));
+        final boardRect = tester.getRect(find.byType(cg.Chessboard));
 
         await playMove(
           tester,
           boardRect,
           'h5',
           'h7',
-          orientation: cg.Side.white,
+          orientation: Side.white,
         );
 
         await tester.pump(const Duration(milliseconds: 500));
         await tester.pumpAndSettle();
-        expect(find.byKey(const Key('h7-whiteRook')), findsOneWidget);
-        expect(find.byKey(const Key('d1-blackQueen')), findsOneWidget);
+        expect(find.byKey(const Key('h7-whiterook')), findsOneWidget);
+        expect(find.byKey(const Key('d1-blackqueen')), findsOneWidget);
 
         await playMove(
           tester,
           boardRect,
           'e3',
           'g1',
-          orientation: cg.Side.white,
+          orientation: Side.white,
         );
 
         await tester.pump(const Duration(milliseconds: 500));
 
         // should have loaded next puzzle
-        expect(find.byKey(const Key('h6-blackKing')), findsOneWidget);
+        expect(find.byKey(const Key('h6-blackking')), findsOneWidget);
       },
       variant: kPlatformVariant,
     );
@@ -142,14 +143,14 @@ void main() {
       // wait for first move to be played
       await tester.pump(const Duration(seconds: 1));
 
-      final boardRect = tester.getRect(find.byType(cg.Board));
+      final boardRect = tester.getRect(find.byType(cg.Chessboard));
 
       await playMove(
         tester,
         boardRect,
         'h5',
         'h7',
-        orientation: cg.Side.white,
+        orientation: Side.white,
       );
 
       await tester.pump(const Duration(milliseconds: 500));
@@ -158,12 +159,12 @@ void main() {
         boardRect,
         'e3',
         'g1',
-        orientation: cg.Side.white,
+        orientation: Side.white,
       );
 
       await tester.pump(const Duration(milliseconds: 500));
       // should have loaded next puzzle
-      expect(find.byKey(const Key('h6-blackKing')), findsOneWidget);
+      expect(find.byKey(const Key('h6-blackking')), findsOneWidget);
 
       await tester.tap(find.text('End run'));
       await tester.pumpAndSettle();
@@ -185,12 +186,12 @@ void main() {
       await tester.pumpWidget(app);
 
       await tester.pump(const Duration(seconds: 1));
-      final boardRect = tester.getRect(find.byType(cg.Board));
+      final boardRect = tester.getRect(find.byType(cg.Chessboard));
 
       await playMove(tester, boardRect, 'h5', 'h6');
 
       await tester.pump(const Duration(milliseconds: 500));
-      expect(find.byKey(const Key('h6-blackKing')), findsOneWidget);
+      expect(find.byKey(const Key('h6-blackking')), findsOneWidget);
     });
   });
 }


### PR DESCRIPTION
I think it makes sense to use the new `ChessboardEditor` widget here as well, since we can reuse the `onEditedSquare` callback to get notified when the user taps a square. With the normal `Chessboard` widget, this is currently not implemented, we only have callback when a (legal) move is made.

Haven't done any work on this yet, just opening the draft to let people know I'll start working on this next.