### PR TITLE
improve display and sharing of master games

### DIFF
--- a/lib/src/model/game/archived_game.dart
+++ b/lib/src/model/game/archived_game.dart
@@ -259,14 +259,32 @@ ClockData _clockDataFromPick(RequiredPick pick) {
 }
 
 Player _playerFromUserGamePick(RequiredPick pick) {
+  final originalName = pick('name').asStringOrNull();
   return Player(
     user: pick('user').asLightUserOrNull(),
-    name: pick('name').asStringOrNull(),
-    rating: pick('rating').asIntOrNull(),
+    name: _removeRatingFromName(originalName),
+    rating:
+        pick('rating').asIntOrNull() ?? _extractRatingFromName(originalName),
     ratingDiff: pick('ratingDiff').asIntOrNull(),
     aiLevel: pick('aiLevel').asIntOrNull(),
     analysis: pick('analysis').letOrNull(_playerAnalysisFromPick),
   );
+}
+
+int? _extractRatingFromName(String? name) {
+  if (name == null) return null;
+  final regex = RegExp(r'\((\d+)\)');
+  final match = regex.firstMatch(name);
+  if (match != null) {
+    return int.tryParse(match.group(1)!);
+  }
+  return null;
+}
+
+String? _removeRatingFromName(String? name) {
+  if (name == null) return null;
+  final regex = RegExp(r'\s*\(\d+\)\s*');
+  return name.replaceAll(regex, '');
 }
 
 PlayerAnalysis _playerAnalysisFromPick(RequiredPick pick) {

--- a/lib/src/model/game/game.dart
+++ b/lib/src/model/game/game.dart
@@ -163,10 +163,12 @@ abstract mixin class BaseGame {
         'Site': lichessUri('/$id').toString(),
         'Date': _dateFormat.format(meta.createdAt),
         'White': white.user?.name ??
+            white.name ??
             (white.aiLevel != null
                 ? 'Stockfish level ${white.aiLevel}'
                 : 'Anonymous'),
         'Black': black.user?.name ??
+            black.name ??
             (black.aiLevel != null
                 ? 'Stockfish level ${black.aiLevel}'
                 : 'Anonymous'),

--- a/lib/src/view/game/game_player.dart
+++ b/lib/src/view/game/game_player.dart
@@ -61,11 +61,13 @@ class GamePlayer extends StatelessWidget {
           Row(
             mainAxisAlignment: MainAxisAlignment.start,
             children: [
-              Icon(
-                player.onGame == true ? Icons.cloud : Icons.cloud_off,
-                color: player.onGame == true ? LichessColors.green : null,
-                size: 14,
-              ),
+              if (player.user != null) ...[
+                Icon(
+                  player.onGame == true ? Icons.cloud : Icons.cloud_off,
+                  color: player.onGame == true ? LichessColors.green : null,
+                  size: 14,
+                ),
+              ],
               const SizedBox(width: 5),
               if (player.user?.isPatron == true) ...[
                 Icon(


### PR DESCRIPTION
Improves the display of master games opened from the masters database in the opening explorer:

- The rating is now parsed (f.ex Carlsen, M. (2882) gets split up) and saved in the rating field.
- The offline icon is no longer shown as it doesn’t apply to master games.
- When opening a game from the database, then viewing it in the analysis board and sharing it as a PGN, the player names and ratings are now included in the PGN.

| **Before** | **After** |
|------------|-----------|
| ![Screenshot_20240901-144106](https://github.com/user-attachments/assets/2ae872c5-f22a-4611-9671-8c63eb83c62e) | ![Screenshot_20240901-144012](https://github.com/user-attachments/assets/7f6e719e-eb5b-4d50-958e-85f6a4014ba7) |
| ![Screenshot_20240901-144117](https://github.com/user-attachments/assets/bdd0cb49-7a0b-4681-9dcb-a0351ba75ee0) | ![Screenshot_20240901-144023](https://github.com/user-attachments/assets/39e01a4d-bc49-4a26-8ae8-80f9e256e335) |

