### PR TITLE
feat: coordinate trainer

### DIFF
--- a/lib/src/model/coordinate_training/coordinate_training_controller.dart
+++ b/lib/src/model/coordinate_training/coordinate_training_controller.dart
@@ -1,0 +1,110 @@
+import 'dart:async';
+import 'dart:math';
+
+import 'package:dartchess/dartchess.dart';
+import 'package:freezed_annotation/freezed_annotation.dart';
+import 'package:riverpod_annotation/riverpod_annotation.dart';
+
+part 'coordinate_training_controller.freezed.dart';
+part 'coordinate_training_controller.g.dart';
+
+enum Guess { correct, incorrect }
+
+@riverpod
+class CoordinateTrainingController extends _$CoordinateTrainingController {
+  final _random = Random(DateTime.now().millisecondsSinceEpoch);
+
+  final _stopwatch = Stopwatch();
+
+  Timer? _updateTimer;
+
+  @override
+  CoordinateTrainingState build() {
+    ref.onDispose(() {
+      _updateTimer?.cancel();
+    });
+    return const CoordinateTrainingState();
+  }
+
+  void startTraining(Duration? timeLimit) {
+    final currentCoord = _randomCoord();
+    state = state.copyWith(
+      currentCoord: currentCoord,
+      nextCoord: _randomCoord(previous: currentCoord),
+      score: 0,
+      timeLimit: timeLimit,
+      elapsed: Duration.zero,
+      lastGuess: null,
+    );
+
+    _updateTimer?.cancel();
+    _stopwatch.reset();
+    _stopwatch.start();
+    _updateTimer = Timer.periodic(const Duration(milliseconds: 100), (_) {
+      if (state.timeLimit != null && _stopwatch.elapsed > state.timeLimit!) {
+        _finishTraining();
+      } else {
+        state = state.copyWith(
+          elapsed: _stopwatch.elapsed,
+        );
+      }
+    });
+  }
+
+  void _finishTraining() {
+    // TODO save score in local storage here (and display high score and/or average score in UI)
+
+    stopTraining();
+  }
+
+  void stopTraining() {
+    _updateTimer?.cancel();
+    state = const CoordinateTrainingState();
+  }
+
+  /// Generate a random square that is not the same as the [previous] square
+  Square _randomCoord({Square? previous}) {
+    while (true) {
+      final square = Square.values[_random.nextInt(Square.values.length)];
+      if (square != previous) {
+        return square;
+      }
+    }
+  }
+
+  void guessCoordinate(Square coord) {
+    final correctGuess = coord == state.currentCoord;
+
+    if (correctGuess) {
+      state = state.copyWith(
+        currentCoord: state.nextCoord,
+        nextCoord: _randomCoord(previous: state.nextCoord),
+        score: state.score + 1,
+      );
+    }
+
+    state = state.copyWith(
+      lastGuess: correctGuess ? Guess.correct : Guess.incorrect,
+    );
+  }
+}
+
+@freezed
+class CoordinateTrainingState with _$CoordinateTrainingState {
+  const CoordinateTrainingState._();
+
+  const factory CoordinateTrainingState({
+    @Default(null) Square? currentCoord,
+    @Default(null) Square? nextCoord,
+    @Default(0) int score,
+    @Default(null) Duration? timeLimit,
+    @Default(null) Duration? elapsed,
+    @Default(null) Guess? lastGuess,
+  }) = _CoordinateTrainingState;
+
+  bool get trainingActive => elapsed != null;
+
+  double? get timeFractionElapsed => (elapsed != null && timeLimit != null)
+      ? elapsed!.inMilliseconds / timeLimit!.inMilliseconds
+      : null;
+}

--- a/lib/src/model/coordinate_training/coordinate_training_preferences.dart
+++ b/lib/src/model/coordinate_training/coordinate_training_preferences.dart
@@ -1,0 +1,136 @@
+import 'dart:convert';
+
+import 'package:flutter/material.dart';
+import 'package:freezed_annotation/freezed_annotation.dart';
+import 'package:lichess_mobile/src/db/shared_preferences.dart';
+import 'package:lichess_mobile/src/utils/l10n_context.dart';
+import 'package:riverpod_annotation/riverpod_annotation.dart';
+
+part 'coordinate_training_preferences.freezed.dart';
+part 'coordinate_training_preferences.g.dart';
+
+enum SideChoice {
+  white,
+  random,
+  black,
+}
+
+String sideChoiceL10n(BuildContext context, SideChoice side) {
+  switch (side) {
+    case SideChoice.white:
+      return context.l10n.white;
+    case SideChoice.black:
+      return context.l10n.black;
+    case SideChoice.random:
+      // TODO l10n
+      return 'Random';
+  }
+}
+
+enum TimeChoice {
+  thirtySeconds(Duration(seconds: 30)),
+  unlimited(null);
+
+  const TimeChoice(this.duration);
+
+  final Duration? duration;
+}
+
+// TODO l10n
+Widget timeChoiceL10n(BuildContext context, TimeChoice time) {
+  switch (time) {
+    case TimeChoice.thirtySeconds:
+      return const Text('30s');
+    case TimeChoice.unlimited:
+      return const Icon(Icons.all_inclusive);
+  }
+}
+
+enum TrainingMode {
+  findSquare,
+  nameSquare,
+}
+
+// TODO l10n
+String trainingModeL10n(BuildContext context, TrainingMode mode) {
+  switch (mode) {
+    case TrainingMode.findSquare:
+      return 'Find Square';
+    case TrainingMode.nameSquare:
+      return 'Name Square';
+  }
+}
+
+@Riverpod(keepAlive: true)
+class CoordinateTrainingPreferences extends _$CoordinateTrainingPreferences {
+  static const String prefKey = 'preferences.coordinate_training';
+
+  @override
+  CoordinateTrainingPrefs build() {
+    final prefs = ref.watch(sharedPreferencesProvider);
+    final stored = prefs.getString(prefKey);
+    return stored != null
+        ? CoordinateTrainingPrefs.fromJson(
+            jsonDecode(stored) as Map<String, dynamic>,
+          )
+        : CoordinateTrainingPrefs.defaults;
+  }
+
+  Future<void> setShowCoordinates(bool showCoordinates) {
+    return _save(state.copyWith(showCoordinates: showCoordinates));
+  }
+
+  Future<void> setShowPieces(bool showPieces) {
+    return _save(state.copyWith(showPieces: showPieces));
+  }
+
+  Future<void> setMode(TrainingMode mode) {
+    return _save(state.copyWith(mode: mode));
+  }
+
+  Future<void> setTimeChoice(TimeChoice timeChoice) {
+    return _save(state.copyWith(timeChoice: timeChoice));
+  }
+
+  Future<void> setSideChoice(SideChoice sideChoice) {
+    return _save(state.copyWith(sideChoice: sideChoice));
+  }
+
+  Future<void> _save(CoordinateTrainingPrefs newState) async {
+    final prefs = ref.read(sharedPreferencesProvider);
+    await prefs.setString(
+      prefKey,
+      jsonEncode(newState.toJson()),
+    );
+    state = newState;
+  }
+}
+
+@Freezed(fromJson: true, toJson: true)
+class CoordinateTrainingPrefs with _$CoordinateTrainingPrefs {
+  const CoordinateTrainingPrefs._();
+
+  const factory CoordinateTrainingPrefs({
+    required bool showCoordinates,
+    required bool showPieces,
+    required TrainingMode mode,
+    required TimeChoice timeChoice,
+    required SideChoice sideChoice,
+  }) = _CoordinateTrainingPrefs;
+
+  static const defaults = CoordinateTrainingPrefs(
+    showCoordinates: false,
+    showPieces: true,
+    mode: TrainingMode.findSquare,
+    timeChoice: TimeChoice.thirtySeconds,
+    sideChoice: SideChoice.random,
+  );
+
+  factory CoordinateTrainingPrefs.fromJson(Map<String, dynamic> json) {
+    try {
+      return _$CoordinateTrainingPrefsFromJson(json);
+    } catch (_) {
+      return defaults;
+    }
+  }
+}

--- a/lib/src/view/coordinate_training/coordinate_display.dart
+++ b/lib/src/view/coordinate_training/coordinate_display.dart
@@ -1,0 +1,135 @@
+import 'package:dartchess/dartchess.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:lichess_mobile/src/model/coordinate_training/coordinate_training_controller.dart';
+
+const Offset _kNextCoordFractionalTranslation = Offset(0.8, 0.3);
+const double _kNextCoordScale = 0.4;
+
+const double _kCurrCoordOpacity = 0.9;
+const double _kNextCoordOpacity = 0.7;
+
+class CoordinateDisplay extends ConsumerStatefulWidget {
+  const CoordinateDisplay({
+    required this.currentCoord,
+    required this.nextCoord,
+  });
+
+  final Square currentCoord;
+
+  final Square nextCoord;
+
+  @override
+  ConsumerState<ConsumerStatefulWidget> createState() =>
+      CoordinateDisplayState();
+}
+
+class CoordinateDisplayState extends ConsumerState<CoordinateDisplay>
+    with SingleTickerProviderStateMixin {
+  late final AnimationController _controller = AnimationController(
+    vsync: this,
+    duration: const Duration(milliseconds: 150),
+  )..value = 1.0;
+
+  late final Animation<double> _scaleAnimation = Tween<double>(
+    begin: _kNextCoordScale,
+    end: 1.0,
+  ).animate(
+    CurvedAnimation(parent: _controller, curve: Curves.linear),
+  );
+
+  late final Animation<Offset> _currCoordSlideInAnimation = Tween<Offset>(
+    begin: _kNextCoordFractionalTranslation,
+    end: Offset.zero,
+  ).animate(
+    CurvedAnimation(parent: _controller, curve: Curves.linear),
+  );
+
+  late final Animation<Offset> _nextCoordSlideInAnimation = Tween<Offset>(
+    begin: const Offset(0.5, 0),
+    end: Offset.zero,
+  ).animate(
+    CurvedAnimation(parent: _controller, curve: Curves.linear),
+  );
+
+  late final Animation<double> _currCoordOpacityAnimation = Tween<double>(
+    begin: _kNextCoordOpacity,
+    end: _kCurrCoordOpacity,
+  ).animate(
+    CurvedAnimation(parent: _controller, curve: Curves.linear),
+  );
+
+  late final Animation<double> _nextCoordFadeInAnimation =
+      Tween<double>(begin: 0.0, end: _kNextCoordOpacity)
+          .animate(CurvedAnimation(parent: _controller, curve: Curves.easeIn));
+
+  @override
+  Widget build(BuildContext context) {
+    final trainingState = ref.watch(coordinateTrainingControllerProvider);
+
+    final textStyle = DefaultTextStyle.of(context).style.copyWith(
+      fontSize: 110.0,
+      fontFamily: 'monospace',
+      fontWeight: FontWeight.bold,
+      fontFeatures: [const FontFeature.tabularFigures()],
+      shadows: const [
+        Shadow(
+          color: Colors.black,
+          offset: Offset(0, 5),
+          blurRadius: 40.0,
+        ),
+      ],
+    );
+
+    return IgnorePointer(
+      child: Stack(
+        children: [
+          FadeTransition(
+            opacity: _currCoordOpacityAnimation,
+            child: SlideTransition(
+              position: _currCoordSlideInAnimation,
+              child: ScaleTransition(
+                scale: _scaleAnimation,
+                child: Text(
+                  trainingState.currentCoord?.name ?? '',
+                  style: textStyle,
+                ),
+              ),
+            ),
+          ),
+          FadeTransition(
+            opacity: _nextCoordFadeInAnimation,
+            child: SlideTransition(
+              position: _nextCoordSlideInAnimation,
+              child: FractionalTranslation(
+                translation: _kNextCoordFractionalTranslation,
+                child: Transform.scale(
+                  scale: _kNextCoordScale,
+                  child: Text(
+                    trainingState.nextCoord?.name ?? '',
+                    style: textStyle,
+                  ),
+                ),
+              ),
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+
+  @override
+  void didUpdateWidget(covariant CoordinateDisplay oldWidget) {
+    super.didUpdateWidget(oldWidget);
+
+    if (oldWidget.nextCoord != widget.nextCoord) {
+      _controller.forward(from: 0.0);
+    }
+  }
+
+  @override
+  void dispose() {
+    _controller.dispose();
+    super.dispose();
+  }
+}

--- a/lib/src/view/coordinate_training/coordinate_training_screen.dart
+++ b/lib/src/view/coordinate_training/coordinate_training_screen.dart
@@ -1,0 +1,535 @@
+import 'dart:async';
+import 'dart:math';
+
+import 'package:chessground/chessground.dart';
+import 'package:dartchess/dartchess.dart';
+import 'package:fast_immutable_collections/fast_immutable_collections.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:lichess_mobile/src/constants.dart';
+import 'package:lichess_mobile/src/model/coordinate_training/coordinate_training_controller.dart';
+import 'package:lichess_mobile/src/model/coordinate_training/coordinate_training_preferences.dart';
+import 'package:lichess_mobile/src/model/settings/board_preferences.dart';
+import 'package:lichess_mobile/src/styles/lichess_colors.dart';
+import 'package:lichess_mobile/src/styles/styles.dart';
+import 'package:lichess_mobile/src/utils/l10n_context.dart';
+import 'package:lichess_mobile/src/utils/screen.dart';
+import 'package:lichess_mobile/src/view/coordinate_training/coordinate_display.dart';
+import 'package:lichess_mobile/src/widgets/adaptive_bottom_sheet.dart';
+import 'package:lichess_mobile/src/widgets/bottom_bar.dart';
+import 'package:lichess_mobile/src/widgets/bottom_bar_button.dart';
+import 'package:lichess_mobile/src/widgets/buttons.dart';
+import 'package:lichess_mobile/src/widgets/list.dart';
+import 'package:lichess_mobile/src/widgets/platform_alert_dialog.dart';
+import 'package:lichess_mobile/src/widgets/platform_scaffold.dart';
+import 'package:lichess_mobile/src/widgets/settings.dart';
+
+Future<void> _coordinateTrainingInfoDialogBuilder(BuildContext context) {
+  return showAdaptiveDialog(
+    context: context,
+    builder: (context) {
+      final content = SingleChildScrollView(
+        child: RichText(
+          text: TextSpan(
+            style: DefaultTextStyle.of(context).style,
+            children: const [
+              TextSpan(
+                text: '\n',
+              ),
+              // TODO add explanation here once l10n download from crowdin works again
+            ],
+          ),
+        ),
+      );
+
+      return PlatformAlertDialog(
+        title: Text(context.l10n.aboutX('Coordinate Training')),
+        content: content,
+        actions: [
+          PlatformDialogAction(
+            onPressed: () => Navigator.of(context).pop(),
+            child: Text(context.l10n.mobileOkButton),
+          ),
+        ],
+      );
+    },
+  );
+}
+
+class CoordinateTrainingScreen extends StatelessWidget {
+  const CoordinateTrainingScreen({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return const PlatformScaffold(
+      appBar: PlatformAppBar(
+        title: Text('Coordinate Training'), // TODO l10n once script works
+      ),
+      body: _Body(),
+    );
+  }
+}
+
+class _Body extends ConsumerStatefulWidget {
+  const _Body();
+
+  @override
+  ConsumerState<_Body> createState() => _BodyState();
+}
+
+class _BodyState extends ConsumerState<_Body> {
+  late Side orientation;
+
+  Square? highlightLastGuess;
+
+  Timer? highlightTimer;
+
+  void _setOrientation(SideChoice choice) {
+    setState(() {
+      orientation = switch (choice) {
+        SideChoice.white => Side.white,
+        SideChoice.black => Side.black,
+        SideChoice.random => Side.values[Random().nextInt(Side.values.length)],
+      };
+    });
+  }
+
+  @override
+  void initState() {
+    super.initState();
+    _setOrientation(ref.read(coordinateTrainingPreferencesProvider).sideChoice);
+  }
+
+  @override
+  void dispose() {
+    super.dispose();
+    highlightTimer?.cancel();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final trainingState = ref.watch(coordinateTrainingControllerProvider);
+    final trainingPrefs = ref.watch(coordinateTrainingPreferencesProvider);
+
+    final IMap<Square, SquareHighlight> squareHighlights =
+        <Square, SquareHighlight>{
+      if (trainingState.trainingActive)
+        if (trainingPrefs.mode == TrainingMode.findSquare) ...{
+          if (highlightLastGuess != null) ...{
+            highlightLastGuess!: SquareHighlight(
+              details: HighlightDetails(
+                solidColor: (trainingState.lastGuess == Guess.correct
+                        ? LichessColors.good
+                        : LichessColors.error)
+                    .withOpacity(
+                  0.5,
+                ),
+              ),
+            ),
+          },
+        } else ...{
+          trainingState.currentCoord!: SquareHighlight(
+            details: HighlightDetails(
+              solidColor: LichessColors.good.withOpacity(
+                0.5,
+              ),
+            ),
+          ),
+        },
+    }.lock;
+
+    return SafeArea(
+      child: Column(
+        children: [
+          Expanded(
+            child: LayoutBuilder(
+              builder: (context, constraints) {
+                final aspectRatio = constraints.biggest.aspectRatio;
+
+                final defaultBoardSize = constraints.biggest.shortestSide;
+                final isTablet = isTabletOrLarger(context);
+                final remainingHeight =
+                    constraints.maxHeight - defaultBoardSize;
+                final isSmallScreen =
+                    remainingHeight < kSmallRemainingHeightLeftBoardThreshold;
+                final boardSize = isTablet || isSmallScreen
+                    ? defaultBoardSize - kTabletBoardTableSidePadding * 2
+                    : defaultBoardSize;
+
+                final direction =
+                    aspectRatio > 1 ? Axis.horizontal : Axis.vertical;
+
+                return Flex(
+                  direction: direction,
+                  mainAxisAlignment: MainAxisAlignment.start,
+                  mainAxisSize: MainAxisSize.max,
+                  crossAxisAlignment: CrossAxisAlignment.center,
+                  children: [
+                    Column(
+                      children: [
+                        _TimeBar(
+                          maxWidth: boardSize,
+                          timeFractionElapsed:
+                              trainingState.timeFractionElapsed,
+                          color: trainingState.lastGuess == Guess.incorrect
+                              ? LichessColors.error
+                              : LichessColors.good,
+                        ),
+                        _TrainingBoard(
+                          boardSize: boardSize,
+                          isTablet: isTablet,
+                          orientation: orientation,
+                          squareHighlights: squareHighlights,
+                          onGuess: _onGuess,
+                        ),
+                      ],
+                    ),
+                    if (trainingState.trainingActive)
+                      Expanded(
+                        child: Column(
+                          mainAxisAlignment: MainAxisAlignment.spaceEvenly,
+                          children: [
+                            _Score(
+                              score: trainingState.score,
+                              size: boardSize / 8,
+                              color: trainingState.lastGuess == Guess.incorrect
+                                  ? LichessColors.error
+                                  : LichessColors.good,
+                            ),
+                            FatButton(
+                              semanticsLabel: 'Abort Training',
+                              onPressed: ref
+                                  .read(
+                                    coordinateTrainingControllerProvider
+                                        .notifier,
+                                  )
+                                  .stopTraining,
+                              child: const Text(
+                                'Abort Training',
+                                style: Styles.bold,
+                              ),
+                            ),
+                          ],
+                        ),
+                      )
+                    else
+                      _Settings(
+                        onSideChoiceSelected: _setOrientation,
+                      ),
+                  ],
+                );
+              },
+            ),
+          ),
+          BottomBar(
+            children: [
+              BottomBarButton(
+                label: context.l10n.menu,
+                onTap: () => showAdaptiveBottomSheet<void>(
+                  context: context,
+                  builder: (BuildContext context) =>
+                      const _CoordinateTrainingMenu(),
+                ),
+                icon: Icons.tune,
+              ),
+              BottomBarButton(
+                icon: Icons.info_outline,
+                label: context.l10n.aboutX('Coordinate Training'),
+                onTap: () => _coordinateTrainingInfoDialogBuilder(context),
+              ),
+            ],
+          ),
+        ],
+      ),
+    );
+  }
+
+  void _onGuess(Square square) {
+    ref
+        .read(coordinateTrainingControllerProvider.notifier)
+        .guessCoordinate(square);
+
+    setState(() {
+      highlightLastGuess = square;
+
+      highlightTimer?.cancel();
+      highlightTimer = Timer(const Duration(milliseconds: 200), () {
+        setState(() {
+          highlightLastGuess = null;
+        });
+      });
+    });
+  }
+}
+
+class _TimeBar extends StatelessWidget {
+  const _TimeBar({
+    required this.maxWidth,
+    required this.timeFractionElapsed,
+    required this.color,
+  });
+
+  final double maxWidth;
+  final double? timeFractionElapsed;
+  final Color color;
+
+  @override
+  Widget build(BuildContext context) {
+    return Align(
+      alignment: Alignment.center,
+      child: SizedBox(
+        width: maxWidth * (timeFractionElapsed ?? 0.0),
+        height: 15.0,
+        child: ColoredBox(
+          color: color,
+        ),
+      ),
+    );
+  }
+}
+
+class _CoordinateTrainingMenu extends ConsumerWidget {
+  const _CoordinateTrainingMenu();
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final trainingPrefs = ref.watch(coordinateTrainingPreferencesProvider);
+
+    return SafeArea(
+      child: Padding(
+        padding: const EdgeInsets.symmetric(vertical: 16.0, horizontal: 8.0),
+        child: SizedBox(
+          width: double.infinity,
+          child: Column(
+            mainAxisSize: MainAxisSize.min,
+            crossAxisAlignment: CrossAxisAlignment.center,
+            children: [
+              ListSection(
+                header: Text(
+                  context.l10n.preferencesDisplay,
+                  style: Styles.sectionTitle,
+                ),
+                children: [
+                  SwitchSettingTile(
+                    title: const Text('Show Coordinates'),
+                    value: trainingPrefs.showCoordinates,
+                    onChanged: ref
+                        .read(coordinateTrainingPreferencesProvider.notifier)
+                        .setShowCoordinates,
+                  ),
+                  SwitchSettingTile(
+                    title: const Text('Show Pieces'),
+                    value: trainingPrefs.showPieces,
+                    onChanged: ref
+                        .read(coordinateTrainingPreferencesProvider.notifier)
+                        .setShowPieces,
+                  ),
+                ],
+              ),
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+}
+
+class _Score extends StatelessWidget {
+  const _Score({
+    required this.size,
+    required this.color,
+    required this.score,
+  });
+
+  final int score;
+
+  final double size;
+
+  final Color color;
+
+  @override
+  Widget build(BuildContext context) {
+    return Padding(
+      padding: const EdgeInsets.only(
+        top: 10.0,
+        left: 10.0,
+        right: 10.0,
+      ),
+      child: Container(
+        decoration: BoxDecoration(
+          borderRadius: const BorderRadius.all(
+            Radius.circular(4.0),
+          ),
+          color: color,
+        ),
+        width: size,
+        height: size,
+        child: Center(
+          child: Text(
+            score.toString(),
+            style: Styles.bold.copyWith(
+              color: Colors.white,
+              fontSize: 24.0,
+            ),
+          ),
+        ),
+      ),
+    );
+  }
+}
+
+class _Settings extends ConsumerStatefulWidget {
+  const _Settings({
+    required this.onSideChoiceSelected,
+  });
+
+  final void Function(SideChoice) onSideChoiceSelected;
+
+  @override
+  ConsumerState<_Settings> createState() => _SettingsState();
+}
+
+class _SettingsState extends ConsumerState<_Settings> {
+  @override
+  Widget build(BuildContext context) {
+    final trainingPrefs = ref.watch(coordinateTrainingPreferencesProvider);
+
+    return Expanded(
+      child: Column(
+        mainAxisAlignment: MainAxisAlignment.start,
+        children: [
+          PlatformListTile(
+            title: Text(context.l10n.side),
+            trailing: Padding(
+              padding: Styles.horizontalBodyPadding,
+              child: Wrap(
+                spacing: 8.0,
+                children: SideChoice.values.map((choice) {
+                  return ChoiceChip(
+                    label: Text(sideChoiceL10n(context, choice)),
+                    selected: trainingPrefs.sideChoice == choice,
+                    showCheckmark: false,
+                    onSelected: (selected) {
+                      widget.onSideChoiceSelected(choice);
+                      ref
+                          .read(coordinateTrainingPreferencesProvider.notifier)
+                          .setSideChoice(choice);
+                    },
+                  );
+                }).toList(),
+              ),
+            ),
+          ),
+          PlatformListTile(
+            title: Text(context.l10n.time),
+            trailing: Padding(
+              padding: Styles.horizontalBodyPadding,
+              child: Wrap(
+                spacing: 8.0,
+                children: TimeChoice.values.map((choice) {
+                  return ChoiceChip(
+                    label: timeChoiceL10n(context, choice),
+                    selected: trainingPrefs.timeChoice == choice,
+                    showCheckmark: false,
+                    onSelected: (selected) {
+                      if (selected) {
+                        ref
+                            .read(
+                              coordinateTrainingPreferencesProvider.notifier,
+                            )
+                            .setTimeChoice(choice);
+                      }
+                    },
+                  );
+                }).toList(),
+              ),
+            ),
+          ),
+          FatButton(
+            semanticsLabel: 'Start Training',
+            onPressed: () => ref
+                .read(coordinateTrainingControllerProvider.notifier)
+                .startTraining(trainingPrefs.timeChoice.duration),
+            child: const Text(
+              // TODO l10n once script works
+              'Start Training',
+              style: Styles.bold,
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+class _TrainingBoard extends ConsumerStatefulWidget {
+  const _TrainingBoard({
+    required this.boardSize,
+    required this.isTablet,
+    required this.orientation,
+    required this.onGuess,
+    required this.squareHighlights,
+  });
+
+  final double boardSize;
+
+  final bool isTablet;
+
+  final Side orientation;
+
+  final void Function(Square) onGuess;
+
+  final IMap<Square, SquareHighlight> squareHighlights;
+
+  @override
+  ConsumerState<_TrainingBoard> createState() => _TrainingBoardState();
+}
+
+class _TrainingBoardState extends ConsumerState<_TrainingBoard> {
+  @override
+  Widget build(BuildContext context) {
+    final boardPrefs = ref.watch(boardPreferencesProvider);
+    final trainingPrefs = ref.watch(coordinateTrainingPreferencesProvider);
+    final trainingState = ref.watch(coordinateTrainingControllerProvider);
+
+    return Column(
+      children: [
+        Stack(
+          alignment: Alignment.center,
+          children: [
+            ChessboardEditor(
+              size: widget.boardSize,
+              pieces: readFen(
+                trainingPrefs.showPieces ? kInitialFEN : kEmptyFEN,
+              ),
+              squareHighlights: widget.squareHighlights,
+              orientation: widget.orientation,
+              settings: ChessboardEditorSettings(
+                pieceAssets: boardPrefs.pieceSet.assets,
+                colorScheme: boardPrefs.boardTheme.colors,
+                enableCoordinates: trainingPrefs.showCoordinates,
+                borderRadius: widget.isTablet
+                    ? const BorderRadius.all(Radius.circular(4.0))
+                    : BorderRadius.zero,
+                boxShadow: widget.isTablet ? boardShadows : const <BoxShadow>[],
+              ),
+              pointerMode: EditorPointerMode.edit,
+              onEditedSquare: (square) {
+                if (trainingState.trainingActive &&
+                    trainingPrefs.mode == TrainingMode.findSquare) {
+                  widget.onGuess(square);
+                }
+              },
+            ),
+            if (trainingState.trainingActive &&
+                trainingPrefs.mode == TrainingMode.findSquare)
+              CoordinateDisplay(
+                currentCoord: trainingState.currentCoord!,
+                nextCoord: trainingState.nextCoord!,
+              ),
+          ],
+        ),
+      ],
+    );
+  }
+}

--- a/test/view/coordinate_training/coordinate_training_screen_test.dart
+++ b/test/view/coordinate_training/coordinate_training_screen_test.dart
@@ -1,0 +1,157 @@
+import 'package:chessground/chessground.dart';
+import 'package:dartchess/dartchess.dart';
+import 'package:flutter/widgets.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:lichess_mobile/src/model/coordinate_training/coordinate_training_controller.dart';
+import 'package:lichess_mobile/src/model/coordinate_training/coordinate_training_preferences.dart';
+import 'package:lichess_mobile/src/view/coordinate_training/coordinate_training_screen.dart';
+
+import '../../test_app.dart';
+
+void main() {
+  group('Coordinate Training', () {
+    testWidgets('Initial state when started in FindSquare mode',
+        (tester) async {
+      final app = await buildTestApp(
+        tester,
+        home: const CoordinateTrainingScreen(),
+      );
+      await tester.pumpWidget(app);
+
+      await tester.tap(find.text('Start Training'));
+      await tester.pumpAndSettle();
+
+      final container = ProviderScope.containerOf(
+        tester.element(find.byType(ChessboardEditor)),
+      );
+      final controllerProvider = coordinateTrainingControllerProvider;
+
+      final trainingPrefsNotifier = container.read(
+        coordinateTrainingPreferencesProvider.notifier,
+      );
+      trainingPrefsNotifier.setMode(TrainingMode.findSquare);
+      // This way all squares can be found via find.byKey(ValueKey('${square.name}-empty'))
+      trainingPrefsNotifier.setShowPieces(false);
+      await tester.pumpAndSettle();
+
+      expect(container.read(controllerProvider).score, 0);
+      expect(container.read(controllerProvider).currentCoord, isNotNull);
+      expect(container.read(controllerProvider).nextCoord, isNotNull);
+      expect(container.read(controllerProvider).trainingActive, true);
+
+      // Current and next coordinate prompt should be displayed
+      expect(
+        find.text(container.read(controllerProvider).currentCoord!.name),
+        findsOneWidget,
+      );
+      expect(
+        find.text(container.read(controllerProvider).nextCoord!.name),
+        findsOneWidget,
+      );
+    });
+
+    testWidgets('Tap wrong square', (tester) async {
+      final app = await buildTestApp(
+        tester,
+        home: const CoordinateTrainingScreen(),
+      );
+      await tester.pumpWidget(app);
+
+      await tester.tap(find.text('Start Training'));
+      await tester.pumpAndSettle();
+
+      final container = ProviderScope.containerOf(
+        tester.element(find.byType(ChessboardEditor)),
+      );
+      final controllerProvider = coordinateTrainingControllerProvider;
+
+      final trainingPrefsNotifier = container.read(
+        coordinateTrainingPreferencesProvider.notifier,
+      );
+      trainingPrefsNotifier.setMode(TrainingMode.findSquare);
+      // This way all squares can be found via find.byKey(ValueKey('${square.name}-empty'))
+      trainingPrefsNotifier.setShowPieces(false);
+      await tester.pumpAndSettle();
+
+      final currentCoord = container.read(controllerProvider).currentCoord;
+      final nextCoord = container.read(controllerProvider).nextCoord;
+
+      final wrongCoord =
+          Square.values[(currentCoord! + 1) % Square.values.length];
+
+      await tester.tap(find.byKey(ValueKey('${wrongCoord.name}-empty')));
+      await tester.pump();
+
+      expect(container.read(controllerProvider).score, 0);
+      expect(container.read(controllerProvider).currentCoord, currentCoord);
+      expect(container.read(controllerProvider).nextCoord, nextCoord);
+      expect(container.read(controllerProvider).trainingActive, true);
+
+      expect(
+        find.byKey(ValueKey('${wrongCoord.name}-highlight')),
+        findsOneWidget,
+      );
+
+      await tester.pump(const Duration(milliseconds: 300));
+      expect(
+        find.byKey(ValueKey('${wrongCoord.name}-highlight')),
+        findsNothing,
+      );
+    });
+
+    testWidgets('Tap correct square', (tester) async {
+      final app = await buildTestApp(
+        tester,
+        home: const CoordinateTrainingScreen(),
+      );
+      await tester.pumpWidget(app);
+
+      await tester.tap(find.text('Start Training'));
+      await tester.pumpAndSettle();
+
+      final container = ProviderScope.containerOf(
+        tester.element(find.byType(ChessboardEditor)),
+      );
+      final controllerProvider = coordinateTrainingControllerProvider;
+
+      final trainingPrefsNotifier = container.read(
+        coordinateTrainingPreferencesProvider.notifier,
+      );
+      trainingPrefsNotifier.setMode(TrainingMode.findSquare);
+      // This way all squares can be found via find.byKey(ValueKey('${square.name}-empty'))
+      trainingPrefsNotifier.setShowPieces(false);
+      await tester.pumpAndSettle();
+
+      final currentCoord = container.read(controllerProvider).currentCoord;
+      final nextCoord = container.read(controllerProvider).nextCoord;
+
+      await tester.tap(find.byKey(ValueKey('${currentCoord!.name}-empty')));
+      await tester.pump();
+
+      expect(
+        find.byKey(ValueKey('${currentCoord.name}-highlight')),
+        findsOneWidget,
+      );
+
+      expect(container.read(controllerProvider).score, 1);
+      expect(container.read(controllerProvider).currentCoord, nextCoord);
+      expect(container.read(controllerProvider).trainingActive, true);
+
+      await tester.pumpAndSettle(const Duration(milliseconds: 300));
+      expect(
+        find.byKey(ValueKey('${currentCoord.name}-highlight')),
+        findsNothing,
+      );
+
+      expect(
+        find.text(container.read(controllerProvider).currentCoord!.name),
+        findsOneWidget,
+      );
+      expect(
+        find.text(container.read(controllerProvider).nextCoord!.name),
+        findsOneWidget,
+      );
+    });
+  });
+}


### PR DESCRIPTION
I think it makes sense to use the new ChessboardEditor widget here as well, since we can reuse the onEditedSquare callback to get notified when the user taps a square. With the normal Chessboard widget, this is currently not implemented, we only have callback when a (legal) move is made.

Haven't done any work on this yet, just opening the draft to let people know I'll start working on this next.
