### PR TITLE
refactor: add PlatformScaffold and PlatformAppBar widgets

### DIFF
--- a/lib/src/view/account/edit_profile_screen.dart
+++ b/lib/src/view/account/edit_profile_screen.dart
@@ -12,7 +12,7 @@ import 'package:lichess_mobile/src/widgets/adaptive_autocomplete.dart';
 import 'package:lichess_mobile/src/widgets/adaptive_text_field.dart';
 import 'package:lichess_mobile/src/widgets/buttons.dart';
 import 'package:lichess_mobile/src/widgets/feedback.dart';
-import 'package:lichess_mobile/src/widgets/platform.dart';
+import 'package:lichess_mobile/src/widgets/platform_scaffold.dart';
 import 'package:result_extensions/result_extensions.dart';
 
 final _countries = countries.values.toList();
@@ -22,25 +22,11 @@ class EditProfileScreen extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    return PlatformWidget(
-      androidBuilder: _buildAndroid,
-      iosBuilder: _buildIos,
-    );
-  }
-
-  Widget _buildAndroid(BuildContext context) {
-    return Scaffold(
-      appBar: AppBar(
+    return PlatformScaffold(
+      appBar: PlatformAppBar(
         title: Text(context.l10n.editProfile),
       ),
       body: _Body(),
-    );
-  }
-
-  Widget _buildIos(BuildContext context) {
-    return CupertinoPageScaffold(
-      navigationBar: const CupertinoNavigationBar(),
-      child: _Body(),
     );
   }
 }

--- a/lib/src/view/account/profile_screen.dart
+++ b/lib/src/view/account/profile_screen.dart
@@ -1,4 +1,3 @@
-import 'package:flutter/cupertino.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:lichess_mobile/src/model/account/account_repository.dart';
@@ -12,7 +11,7 @@ import 'package:lichess_mobile/src/view/user/user_activity.dart';
 import 'package:lichess_mobile/src/view/user/user_profile.dart';
 import 'package:lichess_mobile/src/widgets/buttons.dart';
 import 'package:lichess_mobile/src/widgets/feedback.dart';
-import 'package:lichess_mobile/src/widgets/platform.dart';
+import 'package:lichess_mobile/src/widgets/platform_scaffold.dart';
 import 'package:lichess_mobile/src/widgets/shimmer.dart';
 import 'package:lichess_mobile/src/widgets/user_full_name.dart';
 
@@ -21,17 +20,9 @@ class ProfileScreen extends ConsumerWidget {
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
-    return ConsumerPlatformWidget(
-      ref: ref,
-      androidBuilder: _buildAndroid,
-      iosBuilder: _buildIos,
-    );
-  }
-
-  Widget _buildAndroid(BuildContext context, WidgetRef ref) {
     final account = ref.watch(accountProvider);
-    return Scaffold(
-      appBar: AppBar(
+    return PlatformScaffold(
+      appBar: PlatformAppBar(
         title: account.when(
           data: (user) => user == null
               ? const SizedBox.shrink()
@@ -67,56 +58,6 @@ class ProfileScreen extends ConsumerWidget {
           );
         },
         loading: () => const Center(child: CircularProgressIndicator()),
-        error: (error, _) {
-          return FullScreenRetryRequest(
-            onRetry: () => ref.invalidate(accountProvider),
-          );
-        },
-      ),
-    );
-  }
-
-  Widget _buildIos(BuildContext context, WidgetRef ref) {
-    final account = ref.watch(accountProvider);
-    return CupertinoPageScaffold(
-      navigationBar: CupertinoNavigationBar(
-        middle: account.when(
-          data: (user) => user == null
-              ? const SizedBox.shrink()
-              : UserFullNameWidget(user: user.lightUser),
-          loading: () => const SizedBox.shrink(),
-          error: (error, _) => const SizedBox.shrink(),
-        ),
-        trailing: AppBarIconButton(
-          icon: const Icon(CupertinoIcons.square_pencil),
-          semanticsLabel: context.l10n.editProfile,
-          onPressed: () => pushPlatformRoute(
-            title: context.l10n.editProfile,
-            context,
-            builder: (_) => const EditProfileScreen(),
-          ),
-        ),
-      ),
-      child: account.when(
-        data: (user) {
-          if (user == null) {
-            return Center(
-              child: Text(context.l10n.mobileMustBeLoggedIn),
-            );
-          }
-          return SafeArea(
-            child: ListView(
-              children: [
-                UserProfileWidget(user: user),
-                const AccountPerfCards(),
-                const UserActivityWidget(),
-                const RecentGamesWidget(),
-              ],
-            ),
-          );
-        },
-        loading: () =>
-            const Center(child: CircularProgressIndicator.adaptive()),
         error: (error, _) {
           return FullScreenRetryRequest(
             onRetry: () => ref.invalidate(accountProvider),

--- a/lib/src/view/analysis/analysis_screen.dart
+++ b/lib/src/view/analysis/analysis_screen.dart
@@ -38,6 +38,7 @@ import 'package:lichess_mobile/src/widgets/buttons.dart';
 import 'package:lichess_mobile/src/widgets/feedback.dart';
 import 'package:lichess_mobile/src/widgets/list.dart';
 import 'package:lichess_mobile/src/widgets/platform.dart';
+import 'package:lichess_mobile/src/widgets/platform_scaffold.dart';
 import 'package:popover/popover.dart';
 
 import '../../utils/share.dart';
@@ -134,9 +135,9 @@ class _LoadedAnalysisScreen extends ConsumerWidget {
   Widget _androidBuilder(BuildContext context, WidgetRef ref) {
     final ctrlProvider = analysisControllerProvider(pgn, options);
 
-    return Scaffold(
+    return PlatformScaffold(
       resizeToAvoidBottomInset: false,
-      appBar: AppBar(
+      appBar: PlatformAppBar(
         title: _Title(options: options, title: title),
         actions: [
           _EngineDepth(ctrlProvider),

--- a/lib/src/view/analysis/analysis_share_screen.dart
+++ b/lib/src/view/analysis/analysis_share_screen.dart
@@ -1,6 +1,5 @@
 import 'package:collection/collection.dart';
 import 'package:flutter/cupertino.dart';
-import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:lichess_mobile/src/model/account/account_preferences.dart';
 import 'package:lichess_mobile/src/model/analysis/analysis_controller.dart';
@@ -10,7 +9,7 @@ import 'package:lichess_mobile/src/utils/share.dart';
 import 'package:lichess_mobile/src/widgets/adaptive_choice_picker.dart';
 import 'package:lichess_mobile/src/widgets/adaptive_text_field.dart';
 import 'package:lichess_mobile/src/widgets/buttons.dart';
-import 'package:lichess_mobile/src/widgets/platform.dart';
+import 'package:lichess_mobile/src/widgets/platform_scaffold.dart';
 
 class AnalysisShareScreen extends StatelessWidget {
   const AnalysisShareScreen({required this.pgn, required this.options});
@@ -20,25 +19,11 @@ class AnalysisShareScreen extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    return PlatformWidget(
-      androidBuilder: _buildAndroid,
-      iosBuilder: _buildIos,
-    );
-  }
-
-  Widget _buildAndroid(BuildContext context) {
-    return Scaffold(
-      appBar: AppBar(
+    return PlatformScaffold(
+      appBar: PlatformAppBar(
         title: Text(context.l10n.studyShareAndExport),
       ),
       body: _EditPgnTagsForm(pgn, options),
-    );
-  }
-
-  Widget _buildIos(BuildContext context) {
-    return CupertinoPageScaffold(
-      navigationBar: const CupertinoNavigationBar(),
-      child: _EditPgnTagsForm(pgn, options),
     );
   }
 }

--- a/lib/src/view/board_editor/board_editor_screen.dart
+++ b/lib/src/view/board_editor/board_editor_screen.dart
@@ -17,7 +17,7 @@ import 'package:lichess_mobile/src/view/analysis/analysis_screen.dart';
 import 'package:lichess_mobile/src/view/board_editor/board_editor_menu.dart';
 import 'package:lichess_mobile/src/widgets/adaptive_bottom_sheet.dart';
 import 'package:lichess_mobile/src/widgets/bottom_bar_button.dart';
-import 'package:lichess_mobile/src/widgets/platform.dart';
+import 'package:lichess_mobile/src/widgets/platform_scaffold.dart';
 
 class BoardEditorScreen extends StatelessWidget {
   const BoardEditorScreen({super.key, this.initialFen});
@@ -26,29 +26,11 @@ class BoardEditorScreen extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    return PlatformWidget(
-      androidBuilder: _androidBuilder,
-      iosBuilder: _iosBuilder,
-    );
-  }
-
-  Widget _androidBuilder(BuildContext context) {
-    return Scaffold(
-      appBar: AppBar(
+    return PlatformScaffold(
+      appBar: PlatformAppBar(
         title: Text(context.l10n.boardEditor),
       ),
       body: _Body(initialFen),
-    );
-  }
-
-  Widget _iosBuilder(BuildContext context) {
-    return CupertinoPageScaffold(
-      navigationBar: CupertinoNavigationBar(
-        backgroundColor: Styles.cupertinoScaffoldColor.resolveFrom(context),
-        border: null,
-        middle: Text(context.l10n.boardEditor),
-      ),
-      child: _Body(initialFen),
     );
   }
 }

--- a/lib/src/view/broadcast/broadcast_round_screen.dart
+++ b/lib/src/view/broadcast/broadcast_round_screen.dart
@@ -2,7 +2,6 @@ import 'dart:async';
 
 import 'package:dartchess/dartchess.dart';
 import 'package:fast_immutable_collections/fast_immutable_collections.dart';
-import 'package:flutter/cupertino.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_svg/flutter_svg.dart';
@@ -15,7 +14,7 @@ import 'package:lichess_mobile/src/utils/duration.dart';
 import 'package:lichess_mobile/src/utils/lichess_assets.dart';
 import 'package:lichess_mobile/src/utils/screen.dart';
 import 'package:lichess_mobile/src/widgets/board_thumbnail.dart';
-import 'package:lichess_mobile/src/widgets/platform.dart';
+import 'package:lichess_mobile/src/widgets/platform_scaffold.dart';
 import 'package:lichess_mobile/src/widgets/shimmer.dart';
 
 // height of 1.0 is important because we need to determine the height of the text
@@ -37,31 +36,11 @@ class BroadcastRoundScreen extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    return PlatformWidget(
-      androidBuilder: _androidBuilder,
-      iosBuilder: _iosBuilder,
-    );
-  }
-
-  Widget _androidBuilder(
-    BuildContext context,
-  ) {
-    return Scaffold(
-      appBar: AppBar(
+    return PlatformScaffold(
+      appBar: PlatformAppBar(
         title: Text(broadCastTitle),
       ),
       body: _Body(roundId),
-    );
-  }
-
-  Widget _iosBuilder(
-    BuildContext context,
-  ) {
-    return CupertinoPageScaffold(
-      navigationBar: CupertinoNavigationBar(
-        middle: Text(broadCastTitle),
-      ),
-      child: _Body(roundId),
     );
   }
 }

--- a/lib/src/view/broadcast/broadcasts_list_screen.dart
+++ b/lib/src/view/broadcast/broadcasts_list_screen.dart
@@ -1,4 +1,3 @@
-import 'package:flutter/cupertino.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:intl/intl.dart';
@@ -13,7 +12,7 @@ import 'package:lichess_mobile/src/utils/navigation.dart';
 import 'package:lichess_mobile/src/view/broadcast/broadcast_round_screen.dart';
 import 'package:lichess_mobile/src/view/broadcast/default_broadcast_image.dart';
 import 'package:lichess_mobile/src/widgets/buttons.dart';
-import 'package:lichess_mobile/src/widgets/platform.dart';
+import 'package:lichess_mobile/src/widgets/platform_scaffold.dart';
 import 'package:lichess_mobile/src/widgets/shimmer.dart';
 
 final _dateFormatter = DateFormat.MMMd(Intl.getCurrentLocale()).add_Hm();
@@ -24,31 +23,11 @@ class BroadcastsListScreen extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    return PlatformWidget(
-      androidBuilder: _androidBuilder,
-      iosBuilder: _iosBuilder,
-    );
-  }
-
-  Widget _androidBuilder(
-    BuildContext context,
-  ) {
-    return Scaffold(
-      appBar: AppBar(
+    return PlatformScaffold(
+      appBar: PlatformAppBar(
         title: Text(context.l10n.broadcastLiveBroadcasts),
       ),
       body: const _Body(),
-    );
-  }
-
-  Widget _iosBuilder(
-    BuildContext context,
-  ) {
-    return CupertinoPageScaffold(
-      navigationBar: CupertinoNavigationBar(
-        middle: Text(context.l10n.broadcastLiveBroadcasts),
-      ),
-      child: const _Body(),
     );
   }
 }

--- a/lib/src/view/correspondence/offline_correspondence_game_screen.dart
+++ b/lib/src/view/correspondence/offline_correspondence_game_screen.dart
@@ -24,7 +24,7 @@ import 'package:lichess_mobile/src/widgets/adaptive_action_sheet.dart';
 import 'package:lichess_mobile/src/widgets/board_table.dart';
 import 'package:lichess_mobile/src/widgets/bottom_bar_button.dart';
 import 'package:lichess_mobile/src/widgets/buttons.dart';
-import 'package:lichess_mobile/src/widgets/platform.dart';
+import 'package:lichess_mobile/src/widgets/platform_scaffold.dart';
 
 class OfflineCorrespondenceGameScreen extends StatefulWidget {
   const OfflineCorrespondenceGameScreen({
@@ -57,31 +57,10 @@ class _OfflineCorrespondenceGameScreenState
 
   @override
   Widget build(BuildContext context) {
-    return PlatformWidget(
-      androidBuilder: _androidBuilder,
-      iosBuilder: _iosBuilder,
-    );
-  }
-
-  Widget _androidBuilder(BuildContext context) {
     final (lastModified, game) = currentGame;
-    return Scaffold(
-      appBar: AppBar(title: _Title(game)),
+    return PlatformScaffold(
+      appBar: PlatformAppBar(title: _Title(game)),
       body: _Body(
-        game: game,
-        lastModified: lastModified,
-        onGameChanged: goToNextGame,
-      ),
-    );
-  }
-
-  Widget _iosBuilder(BuildContext context) {
-    final (lastModified, game) = currentGame;
-    return CupertinoPageScaffold(
-      navigationBar: CupertinoNavigationBar(
-        middle: _Title(game),
-      ),
-      child: _Body(
         game: game,
         lastModified: lastModified,
         onGameChanged: goToNextGame,

--- a/lib/src/view/game/archived_game_screen.dart
+++ b/lib/src/view/game/archived_game_screen.dart
@@ -6,7 +6,6 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:lichess_mobile/src/constants.dart';
 import 'package:lichess_mobile/src/model/analysis/analysis_controller.dart';
 import 'package:lichess_mobile/src/model/game/archived_game.dart';
-import 'package:lichess_mobile/src/styles/styles.dart';
 import 'package:lichess_mobile/src/utils/l10n_context.dart';
 import 'package:lichess_mobile/src/utils/navigation.dart';
 import 'package:lichess_mobile/src/view/analysis/analysis_screen.dart';
@@ -19,7 +18,7 @@ import 'package:lichess_mobile/src/widgets/board_table.dart';
 import 'package:lichess_mobile/src/widgets/bottom_bar_button.dart';
 import 'package:lichess_mobile/src/widgets/buttons.dart';
 import 'package:lichess_mobile/src/widgets/countdown_clock.dart';
-import 'package:lichess_mobile/src/widgets/platform.dart';
+import 'package:lichess_mobile/src/widgets/platform_scaffold.dart';
 
 import 'archived_game_screen_providers.dart';
 
@@ -38,54 +37,24 @@ class ArchivedGameScreen extends ConsumerWidget {
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
-    return ConsumerPlatformWidget(
-      ref: ref,
-      androidBuilder: _androidBuilder,
-      iosBuilder: _iosBuilder,
-    );
-  }
-
-  Widget _androidBuilder(BuildContext context, WidgetRef ref) {
-    return Scaffold(
-      appBar: AppBar(
+    return PlatformScaffold(
+      appBar: PlatformAppBar(
         title: _GameTitle(gameData: gameData),
         actions: [
           ToggleSoundButton(),
         ],
       ),
-      body: _BoardBody(
-        gameData: gameData,
-        orientation: orientation,
-        initialCursor: initialCursor,
-      ),
-      bottomNavigationBar:
-          _BottomBar(gameData: gameData, orientation: orientation),
-    );
-  }
-
-  Widget _iosBuilder(BuildContext context, WidgetRef ref) {
-    return CupertinoPageScaffold(
-      navigationBar: CupertinoNavigationBar(
-        backgroundColor: Styles.cupertinoScaffoldColor.resolveFrom(context),
-        border: null,
-        middle: _GameTitle(gameData: gameData),
-        padding: const EdgeInsetsDirectional.only(end: 16.0),
-        trailing: ToggleSoundButton(),
-      ),
-      child: SafeArea(
-        bottom: false,
-        child: Column(
-          children: [
-            Expanded(
-              child: _BoardBody(
-                gameData: gameData,
-                orientation: orientation,
-                initialCursor: initialCursor,
-              ),
+      body: Column(
+        children: [
+          Expanded(
+            child: _BoardBody(
+              gameData: gameData,
+              orientation: orientation,
+              initialCursor: initialCursor,
             ),
-            _BottomBar(gameData: gameData, orientation: orientation),
-          ],
-        ),
+          ),
+          _BottomBar(gameData: gameData, orientation: orientation),
+        ],
       ),
     );
   }

--- a/lib/src/view/game/game_common_widgets.dart
+++ b/lib/src/view/game/game_common_widgets.dart
@@ -1,5 +1,4 @@
 import 'package:dartchess/dartchess.dart';
-import 'package:flutter/cupertino.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:lichess_mobile/src/model/challenge/challenge.dart';
@@ -9,19 +8,19 @@ import 'package:lichess_mobile/src/model/common/time_increment.dart';
 import 'package:lichess_mobile/src/model/game/game.dart';
 import 'package:lichess_mobile/src/model/game/game_share_service.dart';
 import 'package:lichess_mobile/src/model/lobby/game_seek.dart';
-import 'package:lichess_mobile/src/styles/styles.dart';
 import 'package:lichess_mobile/src/utils/l10n_context.dart';
 import 'package:lichess_mobile/src/utils/share.dart';
 import 'package:lichess_mobile/src/widgets/adaptive_action_sheet.dart';
 import 'package:lichess_mobile/src/widgets/adaptive_bottom_sheet.dart';
 import 'package:lichess_mobile/src/widgets/buttons.dart';
 import 'package:lichess_mobile/src/widgets/feedback.dart';
+import 'package:lichess_mobile/src/widgets/platform_scaffold.dart';
 
 import 'game_screen_providers.dart';
 import 'game_settings.dart';
 import 'ping_rating.dart';
 
-class GameAppBar extends ConsumerWidget implements PreferredSizeWidget {
+class GameAppBar extends ConsumerWidget {
   const GameAppBar({this.id, this.seek, this.challenge, super.key});
 
   final GameSeek? seek;
@@ -39,7 +38,7 @@ class GameAppBar extends ConsumerWidget implements PreferredSizeWidget {
         ? ref.watch(shouldPreventGoingBackProvider(id!))
         : const AsyncValue.data(true);
 
-    return AppBar(
+    return PlatformAppBar(
       leading: shouldPreventGoingBackAsync.maybeWhen<Widget?>(
         data: (prevent) => prevent ? pingRating : null,
         orElse: () => pingRating,
@@ -66,71 +65,6 @@ class GameAppBar extends ConsumerWidget implements PreferredSizeWidget {
           ),
       ],
     );
-  }
-
-  @override
-  Size get preferredSize => const Size.fromHeight(kToolbarHeight);
-}
-
-class GameCupertinoNavBar extends ConsumerWidget
-    implements ObstructingPreferredSizeWidget {
-  const GameCupertinoNavBar({this.id, this.seek, this.challenge, super.key});
-
-  final GameSeek? seek;
-  final ChallengeRequest? challenge;
-  final GameFullId? id;
-
-  static const pingRating = Padding(
-    padding: EdgeInsets.symmetric(horizontal: 16.0, vertical: 12.0),
-    child: PingRating(size: 24.0),
-  );
-
-  @override
-  Widget build(BuildContext context, WidgetRef ref) {
-    final shouldPreventGoingBackAsync = id != null
-        ? ref.watch(shouldPreventGoingBackProvider(id!))
-        : const AsyncValue.data(true);
-
-    return CupertinoNavigationBar(
-      backgroundColor: Styles.cupertinoScaffoldColor.resolveFrom(context),
-      border: null,
-      padding: Styles.cupertinoAppBarTrailingWidgetPadding,
-      leading: shouldPreventGoingBackAsync.maybeWhen<Widget?>(
-        data: (prevent) => prevent ? pingRating : null,
-        orElse: () => pingRating,
-      ),
-      middle: id != null
-          ? StandaloneGameTitle(id: id!)
-          : seek != null
-              ? _LobbyGameTitle(seek: seek!)
-              : challenge != null
-                  ? _ChallengeGameTitle(challenge: challenge!)
-                  : const SizedBox.shrink(),
-      trailing: id != null
-          ? AppBarIconButton(
-              onPressed: () => showAdaptiveBottomSheet<void>(
-                context: context,
-                isDismissible: true,
-                isScrollControlled: true,
-                showDragHandle: true,
-                builder: (_) => GameSettings(id: id!),
-              ),
-              semanticsLabel: context.l10n.settingsSettings,
-              icon: const Icon(Icons.settings),
-            )
-          : null,
-    );
-  }
-
-  @override
-  Size get preferredSize =>
-      const Size.fromHeight(kMinInteractiveDimensionCupertino);
-
-  /// True if the navigation bar's background color has no transparency.
-  @override
-  bool shouldFullyObstruct(BuildContext context) {
-    final Color backgroundColor = CupertinoTheme.of(context).barBackgroundColor;
-    return backgroundColor.alpha == 0xFF;
   }
 }
 

--- a/lib/src/view/game/game_screen.dart
+++ b/lib/src/view/game/game_screen.dart
@@ -13,7 +13,7 @@ import 'package:lichess_mobile/src/model/lobby/game_setup.dart';
 import 'package:lichess_mobile/src/navigation.dart';
 import 'package:lichess_mobile/src/utils/navigation.dart';
 import 'package:lichess_mobile/src/view/game/game_loading_board.dart';
-import 'package:lichess_mobile/src/widgets/platform.dart';
+import 'package:lichess_mobile/src/widgets/platform_scaffold.dart';
 import 'package:riverpod_annotation/riverpod_annotation.dart';
 
 import 'game_body.dart';
@@ -174,17 +174,10 @@ class _GameScreenState extends ConsumerState<GameScreen> with RouteAware {
                     destUser: widget.challenge?.destUser,
                   )
                 : const LoadGameError('Could not create the game.');
-        return PlatformWidget(
-          androidBuilder: (context) => Scaffold(
-            resizeToAvoidBottomInset: false,
-            appBar: GameAppBar(id: gameId),
-            body: body,
-          ),
-          iosBuilder: (context) => CupertinoPageScaffold(
-            resizeToAvoidBottomInset: false,
-            navigationBar: GameCupertinoNavBar(id: gameId),
-            child: body,
-          ),
+        return PlatformScaffold(
+          resizeToAvoidBottomInset: false,
+          appBar: GameAppBar(id: gameId),
+          body: body,
         );
       },
       loading: () {
@@ -200,22 +193,12 @@ class _GameScreenState extends ConsumerState<GameScreen> with RouteAware {
                   )
                 : const StandaloneGameLoadingBoard();
 
-        return PlatformWidget(
-          androidBuilder: (context) => Scaffold(
-            resizeToAvoidBottomInset: false,
-            appBar: GameAppBar(seek: widget.seek),
-            body: PopScope(
-              canPop: false,
-              child: loadingBoard,
-            ),
-          ),
-          iosBuilder: (context) => CupertinoPageScaffold(
-            resizeToAvoidBottomInset: false,
-            navigationBar: GameCupertinoNavBar(seek: widget.seek),
-            child: PopScope(
-              canPop: false,
-              child: loadingBoard,
-            ),
+        return PlatformScaffold(
+          resizeToAvoidBottomInset: false,
+          appBar: GameAppBar(seek: widget.seek),
+          body: PopScope(
+            canPop: false,
+            child: loadingBoard,
           ),
         );
       },
@@ -235,17 +218,9 @@ class _GameScreenState extends ConsumerState<GameScreen> with RouteAware {
 
         final body = PopScope(child: message);
 
-        return PlatformWidget(
-          androidBuilder: (context) => Scaffold(
-            resizeToAvoidBottomInset: false,
-            appBar: GameAppBar(seek: widget.seek),
-            body: body,
-          ),
-          iosBuilder: (context) => CupertinoPageScaffold(
-            resizeToAvoidBottomInset: false,
-            navigationBar: GameCupertinoNavBar(seek: widget.seek),
-            child: body,
-          ),
+        return PlatformScaffold(
+          appBar: GameAppBar(seek: widget.seek),
+          body: body,
         );
       },
     );

--- a/lib/src/view/game/message_screen.dart
+++ b/lib/src/view/game/message_screen.dart
@@ -12,7 +12,7 @@ import 'package:lichess_mobile/src/styles/styles.dart';
 import 'package:lichess_mobile/src/utils/l10n_context.dart';
 import 'package:lichess_mobile/src/widgets/adaptive_text_field.dart';
 import 'package:lichess_mobile/src/widgets/buttons.dart';
-import 'package:lichess_mobile/src/widgets/platform.dart';
+import 'package:lichess_mobile/src/widgets/platform_scaffold.dart';
 
 class MessageScreen extends ConsumerStatefulWidget {
   final GameFullId id;
@@ -53,37 +53,12 @@ class _MessageScreenState extends ConsumerState<MessageScreen> with RouteAware {
 
   @override
   Widget build(BuildContext context) {
-    final body = _Body(me: widget.me, id: widget.id);
-
-    return PlatformWidget(
-      androidBuilder: (context) =>
-          _androidBuilder(context: context, body: body),
-      iosBuilder: (context) => _iosBuilder(context: context, body: body),
-    );
-  }
-
-  Widget _androidBuilder({
-    required BuildContext context,
-    required Widget body,
-  }) {
-    return Scaffold(
-      appBar: AppBar(
+    return PlatformScaffold(
+      appBar: PlatformAppBar(
         title: widget.title,
         centerTitle: true,
       ),
-      body: body,
-    );
-  }
-
-  Widget _iosBuilder({
-    required BuildContext context,
-    required Widget body,
-  }) {
-    return CupertinoPageScaffold(
-      navigationBar: CupertinoNavigationBar(
-        middle: widget.title,
-      ),
-      child: body,
+      body: _Body(me: widget.me, id: widget.id),
     );
   }
 }

--- a/lib/src/view/game/offline_correspondence_games_screen.dart
+++ b/lib/src/view/game/offline_correspondence_games_screen.dart
@@ -8,7 +8,7 @@ import 'package:lichess_mobile/src/utils/l10n_context.dart';
 import 'package:lichess_mobile/src/utils/navigation.dart';
 import 'package:lichess_mobile/src/view/correspondence/offline_correspondence_game_screen.dart';
 import 'package:lichess_mobile/src/widgets/board_preview.dart';
-import 'package:lichess_mobile/src/widgets/platform.dart';
+import 'package:lichess_mobile/src/widgets/platform_scaffold.dart';
 import 'package:lichess_mobile/src/widgets/user_full_name.dart';
 import 'package:timeago/timeago.dart' as timeago;
 
@@ -17,27 +17,13 @@ class OfflineCorrespondenceGamesScreen extends ConsumerWidget {
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
-    return ConsumerPlatformWidget(
-      ref: ref,
-      androidBuilder: _buildAndroid,
-      iosBuilder: _buildIos,
-    );
-  }
-
-  Widget _buildIos(BuildContext context, WidgetRef ref) {
-    return CupertinoPageScaffold(
-      navigationBar: const CupertinoNavigationBar(),
-      child: _Body(),
-    );
-  }
-
-  Widget _buildAndroid(BuildContext context, WidgetRef ref) {
     final offlineGames = ref.watch(offlineOngoingCorrespondenceGamesProvider);
-    return Scaffold(
-      appBar: offlineGames.maybeWhen(
-        data: (data) =>
-            AppBar(title: Text(context.l10n.nbGamesInPlay(data.length))),
-        orElse: () => AppBar(title: const SizedBox.shrink()),
+    return PlatformScaffold(
+      appBar: PlatformAppBar(
+        title: offlineGames.maybeWhen(
+          data: (data) => Text(context.l10n.nbGamesInPlay(data.length)),
+          orElse: () => const SizedBox.shrink(),
+        ),
       ),
       body: _Body(),
     );

--- a/lib/src/view/opening_explorer/opening_explorer_screen.dart
+++ b/lib/src/view/opening_explorer/opening_explorer_screen.dart
@@ -12,7 +12,6 @@ import 'package:lichess_mobile/src/model/game/game_repository_providers.dart';
 import 'package:lichess_mobile/src/model/opening_explorer/opening_explorer.dart';
 import 'package:lichess_mobile/src/model/opening_explorer/opening_explorer_preferences.dart';
 import 'package:lichess_mobile/src/model/opening_explorer/opening_explorer_repository.dart';
-import 'package:lichess_mobile/src/styles/styles.dart';
 import 'package:lichess_mobile/src/utils/l10n_context.dart';
 import 'package:lichess_mobile/src/utils/navigation.dart';
 import 'package:lichess_mobile/src/utils/screen.dart';
@@ -22,6 +21,7 @@ import 'package:lichess_mobile/src/widgets/adaptive_bottom_sheet.dart';
 import 'package:lichess_mobile/src/widgets/bottom_bar_button.dart';
 import 'package:lichess_mobile/src/widgets/buttons.dart';
 import 'package:lichess_mobile/src/widgets/platform.dart';
+import 'package:lichess_mobile/src/widgets/platform_scaffold.dart';
 import 'package:lichess_mobile/src/widgets/shimmer.dart';
 import 'package:url_launcher/url_launcher.dart';
 
@@ -42,28 +42,11 @@ class OpeningExplorerScreen extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    return PlatformWidget(
-      androidBuilder: _androidBuilder,
-      iosBuilder: _iosBuilder,
-    );
-  }
-
-  Widget _androidBuilder(BuildContext context) {
-    return Scaffold(
-      appBar: AppBar(
+    return PlatformScaffold(
+      appBar: PlatformAppBar(
         title: Text(context.l10n.openingExplorer),
       ),
       body: _Body(pgn: pgn, options: options),
-    );
-  }
-
-  Widget _iosBuilder(BuildContext context) {
-    return CupertinoPageScaffold(
-      navigationBar: CupertinoNavigationBar(
-        backgroundColor: Styles.cupertinoScaffoldColor.resolveFrom(context),
-        middle: Text(context.l10n.openingExplorer),
-      ),
-      child: _Body(pgn: pgn, options: options),
     );
   }
 }

--- a/lib/src/view/play/challenge_screen.dart
+++ b/lib/src/view/play/challenge_screen.dart
@@ -1,7 +1,6 @@
 import 'dart:async';
 
 import 'package:dartchess/dartchess.dart';
-import 'package:flutter/cupertino.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
@@ -25,7 +24,7 @@ import 'package:lichess_mobile/src/widgets/expanded_section.dart';
 import 'package:lichess_mobile/src/widgets/feedback.dart';
 import 'package:lichess_mobile/src/widgets/list.dart';
 import 'package:lichess_mobile/src/widgets/non_linear_slider.dart';
-import 'package:lichess_mobile/src/widgets/platform.dart';
+import 'package:lichess_mobile/src/widgets/platform_scaffold.dart';
 
 class ChallengeScreen extends StatelessWidget {
   const ChallengeScreen(this.user);
@@ -34,19 +33,10 @@ class ChallengeScreen extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    return PlatformWidget(androidBuilder: _buildAndroid, iosBuilder: _buildIos);
-  }
-
-  Widget _buildIos(BuildContext context) {
-    return CupertinoPageScaffold(
-      navigationBar: const CupertinoNavigationBar(),
-      child: _ChallengeBody(user),
-    );
-  }
-
-  Widget _buildAndroid(BuildContext context) {
-    return Scaffold(
-      appBar: AppBar(title: Text(context.l10n.challengeChallengesX(user.name))),
+    return PlatformScaffold(
+      appBar: PlatformAppBar(
+        title: Text(context.l10n.challengeChallengesX(user.name)),
+      ),
       body: _ChallengeBody(user),
     );
   }

--- a/lib/src/view/play/online_bots_screen.dart
+++ b/lib/src/view/play/online_bots_screen.dart
@@ -17,7 +17,7 @@ import 'package:lichess_mobile/src/view/user/user_screen.dart';
 import 'package:lichess_mobile/src/widgets/adaptive_bottom_sheet.dart';
 import 'package:lichess_mobile/src/widgets/feedback.dart';
 import 'package:lichess_mobile/src/widgets/list.dart';
-import 'package:lichess_mobile/src/widgets/platform.dart';
+import 'package:lichess_mobile/src/widgets/platform_scaffold.dart';
 import 'package:lichess_mobile/src/widgets/user_full_name.dart';
 import 'package:linkify/linkify.dart';
 import 'package:riverpod_annotation/riverpod_annotation.dart';
@@ -53,22 +53,8 @@ class OnlineBotsScreen extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    return PlatformWidget(
-      androidBuilder: _buildAndroid,
-      iosBuilder: _buildIos,
-    );
-  }
-
-  Widget _buildIos(BuildContext context) {
-    return CupertinoPageScaffold(
-      navigationBar: const CupertinoNavigationBar(),
-      child: _Body(),
-    );
-  }
-
-  Widget _buildAndroid(BuildContext context) {
-    return Scaffold(
-      appBar: AppBar(
+    return PlatformScaffold(
+      appBar: PlatformAppBar(
         title: Text(context.l10n.onlineBots),
       ),
       body: _Body(),

--- a/lib/src/view/play/play_screen.dart
+++ b/lib/src/view/play/play_screen.dart
@@ -4,48 +4,28 @@ import 'package:lichess_mobile/src/styles/styles.dart';
 import 'package:lichess_mobile/src/utils/l10n_context.dart';
 import 'package:lichess_mobile/src/view/home/create_game_options.dart';
 import 'package:lichess_mobile/src/view/play/quick_game_button.dart';
-import 'package:lichess_mobile/src/widgets/platform.dart';
+import 'package:lichess_mobile/src/widgets/platform_scaffold.dart';
 
 class PlayScreen extends StatelessWidget {
   const PlayScreen();
 
   @override
   Widget build(BuildContext context) {
-    return PlatformWidget(androidBuilder: _buildAndroid, iosBuilder: _buildIos);
-  }
-
-  Widget _buildIos(BuildContext context) {
-    return const CupertinoPageScaffold(
-      navigationBar: CupertinoNavigationBar(),
-      child: _Body(),
-    );
-  }
-
-  Widget _buildAndroid(BuildContext context) {
-    return Scaffold(
-      appBar: AppBar(
+    return PlatformScaffold(
+      appBar: PlatformAppBar(
         title: Text(context.l10n.play),
       ),
-      body: const _Body(),
-    );
-  }
-}
-
-class _Body extends StatelessWidget {
-  const _Body();
-
-  @override
-  Widget build(BuildContext context) {
-    return SafeArea(
-      child: Column(
-        mainAxisAlignment: MainAxisAlignment.center,
-        children: <Widget>[
-          Padding(
-            padding: Styles.bodySectionPadding,
-            child: const QuickGameButton(),
-          ),
-          const CreateGameOptions(),
-        ],
+      body: SafeArea(
+        child: Column(
+          mainAxisAlignment: MainAxisAlignment.center,
+          children: <Widget>[
+            Padding(
+              padding: Styles.bodySectionPadding,
+              child: const QuickGameButton(),
+            ),
+            const CreateGameOptions(),
+          ],
+        ),
       ),
     );
   }

--- a/lib/src/view/puzzle/dashboard_screen.dart
+++ b/lib/src/view/puzzle/dashboard_screen.dart
@@ -1,6 +1,5 @@
 import 'package:collection/collection.dart';
 import 'package:fl_chart/fl_chart.dart';
-import 'package:flutter/cupertino.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:http/http.dart' show ClientException;
@@ -15,6 +14,7 @@ import 'package:lichess_mobile/src/utils/string.dart';
 import 'package:lichess_mobile/src/widgets/adaptive_choice_picker.dart';
 import 'package:lichess_mobile/src/widgets/buttons.dart';
 import 'package:lichess_mobile/src/widgets/list.dart';
+import 'package:lichess_mobile/src/widgets/platform_scaffold.dart';
 import 'package:lichess_mobile/src/widgets/shimmer.dart';
 import 'package:lichess_mobile/src/widgets/stat_card.dart';
 
@@ -25,21 +25,13 @@ class PuzzleDashboardScreen extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    return Theme.of(context).platform == TargetPlatform.iOS
-        ? const CupertinoPageScaffold(
-            navigationBar: CupertinoNavigationBar(
-              middle: SizedBox.shrink(),
-              trailing: DaysSelector(),
-            ),
-            child: _Body(),
-          )
-        : Scaffold(
-            body: const _Body(),
-            appBar: AppBar(
-              title: const SizedBox.shrink(),
-              actions: const [DaysSelector()],
-            ),
-          );
+    return const PlatformScaffold(
+      body: _Body(),
+      appBar: PlatformAppBar(
+        title: SizedBox.shrink(),
+        actions: [DaysSelector()],
+      ),
+    );
   }
 }
 

--- a/lib/src/view/puzzle/opening_screen.dart
+++ b/lib/src/view/puzzle/opening_screen.dart
@@ -10,7 +10,7 @@ import 'package:lichess_mobile/src/utils/connectivity.dart';
 import 'package:lichess_mobile/src/utils/l10n_context.dart';
 import 'package:lichess_mobile/src/utils/navigation.dart';
 import 'package:lichess_mobile/src/widgets/list.dart';
-import 'package:lichess_mobile/src/widgets/platform.dart';
+import 'package:lichess_mobile/src/widgets/platform_scaffold.dart';
 import 'package:riverpod_annotation/riverpod_annotation.dart';
 
 import 'puzzle_screen.dart';
@@ -37,27 +37,11 @@ class OpeningThemeScreen extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    return PlatformWidget(
-      androidBuilder: _androidBuilder,
-      iosBuilder: _iosBuilder,
-    );
-  }
-
-  Widget _androidBuilder(BuildContext context) {
-    return Scaffold(
-      appBar: AppBar(
+    return PlatformScaffold(
+      appBar: PlatformAppBar(
         title: Text(context.l10n.puzzlePuzzlesByOpenings),
       ),
       body: const _Body(),
-    );
-  }
-
-  Widget _iosBuilder(BuildContext context) {
-    return CupertinoPageScaffold(
-      navigationBar: CupertinoNavigationBar(
-        middle: Text(context.l10n.puzzlePuzzlesByOpenings),
-      ),
-      child: const _Body(),
     );
   }
 }

--- a/lib/src/view/puzzle/puzzle_history_screen.dart
+++ b/lib/src/view/puzzle/puzzle_history_screen.dart
@@ -1,6 +1,5 @@
 import 'package:collection/collection.dart';
 import 'package:fast_immutable_collections/fast_immutable_collections.dart';
-import 'package:flutter/cupertino.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_layout_grid/flutter_layout_grid.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
@@ -16,7 +15,7 @@ import 'package:lichess_mobile/src/utils/screen.dart';
 import 'package:lichess_mobile/src/view/puzzle/puzzle_screen.dart';
 import 'package:lichess_mobile/src/widgets/board_thumbnail.dart';
 import 'package:lichess_mobile/src/widgets/feedback.dart';
-import 'package:lichess_mobile/src/widgets/platform.dart';
+import 'package:lichess_mobile/src/widgets/platform_scaffold.dart';
 import 'package:timeago/timeago.dart' as timeago;
 
 final _dateFormatter = DateFormat.yMMMd(Intl.getCurrentLocale());
@@ -24,21 +23,8 @@ final _dateFormatter = DateFormat.yMMMd(Intl.getCurrentLocale());
 class PuzzleHistoryScreen extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
-    return PlatformWidget(androidBuilder: _buildAndroid, iosBuilder: _buildIos);
-  }
-
-  Widget _buildIos(BuildContext context) {
-    return CupertinoPageScaffold(
-      navigationBar: CupertinoNavigationBar(
-        middle: Text(context.l10n.puzzleHistory),
-      ),
-      child: _Body(),
-    );
-  }
-
-  Widget _buildAndroid(BuildContext context) {
-    return Scaffold(
-      appBar: AppBar(title: Text(context.l10n.puzzleHistory)),
+    return PlatformScaffold(
+      appBar: PlatformAppBar(title: Text(context.l10n.puzzleHistory)),
       body: _Body(),
     );
   }

--- a/lib/src/view/puzzle/puzzle_screen.dart
+++ b/lib/src/view/puzzle/puzzle_screen.dart
@@ -22,7 +22,6 @@ import 'package:lichess_mobile/src/model/puzzle/puzzle_service.dart';
 import 'package:lichess_mobile/src/model/puzzle/puzzle_theme.dart';
 import 'package:lichess_mobile/src/model/settings/board_preferences.dart';
 import 'package:lichess_mobile/src/navigation.dart';
-import 'package:lichess_mobile/src/styles/styles.dart';
 import 'package:lichess_mobile/src/utils/connectivity.dart';
 import 'package:lichess_mobile/src/utils/immersive_mode.dart';
 import 'package:lichess_mobile/src/utils/l10n_context.dart';
@@ -40,7 +39,7 @@ import 'package:lichess_mobile/src/widgets/board_table.dart';
 import 'package:lichess_mobile/src/widgets/bottom_bar_button.dart';
 import 'package:lichess_mobile/src/widgets/buttons.dart';
 import 'package:lichess_mobile/src/widgets/feedback.dart';
-import 'package:lichess_mobile/src/widgets/platform.dart';
+import 'package:lichess_mobile/src/widgets/platform_scaffold.dart';
 
 import 'puzzle_feedback_widget.dart';
 import 'puzzle_session_widget.dart';
@@ -90,44 +89,17 @@ class _PuzzleScreenState extends ConsumerState<PuzzleScreen> with RouteAware {
   @override
   Widget build(BuildContext context) {
     return WakelockWidget(
-      child: PlatformWidget(
-        androidBuilder: _androidBuilder,
-        iosBuilder: _iosBuilder,
-      ),
-    );
-  }
-
-  Widget _androidBuilder(BuildContext context) {
-    return Scaffold(
-      appBar: AppBar(
-        actions: const [
-          _PuzzleSettingsButton(),
-        ],
-        title: _Title(angle: widget.angle),
-      ),
-      body: widget.puzzleId != null
-          ? _LoadPuzzleFromId(angle: widget.angle, id: widget.puzzleId!)
-          : _LoadNextPuzzle(angle: widget.angle),
-    );
-  }
-
-  Widget _iosBuilder(BuildContext context) {
-    return CupertinoPageScaffold(
-      navigationBar: CupertinoNavigationBar(
-        backgroundColor: Styles.cupertinoScaffoldColor.resolveFrom(context),
-        border: null,
-        padding: Styles.cupertinoAppBarTrailingWidgetPadding,
-        middle: _Title(angle: widget.angle),
-        trailing: const Row(
-          mainAxisSize: MainAxisSize.min,
-          children: [
+      child: PlatformScaffold(
+        appBar: PlatformAppBar(
+          actions: const [
             _PuzzleSettingsButton(),
           ],
+          title: _Title(angle: widget.angle),
         ),
+        body: widget.puzzleId != null
+            ? _LoadPuzzleFromId(angle: widget.angle, id: widget.puzzleId!)
+            : _LoadNextPuzzle(angle: widget.angle),
       ),
-      child: widget.puzzleId != null
-          ? _LoadPuzzleFromId(angle: widget.angle, id: widget.puzzleId!)
-          : _LoadNextPuzzle(angle: widget.angle),
     );
   }
 }

--- a/lib/src/view/puzzle/puzzle_themes_screen.dart
+++ b/lib/src/view/puzzle/puzzle_themes_screen.dart
@@ -11,7 +11,7 @@ import 'package:lichess_mobile/src/utils/l10n_context.dart';
 import 'package:lichess_mobile/src/utils/navigation.dart';
 import 'package:lichess_mobile/src/view/puzzle/opening_screen.dart';
 import 'package:lichess_mobile/src/widgets/list.dart';
-import 'package:lichess_mobile/src/widgets/platform.dart';
+import 'package:lichess_mobile/src/widgets/platform_scaffold.dart';
 import 'package:riverpod_annotation/riverpod_annotation.dart';
 
 import 'puzzle_screen.dart';
@@ -50,27 +50,11 @@ class PuzzleThemesScreen extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    return PlatformWidget(
-      androidBuilder: _androidBuilder,
-      iosBuilder: _iosBuilder,
-    );
-  }
-
-  Widget _androidBuilder(BuildContext context) {
-    return Scaffold(
-      appBar: AppBar(
+    return PlatformScaffold(
+      appBar: PlatformAppBar(
         title: Text(context.l10n.puzzlePuzzleThemes),
       ),
       body: const _Body(),
-    );
-  }
-
-  Widget _iosBuilder(BuildContext context) {
-    return CupertinoPageScaffold(
-      navigationBar: CupertinoNavigationBar(
-        middle: Text(context.l10n.puzzlePuzzleThemes),
-      ),
-      child: const _Body(),
     );
   }
 }

--- a/lib/src/view/puzzle/storm_dashboard.dart
+++ b/lib/src/view/puzzle/storm_dashboard.dart
@@ -1,4 +1,3 @@
-import 'package:flutter/cupertino.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:intl/intl.dart';
@@ -9,6 +8,7 @@ import 'package:lichess_mobile/src/styles/lichess_icons.dart';
 import 'package:lichess_mobile/src/styles/styles.dart';
 import 'package:lichess_mobile/src/utils/l10n_context.dart';
 import 'package:lichess_mobile/src/widgets/list.dart';
+import 'package:lichess_mobile/src/widgets/platform_scaffold.dart';
 import 'package:lichess_mobile/src/widgets/shimmer.dart';
 import 'package:lichess_mobile/src/widgets/stat_card.dart';
 
@@ -19,32 +19,19 @@ class StormDashboardModal extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    return Theme.of(context).platform == TargetPlatform.iOS
-        ? CupertinoPageScaffold(
-            navigationBar: CupertinoNavigationBar(
-              middle: Row(
-                mainAxisSize: MainAxisSize.min,
-                children: [
-                  const Icon(LichessIcons.storm, size: 20),
-                  const SizedBox(width: 8.0),
-                  Text(context.l10n.stormHighscores),
-                ],
-              ),
-            ),
-            child: _Body(user: user),
-          )
-        : Scaffold(
-            body: _Body(user: user),
-            appBar: AppBar(
-              title: Row(
-                children: [
-                  const Icon(LichessIcons.storm, size: 20),
-                  const SizedBox(width: 8.0),
-                  Text(context.l10n.stormHighscores),
-                ],
-              ),
-            ),
-          );
+    return PlatformScaffold(
+      body: _Body(user: user),
+      appBar: PlatformAppBar(
+        title: Row(
+          mainAxisSize: MainAxisSize.min,
+          children: [
+            const Icon(LichessIcons.storm, size: 20),
+            const SizedBox(width: 8.0),
+            Text(context.l10n.stormHighscores),
+          ],
+        ),
+      ),
+    );
   }
 }
 

--- a/lib/src/view/puzzle/storm_screen.dart
+++ b/lib/src/view/puzzle/storm_screen.dart
@@ -28,7 +28,7 @@ import 'package:lichess_mobile/src/widgets/bottom_bar_button.dart';
 import 'package:lichess_mobile/src/widgets/buttons.dart';
 import 'package:lichess_mobile/src/widgets/feedback.dart';
 import 'package:lichess_mobile/src/widgets/list.dart';
-import 'package:lichess_mobile/src/widgets/platform.dart';
+import 'package:lichess_mobile/src/widgets/platform_scaffold.dart';
 import 'package:lichess_mobile/src/widgets/yes_no_dialog.dart';
 
 class StormScreen extends ConsumerStatefulWidget {
@@ -44,37 +44,13 @@ class _StormScreenState extends ConsumerState<StormScreen> {
   @override
   Widget build(BuildContext context) {
     return WakelockWidget(
-      child: PlatformWidget(
-        androidBuilder: _androidBuilder,
-        iosBuilder: _iosBuilder,
-      ),
-    );
-  }
-
-  Widget _androidBuilder(BuildContext context) {
-    return Scaffold(
-      appBar: AppBar(
-        actions: [_StormDashboardButton(), ToggleSoundButton()],
-        title: const Text('Puzzle Storm'),
-      ),
-      body: _Load(_boardKey),
-    );
-  }
-
-  Widget _iosBuilder(BuildContext context) {
-    return CupertinoPageScaffold(
-      navigationBar: CupertinoNavigationBar(
-        backgroundColor: Styles.cupertinoScaffoldColor.resolveFrom(context),
-        border: null,
-        padding: Styles.cupertinoAppBarTrailingWidgetPadding,
-        middle: const Text('Puzzle Storm'),
-        trailing: Row(
-          mainAxisSize: MainAxisSize.min,
-          mainAxisAlignment: MainAxisAlignment.end,
-          children: [_StormDashboardButton(), ToggleSoundButton()],
+      child: PlatformScaffold(
+        appBar: PlatformAppBar(
+          actions: [_StormDashboardButton(), ToggleSoundButton()],
+          title: const Text('Puzzle Storm'),
         ),
+        body: _Load(_boardKey),
       ),
-      child: _Load(_boardKey),
     );
   }
 }
@@ -669,28 +645,16 @@ class _RunStats extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    return Theme.of(context).platform == TargetPlatform.iOS
-        ? CupertinoPageScaffold(
-            navigationBar: CupertinoNavigationBar(
-              leading: CupertinoButton(
-                padding: EdgeInsets.zero,
-                onPressed: () {
-                  Navigator.of(context).pop();
-                },
-                child: Text(context.l10n.close),
-              ),
-            ),
-            child: _RunStatsPopup(stats),
-          )
-        : Scaffold(
-            body: _RunStatsPopup(stats),
-            appBar: AppBar(
-              leading: IconButton(
-                icon: const Icon(Icons.close),
-                onPressed: () => Navigator.of(context).pop(),
-              ),
-            ),
-          );
+    return PlatformScaffold(
+      body: _RunStatsPopup(stats),
+      appBar: PlatformAppBar(
+        leading: IconButton(
+          icon: const Icon(Icons.close),
+          onPressed: () => Navigator.of(context).pop(),
+        ),
+        title: const SizedBox.shrink(),
+      ),
+    );
   }
 }
 

--- a/lib/src/view/puzzle/streak_screen.dart
+++ b/lib/src/view/puzzle/streak_screen.dart
@@ -24,7 +24,7 @@ import 'package:lichess_mobile/src/view/analysis/analysis_screen.dart';
 import 'package:lichess_mobile/src/view/settings/toggle_sound_button.dart';
 import 'package:lichess_mobile/src/widgets/board_table.dart';
 import 'package:lichess_mobile/src/widgets/bottom_bar_button.dart';
-import 'package:lichess_mobile/src/widgets/platform.dart';
+import 'package:lichess_mobile/src/widgets/platform_scaffold.dart';
 import 'package:lichess_mobile/src/widgets/yes_no_dialog.dart';
 import 'package:result_extensions/result_extensions.dart';
 
@@ -36,33 +36,13 @@ class StreakScreen extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     return WakelockWidget(
-      child: PlatformWidget(
-        androidBuilder: _androidBuilder,
-        iosBuilder: _iosBuilder,
+      child: PlatformScaffold(
+        appBar: PlatformAppBar(
+          actions: [ToggleSoundButton()],
+          title: const Text('Puzzle Streak'),
+        ),
+        body: const _Load(),
       ),
-    );
-  }
-
-  Widget _androidBuilder(BuildContext context) {
-    return Scaffold(
-      appBar: AppBar(
-        actions: [ToggleSoundButton()],
-        title: const Text('Puzzle Streak'),
-      ),
-      body: const _Load(),
-    );
-  }
-
-  Widget _iosBuilder(BuildContext context) {
-    return CupertinoPageScaffold(
-      navigationBar: CupertinoNavigationBar(
-        backgroundColor: Styles.cupertinoScaffoldColor.resolveFrom(context),
-        border: null,
-        padding: Styles.cupertinoAppBarTrailingWidgetPadding,
-        middle: const Text('Puzzle Streak'),
-        trailing: ToggleSoundButton(),
-      ),
-      child: const _Load(),
     );
   }
 }

--- a/lib/src/view/relation/following_screen.dart
+++ b/lib/src/view/relation/following_screen.dart
@@ -14,7 +14,7 @@ import 'package:lichess_mobile/src/utils/navigation.dart';
 import 'package:lichess_mobile/src/view/user/user_screen.dart';
 import 'package:lichess_mobile/src/widgets/feedback.dart';
 import 'package:lichess_mobile/src/widgets/list.dart';
-import 'package:lichess_mobile/src/widgets/platform.dart';
+import 'package:lichess_mobile/src/widgets/platform_scaffold.dart';
 import 'package:lichess_mobile/src/widgets/user_list_tile.dart';
 import 'package:riverpod_annotation/riverpod_annotation.dart';
 
@@ -33,19 +33,8 @@ class FollowingScreen extends StatelessWidget {
   const FollowingScreen({super.key});
   @override
   Widget build(BuildContext context) {
-    return PlatformWidget(androidBuilder: _buildAndroid, iosBuilder: _buildIos);
-  }
-
-  Widget _buildIos(BuildContext context) {
-    return const CupertinoPageScaffold(
-      navigationBar: CupertinoNavigationBar(),
-      child: _Body(),
-    );
-  }
-
-  Widget _buildAndroid(BuildContext context) {
-    return Scaffold(
-      appBar: AppBar(
+    return PlatformScaffold(
+      appBar: PlatformAppBar(
         title: Text(context.l10n.friends),
       ),
       body: const _Body(),

--- a/lib/src/view/settings/account_preferences_screen.dart
+++ b/lib/src/view/settings/account_preferences_screen.dart
@@ -7,6 +7,7 @@ import 'package:lichess_mobile/src/utils/navigation.dart';
 import 'package:lichess_mobile/src/widgets/adaptive_choice_picker.dart';
 import 'package:lichess_mobile/src/widgets/feedback.dart';
 import 'package:lichess_mobile/src/widgets/list.dart';
+import 'package:lichess_mobile/src/widgets/platform_scaffold.dart';
 import 'package:lichess_mobile/src/widgets/settings.dart';
 
 class AccountPreferencesScreen extends ConsumerStatefulWidget {
@@ -409,33 +410,15 @@ class _AccountPreferencesScreenState
       },
     );
 
-    return Theme.of(context).platform == TargetPlatform.android
-        ? Scaffold(
-            appBar: AppBar(
-              title: Text(context.l10n.preferencesPreferences),
-              actions: [
-                if (isLoading)
-                  const Padding(
-                    padding: EdgeInsets.only(right: 16),
-                    child: SizedBox(
-                      height: 24,
-                      width: 24,
-                      child: Center(
-                        child: CircularProgressIndicator.adaptive(),
-                      ),
-                    ),
-                  ),
-              ],
-            ),
-            body: content,
-          )
-        : CupertinoPageScaffold(
-            navigationBar: CupertinoNavigationBar(
-              trailing:
-                  isLoading ? const CircularProgressIndicator.adaptive() : null,
-            ),
-            child: content,
-          );
+    return PlatformScaffold(
+      appBar: PlatformAppBar(
+        title: Text(context.l10n.preferencesPreferences),
+        actions: [
+          if (isLoading) const PlatformAppBarLoadingIndicator(),
+        ],
+      ),
+      body: content,
+    );
   }
 }
 

--- a/lib/src/view/tools/load_position_screen.dart
+++ b/lib/src/view/tools/load_position_screen.dart
@@ -11,36 +11,18 @@ import 'package:lichess_mobile/src/view/analysis/analysis_screen.dart';
 import 'package:lichess_mobile/src/view/board_editor/board_editor_screen.dart';
 import 'package:lichess_mobile/src/widgets/adaptive_text_field.dart';
 import 'package:lichess_mobile/src/widgets/buttons.dart';
-import 'package:lichess_mobile/src/widgets/platform.dart';
+import 'package:lichess_mobile/src/widgets/platform_scaffold.dart';
 
 class LoadPositionScreen extends StatelessWidget {
   const LoadPositionScreen({super.key});
 
   @override
   Widget build(BuildContext context) {
-    return PlatformWidget(
-      androidBuilder: _androidBuilder,
-      iosBuilder: _iosBuilder,
-    );
-  }
-
-  Widget _androidBuilder(BuildContext context) {
-    return Scaffold(
-      appBar: AppBar(
+    return PlatformScaffold(
+      appBar: PlatformAppBar(
         title: Text(context.l10n.loadPosition),
       ),
       body: const _Body(),
-    );
-  }
-
-  Widget _iosBuilder(BuildContext context) {
-    return CupertinoPageScaffold(
-      navigationBar: CupertinoNavigationBar(
-        backgroundColor: Styles.cupertinoScaffoldColor.resolveFrom(context),
-        border: null,
-        middle: Text(context.l10n.loadPosition),
-      ),
-      child: const _Body(),
     );
   }
 }

--- a/lib/src/view/user/game_history_screen.dart
+++ b/lib/src/view/user/game_history_screen.dart
@@ -1,5 +1,4 @@
 import 'package:dartchess/dartchess.dart';
-import 'package:flutter/cupertino.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:lichess_mobile/src/model/auth/auth_session.dart';
@@ -14,6 +13,7 @@ import 'package:lichess_mobile/src/widgets/adaptive_bottom_sheet.dart';
 import 'package:lichess_mobile/src/widgets/buttons.dart';
 import 'package:lichess_mobile/src/widgets/feedback.dart';
 import 'package:lichess_mobile/src/widgets/list.dart';
+import 'package:lichess_mobile/src/widgets/platform_scaffold.dart';
 
 class GameHistoryScreen extends ConsumerWidget {
   const GameHistoryScreen({
@@ -87,44 +87,12 @@ class GameHistoryScreen extends ConsumerWidget {
       ],
     );
 
-    switch (Theme.of(context).platform) {
-      case TargetPlatform.android:
-        return _buildAndroid(context, ref, title: title, filterBtn: filterBtn);
-      case TargetPlatform.iOS:
-        return _buildIos(context, ref, title: title, filterBtn: filterBtn);
-      default:
-        assert(false, 'Unexpected platform ${Theme.of(context).platform}');
-        return const SizedBox.shrink();
-    }
-  }
-
-  Widget _buildIos(
-    BuildContext context,
-    WidgetRef ref, {
-    required Widget title,
-    required Widget filterBtn,
-  }) {
-    return CupertinoPageScaffold(
-      navigationBar: CupertinoNavigationBar(
-        padding: const EdgeInsetsDirectional.only(
+    return PlatformScaffold(
+      appBar: PlatformAppBar(
+        cupertinoPadding: const EdgeInsetsDirectional.only(
           start: 16.0,
           end: 8.0,
         ),
-        middle: title,
-        trailing: filterBtn,
-      ),
-      child: _Body(user: user, isOnline: isOnline, gameFilter: gameFilter),
-    );
-  }
-
-  Widget _buildAndroid(
-    BuildContext context,
-    WidgetRef ref, {
-    required Widget title,
-    required Widget filterBtn,
-  }) {
-    return Scaffold(
-      appBar: AppBar(
         title: title,
         actions: [filterBtn],
       ),

--- a/lib/src/view/user/leaderboard_screen.dart
+++ b/lib/src/view/user/leaderboard_screen.dart
@@ -1,6 +1,5 @@
 import 'dart:math' as math;
 
-import 'package:flutter/cupertino.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_layout_grid/flutter_layout_grid.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
@@ -12,7 +11,7 @@ import 'package:lichess_mobile/src/utils/l10n_context.dart';
 import 'package:lichess_mobile/src/utils/navigation.dart';
 import 'package:lichess_mobile/src/view/user/user_screen.dart';
 import 'package:lichess_mobile/src/widgets/list.dart';
-import 'package:lichess_mobile/src/widgets/platform.dart';
+import 'package:lichess_mobile/src/widgets/platform_scaffold.dart';
 import 'package:lichess_mobile/src/widgets/user_full_name.dart';
 
 /// Create a Screen with Top 10 players for each Lichess Variant
@@ -21,19 +20,8 @@ class LeaderboardScreen extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    return PlatformWidget(androidBuilder: _buildAndroid, iosBuilder: _buildIos);
-  }
-
-  Widget _buildIos(BuildContext context) {
-    return const CupertinoPageScaffold(
-      navigationBar: CupertinoNavigationBar(),
-      child: _Body(),
-    );
-  }
-
-  Widget _buildAndroid(BuildContext context) {
-    return Scaffold(
-      appBar: AppBar(
+    return PlatformScaffold(
+      appBar: PlatformAppBar(
         title: Text(context.l10n.leaderboard),
       ),
       body: const _Body(),

--- a/lib/src/view/user/perf_stats_screen.dart
+++ b/lib/src/view/user/perf_stats_screen.dart
@@ -30,6 +30,7 @@ import 'package:lichess_mobile/src/widgets/buttons.dart';
 import 'package:lichess_mobile/src/widgets/feedback.dart';
 import 'package:lichess_mobile/src/widgets/list.dart';
 import 'package:lichess_mobile/src/widgets/platform.dart';
+import 'package:lichess_mobile/src/widgets/platform_scaffold.dart';
 import 'package:lichess_mobile/src/widgets/rating.dart';
 import 'package:lichess_mobile/src/widgets/stat_card.dart';
 import 'package:lichess_mobile/src/widgets/user_full_name.dart';
@@ -54,28 +55,12 @@ class PerfStatsScreen extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    return PlatformWidget(
-      androidBuilder: _androidBuilder,
-      iosBuilder: _iosBuilder,
-    );
-  }
-
-  Widget _androidBuilder(BuildContext context) {
-    return Scaffold(
-      appBar: AppBar(
-        titleSpacing: 0,
+    return PlatformScaffold(
+      appBar: PlatformAppBar(
+        androidTitleSpacing: 0,
         title: _Title(user: user, perf: perf),
       ),
       body: _Body(user: user, perf: perf),
-    );
-  }
-
-  Widget _iosBuilder(BuildContext context) {
-    return CupertinoPageScaffold(
-      navigationBar: CupertinoNavigationBar(
-        middle: _Title(user: user, perf: perf),
-      ),
-      child: _Body(user: user, perf: perf),
     );
   }
 }

--- a/lib/src/view/user/player_screen.dart
+++ b/lib/src/view/user/player_screen.dart
@@ -17,6 +17,7 @@ import 'package:lichess_mobile/src/view/user/user_screen.dart';
 import 'package:lichess_mobile/src/widgets/buttons.dart';
 import 'package:lichess_mobile/src/widgets/list.dart';
 import 'package:lichess_mobile/src/widgets/platform.dart';
+import 'package:lichess_mobile/src/widgets/platform_scaffold.dart';
 import 'package:lichess_mobile/src/widgets/shimmer.dart';
 import 'package:lichess_mobile/src/widgets/user_full_name.dart';
 
@@ -34,26 +35,12 @@ class PlayerScreen extends ConsumerWidget {
           ref.read(onlineFriendsProvider.notifier).stopWatchingFriends();
         }
       },
-      child: PlatformWidget(
-        androidBuilder: _androidBuilder,
-        iosBuilder: _iosBuilder,
+      child: PlatformScaffold(
+        appBar: PlatformAppBar(
+          title: Text(context.l10n.players),
+        ),
+        body: _Body(),
       ),
-    );
-  }
-
-  Widget _androidBuilder(BuildContext context) {
-    return Scaffold(
-      appBar: AppBar(
-        title: Text(context.l10n.players),
-      ),
-      body: _Body(),
-    );
-  }
-
-  Widget _iosBuilder(BuildContext context) {
-    return CupertinoPageScaffold(
-      navigationBar: const CupertinoNavigationBar(),
-      child: _Body(),
     );
   }
 }

--- a/lib/src/view/user/user_screen.dart
+++ b/lib/src/view/user/user_screen.dart
@@ -1,4 +1,3 @@
-import 'package:flutter/cupertino.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:http/http.dart' show ClientException;
@@ -12,7 +11,7 @@ import 'package:lichess_mobile/src/utils/l10n_context.dart';
 import 'package:lichess_mobile/src/view/user/recent_games.dart';
 import 'package:lichess_mobile/src/widgets/feedback.dart';
 import 'package:lichess_mobile/src/widgets/list.dart';
-import 'package:lichess_mobile/src/widgets/platform.dart';
+import 'package:lichess_mobile/src/widgets/platform_scaffold.dart';
 import 'package:lichess_mobile/src/widgets/user_full_name.dart';
 import 'package:url_launcher/url_launcher.dart';
 
@@ -32,88 +31,32 @@ class UserScreen extends ConsumerStatefulWidget {
 class _UserScreenState extends ConsumerState<UserScreen> {
   bool isLoading = false;
 
-  @override
-  Widget build(BuildContext context) {
-    return ConsumerPlatformWidget(
-      ref: ref,
-      androidBuilder: _buildAndroid,
-      iosBuilder: _buildIos,
-    );
-  }
-
   void setIsLoading(bool value) {
     setState(() {
       isLoading = value;
     });
   }
 
-  Widget _buildAndroid(BuildContext context, WidgetRef ref) {
+  @override
+  Widget build(BuildContext context) {
     final asyncUser = ref.watch(userAndStatusProvider(id: widget.user.id));
     final updatedLightUser = asyncUser.maybeWhen(
       data: (data) => data.$1.lightUser.copyWith(isOnline: data.$2.online),
       orElse: () => null,
     );
-    return Scaffold(
-      appBar: AppBar(
+    return PlatformScaffold(
+      appBar: PlatformAppBar(
         title: UserFullNameWidget(
           user: updatedLightUser ?? widget.user,
           shouldShowOnline: updatedLightUser != null,
         ),
         actions: [
-          if (isLoading)
-            const Padding(
-              padding: EdgeInsets.only(right: 16),
-              child: SizedBox(
-                height: 24,
-                width: 24,
-                child: Center(
-                  child: CircularProgressIndicator(),
-                ),
-              ),
-            ),
+          if (isLoading) const PlatformAppBarLoadingIndicator(),
         ],
       ),
       body: asyncUser.when(
         data: (data) => _UserProfileListView(data.$1, isLoading, setIsLoading),
         loading: () => const Center(child: CircularProgressIndicator()),
-        error: (error, _) {
-          if (error is ClientException && error.message.contains('404')) {
-            return Center(
-              child: Text(
-                textAlign: TextAlign.center,
-                context.l10n.usernameNotFound(widget.user.name),
-                style: Styles.bold,
-              ),
-            );
-          }
-          return FullScreenRetryRequest(
-            onRetry: () => ref.invalidate(userProvider(id: widget.user.id)),
-          );
-        },
-      ),
-    );
-  }
-
-  Widget _buildIos(BuildContext context, WidgetRef ref) {
-    final asyncUser = ref.watch(userAndStatusProvider(id: widget.user.id));
-    final updatedLightUser = asyncUser.maybeWhen(
-      data: (data) => data.$1.lightUser.copyWith(isOnline: data.$2.online),
-      orElse: () => null,
-    );
-    return CupertinoPageScaffold(
-      navigationBar: CupertinoNavigationBar(
-        middle: UserFullNameWidget(
-          user: updatedLightUser ?? widget.user,
-          shouldShowOnline: updatedLightUser != null,
-        ),
-        trailing: isLoading ? const CircularProgressIndicator.adaptive() : null,
-      ),
-      child: asyncUser.when(
-        data: (data) => SafeArea(
-          child: _UserProfileListView(data.$1, isLoading, setIsLoading),
-        ),
-        loading: () =>
-            const Center(child: CircularProgressIndicator.adaptive()),
         error: (error, _) {
           if (error is ClientException && error.message.contains('404')) {
             return Center(

--- a/lib/src/view/watch/live_tv_channels_screen.dart
+++ b/lib/src/view/watch/live_tv_channels_screen.dart
@@ -1,4 +1,3 @@
-import 'package:flutter/cupertino.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:lichess_mobile/src/constants.dart';
@@ -9,7 +8,7 @@ import 'package:lichess_mobile/src/utils/focus_detector.dart';
 import 'package:lichess_mobile/src/utils/navigation.dart';
 import 'package:lichess_mobile/src/view/watch/tv_screen.dart';
 import 'package:lichess_mobile/src/widgets/board_preview.dart';
-import 'package:lichess_mobile/src/widgets/platform.dart';
+import 'package:lichess_mobile/src/widgets/platform_scaffold.dart';
 import 'package:lichess_mobile/src/widgets/user_full_name.dart';
 
 class LiveTvChannelsScreen extends ConsumerWidget {
@@ -26,32 +25,12 @@ class LiveTvChannelsScreen extends ConsumerWidget {
           ref.read(liveTvChannelsProvider.notifier).stopWatching();
         }
       },
-      child: PlatformWidget(
-        androidBuilder: _androidBuilder,
-        iosBuilder: _iosBuilder,
+      child: const PlatformScaffold(
+        appBar: PlatformAppBar(
+          title: Text('Lichess TV'),
+        ),
+        body: _Body(),
       ),
-    );
-  }
-
-  Widget _androidBuilder(
-    BuildContext context,
-  ) {
-    return Scaffold(
-      appBar: AppBar(
-        title: const Text('Lichess TV'),
-      ),
-      body: const _Body(),
-    );
-  }
-
-  Widget _iosBuilder(
-    BuildContext context,
-  ) {
-    return const CupertinoPageScaffold(
-      navigationBar: CupertinoNavigationBar(
-        middle: Text('Lichess TV'),
-      ),
-      child: _Body(),
     );
   }
 }

--- a/lib/src/view/watch/tv_screen.dart
+++ b/lib/src/view/watch/tv_screen.dart
@@ -8,7 +8,6 @@ import 'package:lichess_mobile/src/model/common/id.dart';
 import 'package:lichess_mobile/src/model/settings/board_preferences.dart';
 import 'package:lichess_mobile/src/model/tv/tv_channel.dart';
 import 'package:lichess_mobile/src/model/tv/tv_controller.dart';
-import 'package:lichess_mobile/src/styles/styles.dart';
 import 'package:lichess_mobile/src/utils/focus_detector.dart';
 import 'package:lichess_mobile/src/utils/l10n_context.dart';
 import 'package:lichess_mobile/src/view/game/game_player.dart';
@@ -17,7 +16,7 @@ import 'package:lichess_mobile/src/widgets/board_table.dart';
 import 'package:lichess_mobile/src/widgets/bottom_bar_button.dart';
 import 'package:lichess_mobile/src/widgets/buttons.dart';
 import 'package:lichess_mobile/src/widgets/countdown_clock.dart';
-import 'package:lichess_mobile/src/widgets/platform.dart';
+import 'package:lichess_mobile/src/widgets/platform_scaffold.dart';
 
 class TvScreen extends ConsumerStatefulWidget {
   const TvScreen({required this.channel, this.initialGame, super.key});
@@ -47,46 +46,19 @@ class _TvScreenState extends ConsumerState<TvScreen> {
           ref.read(_tvGameCtrl.notifier).stopWatching();
         }
       },
-      child: PlatformWidget(
-        androidBuilder: _androidBuilder,
-        iosBuilder: _iosBuilder,
-      ),
-    );
-  }
-
-  Widget _androidBuilder(
-    BuildContext context,
-  ) {
-    return Scaffold(
-      appBar: AppBar(
-        title: Text('${widget.channel.label} TV'),
-        actions: [
-          ToggleSoundButton(),
-        ],
-      ),
-      body: _Body(
-        widget.channel,
-        widget.initialGame,
-        whiteClockKey: _whiteClockKey,
-        blackClockKey: _blackClockKey,
-      ),
-    );
-  }
-
-  Widget _iosBuilder(
-    BuildContext context,
-  ) {
-    return CupertinoPageScaffold(
-      navigationBar: CupertinoNavigationBar(
-        padding: Styles.cupertinoAppBarTrailingWidgetPadding,
-        middle: Text('${widget.channel.label} TV'),
-        trailing: ToggleSoundButton(),
-      ),
-      child: _Body(
-        widget.channel,
-        widget.initialGame,
-        whiteClockKey: _whiteClockKey,
-        blackClockKey: _blackClockKey,
+      child: PlatformScaffold(
+        appBar: PlatformAppBar(
+          title: Text('${widget.channel.label} TV'),
+          actions: [
+            ToggleSoundButton(),
+          ],
+        ),
+        body: _Body(
+          widget.channel,
+          widget.initialGame,
+          whiteClockKey: _whiteClockKey,
+          blackClockKey: _blackClockKey,
+        ),
       ),
     );
   }

--- a/lib/src/widgets/platform_scaffold.dart
+++ b/lib/src/widgets/platform_scaffold.dart
@@ -1,0 +1,177 @@
+import 'package:flutter/cupertino.dart';
+import 'package:flutter/material.dart';
+import 'package:lichess_mobile/src/styles/styles.dart';
+import 'package:lichess_mobile/src/widgets/platform.dart';
+
+/// Displays an [AppBar] for Android and a [CupertinoNavigationBar] for iOS.
+///
+/// Intended to be passed to [PlatformScaffold].
+class PlatformAppBar extends StatelessWidget {
+  const PlatformAppBar({
+    super.key,
+    required this.title,
+    this.centerTitle = false,
+    this.leading,
+    this.actions = const [],
+    this.cupertinoPadding,
+    this.androidTitleSpacing,
+  });
+
+  /// Widget to place at the start of the navigation bar
+  ///
+  /// See [AppBar.leading] and [CupertinoNavigationBar.leading] for details
+  final Widget? leading;
+
+  /// The title displayed in the middle of the bar.
+  ///
+  /// On Android, this is [AppBar.title], on iOS [CupertinoNavigationBar.middle]
+  final Widget title;
+
+  /// On Android, this is passed directly to [AppBar.centerTitle]. Has no effect on iOS.
+  final bool centerTitle;
+
+  /// Action widgets to place at the end of the navigation bar.
+  ///
+  /// On Android, this is passed directlty to [AppBar.actions].
+  /// On iOS, this is wrapped in a [Row] and passed to [CupertinoNavigationBar.trailing]
+  final List<Widget> actions;
+
+  /// Will be passed to [CupertinoNavigationBar.padding] on iOS. Has no effect on Android.
+  ///
+  /// If null, will use [Styles.cupertinoAppBarTrailingWidgetPadding].
+  final EdgeInsetsDirectional? cupertinoPadding;
+
+  /// Will be passed to [AppBar.titleSpacing] on Android. Has no effect on iOS.
+  final double? androidTitleSpacing;
+
+  AppBar _androidBuilder(BuildContext context) {
+    return AppBar(
+      key: key,
+      titleSpacing: androidTitleSpacing,
+      leading: leading,
+      title: title,
+      centerTitle: centerTitle,
+      actions: actions,
+    );
+  }
+
+  CupertinoNavigationBar _iosBuilder(BuildContext context) {
+    return CupertinoNavigationBar(
+      key: key,
+      backgroundColor: Styles.cupertinoScaffoldColor.resolveFrom(context),
+      border: null,
+      padding: cupertinoPadding ?? Styles.cupertinoAppBarTrailingWidgetPadding,
+      middle: title,
+      trailing: Row(
+        mainAxisSize: MainAxisSize.min,
+        children: actions,
+      ),
+    );
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return PlatformWidget(
+      androidBuilder: _androidBuilder,
+      iosBuilder: _iosBuilder,
+    );
+  }
+}
+
+/// A platform-aware circular loading indicator to be used in [PlatformAppBar.actions].
+class PlatformAppBarLoadingIndicator extends StatelessWidget {
+  const PlatformAppBarLoadingIndicator({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return PlatformWidget(
+      iosBuilder: (_) => const CircularProgressIndicator.adaptive(),
+      androidBuilder: (_) => const Padding(
+        padding: EdgeInsets.only(right: 16),
+        child: SizedBox(
+          height: 24,
+          width: 24,
+          child: Center(
+            child: CircularProgressIndicator.adaptive(),
+          ),
+        ),
+      ),
+    );
+  }
+}
+
+class _CupertinoNavBarWrapper extends StatelessWidget
+    implements ObstructingPreferredSizeWidget {
+  const _CupertinoNavBarWrapper({
+    required this.child,
+  });
+
+  final Widget child;
+
+  @override
+  Widget build(BuildContext context) => child;
+
+  @override
+  Size get preferredSize =>
+      const Size.fromHeight(kMinInteractiveDimensionCupertino);
+
+  /// True if the navigation bar's background color has no transparency.
+  @override
+  bool shouldFullyObstruct(BuildContext context) {
+    final Color backgroundColor = CupertinoTheme.of(context).barBackgroundColor;
+    return backgroundColor.alpha == 0xFF;
+  }
+}
+
+/// A screen with a navigation bar and a body that adapts to the platform.
+///
+/// On Android, this is a [Scaffold] with an [AppBar],
+/// on iOS a [CupertinoPageScaffold] with a [CupertinoNavigationBar].
+///
+/// See [PlatformAppBar] for an app bar that adapts to the platform and needs to be passed to this widget.
+class PlatformScaffold extends StatelessWidget {
+  const PlatformScaffold({
+    super.key,
+    required this.appBar,
+    required this.body,
+    this.resizeToAvoidBottomInset = true,
+  });
+
+  /// Acts as the [AppBar] for Android and as the [CupertinoNavigationBar] for iOS.
+  ///
+  /// Usually an instance of [PlatformAppBar].
+  final Widget appBar;
+
+  /// The main content of the screen, displayed below the navigation bar.
+  final Widget body;
+
+  /// See [Scaffold.resizeToAvoidBottomInset] and [CupertinoPageScaffold.resizeToAvoidBottomInset]
+  final bool resizeToAvoidBottomInset;
+
+  Widget _androidBuilder(BuildContext context) {
+    return Scaffold(
+      resizeToAvoidBottomInset: resizeToAvoidBottomInset,
+      appBar: PreferredSize(
+        preferredSize: const Size.fromHeight(kToolbarHeight),
+        child: appBar,
+      ),
+      body: body,
+    );
+  }
+
+  Widget _iosBuilder(BuildContext context) {
+    return CupertinoPageScaffold(
+      resizeToAvoidBottomInset: resizeToAvoidBottomInset,
+      navigationBar: _CupertinoNavBarWrapper(child: appBar),
+      child: body,
+    );
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return PlatformWidget(
+      androidBuilder: _androidBuilder,
+      iosBuilder: _iosBuilder,
+    );
+  }
+}


### PR DESCRIPTION
We had many screens where there was a lot of code duplication between androidBuilder and iosBuilder when using PlatformWidget. With these two new classes we clean a lot of this up.

Custom screens that need to do something different for Android vs iOS still use PlatformWidget.

This may be a bit more controversial than #938, and I'm totally fine if you don't want to merge this, I had a lot of fun refactoring and learned a lot anyway. I think this change would improve readability of the code base, especially for new contributors.

If you agree, I can again make some screenshots, confirming that everything still looks as before (I can only test Android though, not iOS)
