### PR TITLE
refactor: add PlatformAlertDialog

### DIFF
--- a/lib/src/view/game/game_body.dart
+++ b/lib/src/view/game/game_body.dart
@@ -29,6 +29,7 @@ import 'package:lichess_mobile/src/widgets/bottom_bar.dart';
 import 'package:lichess_mobile/src/widgets/bottom_bar_button.dart';
 import 'package:lichess_mobile/src/widgets/buttons.dart';
 import 'package:lichess_mobile/src/widgets/countdown_clock.dart';
+import 'package:lichess_mobile/src/widgets/platform_alert_dialog.dart';
 import 'package:lichess_mobile/src/widgets/user_full_name.dart';
 import 'package:lichess_mobile/src/widgets/yes_no_dialog.dart';
 
@@ -874,35 +875,19 @@ class _GameNegotiationDialog extends StatelessWidget {
       onAccept();
     }
 
-    if (Theme.of(context).platform == TargetPlatform.iOS) {
-      return CupertinoAlertDialog(
-        content: title,
-        actions: [
-          CupertinoDialogAction(
-            onPressed: accept,
-            child: Text(context.l10n.accept),
-          ),
-          CupertinoDialogAction(
-            onPressed: decline,
-            child: Text(context.l10n.decline),
-          ),
-        ],
-      );
-    } else {
-      return AlertDialog(
-        content: title,
-        actions: [
-          TextButton(
-            onPressed: accept,
-            child: Text(context.l10n.accept),
-          ),
-          TextButton(
-            onPressed: decline,
-            child: Text(context.l10n.decline),
-          ),
-        ],
-      );
-    }
+    return PlatformAlertDialog(
+      content: title,
+      actions: [
+        PlatformDialogAction(
+          onPressed: accept,
+          child: Text(context.l10n.accept),
+        ),
+        PlatformDialogAction(
+          onPressed: decline,
+          child: Text(context.l10n.decline),
+        ),
+      ],
+    );
   }
 }
 
@@ -926,35 +911,19 @@ class _ThreefoldDialog extends ConsumerWidget {
       ref.read(gameControllerProvider(id).notifier).claimDraw();
     }
 
-    if (Theme.of(context).platform == TargetPlatform.iOS) {
-      return CupertinoAlertDialog(
-        content: content,
-        actions: [
-          CupertinoDialogAction(
-            onPressed: accept,
-            child: Text(context.l10n.claimADraw),
-          ),
-          CupertinoDialogAction(
-            onPressed: decline,
-            child: Text(context.l10n.cancel),
-          ),
-        ],
-      );
-    } else {
-      return AlertDialog(
-        content: content,
-        actions: [
-          TextButton(
-            onPressed: accept,
-            child: Text(context.l10n.claimADraw),
-          ),
-          TextButton(
-            onPressed: decline,
-            child: Text(context.l10n.cancel),
-          ),
-        ],
-      );
-    }
+    return PlatformAlertDialog(
+      content: content,
+      actions: [
+        PlatformDialogAction(
+          onPressed: accept,
+          child: Text(context.l10n.claimADraw),
+        ),
+        PlatformDialogAction(
+          onPressed: decline,
+          child: Text(context.l10n.cancel),
+        ),
+      ],
+    );
   }
 }
 
@@ -982,36 +951,20 @@ class _ClaimWinDialog extends ConsumerWidget {
       ref.read(ctrlProvider.notifier).forceDraw();
     }
 
-    if (Theme.of(context).platform == TargetPlatform.iOS) {
-      return CupertinoAlertDialog(
-        content: content,
-        actions: [
-          CupertinoDialogAction(
-            onPressed: gameState.game.canClaimWin ? onClaimWin : null,
-            isDefaultAction: true,
-            child: Text(context.l10n.forceResignation),
-          ),
-          CupertinoDialogAction(
-            onPressed: gameState.game.canClaimWin ? onClaimDraw : null,
-            child: Text(context.l10n.forceDraw),
-          ),
-        ],
-      );
-    } else {
-      return AlertDialog(
-        content: content,
-        actions: [
-          TextButton(
-            onPressed: gameState.game.canClaimWin ? onClaimWin : null,
-            child: Text(context.l10n.forceResignation),
-          ),
-          TextButton(
-            onPressed: gameState.game.canClaimWin ? onClaimDraw : null,
-            child: Text(context.l10n.forceDraw),
-          ),
-        ],
-      );
-    }
+    return PlatformAlertDialog(
+      content: content,
+      actions: [
+        PlatformDialogAction(
+          onPressed: gameState.game.canClaimWin ? onClaimWin : null,
+          cupertinoIsDefaultAction: true,
+          child: Text(context.l10n.forceResignation),
+        ),
+        PlatformDialogAction(
+          onPressed: gameState.game.canClaimWin ? onClaimDraw : null,
+          child: Text(context.l10n.forceDraw),
+        ),
+      ],
+    );
   }
 }
 

--- a/lib/src/view/puzzle/storm_screen.dart
+++ b/lib/src/view/puzzle/storm_screen.dart
@@ -29,6 +29,7 @@ import 'package:lichess_mobile/src/widgets/bottom_bar_button.dart';
 import 'package:lichess_mobile/src/widgets/buttons.dart';
 import 'package:lichess_mobile/src/widgets/feedback.dart';
 import 'package:lichess_mobile/src/widgets/list.dart';
+import 'package:lichess_mobile/src/widgets/platform_alert_dialog.dart';
 import 'package:lichess_mobile/src/widgets/platform_scaffold.dart';
 import 'package:lichess_mobile/src/widgets/yes_no_dialog.dart';
 
@@ -259,27 +260,17 @@ Future<void> _stormInfoDialogBuilder(BuildContext context) {
           ),
         ),
       );
-      return Theme.of(context).platform == TargetPlatform.iOS
-          ? CupertinoAlertDialog(
-              title: Text(context.l10n.aboutX('Puzzle Storm')),
-              content: content,
-              actions: [
-                CupertinoDialogAction(
-                  onPressed: () => Navigator.of(context).pop(),
-                  child: Text(context.l10n.mobileOkButton),
-                ),
-              ],
-            )
-          : AlertDialog(
-              title: Text(context.l10n.aboutX('Puzzle Storm')),
-              content: content,
-              actions: [
-                TextButton(
-                  onPressed: () => Navigator.of(context).pop(),
-                  child: Text(context.l10n.mobileOkButton),
-                ),
-              ],
-            );
+
+      return PlatformAlertDialog(
+        title: Text(context.l10n.aboutX('Puzzle Storm')),
+        content: content,
+        actions: [
+          PlatformDialogAction(
+            onPressed: () => Navigator.of(context).pop(),
+            child: Text(context.l10n.mobileOkButton),
+          ),
+        ],
+      );
     },
   );
 }

--- a/lib/src/view/puzzle/streak_screen.dart
+++ b/lib/src/view/puzzle/streak_screen.dart
@@ -25,6 +25,7 @@ import 'package:lichess_mobile/src/view/settings/toggle_sound_button.dart';
 import 'package:lichess_mobile/src/widgets/board_table.dart';
 import 'package:lichess_mobile/src/widgets/bottom_bar.dart';
 import 'package:lichess_mobile/src/widgets/bottom_bar_button.dart';
+import 'package:lichess_mobile/src/widgets/platform_alert_dialog.dart';
 import 'package:lichess_mobile/src/widgets/platform_scaffold.dart';
 import 'package:lichess_mobile/src/widgets/yes_no_dialog.dart';
 import 'package:result_extensions/result_extensions.dart';
@@ -337,29 +338,16 @@ class _BottomBar extends ConsumerWidget {
   Future<void> _streakInfoDialogBuilder(BuildContext context) {
     return showAdaptiveDialog(
       context: context,
-      builder: (context) {
-        return Theme.of(context).platform == TargetPlatform.iOS
-            ? CupertinoAlertDialog(
-                title: Text(context.l10n.aboutX('Puzzle Streak')),
-                content: Text(context.l10n.puzzleStreakDescription),
-                actions: [
-                  CupertinoDialogAction(
-                    onPressed: () => Navigator.of(context).pop(),
-                    child: Text(context.l10n.mobileOkButton),
-                  ),
-                ],
-              )
-            : AlertDialog(
-                title: Text(context.l10n.aboutX('Puzzle Streak')),
-                content: Text(context.l10n.puzzleStreakDescription),
-                actions: [
-                  TextButton(
-                    onPressed: () => Navigator.of(context).pop(),
-                    child: Text(context.l10n.mobileOkButton),
-                  ),
-                ],
-              );
-      },
+      builder: (context) => PlatformAlertDialog(
+        title: Text(context.l10n.aboutX('Puzzle Streak')),
+        content: Text(context.l10n.puzzleStreakDescription),
+        actions: [
+          PlatformDialogAction(
+            onPressed: () => Navigator.of(context).pop(),
+            child: Text(context.l10n.mobileOkButton),
+          ),
+        ],
+      ),
     );
   }
 }
@@ -405,38 +393,21 @@ class _RetryFetchPuzzleDialog extends ConsumerWidget {
     final canRetry = state.nextPuzzleStreakFetchError &&
         !state.nextPuzzleStreakFetchIsRetrying;
 
-    if (Theme.of(context).platform == TargetPlatform.iOS) {
-      return CupertinoAlertDialog(
-        title: const Text(title),
-        content: const Text(content),
-        actions: [
-          CupertinoDialogAction(
-            onPressed: () => Navigator.of(context).pop(),
-            isDestructiveAction: true,
-            child: Text(context.l10n.cancel),
-          ),
-          CupertinoDialogAction(
-            onPressed: canRetry ? retryStreakNext : null,
-            isDefaultAction: true,
-            child: Text(context.l10n.retry),
-          ),
-        ],
-      );
-    } else {
-      return AlertDialog(
-        title: const Text(title),
-        content: const Text(content),
-        actions: [
-          TextButton(
-            onPressed: () => Navigator.of(context).pop(),
-            child: Text(context.l10n.cancel),
-          ),
-          TextButton(
-            onPressed: canRetry ? retryStreakNext : null,
-            child: Text(context.l10n.retry),
-          ),
-        ],
-      );
-    }
+    return PlatformAlertDialog(
+      title: const Text(title),
+      content: const Text(content),
+      actions: [
+        PlatformDialogAction(
+          onPressed: () => Navigator.of(context).pop(),
+          cupertinoIsDestructiveAction: true,
+          child: Text(context.l10n.cancel),
+        ),
+        PlatformDialogAction(
+          onPressed: canRetry ? retryStreakNext : null,
+          cupertinoIsDefaultAction: true,
+          child: Text(context.l10n.retry),
+        ),
+      ],
+    );
   }
 }

--- a/lib/src/widgets/platform_alert_dialog.dart
+++ b/lib/src/widgets/platform_alert_dialog.dart
@@ -1,0 +1,77 @@
+import 'package:flutter/cupertino.dart';
+import 'package:flutter/material.dart';
+import 'package:lichess_mobile/src/widgets/platform.dart';
+
+/// Displays an [AlertDialog] for Android and a [CupertinoAlertDialog] for iOS.
+class PlatformAlertDialog extends StatelessWidget {
+  const PlatformAlertDialog({
+    super.key,
+    this.title,
+    this.content,
+    this.actions = const <PlatformDialogAction>[],
+  });
+
+  /// See [AlertDialog.title] for Android and [CupertinoAlertDialog.title] for iOS.
+  final Widget? title;
+
+  /// See [AlertDialog.content] for Android and [CupertinoAlertDialog.content] for iOS.
+  final Widget? content;
+
+  /// See [AlertDialog.actions] for Android and [CupertinoAlertDialog.actions] for iOS.
+  final List<PlatformDialogAction> actions;
+
+  @override
+  Widget build(BuildContext context) {
+    return PlatformWidget(
+      androidBuilder: (context) => AlertDialog(
+        title: title,
+        content: content,
+        actions: actions,
+      ),
+      iosBuilder: (context) => CupertinoAlertDialog(
+        title: title,
+        content: content,
+        actions: actions,
+      ),
+    );
+  }
+}
+
+/// To be used with [PlatformAlertDialog.actions]. Displays a [TextButton] for Android and a [CupertinoDialogAction] for iOS.
+class PlatformDialogAction extends StatelessWidget {
+  const PlatformDialogAction({
+    super.key,
+    required this.onPressed,
+    required this.child,
+    this.cupertinoIsDefaultAction = false,
+    this.cupertinoIsDestructiveAction = false,
+  });
+
+  /// Callback invoked when the action is pressed.
+  final VoidCallback? onPressed;
+
+  /// See [TextButton.child] for Android and [CupertinoDialogAction.child] for iOS.
+  final Widget child;
+
+  /// Passed to [CupertinoDialogAction.isDefaultAction] on iOS, no effect on Android.
+  final bool cupertinoIsDefaultAction;
+
+  /// Passed to [CupertinoDialogAction.isDestructiveAction] on iOS, no effect on Android.
+  final bool cupertinoIsDestructiveAction;
+
+  @override
+  Widget build(BuildContext context) {
+    return PlatformWidget(
+      androidBuilder: (context) => TextButton(
+        onPressed: onPressed,
+        child: child,
+      ),
+      iosBuilder: (context) => CupertinoDialogAction(
+        onPressed: onPressed,
+        isDefaultAction: cupertinoIsDefaultAction,
+        isDestructiveAction: cupertinoIsDestructiveAction,
+        child: child,
+      ),
+    );
+  }
+}

--- a/lib/src/widgets/yes_no_dialog.dart
+++ b/lib/src/widgets/yes_no_dialog.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/cupertino.dart';
 import 'package:flutter/material.dart';
 import 'package:lichess_mobile/src/utils/l10n_context.dart';
+import 'package:lichess_mobile/src/widgets/platform_alert_dialog.dart';
 
 class YesNoDialog extends StatelessWidget {
   const YesNoDialog({
@@ -20,37 +21,19 @@ class YesNoDialog extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    if (Theme.of(context).platform == TargetPlatform.iOS) {
-      return CupertinoAlertDialog(
-        title: title,
-        content: content,
-        actions: [
-          CupertinoDialogAction(
-            onPressed: onNo,
-            child: Text(context.l10n.no),
-          ),
-          CupertinoDialogAction(
-            onPressed: onYes,
-            child: Text(context.l10n.yes),
-          ),
-        ],
-      );
-    } else {
-      return AlertDialog(
-        title: title,
-        content: content,
-        alignment: alignment,
-        actions: [
-          TextButton(
-            onPressed: onNo,
-            child: Text(context.l10n.no),
-          ),
-          TextButton(
-            onPressed: onYes,
-            child: Text(context.l10n.yes),
-          ),
-        ],
-      );
-    }
+    return PlatformAlertDialog(
+      title: title,
+      content: content,
+      actions: [
+        PlatformDialogAction(
+          onPressed: onNo,
+          child: Text(context.l10n.no),
+        ),
+        PlatformDialogAction(
+          onPressed: onYes,
+          child: Text(context.l10n.yes),
+        ),
+      ],
+    );
   }
 }


### PR DESCRIPTION
In a similar spirit to `PlatformScaffold`, but implementation was much more straight-forward. So I think one screenshot is enough:

![Screenshot_1725396066](https://github.com/user-attachments/assets/d679be68-dff5-479e-8950-b31435f6aa58)
