### PR TITLE
[BoardAnalysis] disable board analysis if more than 32 pieces on board

### DIFF
--- a/lib/src/view/board_editor/board_editor_screen.dart
+++ b/lib/src/view/board_editor/board_editor_screen.dart
@@ -300,6 +300,7 @@ class _BottomBar extends ConsumerWidget {
   @override
   Widget build(BuildContext context, WidgetRef ref) {
     final editorState = ref.watch(boardEditorControllerProvider(initialFen));
+    final pieceCount = editorState.pieces.length;
 
     return BottomBar(
       children: [
@@ -324,7 +325,10 @@ class _BottomBar extends ConsumerWidget {
         BottomBarButton(
           label: context.l10n.analysis,
           key: const Key('analysis-board-button'),
-          onTap: editorState.pgn != null
+          onTap: editorState.pgn != null &&
+                  // 1 condition (of many) where stockfish segfaults
+                  pieceCount > 0 &&
+                  pieceCount <= 32
               ? () {
                   pushPlatformRoute(
                     context,


### PR DESCRIPTION
Implements a partial fix for #1005 

![Screenshot_1726572687](https://github.com/user-attachments/assets/6f4c64ae-e503-42df-b276-016d69b9f221)
