### PR TITLE
fix castling in 960

### DIFF
--- a/lib/src/model/common/node.dart
+++ b/lib/src/model/common/node.dart
@@ -192,10 +192,14 @@ abstract class Node {
     bool prepend = false,
   }) {
     final pos = nodeAt(path).position;
-    final isKingMove =
-        move is NormalMove && pos.board.roleAt(move.from) == Role.king;
+
+    final potentialAltCastlingMove = move is NormalMove &&
+        pos.board.roleAt(move.from) == Role.king &&
+        pos.board.roleAt(move.to) != Role.rook;
+
     final convertedMove =
-        isKingMove ? convertAltCastlingMove(move) ?? move : move;
+        potentialAltCastlingMove ? convertAltCastlingMove(move) ?? move : move;
+
     final (newPos, newSan) = pos.makeSan(convertedMove);
     final newNode = Branch(
       sanMove: SanMove(newSan, convertedMove),

--- a/test/model/common/node_test.dart
+++ b/test/model/common/node_test.dart
@@ -516,6 +516,19 @@ void main() {
       root.addMoveAt(previousUciPath, move!);
       expect(root.makePgn(), isNot(initialPng));
     });
+    test(
+        'do not convert castling move if rook is on the alternative castling square',
+        () {
+      const pgn =
+          '[FEN "rnbqkbnr/pppppppp/8/8/8/2NBQ3/PPPPPPPP/2R1KBNR w KQkq - 0 1"]';
+      final root = Root.fromPgnGame(PgnGame.parsePgn(pgn));
+      final initialPng = root.makePgn();
+      final previousUciPath = root.mainlinePath.penultimate;
+      final move = Move.parse('e1c1');
+      root.addMoveAt(previousUciPath, move!);
+      expect(root.makePgn(), isNot(initialPng));
+      expect(root.mainline.last.sanMove.move, move);
+    });
   });
 }
 


### PR DESCRIPTION
Fix #983: Implements logic to avoid converting the castling move when the rook is on the same square, along with a test case to prevent similar issues in the future.