### PR TITLE
Disable Watch tab when offline

### DIFF
--- a/lib/src/navigation.dart
+++ b/lib/src/navigation.dart
@@ -63,6 +63,15 @@ enum BottomTab {
         return Icons.settings;
     }
   }
+
+  bool enabled({required bool isOnline}) {
+    switch (this) {
+      case BottomTab.watch:
+        return isOnline;
+      default:
+        return true;
+    }
+  }
 }
 
 final currentBottomTabProvider =
@@ -151,6 +160,7 @@ class BottomNavScaffold extends ConsumerWidget {
                     NavigationDestination(
                       icon: Icon(tab == currentTab ? tab.activeIcon : tab.icon),
                       label: tab.label(context.l10n),
+                      enabled: tab.enabled(isOnline: isOnline),
                     ),
                 ],
                 onDestinationSelected: (i) =>


### PR DESCRIPTION
A small part of #462.

## Android

[offline online.webm](https://github.com/user-attachments/assets/6b6a046e-1c29-4d3a-bff4-ecc1a942f23b)

## iOS

The Cupertino design language [discourages](https://developer.apple.com/design/human-interface-guidelines/tab-bars/) disabled buttons (Material doesn't seem to have anything against it):

> Don’t disable or hide tab bar buttons, even when their content is unavailable. Having tab bar buttons available in some cases but not others makes your app’s interface appear unstable and unpredictable. If a section is empty, explain why its content is unavailable.

So I haven't modified the iOS widgets. If we'd prefer to keep the design consistent, we can of course just close this PR, but we should update the description of #462 accordingly.