### PR TITLE
Suggestion: Draw clock edge to edge

### DIFF
--- a/lib/src/view/clock/clock_screen.dart
+++ b/lib/src/view/clock/clock_screen.dart
@@ -28,25 +28,23 @@ class _Body extends ConsumerWidget {
   Widget build(BuildContext context, WidgetRef ref) {
     final state = ref.watch(clockControllerProvider);
 
-    return SafeArea(
-      child: Column(
-        crossAxisAlignment: CrossAxisAlignment.stretch,
-        children: [
-          Expanded(
-            child: ClockTile(
-              playerType: ClockPlayerType.top,
-              clockState: state,
-            ),
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.stretch,
+      children: [
+        Expanded(
+          child: ClockTile(
+            playerType: ClockPlayerType.top,
+            clockState: state,
           ),
-          const ClockSettings(),
-          Expanded(
-            child: ClockTile(
-              playerType: ClockPlayerType.bottom,
-              clockState: state,
-            ),
+        ),
+        const ClockSettings(),
+        Expanded(
+          child: ClockTile(
+            playerType: ClockPlayerType.bottom,
+            clockState: state,
           ),
-        ],
-      ),
+        ),
+      ],
     );
   }
 }


### PR DESCRIPTION
This is just a suggestion but I think drawing edge to edge on the clock screen makes things look nicer on both Android and iOS.

<details>
  <summary>iOS Screenshots</summary>

  | Before  | After |
  | ------------- | ------------- |
  |![ios_before](https://github.com/user-attachments/assets/1e97c0b2-4403-4cb7-abbb-d3a49fefb00a)  | ![ios_after](https://github.com/user-attachments/assets/41f54978-ef78-47fd-ab51-65d2baa3d3db)
</details>

<details>
  <summary>Android Screenshots</summary>

  | Before  | After |
  | ------------- | ------------- |
  | ![android_before](https://github.com/user-attachments/assets/4f0f9d51-d46f-485e-80ba-0c908eaa6e49) | ![android_after](https://github.com/user-attachments/assets/6ff58f63-1800-43ef-92fc-59cf6e286953)
</details>