### PR TITLE
feat: link opening name to lichess page instead of wikibooks in explorer

### DIFF
--- a/lib/src/model/analysis/analysis_controller.dart
+++ b/lib/src/model/analysis/analysis_controller.dart
@@ -145,7 +145,6 @@ class AnalysisController extends _$AnalysisController {
       lastMove: lastMove,
       pov: options.orientation,
       contextOpening: options.opening,
-      wikiBooksUrl: _wikiBooksUrl(currentPath),
       isLocalEvaluationAllowed: options.isLocalEvaluationAllowed,
       isLocalEvaluationEnabled: prefs.enableLocalEvaluation,
       displayMode: DisplayMode.moves,
@@ -433,7 +432,6 @@ class AnalysisController extends _$AnalysisController {
         isOnMainline: _root.isOnMainline(path),
         currentNode: AnalysisCurrentNode.fromNode(currentNode),
         currentBranchOpening: opening,
-        wikiBooksUrl: _wikiBooksUrl(path),
         lastMove: currentNode.sanMove.move,
         promotionMove: null,
         root: rootView,
@@ -444,7 +442,6 @@ class AnalysisController extends _$AnalysisController {
         isOnMainline: _root.isOnMainline(path),
         currentNode: AnalysisCurrentNode.fromNode(currentNode),
         currentBranchOpening: opening,
-        wikiBooksUrl: _wikiBooksUrl(path),
         lastMove: null,
         promotionMove: null,
         root: rootView,
@@ -475,19 +472,6 @@ class AnalysisController extends _$AnalysisController {
         );
       }
     }
-  }
-
-  String? _wikiBooksUrl(UciPath path) {
-    if (_root.position.ply > 30) {
-      return null;
-    }
-    final nodes = _root.branchesOn(path);
-    final moves = nodes.map((node) {
-      final move = node.view.sanMove.san;
-      final moveNr = (node.position.ply / 2).ceil();
-      return node.position.ply.isOdd ? '$moveNr._$move' : '$moveNr...$move';
-    });
-    return 'https://en.wikibooks.org/wiki/Chess_Opening_Theory/${moves.join("/")}';
   }
 
   void _startEngineEval() {
@@ -679,9 +663,6 @@ class AnalysisState with _$AnalysisState {
 
     /// The opening of the current branch.
     Opening? currentBranchOpening,
-
-    /// wikibooks.org opening theory page for the current path
-    String? wikiBooksUrl,
 
     /// Optional server analysis to display player stats.
     ({PlayerAnalysis white, PlayerAnalysis black})? playersAnalysis,

--- a/lib/src/model/opening_explorer/opening_explorer_repository.dart
+++ b/lib/src/model/opening_explorer/opening_explorer_repository.dart
@@ -143,13 +143,3 @@ class OpeningExplorerRepository {
     );
   }
 }
-
-@riverpod
-Future<bool> wikiBooksPageExists(
-  WikiBooksPageExistsRef ref, {
-  required String url,
-}) async {
-  final client = ref.read(defaultClientProvider);
-  final response = await client.get(Uri.parse(url));
-  return response.statusCode == 200;
-}

--- a/lib/src/view/opening_explorer/opening_explorer_screen.dart
+++ b/lib/src/view/opening_explorer/opening_explorer_screen.dart
@@ -248,7 +248,6 @@ class _OpeningExplorerState extends ConsumerState<_OpeningExplorer> {
             pgn: widget.pgn,
             options: widget.options,
             opening: opening,
-            wikiBooksUrl: analysisState.wikiBooksUrl,
             explorerContent: lastExplorerWidgets ??
                 [
                   Shimmer(
@@ -270,7 +269,6 @@ class _OpeningExplorerState extends ConsumerState<_OpeningExplorer> {
             options: widget.options,
             opening: opening,
             openingExplorer: openingExplorer,
-            wikiBooksUrl: analysisState.wikiBooksUrl,
             explorerContent: [
               Center(
                 child: Padding(
@@ -345,7 +343,6 @@ class _OpeningExplorerState extends ConsumerState<_OpeningExplorer> {
           options: widget.options,
           opening: opening,
           openingExplorer: openingExplorer,
-          wikiBooksUrl: analysisState.wikiBooksUrl,
           explorerContent: explorerContent,
         );
       },
@@ -353,7 +350,6 @@ class _OpeningExplorerState extends ConsumerState<_OpeningExplorer> {
         pgn: widget.pgn,
         options: widget.options,
         opening: opening,
-        wikiBooksUrl: analysisState.wikiBooksUrl,
         explorerContent: lastExplorerWidgets ??
             [
               Shimmer(
@@ -386,7 +382,6 @@ class _OpeningExplorerView extends StatelessWidget {
     required this.options,
     required this.opening,
     required this.openingExplorer,
-    required this.wikiBooksUrl,
     required this.explorerContent,
   }) : loading = false;
 
@@ -394,7 +389,6 @@ class _OpeningExplorerView extends StatelessWidget {
     required this.pgn,
     required this.options,
     required this.opening,
-    required this.wikiBooksUrl,
     required this.explorerContent,
   })  : loading = true,
         openingExplorer = null;
@@ -403,7 +397,6 @@ class _OpeningExplorerView extends StatelessWidget {
   final AnalysisOptions options;
   final Opening? opening;
   final ({OpeningExplorerEntry entry, bool isIndexing})? openingExplorer;
-  final String? wikiBooksUrl;
   final List<Widget> explorerContent;
   final bool loading;
 
@@ -435,7 +428,6 @@ class _OpeningExplorerView extends StatelessWidget {
                   flex: 75,
                   child: _Opening(
                     opening: opening!,
-                    wikiBooksUrl: wikiBooksUrl,
                   ),
                 ),
               if (openingExplorer?.isIndexing == true)
@@ -472,33 +464,25 @@ class _OpeningExplorerView extends StatelessWidget {
 class _Opening extends ConsumerWidget {
   const _Opening({
     required this.opening,
-    required this.wikiBooksUrl,
   });
 
   final Opening opening;
-  final String? wikiBooksUrl;
   @override
   Widget build(BuildContext context, WidgetRef ref) {
-    final openingWidget = Text(
-      '${opening.eco.isEmpty ? "" : "${opening.eco} "}${opening.name}',
-      style: TextStyle(
-        color: Theme.of(context).colorScheme.onSecondaryContainer,
-        fontWeight: FontWeight.bold,
+    return GestureDetector(
+      onTap: opening.name == context.l10n.startPosition
+          ? null
+          : () => launchUrl(
+                Uri.parse('https://lichess.org/opening/${opening.name}'),
+              ),
+      child: Text(
+        '${opening.eco.isEmpty ? "" : "${opening.eco} "}${opening.name}',
+        style: TextStyle(
+          color: Theme.of(context).colorScheme.onSecondaryContainer,
+          fontWeight: FontWeight.bold,
+        ),
       ),
     );
-
-    return wikiBooksUrl == null
-        ? openingWidget
-        : ref.watch(wikiBooksPageExistsProvider(url: wikiBooksUrl!)).when(
-              data: (wikiBooksPageExists) => wikiBooksPageExists
-                  ? GestureDetector(
-                      onTap: () => launchUrl(Uri.parse(wikiBooksUrl!)),
-                      child: openingWidget,
-                    )
-                  : openingWidget,
-              loading: () => openingWidget,
-              error: (e, s) => openingWidget,
-            );
   }
 }
 

--- a/test/view/opening_explorer/opening_explorer_screen_test.dart
+++ b/test/view/opening_explorer/opening_explorer_screen_test.dart
@@ -28,9 +28,6 @@ void main() {
         return mockResponse(playerOpeningExplorerResponse, 200);
       }
     }
-    if (request.url.host == 'en.wikibooks.org') {
-      return mockResponse('', 200);
-    }
     return mockResponse('', 404);
   });
 


### PR DESCRIPTION
The name of the opening in the opening explorer now links to pages in https://lichess.org/opening/ instead of in https://en.wikibooks.org/wiki/Chess_Opening_Theory/.
Discussed recently in #836. 