### PR TITLE
Improve share pgn

### DIFF
--- a/lib/src/view/analysis/analysis_share_screen.dart
+++ b/lib/src/view/analysis/analysis_share_screen.dart
@@ -66,6 +66,26 @@ class _EditPgnTagsFormState extends ConsumerState<_EditPgnTagsForm> {
   final Map<String, FocusNode> _focusNodes = {};
 
   @override
+  void initState() {
+    super.initState();
+    final ctrlProvider = analysisControllerProvider(widget.pgn, widget.options);
+    final pgnHeaders = ref.read(ctrlProvider).pgnHeaders;
+
+    for (final entry in pgnHeaders.entries) {
+      _controllers[entry.key] = TextEditingController(text: entry.value);
+      _focusNodes[entry.key] = FocusNode();
+      _focusNodes[entry.key]!.addListener(() {
+        if (!_focusNodes[entry.key]!.hasFocus) {
+          ref.read(ctrlProvider.notifier).updatePgnHeader(
+                entry.key,
+                _controllers[entry.key]!.text,
+              );
+        }
+      });
+    }
+  }
+
+  @override
   void dispose() {
     for (final controller in _controllers.values) {
       controller.dispose();
@@ -123,20 +143,6 @@ class _EditPgnTagsFormState extends ConsumerState<_EditPgnTagsForm> {
                     (e) => showRatings || !_ratingHeaders.contains(e.key),
                   )
                       .mapIndexed((index, e) {
-                    if (!_controllers.containsKey(e.key)) {
-                      _controllers[e.key] =
-                          TextEditingController(text: e.value);
-                      _focusNodes[e.key] = FocusNode();
-                      _focusNodes[e.key]!.addListener(() {
-                        if (!_focusNodes[e.key]!.hasFocus) {
-                          ref.read(ctrlProvider.notifier).updatePgnHeader(
-                                e.key,
-                                _controllers[e.key]!.text,
-                              );
-                        }
-                      });
-                    }
-
                     return Padding(
                       padding: Styles.horizontalBodyPadding
                           .add(const EdgeInsets.only(bottom: 8.0)),

--- a/lib/src/view/analysis/analysis_share_screen.dart
+++ b/lib/src/view/analysis/analysis_share_screen.dart
@@ -1,4 +1,5 @@
 import 'package:collection/collection.dart';
+import 'package:fast_immutable_collections/fast_immutable_collections.dart';
 import 'package:flutter/cupertino.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
@@ -50,17 +51,64 @@ const Set<String> _ratingHeaders = {
   'BlackRatingDiff',
 };
 
-class _EditPgnTagsForm extends ConsumerWidget {
+class _EditPgnTagsForm extends ConsumerStatefulWidget {
   const _EditPgnTagsForm(this.pgn, this.options);
 
   final String pgn;
   final AnalysisOptions options;
 
   @override
-  Widget build(BuildContext context, WidgetRef ref) {
-    final ctrlProvider = analysisControllerProvider(pgn, options);
+  _EditPgnTagsFormState createState() => _EditPgnTagsFormState();
+}
+
+class _EditPgnTagsFormState extends ConsumerState<_EditPgnTagsForm> {
+  final Map<String, TextEditingController> _controllers = {};
+  final Map<String, FocusNode> _focusNodes = {};
+
+  @override
+  void dispose() {
+    for (final controller in _controllers.values) {
+      controller.dispose();
+    }
+    for (final focusNode in _focusNodes.values) {
+      focusNode.dispose();
+    }
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final ctrlProvider = analysisControllerProvider(widget.pgn, widget.options);
     final pgnHeaders = ref.watch(ctrlProvider.select((c) => c.pgnHeaders));
     final showRatingAsync = ref.watch(showRatingsPrefProvider);
+
+    /// Moves focus to the next field or shows a picker for 'Result'.
+    void focusAndSelectNextField(int index, IMap<String, String> pgnHeaders) {
+      if (index + 1 < pgnHeaders.entries.length) {
+        final nextEntry = pgnHeaders.entries.elementAt(index + 1);
+        if (nextEntry.key == 'Result') {
+          showChoicePicker(
+            context,
+            choices: ['1-0', '0-1', '1/2-1/2', '*'],
+            selectedItem: nextEntry.value,
+            labelBuilder: (choice) => Text(choice),
+            onSelectedItemChanged: (choice) {
+              ref
+                  .read(ctrlProvider.notifier)
+                  .updatePgnHeader(nextEntry.key, choice);
+              _controllers[nextEntry.key]!.text = choice;
+              focusAndSelectNextField(index + 1, pgnHeaders);
+            },
+          );
+        } else {
+          _focusNodes[nextEntry.key]!.requestFocus();
+          _controllers[nextEntry.key]!.selection = TextSelection(
+            baseOffset: 0,
+            extentOffset: _controllers[nextEntry.key]!.text.length,
+          );
+        }
+      }
+    }
 
     return showRatingAsync.maybeWhen(
       data: (showRatings) {
@@ -75,6 +123,20 @@ class _EditPgnTagsForm extends ConsumerWidget {
                     (e) => showRatings || !_ratingHeaders.contains(e.key),
                   )
                       .mapIndexed((index, e) {
+                    if (!_controllers.containsKey(e.key)) {
+                      _controllers[e.key] =
+                          TextEditingController(text: e.value);
+                      _focusNodes[e.key] = FocusNode();
+                      _focusNodes[e.key]!.addListener(() {
+                        if (!_focusNodes[e.key]!.hasFocus) {
+                          ref.read(ctrlProvider.notifier).updatePgnHeader(
+                                e.key,
+                                _controllers[e.key]!.text,
+                              );
+                        }
+                      });
+                    }
+
                     return Padding(
                       padding: Styles.horizontalBodyPadding
                           .add(const EdgeInsets.only(bottom: 8.0)),
@@ -93,6 +155,7 @@ class _EditPgnTagsForm extends ConsumerWidget {
                           const SizedBox(width: 8),
                           Expanded(
                             child: AdaptiveTextField(
+                              focusNode: _focusNodes[e.key],
                               cupertinoDecoration: BoxDecoration(
                                 color: CupertinoColors.tertiarySystemBackground,
                                 border: Border.all(
@@ -101,21 +164,18 @@ class _EditPgnTagsForm extends ConsumerWidget {
                                 ),
                                 borderRadius: BorderRadius.circular(8),
                               ),
-                              controller: TextEditingController.fromValue(
-                                TextEditingValue(
-                                  text: e.value,
-                                  selection: TextSelection(
-                                    baseOffset: 0,
-                                    extentOffset: e.value.length,
-                                  ),
-                                ),
-                              ),
+                              controller: _controllers[e.key],
                               textInputAction: TextInputAction.next,
                               keyboardType:
                                   e.key == 'WhiteElo' || e.key == 'BlackElo'
                                       ? TextInputType.number
                                       : TextInputType.text,
                               onTap: () {
+                                _controllers[e.key]!.selection = TextSelection(
+                                  baseOffset: 0,
+                                  extentOffset:
+                                      _controllers[e.key]!.text.length,
+                                );
                                 if (e.key == 'Result') {
                                   showChoicePicker(
                                     context,
@@ -126,6 +186,11 @@ class _EditPgnTagsForm extends ConsumerWidget {
                                       ref
                                           .read(ctrlProvider.notifier)
                                           .updatePgnHeader(e.key, choice);
+                                      _controllers[e.key]!.text = choice;
+                                      focusAndSelectNextField(
+                                        index,
+                                        pgnHeaders,
+                                      );
                                     },
                                   );
                                 }
@@ -134,6 +199,7 @@ class _EditPgnTagsForm extends ConsumerWidget {
                                 ref
                                     .read(ctrlProvider.notifier)
                                     .updatePgnHeader(e.key, value);
+                                focusAndSelectNextField(index, pgnHeaders);
                               },
                             ),
                           ),
@@ -154,8 +220,8 @@ class _EditPgnTagsForm extends ConsumerWidget {
                             text: ref
                                 .read(
                                   analysisControllerProvider(
-                                    pgn,
-                                    options,
+                                    widget.pgn,
+                                    widget.options,
                                   ).notifier,
                                 )
                                 .makeGamePgn(),


### PR DESCRIPTION
fix #948 
This pull request improves the sharing of PGNs:

- The values of entered text are now saved automatically, so the user doesn't need to submit to save the text.
- Submitting a field automatically jumps to the next one and selects all text. If the next field is the "Result" field, a choice picker will appear.
- Tapping on a field automatically selects all the text.


https://github.com/user-attachments/assets/4b33655a-6684-4d24-a47f-569b50a15b6b




Remarks:
- not tested on iOS
 
