### PR TITLE
refactor: add common widget for BottomBar

### DIFF
--- a/lib/src/view/analysis/analysis_screen.dart
+++ b/lib/src/view/analysis/analysis_screen.dart
@@ -33,6 +33,7 @@ import 'package:lichess_mobile/src/view/engine/engine_gauge.dart';
 import 'package:lichess_mobile/src/view/opening_explorer/opening_explorer_screen.dart';
 import 'package:lichess_mobile/src/widgets/adaptive_action_sheet.dart';
 import 'package:lichess_mobile/src/widgets/adaptive_bottom_sheet.dart';
+import 'package:lichess_mobile/src/widgets/bottom_bar.dart';
 import 'package:lichess_mobile/src/widgets/bottom_bar_button.dart';
 import 'package:lichess_mobile/src/widgets/buttons.dart';
 import 'package:lichess_mobile/src/widgets/feedback.dart';
@@ -590,81 +591,57 @@ class _BottomBar extends ConsumerWidget {
     final canShowGameSummary =
         ref.watch(ctrlProvider.select((value) => value.canShowGameSummary));
 
-    return Container(
-      color: Theme.of(context).platform == TargetPlatform.iOS
-          ? CupertinoTheme.of(context).barBackgroundColor
-          : Theme.of(context).bottomAppBarTheme.color,
-      child: SafeArea(
-        top: false,
-        child: SizedBox(
-          height: kBottomBarHeight,
-          child: Row(
-            mainAxisAlignment: MainAxisAlignment.spaceAround,
-            children: [
-              Expanded(
-                child: BottomBarButton(
-                  label: context.l10n.menu,
-                  onTap: () {
-                    _showAnalysisMenu(context, ref);
-                  },
-                  icon: Icons.menu,
-                ),
-              ),
-              if (canShowGameSummary)
-                Expanded(
-                  child: BottomBarButton(
-                    label: displayMode == DisplayMode.summary
-                        ? 'Moves'
-                        : 'Summary',
-                    onTap: () {
-                      ref.read(ctrlProvider.notifier).toggleDisplayMode();
-                    },
-                    icon: displayMode == DisplayMode.summary
-                        ? LichessIcons.flow_cascade
-                        : Icons.area_chart,
-                  ),
-                ),
-              Expanded(
-                child: BottomBarButton(
-                  label: context.l10n.openingExplorer,
-                  onTap: () => pushPlatformRoute(
-                    context,
-                    builder: (_) => OpeningExplorerScreen(
-                      pgn: pgn,
-                      options: options,
-                    ),
-                  ),
-                  icon: Icons.explore,
-                ),
-              ),
-              Expanded(
-                child: RepeatButton(
-                  onLongPress: canGoBack ? () => _moveBackward(ref) : null,
-                  child: BottomBarButton(
-                    key: const ValueKey('goto-previous'),
-                    onTap: canGoBack ? () => _moveBackward(ref) : null,
-                    label: 'Previous',
-                    icon: CupertinoIcons.chevron_back,
-                    showTooltip: false,
-                  ),
-                ),
-              ),
-              Expanded(
-                child: RepeatButton(
-                  onLongPress: canGoNext ? () => _moveForward(ref) : null,
-                  child: BottomBarButton(
-                    key: const ValueKey('goto-next'),
-                    icon: CupertinoIcons.chevron_forward,
-                    label: context.l10n.next,
-                    onTap: canGoNext ? () => _moveForward(ref) : null,
-                    showTooltip: false,
-                  ),
-                ),
-              ),
-            ],
+    return BottomBar(
+      children: [
+        BottomBarButton(
+          label: context.l10n.menu,
+          onTap: () {
+            _showAnalysisMenu(context, ref);
+          },
+          icon: Icons.menu,
+        ),
+        if (canShowGameSummary)
+          BottomBarButton(
+            label: displayMode == DisplayMode.summary ? 'Moves' : 'Summary',
+            onTap: () {
+              ref.read(ctrlProvider.notifier).toggleDisplayMode();
+            },
+            icon: displayMode == DisplayMode.summary
+                ? LichessIcons.flow_cascade
+                : Icons.area_chart,
+          ),
+        BottomBarButton(
+          label: context.l10n.openingExplorer,
+          onTap: () => pushPlatformRoute(
+            context,
+            builder: (_) => OpeningExplorerScreen(
+              pgn: pgn,
+              options: options,
+            ),
+          ),
+          icon: Icons.explore,
+        ),
+        RepeatButton(
+          onLongPress: canGoBack ? () => _moveBackward(ref) : null,
+          child: BottomBarButton(
+            key: const ValueKey('goto-previous'),
+            onTap: canGoBack ? () => _moveBackward(ref) : null,
+            label: 'Previous',
+            icon: CupertinoIcons.chevron_back,
+            showTooltip: false,
           ),
         ),
-      ),
+        RepeatButton(
+          onLongPress: canGoNext ? () => _moveForward(ref) : null,
+          child: BottomBarButton(
+            key: const ValueKey('goto-next'),
+            icon: CupertinoIcons.chevron_forward,
+            label: context.l10n.next,
+            onTap: canGoNext ? () => _moveForward(ref) : null,
+            showTooltip: false,
+          ),
+        ),
+      ],
     );
   }
 

--- a/lib/src/view/board_editor/board_editor_screen.dart
+++ b/lib/src/view/board_editor/board_editor_screen.dart
@@ -16,6 +16,7 @@ import 'package:lichess_mobile/src/utils/share.dart';
 import 'package:lichess_mobile/src/view/analysis/analysis_screen.dart';
 import 'package:lichess_mobile/src/view/board_editor/board_editor_menu.dart';
 import 'package:lichess_mobile/src/widgets/adaptive_bottom_sheet.dart';
+import 'package:lichess_mobile/src/widgets/bottom_bar.dart';
 import 'package:lichess_mobile/src/widgets/bottom_bar_button.dart';
 import 'package:lichess_mobile/src/widgets/platform.dart';
 
@@ -318,84 +319,59 @@ class _BottomBar extends ConsumerWidget {
   Widget build(BuildContext context, WidgetRef ref) {
     final editorState = ref.watch(boardEditorControllerProvider(initialFen));
 
-    return Container(
-      color: Theme.of(context).platform == TargetPlatform.iOS
-          ? CupertinoDynamicColor.resolve(
-              CupertinoColors.tertiarySystemGroupedBackground,
-              context,
-            )
-          : Theme.of(context).bottomAppBarTheme.color,
-      child: SafeArea(
-        top: false,
-        child: SizedBox(
-          height: kBottomBarHeight,
-          child: Row(
-            mainAxisAlignment: MainAxisAlignment.spaceAround,
-            children: [
-              Expanded(
-                child: BottomBarButton(
-                  label: context.l10n.menu,
-                  onTap: () => showAdaptiveBottomSheet<void>(
-                    context: context,
-                    builder: (BuildContext context) => BoardEditorMenu(
-                      initialFen: initialFen,
-                    ),
-                  ),
-                  icon: Icons.tune,
-                ),
-              ),
-              Expanded(
-                child: BottomBarButton(
-                  key: const Key('flip-button'),
-                  label: context.l10n.flipBoard,
-                  onTap: ref
-                      .read(boardEditorControllerProvider(initialFen).notifier)
-                      .flipBoard,
-                  icon: CupertinoIcons.arrow_2_squarepath,
-                ),
-              ),
-              Expanded(
-                child: BottomBarButton(
-                  label: context.l10n.analysis,
-                  key: const Key('analysis-board-button'),
-                  onTap: editorState.pgn != null
-                      ? () {
-                          pushPlatformRoute(
-                            context,
-                            rootNavigator: true,
-                            builder: (context) => AnalysisScreen(
-                              pgnOrId: editorState.pgn!,
-                              options: AnalysisOptions(
-                                isLocalEvaluationAllowed: true,
-                                variant: Variant.fromPosition,
-                                orientation: editorState.orientation,
-                                id: standaloneAnalysisId,
-                              ),
-                            ),
-                          );
-                        }
-                      : null,
-                  icon: Icons.biotech,
-                ),
-              ),
-              Expanded(
-                child: BottomBarButton(
-                  label: context.l10n.mobileSharePositionAsFEN,
-                  onTap: () => launchShareDialog(
-                    context,
-                    text: editorState.fen,
-                  ),
-                  icon: Theme.of(context).platform == TargetPlatform.iOS
-                      ? CupertinoIcons.share
-                      : Icons.share,
-                ),
-              ),
-              const SizedBox(height: 26.0),
-              const SizedBox(height: 20.0),
-            ],
+    return BottomBar(
+      children: [
+        BottomBarButton(
+          label: context.l10n.menu,
+          onTap: () => showAdaptiveBottomSheet<void>(
+            context: context,
+            builder: (BuildContext context) => BoardEditorMenu(
+              initialFen: initialFen,
+            ),
           ),
+          icon: Icons.tune,
         ),
-      ),
+        BottomBarButton(
+          key: const Key('flip-button'),
+          label: context.l10n.flipBoard,
+          onTap: ref
+              .read(boardEditorControllerProvider(initialFen).notifier)
+              .flipBoard,
+          icon: CupertinoIcons.arrow_2_squarepath,
+        ),
+        BottomBarButton(
+          label: context.l10n.analysis,
+          key: const Key('analysis-board-button'),
+          onTap: editorState.pgn != null
+              ? () {
+                  pushPlatformRoute(
+                    context,
+                    rootNavigator: true,
+                    builder: (context) => AnalysisScreen(
+                      pgnOrId: editorState.pgn!,
+                      options: AnalysisOptions(
+                        isLocalEvaluationAllowed: true,
+                        variant: Variant.fromPosition,
+                        orientation: editorState.orientation,
+                        id: standaloneAnalysisId,
+                      ),
+                    ),
+                  );
+                }
+              : null,
+          icon: Icons.biotech,
+        ),
+        BottomBarButton(
+          label: context.l10n.mobileSharePositionAsFEN,
+          onTap: () => launchShareDialog(
+            context,
+            text: editorState.fen,
+          ),
+          icon: Theme.of(context).platform == TargetPlatform.iOS
+              ? CupertinoIcons.share
+              : Icons.share,
+        ),
+      ],
     );
   }
 }

--- a/lib/src/view/correspondence/offline_correspondence_game_screen.dart
+++ b/lib/src/view/correspondence/offline_correspondence_game_screen.dart
@@ -4,7 +4,6 @@ import 'package:dartchess/dartchess.dart';
 import 'package:flutter/cupertino.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
-import 'package:lichess_mobile/src/constants.dart';
 import 'package:lichess_mobile/src/model/analysis/analysis_controller.dart';
 import 'package:lichess_mobile/src/model/common/chess.dart';
 import 'package:lichess_mobile/src/model/common/service/move_feedback.dart';
@@ -22,6 +21,7 @@ import 'package:lichess_mobile/src/view/game/correspondence_clock_widget.dart';
 import 'package:lichess_mobile/src/view/game/game_player.dart';
 import 'package:lichess_mobile/src/widgets/adaptive_action_sheet.dart';
 import 'package:lichess_mobile/src/widgets/board_table.dart';
+import 'package:lichess_mobile/src/widgets/bottom_bar.dart';
 import 'package:lichess_mobile/src/widgets/bottom_bar_button.dart';
 import 'package:lichess_mobile/src/widgets/buttons.dart';
 import 'package:lichess_mobile/src/widgets/platform.dart';
@@ -257,115 +257,92 @@ class _BodyState extends ConsumerState<_Body> {
             ),
           ),
         ),
-        Container(
-          color: Theme.of(context).platform == TargetPlatform.iOS
-              ? CupertinoTheme.of(context).barBackgroundColor
-              : Theme.of(context).bottomAppBarTheme.color,
-          child: SafeArea(
-            top: false,
-            child: SizedBox(
-              height: kBottomBarHeight,
-              child: Row(
-                mainAxisAlignment: MainAxisAlignment.spaceAround,
-                children: [
-                  Expanded(
-                    child: BottomBarButton(
-                      label: context.l10n.flipBoard,
-                      onTap: () {
-                        setState(() {
-                          isBoardTurned = !isBoardTurned;
-                        });
-                      },
-                      icon: CupertinoIcons.arrow_2_squarepath,
+        BottomBar(
+          children: [
+            BottomBarButton(
+              label: context.l10n.flipBoard,
+              onTap: () {
+                setState(() {
+                  isBoardTurned = !isBoardTurned;
+                });
+              },
+              icon: CupertinoIcons.arrow_2_squarepath,
+            ),
+            BottomBarButton(
+              label: context.l10n.analysis,
+              onTap: () {
+                pushPlatformRoute(
+                  context,
+                  builder: (_) => AnalysisScreen(
+                    pgnOrId: game.makePgn(),
+                    options: AnalysisOptions(
+                      isLocalEvaluationAllowed: false,
+                      variant: game.variant,
+                      initialMoveCursor: stepCursor,
+                      orientation: game.youAre,
+                      id: game.id,
+                      division: game.meta.division,
                     ),
+                    title: context.l10n.analysis,
                   ),
-                  Expanded(
-                    child: BottomBarButton(
-                      label: context.l10n.analysis,
-                      onTap: () {
-                        pushPlatformRoute(
-                          context,
-                          builder: (_) => AnalysisScreen(
-                            pgnOrId: game.makePgn(),
-                            options: AnalysisOptions(
-                              isLocalEvaluationAllowed: false,
-                              variant: game.variant,
-                              initialMoveCursor: stepCursor,
-                              orientation: game.youAre,
-                              id: game.id,
-                              division: game.meta.division,
-                            ),
-                            title: context.l10n.analysis,
-                          ),
-                        );
-                      },
-                      icon: Icons.biotech,
-                    ),
-                  ),
-                  Expanded(
-                    child: BottomBarButton(
-                      label: 'Go to the next game',
-                      icon: Icons.skip_next,
-                      onTap: offlineOngoingGames.maybeWhen(
-                        data: (games) {
-                          final nextTurn = games
-                              .whereNot((g) => g.$2.id == game.id)
-                              .firstWhereOrNull((g) => g.$2.isPlayerTurn);
-                          return nextTurn != null
-                              ? () {
-                                  widget.onGameChanged(nextTurn);
-                                }
-                              : null;
-                        },
-                        orElse: () => null,
-                      ),
-                    ),
-                  ),
-                  Expanded(
-                    child: BottomBarButton(
-                      label: context.l10n.mobileCorrespondenceClearSavedMove,
-                      onTap: game.registeredMoveAtPgn != null
-                          ? () {
-                              showConfirmDialog<void>(
-                                context,
-                                title: Text(
-                                  context
-                                      .l10n.mobileCorrespondenceClearSavedMove,
-                                ),
-                                isDestructiveAction: true,
-                                onConfirm: (_) => deleteRegisteredMove(),
-                              );
-                            }
-                          : null,
-                      icon: Icons.save,
-                    ),
-                  ),
-                  Expanded(
-                    child: RepeatButton(
-                      onLongPress: canGoBackward ? () => moveBackward() : null,
-                      child: BottomBarButton(
-                        onTap: canGoBackward ? () => moveBackward() : null,
-                        label: 'Previous',
-                        icon: CupertinoIcons.chevron_back,
-                        showTooltip: false,
-                      ),
-                    ),
-                  ),
-                  Expanded(
-                    child: RepeatButton(
-                      onLongPress: canGoForward ? () => moveForward() : null,
-                      child: BottomBarButton(
-                        onTap: canGoForward ? () => moveForward() : null,
-                        label: context.l10n.next,
-                        icon: CupertinoIcons.chevron_forward,
-                        showTooltip: false,
-                      ),
-                    ),
-                  ),
-                ],
+                );
+              },
+              icon: Icons.biotech,
+            ),
+            BottomBarButton(
+              label: 'Go to the next game',
+              icon: Icons.skip_next,
+              onTap: offlineOngoingGames.maybeWhen(
+                data: (games) {
+                  final nextTurn = games
+                      .whereNot((g) => g.$2.id == game.id)
+                      .firstWhereOrNull((g) => g.$2.isPlayerTurn);
+                  return nextTurn != null
+                      ? () {
+                          widget.onGameChanged(nextTurn);
+                        }
+                      : null;
+                },
+                orElse: () => null,
               ),
             ),
-          ),
+            BottomBarButton(
+              label: context.l10n.mobileCorrespondenceClearSavedMove,
+              onTap: game.registeredMoveAtPgn != null
+                  ? () {
+                      showConfirmDialog<void>(
+                        context,
+                        title: Text(
+                          context.l10n.mobileCorrespondenceClearSavedMove,
+                        ),
+                        isDestructiveAction: true,
+                        onConfirm: (_) => deleteRegisteredMove(),
+                      );
+                    }
+                  : null,
+              icon: Icons.save,
+            ),
+            RepeatButton(
+              onLongPress: canGoBackward ? () => moveBackward() : null,
+              child: BottomBarButton(
+                onTap: canGoBackward ? () => moveBackward() : null,
+                label: 'Previous',
+                icon: CupertinoIcons.chevron_back,
+                showTooltip: false,
+              ),
+            ),
+            Expanded(
+              child: RepeatButton(
+                onLongPress: canGoForward ? () => moveForward() : null,
+                child: BottomBarButton(
+                  onTap: canGoForward ? () => moveForward() : null,
+                  label: context.l10n.next,
+                  icon: CupertinoIcons.chevron_forward,
+                  showTooltip: false,
+                ),
+              ),
+            ),
+          ],
         ),
       ],
     );

--- a/lib/src/view/game/archived_game_screen.dart
+++ b/lib/src/view/game/archived_game_screen.dart
@@ -3,7 +3,6 @@ import 'package:dartchess/dartchess.dart';
 import 'package:flutter/cupertino.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
-import 'package:lichess_mobile/src/constants.dart';
 import 'package:lichess_mobile/src/model/analysis/analysis_controller.dart';
 import 'package:lichess_mobile/src/model/game/archived_game.dart';
 import 'package:lichess_mobile/src/styles/styles.dart';
@@ -16,6 +15,7 @@ import 'package:lichess_mobile/src/view/game/game_result_dialog.dart';
 import 'package:lichess_mobile/src/view/settings/toggle_sound_button.dart';
 import 'package:lichess_mobile/src/widgets/adaptive_action_sheet.dart';
 import 'package:lichess_mobile/src/widgets/board_table.dart';
+import 'package:lichess_mobile/src/widgets/bottom_bar.dart';
 import 'package:lichess_mobile/src/widgets/bottom_bar_button.dart';
 import 'package:lichess_mobile/src/widgets/buttons.dart';
 import 'package:lichess_mobile/src/widgets/countdown_clock.dart';
@@ -240,109 +240,89 @@ class _BottomBar extends ConsumerWidget {
     final canGoBackward = ref.watch(canGoBackwardProvider(gameData.id));
     final gameCursor = ref.watch(gameCursorProvider(gameData.id));
 
-    return Container(
-      color: Theme.of(context).platform == TargetPlatform.iOS
-          ? null
-          : Theme.of(context).bottomAppBarTheme.color,
-      child: SafeArea(
-        top: false,
-        child: SizedBox(
-          height: kBottomBarHeight,
-          child: Row(
-            children: [
-              Expanded(
-                child: BottomBarButton(
-                  label: context.l10n.menu,
-                  onTap: () {
-                    _showGameMenu(context, ref);
-                  },
-                  icon: Icons.menu,
-                ),
-              ),
-              gameCursor.when(
-                data: (data) {
-                  return Expanded(
-                    child: BottomBarButton(
-                      label: context.l10n.mobileShowResult,
-                      icon: Icons.info_outline,
-                      onTap: () {
-                        showAdaptiveDialog<void>(
-                          context: context,
-                          builder: (context) =>
-                              ArchivedGameResultDialog(game: data.$1),
-                          barrierDismissible: true,
-                        );
-                      },
-                    ),
+    return BottomBar(
+      children: [
+        BottomBarButton(
+          label: context.l10n.menu,
+          onTap: () {
+            _showGameMenu(context, ref);
+          },
+          icon: Icons.menu,
+        ),
+        gameCursor.when(
+          data: (data) {
+            return Expanded(
+              child: BottomBarButton(
+                label: context.l10n.mobileShowResult,
+                icon: Icons.info_outline,
+                onTap: () {
+                  showAdaptiveDialog<void>(
+                    context: context,
+                    builder: (context) =>
+                        ArchivedGameResultDialog(game: data.$1),
+                    barrierDismissible: true,
                   );
                 },
-                loading: () => const SizedBox.shrink(),
-                error: (_, __) => const SizedBox.shrink(),
               ),
-              Expanded(
-                child: BottomBarButton(
-                  label: context.l10n.gameAnalysis,
-                  onTap: ref.read(gameCursorProvider(gameData.id)).hasValue
-                      ? () {
-                          final (game, cursor) = ref
-                              .read(
-                                gameCursorProvider(gameData.id),
-                              )
-                              .requireValue;
+            );
+          },
+          loading: () => const SizedBox.shrink(),
+          error: (_, __) => const SizedBox.shrink(),
+        ),
+        BottomBarButton(
+          label: context.l10n.gameAnalysis,
+          onTap: ref.read(gameCursorProvider(gameData.id)).hasValue
+              ? () {
+                  final (game, cursor) = ref
+                      .read(
+                        gameCursorProvider(gameData.id),
+                      )
+                      .requireValue;
 
-                          pushPlatformRoute(
-                            context,
-                            builder: (context) => AnalysisScreen(
-                              title: context.l10n.gameAnalysis,
-                              pgnOrId: game.makePgn(),
-                              options: AnalysisOptions(
-                                isLocalEvaluationAllowed: true,
-                                variant: gameData.variant,
-                                initialMoveCursor: cursor,
-                                orientation: orientation,
-                                id: gameData.id,
-                                opening: gameData.opening,
-                                serverAnalysis: game.serverAnalysis,
-                                division: game.meta.division,
-                              ),
-                            ),
-                          );
-                        }
-                      : null,
-                  icon: Icons.biotech,
-                ),
-              ),
-              Expanded(
-                child: RepeatButton(
-                  onLongPress:
-                      canGoBackward ? () => _cursorBackward(ref) : null,
-                  child: BottomBarButton(
-                    key: const ValueKey('cursor-back'),
-                    // TODO add translation
-                    label: 'Backward',
-                    showTooltip: false,
-                    onTap: canGoBackward ? () => _cursorBackward(ref) : null,
-                    icon: CupertinoIcons.chevron_back,
-                  ),
-                ),
-              ),
-              Expanded(
-                child: RepeatButton(
-                  onLongPress: canGoForward ? () => _cursorForward(ref) : null,
-                  child: BottomBarButton(
-                    key: const ValueKey('cursor-forward'),
-                    // TODO add translation
-                    label: 'Forward',
-                    showTooltip: false,
-                    onTap: canGoForward ? () => _cursorForward(ref) : null,
-                    icon: CupertinoIcons.chevron_forward,
-                  ),
-                ),
-              ),
-            ],
+                  pushPlatformRoute(
+                    context,
+                    builder: (context) => AnalysisScreen(
+                      title: context.l10n.gameAnalysis,
+                      pgnOrId: game.makePgn(),
+                      options: AnalysisOptions(
+                        isLocalEvaluationAllowed: true,
+                        variant: gameData.variant,
+                        initialMoveCursor: cursor,
+                        orientation: orientation,
+                        id: gameData.id,
+                        opening: gameData.opening,
+                        serverAnalysis: game.serverAnalysis,
+                        division: game.meta.division,
+                      ),
+                    ),
+                  );
+                }
+              : null,
+          icon: Icons.biotech,
+        ),
+        RepeatButton(
+          onLongPress: canGoBackward ? () => _cursorBackward(ref) : null,
+          child: BottomBarButton(
+            key: const ValueKey('cursor-back'),
+            // TODO add translation
+            label: 'Backward',
+            showTooltip: false,
+            onTap: canGoBackward ? () => _cursorBackward(ref) : null,
+            icon: CupertinoIcons.chevron_back,
           ),
         ),
-      ),
+        RepeatButton(
+          onLongPress: canGoForward ? () => _cursorForward(ref) : null,
+          child: BottomBarButton(
+            key: const ValueKey('cursor-forward'),
+            // TODO add translation
+            label: 'Forward',
+            showTooltip: false,
+            onTap: canGoForward ? () => _cursorForward(ref) : null,
+            icon: CupertinoIcons.chevron_forward,
+          ),
+        ),
+      ],
     );
   }
 

--- a/lib/src/view/game/game_body.dart
+++ b/lib/src/view/game/game_body.dart
@@ -7,7 +7,6 @@ import 'package:dartchess/dartchess.dart';
 import 'package:flutter/cupertino.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
-import 'package:lichess_mobile/src/constants.dart';
 import 'package:lichess_mobile/src/model/account/account_preferences.dart';
 import 'package:lichess_mobile/src/model/account/account_repository.dart';
 import 'package:lichess_mobile/src/model/common/id.dart';
@@ -26,6 +25,7 @@ import 'package:lichess_mobile/src/view/game/correspondence_clock_widget.dart';
 import 'package:lichess_mobile/src/view/game/message_screen.dart';
 import 'package:lichess_mobile/src/widgets/adaptive_action_sheet.dart';
 import 'package:lichess_mobile/src/widgets/board_table.dart';
+import 'package:lichess_mobile/src/widgets/bottom_bar.dart';
 import 'package:lichess_mobile/src/widgets/bottom_bar_button.dart';
 import 'package:lichess_mobile/src/widgets/buttons.dart';
 import 'package:lichess_mobile/src/widgets/countdown_clock.dart';
@@ -443,212 +443,189 @@ class _GameBottomBar extends ConsumerWidget {
             : null;
 
         return [
-          Expanded(
-            child: BottomBarButton(
-              label: context.l10n.menu,
-              onTap: () {
-                _showGameMenu(context, ref);
-              },
-              icon: Icons.menu,
-            ),
+          BottomBarButton(
+            label: context.l10n.menu,
+            onTap: () {
+              _showGameMenu(context, ref);
+            },
+            icon: Icons.menu,
           ),
           if (!gameState.game.playable)
-            Expanded(
-              child: BottomBarButton(
-                label: context.l10n.mobileShowResult,
-                onTap: () {
-                  showAdaptiveDialog<void>(
-                    context: context,
-                    builder: (context) => GameResultDialog(
-                      id: id,
-                      onNewOpponentCallback: onNewOpponentCallback,
-                    ),
-                    barrierDismissible: true,
-                  );
-                },
-                icon: Icons.info_outline,
-              ),
+            BottomBarButton(
+              label: context.l10n.mobileShowResult,
+              onTap: () {
+                showAdaptiveDialog<void>(
+                  context: context,
+                  builder: (context) => GameResultDialog(
+                    id: id,
+                    onNewOpponentCallback: onNewOpponentCallback,
+                  ),
+                  barrierDismissible: true,
+                );
+              },
+              icon: Icons.info_outline,
             ),
           if (gameState.game.playable &&
               gameState.game.opponent?.offeringDraw == true)
-            Expanded(
-              child: BottomBarButton(
-                label: context.l10n.yourOpponentOffersADraw,
-                highlighted: true,
-                onTap: () {
-                  showAdaptiveDialog<void>(
-                    context: context,
-                    builder: (context) => _GameNegotiationDialog(
-                      title: Text(context.l10n.yourOpponentOffersADraw),
-                      onAccept: () {
-                        ref
-                            .read(gameControllerProvider(id).notifier)
-                            .offerOrAcceptDraw();
-                      },
-                      onDecline: () {
-                        ref
-                            .read(gameControllerProvider(id).notifier)
-                            .cancelOrDeclineDraw();
-                      },
-                    ),
-                    barrierDismissible: true,
-                  );
-                },
-                icon: Icons.handshake_outlined,
-              ),
+            BottomBarButton(
+              label: context.l10n.yourOpponentOffersADraw,
+              highlighted: true,
+              onTap: () {
+                showAdaptiveDialog<void>(
+                  context: context,
+                  builder: (context) => _GameNegotiationDialog(
+                    title: Text(context.l10n.yourOpponentOffersADraw),
+                    onAccept: () {
+                      ref
+                          .read(gameControllerProvider(id).notifier)
+                          .offerOrAcceptDraw();
+                    },
+                    onDecline: () {
+                      ref
+                          .read(gameControllerProvider(id).notifier)
+                          .cancelOrDeclineDraw();
+                    },
+                  ),
+                  barrierDismissible: true,
+                );
+              },
+              icon: Icons.handshake_outlined,
             )
           else if (gameState.game.playable &&
               gameState.game.isThreefoldRepetition == true)
-            Expanded(
-              child: BottomBarButton(
-                label: context.l10n.threefoldRepetition,
-                highlighted: true,
-                onTap: () {
-                  showAdaptiveDialog<void>(
-                    context: context,
-                    builder: (context) => _ThreefoldDialog(id: id),
-                    barrierDismissible: true,
-                  );
-                },
-                icon: Icons.handshake_outlined,
-              ),
+            BottomBarButton(
+              label: context.l10n.threefoldRepetition,
+              highlighted: true,
+              onTap: () {
+                showAdaptiveDialog<void>(
+                  context: context,
+                  builder: (context) => _ThreefoldDialog(id: id),
+                  barrierDismissible: true,
+                );
+              },
+              icon: Icons.handshake_outlined,
             )
           else if (gameState.game.playable &&
               gameState.game.opponent?.proposingTakeback == true)
-            Expanded(
-              child: BottomBarButton(
-                label: context.l10n.yourOpponentProposesATakeback,
-                highlighted: true,
-                onTap: () {
-                  showAdaptiveDialog<void>(
-                    context: context,
-                    builder: (context) => _GameNegotiationDialog(
-                      title: Text(context.l10n.yourOpponentProposesATakeback),
-                      onAccept: () {
-                        ref
-                            .read(gameControllerProvider(id).notifier)
-                            .acceptTakeback();
-                      },
-                      onDecline: () {
-                        ref
-                            .read(gameControllerProvider(id).notifier)
-                            .cancelOrDeclineTakeback();
-                      },
-                    ),
-                    barrierDismissible: true,
-                  );
-                },
-                icon: CupertinoIcons.arrowshape_turn_up_left,
-              ),
+            BottomBarButton(
+              label: context.l10n.yourOpponentProposesATakeback,
+              highlighted: true,
+              onTap: () {
+                showAdaptiveDialog<void>(
+                  context: context,
+                  builder: (context) => _GameNegotiationDialog(
+                    title: Text(context.l10n.yourOpponentProposesATakeback),
+                    onAccept: () {
+                      ref
+                          .read(gameControllerProvider(id).notifier)
+                          .acceptTakeback();
+                    },
+                    onDecline: () {
+                      ref
+                          .read(gameControllerProvider(id).notifier)
+                          .cancelOrDeclineTakeback();
+                    },
+                  ),
+                  barrierDismissible: true,
+                );
+              },
+              icon: CupertinoIcons.arrowshape_turn_up_left,
             )
           else if (gameState.game.finished)
-            Expanded(
-              child: BottomBarButton(
-                label: context.l10n.gameAnalysis,
-                icon: Icons.biotech,
-                onTap: () {
-                  pushPlatformRoute(
-                    context,
-                    builder: (_) => AnalysisScreen(
-                      pgnOrId: gameState.analysisPgn,
-                      options: gameState.analysisOptions,
-                      title: context.l10n.gameAnalysis,
-                    ),
-                  );
-                },
-              ),
+            BottomBarButton(
+              label: context.l10n.gameAnalysis,
+              icon: Icons.biotech,
+              onTap: () {
+                pushPlatformRoute(
+                  context,
+                  builder: (_) => AnalysisScreen(
+                    pgnOrId: gameState.analysisPgn,
+                    options: gameState.analysisOptions,
+                    title: context.l10n.gameAnalysis,
+                  ),
+                );
+              },
             )
           else
-            Expanded(
-              child: BottomBarButton(
-                label: context.l10n.resign,
-                onTap: gameState.game.resignable
-                    ? gameState.shouldConfirmResignAndDrawOffer
-                        ? () => _showConfirmDialog(
-                              context,
-                              description: Text(context.l10n.resignTheGame),
-                              onConfirm: () {
-                                ref
-                                    .read(gameControllerProvider(id).notifier)
-                                    .resignGame();
-                              },
-                            )
-                        : () {
-                            ref
-                                .read(gameControllerProvider(id).notifier)
-                                .resignGame();
-                          }
-                    : null,
-                icon: Icons.flag,
-              ),
+            BottomBarButton(
+              label: context.l10n.resign,
+              onTap: gameState.game.resignable
+                  ? gameState.shouldConfirmResignAndDrawOffer
+                      ? () => _showConfirmDialog(
+                            context,
+                            description: Text(context.l10n.resignTheGame),
+                            onConfirm: () {
+                              ref
+                                  .read(gameControllerProvider(id).notifier)
+                                  .resignGame();
+                            },
+                          )
+                      : () {
+                          ref
+                              .read(gameControllerProvider(id).notifier)
+                              .resignGame();
+                        }
+                  : null,
+              icon: Icons.flag,
             ),
           if (gameState.game.meta.speed == Speed.correspondence &&
               !gameState.game.finished)
-            Expanded(
-              child: BottomBarButton(
-                label: 'Go to the next game',
-                icon: Icons.skip_next,
-                onTap: ongoingGames.maybeWhen(
-                  data: (games) {
-                    final nextTurn = games
-                        .whereNot((g) => g.fullId == id)
-                        .firstWhereOrNull((g) => g.isMyTurn);
-                    return nextTurn != null
-                        ? () => onLoadGameCallback(nextTurn.fullId)
-                        : null;
-                  },
-                  orElse: () => null,
-                ),
+            BottomBarButton(
+              label: 'Go to the next game',
+              icon: Icons.skip_next,
+              onTap: ongoingGames.maybeWhen(
+                data: (games) {
+                  final nextTurn = games
+                      .whereNot((g) => g.fullId == id)
+                      .firstWhereOrNull((g) => g.isMyTurn);
+                  return nextTurn != null
+                      ? () => onLoadGameCallback(nextTurn.fullId)
+                      : null;
+                },
+                orElse: () => null,
               ),
             ),
-          Expanded(
+          BottomBarButton(
+            label: context.l10n.chat,
+            onTap: isChatEnabled
+                ? () {
+                    pushPlatformRoute(
+                      context,
+                      builder: (BuildContext context) {
+                        return MessageScreen(
+                          title: UserFullNameWidget(
+                            user: gameState.game.opponent?.user,
+                          ),
+                          me: gameState.game.me?.user,
+                          id: id,
+                        );
+                      },
+                    );
+                  }
+                : null,
+            icon: Theme.of(context).platform == TargetPlatform.iOS
+                ? CupertinoIcons.chat_bubble
+                : Icons.chat_bubble_outline,
+            chip: chatUnreadChip,
+          ),
+          RepeatButton(
+            onLongPress:
+                gameState.canGoBackward ? () => _moveBackward(ref) : null,
             child: BottomBarButton(
-              label: context.l10n.chat,
-              onTap: isChatEnabled
-                  ? () {
-                      pushPlatformRoute(
-                        context,
-                        builder: (BuildContext context) {
-                          return MessageScreen(
-                            title: UserFullNameWidget(
-                              user: gameState.game.opponent?.user,
-                            ),
-                            me: gameState.game.me?.user,
-                            id: id,
-                          );
-                        },
-                      );
-                    }
-                  : null,
-              icon: Theme.of(context).platform == TargetPlatform.iOS
-                  ? CupertinoIcons.chat_bubble
-                  : Icons.chat_bubble_outline,
-              chip: chatUnreadChip,
+              onTap: gameState.canGoBackward ? () => _moveBackward(ref) : null,
+              label: 'Previous',
+              icon: CupertinoIcons.chevron_back,
+              showTooltip: false,
             ),
           ),
-          Expanded(
-            child: RepeatButton(
-              onLongPress:
-                  gameState.canGoBackward ? () => _moveBackward(ref) : null,
-              child: BottomBarButton(
-                onTap:
-                    gameState.canGoBackward ? () => _moveBackward(ref) : null,
-                label: 'Previous',
-                icon: CupertinoIcons.chevron_back,
-                showTooltip: false,
-              ),
-            ),
-          ),
-          Expanded(
-            child: RepeatButton(
-              onLongPress:
-                  gameState.canGoForward ? () => _moveForward(ref) : null,
-              child: BottomBarButton(
-                onTap: gameState.canGoForward ? () => _moveForward(ref) : null,
-                label: context.l10n.next,
-                icon: CupertinoIcons.chevron_forward,
-                showTooltip: false,
-              ),
+          RepeatButton(
+            onLongPress:
+                gameState.canGoForward ? () => _moveForward(ref) : null,
+            child: BottomBarButton(
+              onTap: gameState.canGoForward ? () => _moveForward(ref) : null,
+              label: context.l10n.next,
+              icon: CupertinoIcons.chevron_forward,
+              showTooltip: false,
             ),
           ),
         ];
@@ -657,19 +634,8 @@ class _GameBottomBar extends ConsumerWidget {
       error: (e, s) => [],
     );
 
-    return Container(
-      color: Theme.of(context).platform == TargetPlatform.iOS
-          ? null
-          : Theme.of(context).bottomAppBarTheme.color,
-      child: SafeArea(
-        top: false,
-        child: SizedBox(
-          height: kBottomBarHeight,
-          child: Row(
-            children: children,
-          ),
-        ),
-      ),
+    return BottomBar(
+      children: children,
     );
   }
 

--- a/lib/src/view/game/game_loading_board.dart
+++ b/lib/src/view/game/game_loading_board.dart
@@ -10,6 +10,7 @@ import 'package:lichess_mobile/src/model/lobby/lobby_numbers.dart';
 import 'package:lichess_mobile/src/model/user/user.dart';
 import 'package:lichess_mobile/src/utils/l10n_context.dart';
 import 'package:lichess_mobile/src/widgets/board_table.dart';
+import 'package:lichess_mobile/src/widgets/bottom_bar.dart';
 import 'package:lichess_mobile/src/widgets/bottom_bar_button.dart';
 import 'package:lichess_mobile/src/widgets/platform.dart';
 import 'package:lichess_mobile/src/widgets/user_full_name.dart';
@@ -73,7 +74,7 @@ class LobbyScreenLoadingContent extends StatelessWidget {
             ),
           ),
         ),
-        _BottomBar(
+        BottomBar(
           children: [
             BottomBarButton(
               onTap: () async {
@@ -148,7 +149,7 @@ class ChallengeLoadingContent extends StatelessWidget {
             ),
           ),
         ),
-        _BottomBar(
+        BottomBar(
           children: [
             BottomBarButton(
               onTap: () async {
@@ -221,7 +222,7 @@ class LoadGameError extends StatelessWidget {
             ),
           ),
         ),
-        _BottomBar(
+        BottomBar(
           children: [
             BottomBarButton(
               onTap: () => Navigator.of(context).pop(),
@@ -295,7 +296,7 @@ class ChallengeDeclinedBoard extends StatelessWidget {
             ),
           ),
         ),
-        _BottomBar(
+        BottomBar(
           children: [
             BottomBarButton(
               onTap: () => Navigator.of(context).pop(),
@@ -306,33 +307,6 @@ class ChallengeDeclinedBoard extends StatelessWidget {
           ],
         ),
       ],
-    );
-  }
-}
-
-class _BottomBar extends StatelessWidget {
-  const _BottomBar({
-    required this.children,
-  });
-
-  final List<Widget> children;
-
-  @override
-  Widget build(BuildContext context) {
-    return Container(
-      color: Theme.of(context).platform == TargetPlatform.iOS
-          ? CupertinoTheme.of(context).barBackgroundColor
-          : Theme.of(context).bottomAppBarTheme.color,
-      child: SafeArea(
-        top: false,
-        child: SizedBox(
-          height: kBottomBarHeight,
-          child: Row(
-            mainAxisAlignment: MainAxisAlignment.spaceAround,
-            children: children,
-          ),
-        ),
-      ),
     );
   }
 }

--- a/lib/src/view/opening_explorer/opening_explorer_screen.dart
+++ b/lib/src/view/opening_explorer/opening_explorer_screen.dart
@@ -19,6 +19,7 @@ import 'package:lichess_mobile/src/utils/screen.dart';
 import 'package:lichess_mobile/src/view/analysis/analysis_board.dart';
 import 'package:lichess_mobile/src/view/game/archived_game_screen.dart';
 import 'package:lichess_mobile/src/widgets/adaptive_bottom_sheet.dart';
+import 'package:lichess_mobile/src/widgets/bottom_bar.dart';
 import 'package:lichess_mobile/src/widgets/bottom_bar_button.dart';
 import 'package:lichess_mobile/src/widgets/buttons.dart';
 import 'package:lichess_mobile/src/widgets/platform.dart';
@@ -955,68 +956,48 @@ class _BottomBar extends ConsumerWidget {
       OpeningDatabase.player => context.l10n.player,
     };
 
-    return Container(
-      color: Theme.of(context).platform == TargetPlatform.iOS
-          ? CupertinoTheme.of(context).barBackgroundColor
-          : Theme.of(context).bottomAppBarTheme.color,
-      child: SafeArea(
-        top: false,
-        child: SizedBox(
-          height: kBottomBarHeight,
-          child: Row(
-            mainAxisAlignment: MainAxisAlignment.spaceAround,
-            children: [
-              Expanded(
-                child: BottomBarButton(
-                  label: dbLabel,
-                  showLabel: true,
-                  onTap: () => showAdaptiveBottomSheet<void>(
-                    context: context,
-                    isScrollControlled: true,
-                    showDragHandle: true,
-                    isDismissible: true,
-                    builder: (_) => OpeningExplorerSettings(pgn, options),
-                  ),
-                  icon: Icons.tune,
-                ),
-              ),
-              Expanded(
-                child: BottomBarButton(
-                  label: 'Flip',
-                  tooltip: context.l10n.flipBoard,
-                  showLabel: true,
-                  onTap: () => ref.read(ctrlProvider.notifier).toggleBoard(),
-                  icon: CupertinoIcons.arrow_2_squarepath,
-                ),
-              ),
-              Expanded(
-                child: RepeatButton(
-                  onLongPress: canGoBack ? () => _moveBackward(ref) : null,
-                  child: BottomBarButton(
-                    onTap: canGoBack ? () => _moveBackward(ref) : null,
-                    label: 'Previous',
-                    showLabel: true,
-                    icon: CupertinoIcons.chevron_back,
-                    showTooltip: false,
-                  ),
-                ),
-              ),
-              Expanded(
-                child: RepeatButton(
-                  onLongPress: canGoNext ? () => _moveForward(ref) : null,
-                  child: BottomBarButton(
-                    icon: CupertinoIcons.chevron_forward,
-                    label: 'Next',
-                    showLabel: true,
-                    onTap: canGoNext ? () => _moveForward(ref) : null,
-                    showTooltip: false,
-                  ),
-                ),
-              ),
-            ],
+    return BottomBar(
+      children: [
+        BottomBarButton(
+          label: dbLabel,
+          showLabel: true,
+          onTap: () => showAdaptiveBottomSheet<void>(
+            context: context,
+            isScrollControlled: true,
+            showDragHandle: true,
+            isDismissible: true,
+            builder: (_) => OpeningExplorerSettings(pgn, options),
+          ),
+          icon: Icons.tune,
+        ),
+        BottomBarButton(
+          label: 'Flip',
+          tooltip: context.l10n.flipBoard,
+          showLabel: true,
+          onTap: () => ref.read(ctrlProvider.notifier).toggleBoard(),
+          icon: CupertinoIcons.arrow_2_squarepath,
+        ),
+        RepeatButton(
+          onLongPress: canGoBack ? () => _moveBackward(ref) : null,
+          child: BottomBarButton(
+            onTap: canGoBack ? () => _moveBackward(ref) : null,
+            label: 'Previous',
+            showLabel: true,
+            icon: CupertinoIcons.chevron_back,
+            showTooltip: false,
           ),
         ),
-      ),
+        RepeatButton(
+          onLongPress: canGoNext ? () => _moveForward(ref) : null,
+          child: BottomBarButton(
+            icon: CupertinoIcons.chevron_forward,
+            label: 'Next',
+            showLabel: true,
+            onTap: canGoNext ? () => _moveForward(ref) : null,
+            showTooltip: false,
+          ),
+        ),
+      ],
     );
   }
 

--- a/lib/src/view/puzzle/puzzle_screen.dart
+++ b/lib/src/view/puzzle/puzzle_screen.dart
@@ -37,6 +37,7 @@ import 'package:lichess_mobile/src/widgets/adaptive_action_sheet.dart';
 import 'package:lichess_mobile/src/widgets/adaptive_bottom_sheet.dart';
 import 'package:lichess_mobile/src/widgets/adaptive_choice_picker.dart';
 import 'package:lichess_mobile/src/widgets/board_table.dart';
+import 'package:lichess_mobile/src/widgets/bottom_bar.dart';
 import 'package:lichess_mobile/src/widgets/bottom_bar_button.dart';
 import 'package:lichess_mobile/src/widgets/buttons.dart';
 import 'package:lichess_mobile/src/widgets/feedback.dart';
@@ -412,105 +413,79 @@ class _BottomBar extends ConsumerWidget {
     final puzzleState = ref.watch(ctrlProvider);
     final isDailyPuzzle = puzzleState.puzzle.isDailyPuzzle == true;
 
-    return Container(
-      color: Theme.of(context).platform == TargetPlatform.iOS
-          ? null
-          : Theme.of(context).bottomAppBarTheme.color,
-      child: SafeArea(
-        top: false,
-        child: SizedBox(
-          height: kBottomBarHeight,
-          child: Row(
-            mainAxisAlignment: MainAxisAlignment.spaceAround,
-            children: [
-              if (initialPuzzleContext.userId != null &&
-                  !isDailyPuzzle &&
-                  puzzleState.mode != PuzzleMode.view)
-                _DifficultySelector(
-                  initialPuzzleContext: initialPuzzleContext,
-                  ctrlProvider: ctrlProvider,
-                ),
-              if (puzzleState.mode != PuzzleMode.view)
-                BottomBarButton(
-                  icon: Icons.help,
-                  label: context.l10n.viewTheSolution,
-                  showLabel: true,
-                  onTap: puzzleState.canViewSolution
-                      ? () => ref.read(ctrlProvider.notifier).viewSolution()
-                      : null,
-                ),
-              if (puzzleState.mode == PuzzleMode.view)
-                Expanded(
-                  child: BottomBarButton(
-                    label: context.l10n.menu,
-                    onTap: () {
-                      _showPuzzleMenu(context, ref);
-                    },
-                    icon: Icons.menu,
-                  ),
-                ),
-              if (puzzleState.mode == PuzzleMode.view)
-                Expanded(
-                  child: BottomBarButton(
-                    onTap: () {
-                      ref.read(ctrlProvider.notifier).toggleLocalEvaluation();
-                    },
-                    label: context.l10n.toggleLocalEvaluation,
-                    icon: CupertinoIcons.gauge,
-                    highlighted: puzzleState.isLocalEvalEnabled,
-                  ),
-                ),
-              if (puzzleState.mode == PuzzleMode.view)
-                Expanded(
-                  child: RepeatButton(
-                    triggerDelays: _repeatTriggerDelays,
-                    onLongPress:
-                        puzzleState.canGoBack ? () => _moveBackward(ref) : null,
-                    child: BottomBarButton(
-                      onTap: puzzleState.canGoBack
-                          ? () => _moveBackward(ref)
-                          : null,
-                      label: 'Previous',
-                      icon: CupertinoIcons.chevron_back,
-                      showTooltip: false,
-                    ),
-                  ),
-                ),
-              if (puzzleState.mode == PuzzleMode.view)
-                Expanded(
-                  child: RepeatButton(
-                    triggerDelays: _repeatTriggerDelays,
-                    onLongPress:
-                        puzzleState.canGoNext ? () => _moveForward(ref) : null,
-                    child: BottomBarButton(
-                      onTap: puzzleState.canGoNext
-                          ? () => _moveForward(ref)
-                          : null,
-                      label: context.l10n.next,
-                      icon: CupertinoIcons.chevron_forward,
-                      showTooltip: false,
-                      blink: puzzleState.viewedSolutionRecently,
-                    ),
-                  ),
-                ),
-              if (puzzleState.mode == PuzzleMode.view)
-                Expanded(
-                  child: BottomBarButton(
-                    onTap: puzzleState.mode == PuzzleMode.view &&
-                            puzzleState.nextContext != null
-                        ? () => ref
-                            .read(ctrlProvider.notifier)
-                            .loadPuzzle(puzzleState.nextContext!)
-                        : null,
-                    highlighted: true,
-                    label: context.l10n.puzzleContinueTraining,
-                    icon: CupertinoIcons.play_arrow_solid,
-                  ),
-                ),
-            ],
+    return BottomBar(
+      mainAxisAlignment: MainAxisAlignment.spaceAround,
+      children: [
+        if (initialPuzzleContext.userId != null &&
+            !isDailyPuzzle &&
+            puzzleState.mode != PuzzleMode.view)
+          _DifficultySelector(
+            initialPuzzleContext: initialPuzzleContext,
+            ctrlProvider: ctrlProvider,
           ),
-        ),
-      ),
+        if (puzzleState.mode != PuzzleMode.view)
+          BottomBarButton(
+            icon: Icons.help,
+            label: context.l10n.viewTheSolution,
+            showLabel: true,
+            onTap: puzzleState.canViewSolution
+                ? () => ref.read(ctrlProvider.notifier).viewSolution()
+                : null,
+          ),
+        if (puzzleState.mode == PuzzleMode.view)
+          BottomBarButton(
+            label: context.l10n.menu,
+            onTap: () {
+              _showPuzzleMenu(context, ref);
+            },
+            icon: Icons.menu,
+          ),
+        if (puzzleState.mode == PuzzleMode.view)
+          BottomBarButton(
+            onTap: () {
+              ref.read(ctrlProvider.notifier).toggleLocalEvaluation();
+            },
+            label: context.l10n.toggleLocalEvaluation,
+            icon: CupertinoIcons.gauge,
+            highlighted: puzzleState.isLocalEvalEnabled,
+          ),
+        if (puzzleState.mode == PuzzleMode.view)
+          RepeatButton(
+            triggerDelays: _repeatTriggerDelays,
+            onLongPress:
+                puzzleState.canGoBack ? () => _moveBackward(ref) : null,
+            child: BottomBarButton(
+              onTap: puzzleState.canGoBack ? () => _moveBackward(ref) : null,
+              label: 'Previous',
+              icon: CupertinoIcons.chevron_back,
+              showTooltip: false,
+            ),
+          ),
+        if (puzzleState.mode == PuzzleMode.view)
+          RepeatButton(
+            triggerDelays: _repeatTriggerDelays,
+            onLongPress: puzzleState.canGoNext ? () => _moveForward(ref) : null,
+            child: BottomBarButton(
+              onTap: puzzleState.canGoNext ? () => _moveForward(ref) : null,
+              label: context.l10n.next,
+              icon: CupertinoIcons.chevron_forward,
+              showTooltip: false,
+              blink: puzzleState.viewedSolutionRecently,
+            ),
+          ),
+        if (puzzleState.mode == PuzzleMode.view)
+          BottomBarButton(
+            onTap: puzzleState.mode == PuzzleMode.view &&
+                    puzzleState.nextContext != null
+                ? () => ref
+                    .read(ctrlProvider.notifier)
+                    .loadPuzzle(puzzleState.nextContext!)
+                : null,
+            highlighted: true,
+            label: context.l10n.puzzleContinueTraining,
+            icon: CupertinoIcons.play_arrow_solid,
+          ),
+      ],
     );
   }
 

--- a/lib/src/view/puzzle/storm_screen.dart
+++ b/lib/src/view/puzzle/storm_screen.dart
@@ -24,6 +24,7 @@ import 'package:lichess_mobile/src/view/puzzle/storm_clock.dart';
 import 'package:lichess_mobile/src/view/puzzle/storm_dashboard.dart';
 import 'package:lichess_mobile/src/view/settings/toggle_sound_button.dart';
 import 'package:lichess_mobile/src/widgets/board_table.dart';
+import 'package:lichess_mobile/src/widgets/bottom_bar.dart';
 import 'package:lichess_mobile/src/widgets/bottom_bar_button.dart';
 import 'package:lichess_mobile/src/widgets/buttons.dart';
 import 'package:lichess_mobile/src/widgets/feedback.dart';
@@ -607,58 +608,45 @@ class _BottomBar extends ConsumerWidget {
   @override
   Widget build(BuildContext context, WidgetRef ref) {
     final stormState = ref.watch(ctrl);
-    return Container(
-      color: Theme.of(context).platform == TargetPlatform.iOS
-          ? null
-          : Theme.of(context).bottomAppBarTheme.color,
-      child: SafeArea(
-        top: false,
-        child: SizedBox(
-          height: kBottomBarHeight,
-          child: Row(
-            mainAxisAlignment: MainAxisAlignment.spaceAround,
-            children: [
-              if (stormState.mode == StormMode.initial)
-                BottomBarButton(
-                  icon: Icons.info_outline,
-                  label: context.l10n.aboutX('Storm'),
-                  showLabel: true,
-                  onTap: () => _stormInfoDialogBuilder(context),
-                ),
-              BottomBarButton(
-                icon: Icons.delete,
-                label: context.l10n.stormNewRun.split('(').first.trimRight(),
-                showLabel: true,
-                onTap: () {
-                  stormState.clock.reset();
-                  ref.invalidate(stormProvider);
-                },
-              ),
-              if (stormState.mode == StormMode.running)
-                BottomBarButton(
-                  icon: LichessIcons.flag,
-                  label: context.l10n.stormEndRun.split('(').first.trimRight(),
-                  showLabel: true,
-                  onTap: stormState.puzzleIndex >= 1
-                      ? () {
-                          if (stormState.clock.startAt != null) {
-                            stormState.clock.sendEnd();
-                          }
-                        }
-                      : null,
-                ),
-              if (stormState.mode == StormMode.ended &&
-                  stormState.stats != null)
-                BottomBarButton(
-                  icon: Icons.open_in_new,
-                  label: 'Result',
-                  showLabel: true,
-                  onTap: () => _showStats(context, stormState.stats!),
-                ),
-            ],
+    return BottomBar(
+      children: [
+        if (stormState.mode == StormMode.initial)
+          BottomBarButton(
+            icon: Icons.info_outline,
+            label: context.l10n.aboutX('Storm'),
+            showLabel: true,
+            onTap: () => _stormInfoDialogBuilder(context),
           ),
+        BottomBarButton(
+          icon: Icons.delete,
+          label: context.l10n.stormNewRun.split('(').first.trimRight(),
+          showLabel: true,
+          onTap: () {
+            stormState.clock.reset();
+            ref.invalidate(stormProvider);
+          },
         ),
-      ),
+        if (stormState.mode == StormMode.running)
+          BottomBarButton(
+            icon: LichessIcons.flag,
+            label: context.l10n.stormEndRun.split('(').first.trimRight(),
+            showLabel: true,
+            onTap: stormState.puzzleIndex >= 1
+                ? () {
+                    if (stormState.clock.startAt != null) {
+                      stormState.clock.sendEnd();
+                    }
+                  }
+                : null,
+          ),
+        if (stormState.mode == StormMode.ended && stormState.stats != null)
+          BottomBarButton(
+            icon: Icons.open_in_new,
+            label: 'Result',
+            showLabel: true,
+            onTap: () => _showStats(context, stormState.stats!),
+          ),
+      ],
     );
   }
 }

--- a/lib/src/view/puzzle/streak_screen.dart
+++ b/lib/src/view/puzzle/streak_screen.dart
@@ -23,6 +23,7 @@ import 'package:lichess_mobile/src/utils/share.dart';
 import 'package:lichess_mobile/src/view/analysis/analysis_screen.dart';
 import 'package:lichess_mobile/src/view/settings/toggle_sound_button.dart';
 import 'package:lichess_mobile/src/widgets/board_table.dart';
+import 'package:lichess_mobile/src/widgets/bottom_bar.dart';
 import 'package:lichess_mobile/src/widgets/bottom_bar_button.dart';
 import 'package:lichess_mobile/src/widgets/platform.dart';
 import 'package:lichess_mobile/src/widgets/yes_no_dialog.dart';
@@ -266,109 +267,87 @@ class _BottomBar extends ConsumerWidget {
         puzzleControllerProvider(initialPuzzleContext, initialStreak: streak);
     final puzzleState = ref.watch(ctrlProvider);
 
-    return Container(
-      color: Theme.of(context).platform == TargetPlatform.iOS
-          ? null
-          : Theme.of(context).bottomAppBarTheme.color,
-      child: SafeArea(
-        top: false,
-        child: SizedBox(
-          height: kBottomBarHeight,
-          child: Row(
-            mainAxisAlignment: MainAxisAlignment.spaceAround,
-            children: [
-              if (!puzzleState.streak!.finished)
-                BottomBarButton(
-                  icon: Icons.info_outline,
-                  label: context.l10n.aboutX('Streak'),
-                  showLabel: true,
-                  onTap: () => _streakInfoDialogBuilder(context),
-                ),
-              if (!puzzleState.streak!.finished)
-                BottomBarButton(
-                  icon: Icons.skip_next,
-                  label: context.l10n.skipThisMove,
-                  showLabel: true,
-                  onTap: puzzleState.streak!.hasSkipped ||
-                          puzzleState.mode == PuzzleMode.view
-                      ? null
-                      : () => ref.read(ctrlProvider.notifier).skipMove(),
-                ),
-              if (puzzleState.streak!.finished)
-                Expanded(
-                  child: BottomBarButton(
-                    onTap: () {
-                      launchShareDialog(
-                        context,
-                        text: lichessUri(
-                          '/training/${puzzleState.puzzle.puzzle.id}',
-                        ).toString(),
-                      );
-                    },
-                    label: 'Share this puzzle',
-                    icon: Theme.of(context).platform == TargetPlatform.iOS
-                        ? CupertinoIcons.share
-                        : Icons.share,
-                  ),
-                ),
-              if (puzzleState.streak!.finished)
-                Expanded(
-                  child: BottomBarButton(
-                    onTap: () {
-                      pushPlatformRoute(
-                        context,
-                        builder: (context) => AnalysisScreen(
-                          title: context.l10n.analysis,
-                          pgnOrId: ref.read(ctrlProvider.notifier).makePgn(),
-                          options: AnalysisOptions(
-                            isLocalEvaluationAllowed: true,
-                            variant: Variant.standard,
-                            orientation: puzzleState.pov,
-                            id: standaloneAnalysisId,
-                            initialMoveCursor: 0,
-                          ),
-                        ),
-                      );
-                    },
-                    label: context.l10n.analysis,
-                    icon: Icons.biotech,
-                  ),
-                ),
-              if (puzzleState.streak!.finished)
-                Expanded(
-                  child: BottomBarButton(
-                    onTap: puzzleState.canGoBack
-                        ? () => ref.read(ctrlProvider.notifier).userPrevious()
-                        : null,
-                    label: 'Previous',
-                    icon: CupertinoIcons.chevron_back,
-                  ),
-                ),
-              if (puzzleState.streak!.finished)
-                Expanded(
-                  child: BottomBarButton(
-                    onTap: puzzleState.canGoNext
-                        ? () => ref.read(ctrlProvider.notifier).userNext()
-                        : null,
-                    label: context.l10n.next,
-                    icon: CupertinoIcons.chevron_forward,
-                  ),
-                ),
-              if (puzzleState.streak!.finished)
-                Expanded(
-                  child: BottomBarButton(
-                    onTap: ref.read(streakProvider).isLoading == false
-                        ? () => ref.invalidate(streakProvider)
-                        : null,
-                    highlighted: true,
-                    label: context.l10n.puzzleNewStreak,
-                    icon: CupertinoIcons.play_arrow_solid,
-                  ),
-                ),
-            ],
+    return BottomBar(
+      children: [
+        if (!puzzleState.streak!.finished)
+          BottomBarButton(
+            icon: Icons.info_outline,
+            label: context.l10n.aboutX('Streak'),
+            showLabel: true,
+            onTap: () => _streakInfoDialogBuilder(context),
           ),
-        ),
-      ),
+        if (!puzzleState.streak!.finished)
+          BottomBarButton(
+            icon: Icons.skip_next,
+            label: context.l10n.skipThisMove,
+            showLabel: true,
+            onTap: puzzleState.streak!.hasSkipped ||
+                    puzzleState.mode == PuzzleMode.view
+                ? null
+                : () => ref.read(ctrlProvider.notifier).skipMove(),
+          ),
+        if (puzzleState.streak!.finished)
+          BottomBarButton(
+            onTap: () {
+              launchShareDialog(
+                context,
+                text: lichessUri(
+                  '/training/${puzzleState.puzzle.puzzle.id}',
+                ).toString(),
+              );
+            },
+            label: 'Share this puzzle',
+            icon: Theme.of(context).platform == TargetPlatform.iOS
+                ? CupertinoIcons.share
+                : Icons.share,
+          ),
+        if (puzzleState.streak!.finished)
+          BottomBarButton(
+            onTap: () {
+              pushPlatformRoute(
+                context,
+                builder: (context) => AnalysisScreen(
+                  title: context.l10n.analysis,
+                  pgnOrId: ref.read(ctrlProvider.notifier).makePgn(),
+                  options: AnalysisOptions(
+                    isLocalEvaluationAllowed: true,
+                    variant: Variant.standard,
+                    orientation: puzzleState.pov,
+                    id: standaloneAnalysisId,
+                    initialMoveCursor: 0,
+                  ),
+                ),
+              );
+            },
+            label: context.l10n.analysis,
+            icon: Icons.biotech,
+          ),
+        if (puzzleState.streak!.finished)
+          BottomBarButton(
+            onTap: puzzleState.canGoBack
+                ? () => ref.read(ctrlProvider.notifier).userPrevious()
+                : null,
+            label: 'Previous',
+            icon: CupertinoIcons.chevron_back,
+          ),
+        if (puzzleState.streak!.finished)
+          BottomBarButton(
+            onTap: puzzleState.canGoNext
+                ? () => ref.read(ctrlProvider.notifier).userNext()
+                : null,
+            label: context.l10n.next,
+            icon: CupertinoIcons.chevron_forward,
+          ),
+        if (puzzleState.streak!.finished)
+          BottomBarButton(
+            onTap: ref.read(streakProvider).isLoading == false
+                ? () => ref.invalidate(streakProvider)
+                : null,
+            highlighted: true,
+            label: context.l10n.puzzleNewStreak,
+            icon: CupertinoIcons.play_arrow_solid,
+          ),
+      ],
     );
   }
 

--- a/lib/src/view/watch/tv_screen.dart
+++ b/lib/src/view/watch/tv_screen.dart
@@ -14,6 +14,7 @@ import 'package:lichess_mobile/src/utils/l10n_context.dart';
 import 'package:lichess_mobile/src/view/game/game_player.dart';
 import 'package:lichess_mobile/src/view/settings/toggle_sound_button.dart';
 import 'package:lichess_mobile/src/widgets/board_table.dart';
+import 'package:lichess_mobile/src/widgets/bottom_bar.dart';
 import 'package:lichess_mobile/src/widgets/bottom_bar_button.dart';
 import 'package:lichess_mobile/src/widgets/buttons.dart';
 import 'package:lichess_mobile/src/widgets/countdown_clock.dart';
@@ -209,72 +210,54 @@ class _BottomBar extends ConsumerWidget {
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
-    return Container(
-      color: Theme.of(context).platform == TargetPlatform.iOS
-          ? null
-          : Theme.of(context).bottomAppBarTheme.color,
-      child: SafeArea(
-        top: false,
-        child: SizedBox(
-          height: kBottomBarHeight,
-          child: Row(
-            mainAxisAlignment: MainAxisAlignment.spaceAround,
-            children: [
-              Expanded(
-                child: BottomBarButton(
-                  label: context.l10n.flipBoard,
-                  onTap: () => _flipBoard(ref),
-                  icon: CupertinoIcons.arrow_2_squarepath,
-                ),
-              ),
-              Expanded(
-                child: RepeatButton(
-                  onLongPress: ref
-                          .read(tvControllerProvider(tvChannel, game).notifier)
-                          .canGoBack()
-                      ? () => _moveBackward(ref)
-                      : null,
-                  child: BottomBarButton(
-                    key: const ValueKey('goto-previous'),
-                    onTap: ref
-                            .read(
-                              tvControllerProvider(tvChannel, game).notifier,
-                            )
-                            .canGoBack()
-                        ? () => _moveBackward(ref)
-                        : null,
-                    label: 'Previous',
-                    icon: CupertinoIcons.chevron_back,
-                    showTooltip: false,
-                  ),
-                ),
-              ),
-              Expanded(
-                child: RepeatButton(
-                  onLongPress: ref
-                          .read(tvControllerProvider(tvChannel, game).notifier)
-                          .canGoForward()
-                      ? () => _moveForward(ref)
-                      : null,
-                  child: BottomBarButton(
-                    key: const ValueKey('goto-next'),
-                    icon: CupertinoIcons.chevron_forward,
-                    label: context.l10n.next,
-                    onTap: ref
-                            .read(
-                              tvControllerProvider(tvChannel, game).notifier,
-                            )
-                            .canGoForward()
-                        ? () => _moveForward(ref)
-                        : null,
-                    showTooltip: false,
-                  ),
-                ),
-              ),
-            ],
+    return BottomBar(
+      children: [
+        BottomBarButton(
+          label: context.l10n.flipBoard,
+          onTap: () => _flipBoard(ref),
+          icon: CupertinoIcons.arrow_2_squarepath,
+        ),
+        RepeatButton(
+          onLongPress: ref
+                  .read(tvControllerProvider(tvChannel, game).notifier)
+                  .canGoBack()
+              ? () => _moveBackward(ref)
+              : null,
+          child: BottomBarButton(
+            key: const ValueKey('goto-previous'),
+            onTap: ref
+                    .read(
+                      tvControllerProvider(tvChannel, game).notifier,
+                    )
+                    .canGoBack()
+                ? () => _moveBackward(ref)
+                : null,
+            label: 'Previous',
+            icon: CupertinoIcons.chevron_back,
+            showTooltip: false,
           ),
         ),
-      ),
+        RepeatButton(
+          onLongPress: ref
+                  .read(tvControllerProvider(tvChannel, game).notifier)
+                  .canGoForward()
+              ? () => _moveForward(ref)
+              : null,
+          child: BottomBarButton(
+            key: const ValueKey('goto-next'),
+            icon: CupertinoIcons.chevron_forward,
+            label: context.l10n.next,
+            onTap: ref
+                    .read(
+                      tvControllerProvider(tvChannel, game).notifier,
+                    )
+                    .canGoForward()
+                ? () => _moveForward(ref)
+                : null,
+            showTooltip: false,
+          ),
+        ),
+      ],
     );
   }
 

--- a/lib/src/widgets/bottom_bar.dart
+++ b/lib/src/widgets/bottom_bar.dart
@@ -1,0 +1,38 @@
+import 'package:flutter/cupertino.dart';
+import 'package:flutter/material.dart';
+import 'package:lichess_mobile/src/constants.dart';
+
+/// A container in the style of a bottom app bar, containg a [Row] of children widgets.
+///
+/// The height of the bar is always [kBottomBarHeight].
+class BottomBar extends StatelessWidget {
+  const BottomBar({
+    required this.children,
+    this.mainAxisAlignment = MainAxisAlignment.spaceAround,
+  });
+
+  /// Children to display in the bottom bar's [Row]. Typically instances of [BottomBarButton].
+  final List<Widget> children;
+
+  /// Alignment of the bottom bar's internal row. Defaults to [MainAxisAlignment.spaceAround].
+  final MainAxisAlignment mainAxisAlignment;
+
+  @override
+  Widget build(BuildContext context) {
+    return Container(
+      color: Theme.of(context).platform == TargetPlatform.iOS
+          ? CupertinoTheme.of(context).barBackgroundColor
+          : Theme.of(context).bottomAppBarTheme.color,
+      child: SafeArea(
+        top: false,
+        child: SizedBox(
+          height: kBottomBarHeight,
+          child: Row(
+            mainAxisAlignment: mainAxisAlignment,
+            children: children,
+          ),
+        ),
+      ),
+    );
+  }
+}


### PR DESCRIPTION
This gets rid of a lot of code duplication and makes it more straight-forward to build new screens for new features.

Note that the Row in BottomBar now has MainAxisAlignment.spaceAround by default, so it's not necessary anymore to wrap buttons in `Expanded`.