### PR TITLE
🧹  Update FVM config files for FVM 3.0

### DIFF
--- a/.fvm/fvm_config.json
+++ b/.fvm/fvm_config.json
@@ -1,4 +1,0 @@
-{
-  "flutterSdkVersion": "beta",
-  "flavors": {}
-}

--- a/.fvmrc
+++ b/.fvmrc
@@ -1,0 +1,4 @@
+{
+  "flutter": "beta",
+  "flavors": {}
+}

--- a/.gitignore
+++ b/.gitignore
@@ -35,4 +35,6 @@ doc/api/
 *.ipr
 *.iws
 .idea/
-.fvm/flutter_sdk
+
+# FVM Version Cache
+.fvm/

--- a/docs/internationalisation.md
+++ b/docs/internationalisation.md
@@ -1,7 +1,7 @@
 # Internationalisation
 
 We're using the standard way of internationalising our app, as desbribed in the
-[official documentation)(https://docs.flutter.dev/ui/accessibility-and-internationalization/internationalization#setting-up).
+[official documentation](https://docs.flutter.dev/ui/accessibility-and-internationalization/internationalization#setting-up).
 
 What is specific to this project is the way we produce the template `lib/l10n/app_en.arb` file.
 

--- a/docs/setting_dev_env.md
+++ b/docs/setting_dev_env.md
@@ -25,6 +25,8 @@ Note that this application is not meant to be run on web platform.
 
 If you want to use FVM to manage your Flutter versions effectively, please consult the [FVM (Flutter Version Management) guide](https://fvm.app/documentation/getting-started/installation) for comprehensive instructions on installing Flutter on your specific operating system.
 
+This project is currently using FVM 3.x.
+
 **Pro Tip:** Remember to prepend the 'flutter' prefix when using FVM commands, like this: `fvm flutter [command]`.
 
 ## Lila Server


### PR DESCRIPTION
Hello again 🙂

FVM 3.x is available as of 2024-02-19, so it seems it's probably been enough time for folks to upgrade. As described in the [changelog](https://github.com/leoafarias/fvm/blob/main/CHANGELOG.md#breaking-changes), `.fvmrc` is the new config file; `.fvm/fvm_config.json` is now a legacy file.

So this PR is just a bit of tidying to upgrade to FVM 3.0+. Looking forward to your feedback!