### PR TITLE
fix: ignore pointer events when editing widgets

### DIFF
--- a/lib/src/view/home/home_tab_screen.dart
+++ b/lib/src/view/home/home_tab_screen.dart
@@ -372,7 +372,12 @@ class _EditableWidget extends ConsumerWidget {
                   },
                 ),
               ),
-              Expanded(child: child),
+              Expanded(
+                child: IgnorePointer(
+                  ignoring: isEditing,
+                  child: child,
+                ),
+              ),
             ],
           )
         : isEnabled


### PR DESCRIPTION
Closes #915

[editing.webm](https://github.com/user-attachments/assets/d781a7d8-1fa1-4fc7-9f08-bb7e43924f6a)
