### PR TITLE
feat: make analysis tree view more "tree like"

### DIFF
--- a/lib/src/model/analysis/analysis_controller.dart
+++ b/lib/src/model/analysis/analysis_controller.dart
@@ -265,16 +265,24 @@ class AnalysisController extends _$AnalysisController {
     _setPath(path);
   }
 
-  void showAllVariations(UciPath path) {
-    final parent = _root.parentAt(path);
-    for (final node in parent.children) {
-      node.isHidden = false;
+  void expandVariations(UciPath path) {
+    final node = _root.nodeAt(path);
+    for (final child in node.children) {
+      child.isHidden = false;
+      for (final grandChild in child.children) {
+        grandChild.isHidden = false;
+      }
     }
     state = state.copyWith(root: _root.view);
   }
 
-  void hideVariation(UciPath path) {
-    _root.hideVariationAt(path);
+  void collapseVariations(UciPath path) {
+    final node = _root.parentAt(path);
+
+    for (final child in node.children) {
+      child.isHidden = true;
+    }
+
     state = state.copyWith(root: _root.view);
   }
 

--- a/lib/src/model/common/node.dart
+++ b/lib/src/model/common/node.dart
@@ -234,22 +234,6 @@ abstract class Node {
     parentAt(path).children.removeWhere((child) => child.id == path.last);
   }
 
-  /// Hides the variation from the node at the given path.
-  void hideVariationAt(UciPath path) {
-    final nodes = nodesOn(path).toList();
-    for (int i = nodes.length - 2; i >= 0; i--) {
-      final node = nodes[i + 1];
-      final parent = nodes[i];
-      if (node is Branch && parent.children.length > 1) {
-        for (final child in parent.children) {
-          if (child.id == node.id) {
-            child.isHidden = true;
-          }
-        }
-      }
-    }
-  }
-
   /// Promotes the node at the given path.
   void promoteAt(UciPath path, {required bool toMainline}) {
     final nodes = nodesOn(path).toList();

--- a/lib/src/model/common/node.dart
+++ b/lib/src/model/common/node.dart
@@ -484,8 +484,8 @@ class Root extends Node {
       position: PgnGame.startingPosition(game.headers),
     );
 
-    final List<({PgnNode<PgnNodeData> from, Node to})> stack = [
-      (from: game.moves, to: root),
+    final List<({PgnNode<PgnNodeData> from, Node to, int nesting})> stack = [
+      (from: game.moves, to: root, nesting: 1),
     ];
 
     while (stack.isNotEmpty) {
@@ -503,7 +503,7 @@ class Root extends Node {
           final branch = Branch(
             sanMove: SanMove(childFrom.data.san, move),
             position: newPos,
-            isHidden: hideVariations && childIdx > 0,
+            isHidden: frame.nesting > 2 || hideVariations && childIdx > 0,
             lichessAnalysisComments:
                 isLichessAnalysis ? comments?.toList() : null,
             startingComments: isLichessAnalysis
@@ -516,7 +516,17 @@ class Root extends Node {
           );
 
           frame.to.addChild(branch);
-          stack.add((from: childFrom, to: branch));
+          stack.add(
+            (
+              from: childFrom,
+              to: branch,
+              nesting: frame.from.children.length == 1 ||
+                      // mainline continuation
+                      (childIdx == 0 && frame.nesting == 1)
+                  ? frame.nesting
+                  : frame.nesting + 1,
+            ),
+          );
 
           onVisitNode?.call(root, branch, isMainline);
         }

--- a/lib/src/model/common/uci.dart
+++ b/lib/src/model/common/uci.dart
@@ -90,6 +90,8 @@ class UciPath with _$UciPath {
     return UciPath(path.toString());
   }
 
+  factory UciPath.join(UciPath a, UciPath b) => UciPath(a.value + b.value);
+
   /// Creates a UciPath from a list of UCI moves.
   ///
   /// Throws an [ArgumentError] if any of the moves is invalid.

--- a/lib/src/view/analysis/tree_view.dart
+++ b/lib/src/view/analysis/tree_view.dart
@@ -239,6 +239,7 @@ class _PgnTreeView extends StatelessWidget {
                     parent: nodes.last,
                     params: params,
                     initialPath: sidelineInitialPath,
+                    nesting: 1,
                   ),
               ];
             },
@@ -490,6 +491,7 @@ class _SideLines extends StatelessWidget {
     required this.firstMoveKey,
     required this.initialPath,
     required this.params,
+    required this.nesting,
   });
 
   final ViewBranch firstNode;
@@ -497,6 +499,7 @@ class _SideLines extends StatelessWidget {
   final GlobalKey firstMoveKey;
   final UciPath initialPath;
   final _PgnTreeViewParams params;
+  final int nesting;
 
   @override
   Widget build(BuildContext context) {
@@ -528,6 +531,7 @@ class _SideLines extends StatelessWidget {
               UciPath.fromIds(sidelineNodes.map((node) => node.id)),
             ),
             params: params,
+            nesting: nesting + 1,
           ),
       ],
     );
@@ -581,6 +585,7 @@ class _IndentedSideLines extends StatefulWidget {
     required this.parent,
     required this.initialPath,
     required this.params,
+    required this.nesting,
   });
 
   final Iterable<ViewBranch> sideLines;
@@ -590,6 +595,8 @@ class _IndentedSideLines extends StatefulWidget {
   final UciPath initialPath;
 
   final _PgnTreeViewParams params;
+
+  final int nesting;
 
   @override
   State<_IndentedSideLines> createState() => _IndentedSideLinesState();
@@ -649,14 +656,15 @@ class _IndentedSideLinesState extends State<_IndentedSideLines> {
             firstMoveKey: _keys[i],
             initialPath: widget.initialPath,
             params: widget.params,
+            nesting: widget.nesting,
           ),
         )
         .toList();
 
-    const padding = 12.0;
+    final padding = widget.nesting < 6 ? 12.0 : 0.0;
     return RepaintBoundary(
       child: Padding(
-        padding: const EdgeInsets.only(left: padding),
+        padding: EdgeInsets.only(left: padding),
         child: CustomPaint(
           painter: _IndentPainter(
             sideLineStartPositions: _sideLineStartPositions,

--- a/lib/src/view/analysis/tree_view.dart
+++ b/lib/src/view/analysis/tree_view.dart
@@ -615,6 +615,10 @@ class _IndentedSideLinesState extends State<_IndentedSideLines> {
   final GlobalKey _columnKey = GlobalKey();
 
   void _redrawIndents() {
+    _keys = List.generate(
+      _visibleSideLines().length + (_hasHiddenLines() ? 1 : 0),
+      (_) => GlobalKey(),
+    );
     WidgetsBinding.instance.addPostFrameCallback((_) {
       final RenderBox? columnBox =
           _columnKey.currentContext?.findRenderObject() as RenderBox?;
@@ -635,6 +639,11 @@ class _IndentedSideLinesState extends State<_IndentedSideLines> {
     });
   }
 
+  bool _hasHiddenLines() => widget.sideLines.any((node) => node.isHidden);
+
+  Iterable<ViewBranch> _visibleSideLines() =>
+      widget.sideLines.whereNot((node) => node.isHidden);
+
   @override
   void initState() {
     super.initState();
@@ -651,16 +660,7 @@ class _IndentedSideLinesState extends State<_IndentedSideLines> {
 
   @override
   Widget build(BuildContext context) {
-    final hasHiddenLines = widget.sideLines.any((node) => node.isHidden);
-
-    final visibleSideLines = widget.sideLines.whereNot((node) => node.isHidden);
-
-    _keys = List.generate(
-      visibleSideLines.length + (hasHiddenLines ? 1 : 0),
-      (_) => GlobalKey(),
-    );
-
-    final sideLineWidgets = visibleSideLines
+    final sideLineWidgets = _visibleSideLines()
         .mapIndexed(
           (i, firstSidelineNode) => _SideLines(
             firstNode: firstSidelineNode,
@@ -688,7 +688,7 @@ class _IndentedSideLinesState extends State<_IndentedSideLines> {
             crossAxisAlignment: CrossAxisAlignment.start,
             children: [
               ...sideLineWidgets,
-              if (hasHiddenLines)
+              if (_hasHiddenLines())
                 GestureDetector(
                   child: Icon(
                     Icons.add_box,

--- a/lib/src/view/analysis/tree_view.dart
+++ b/lib/src/view/analysis/tree_view.dart
@@ -686,7 +686,7 @@ class _IndentedSideLinesState extends State<_IndentedSideLines> {
                     Icons.add_box,
                     color: _textColor(context, 0.6),
                     key: _keys.last,
-                    size: _baseTextStyle.fontSize,
+                    size: _baseTextStyle.fontSize! + 5,
                   ),
                   onTap: () {
                     widget.params

--- a/lib/src/view/analysis/tree_view.dart
+++ b/lib/src/view/analysis/tree_view.dart
@@ -294,7 +294,7 @@ class _PgnTreeViewState extends State<_PgnTreeView> {
             containsCurrentMove: containsCurrentMove,
           );
         } else {
-          // Avoid expensive rebuilds by caching parts of the tree that did not change across a path change
+          // Avoid expensive rebuilds ([State.build]) of the entire PGN tree by caching parts of the tree that did not change across a path change
           return subtrees[i];
         }
       },

--- a/lib/src/view/analysis/tree_view.dart
+++ b/lib/src/view/analysis/tree_view.dart
@@ -203,7 +203,7 @@ class _PgnTreeView extends StatelessWidget {
               rootComments?.any((c) => c.text?.isNotEmpty == true) == true)
             Text.rich(
               TextSpan(
-                children: comments(rootComments!, textStyle: _baseTextStyle),
+                children: _comments(rootComments!, textStyle: _baseTextStyle),
               ),
             ),
           ..._mainlineParts(root).map(
@@ -278,7 +278,7 @@ List<InlineSpan> _buildInlineSideLine({
               style: textStyle,
             ),
           ],
-          ...moveWithComment(
+          ..._moveWithComment(
             node,
             parent: i == 0 ? parent : sidelineNodes[i - 1],
             lineInfo: (
@@ -322,7 +322,7 @@ enum _LineType {
 /// Metadata about a move's role in the tree view.
 typedef _LineInfo = ({_LineType type, bool startLine});
 
-List<InlineSpan> moveWithComment(
+List<InlineSpan> _moveWithComment(
   ViewBranch branch, {
   required ViewNode parent,
   required TextStyle textStyle,
@@ -345,7 +345,7 @@ List<InlineSpan> moveWithComment(
       ),
     ),
     if (params.shouldShowComments && branch.hasTextComment)
-      ...comments(branch.comments!, textStyle: textStyle),
+      ..._comments(branch.comments!, textStyle: textStyle),
   ];
 }
 
@@ -377,7 +377,7 @@ class _SideLinePart extends ConsumerWidget {
 
     var path = initialPath + nodes.first.id;
     final moves = [
-      ...moveWithComment(
+      ..._moveWithComment(
         nodes.first,
         parent: parent,
         lineInfo: (
@@ -392,7 +392,7 @@ class _SideLinePart extends ConsumerWidget {
       ...nodes.take(nodes.length - 1).map(
         (node) {
           final moves = [
-            ...moveWithComment(
+            ..._moveWithComment(
               node.children.first,
               parent: node,
               lineInfo: (
@@ -456,7 +456,7 @@ class _MainLinePart extends ConsumerWidget {
               (i, node) {
                 final mainlineNode = node.children.first;
                 final moves = [
-                  moveWithComment(
+                  _moveWithComment(
                     mainlineNode,
                     parent: node,
                     lineInfo: (
@@ -972,7 +972,7 @@ class _MoveContextMenu extends ConsumerWidget {
   }
 }
 
-List<TextSpan> comments(
+List<TextSpan> _comments(
   IList<PgnComment> comments, {
   required TextStyle textStyle,
 }) =>

--- a/lib/src/view/analysis/tree_view.dart
+++ b/lib/src/view/analysis/tree_view.dart
@@ -841,12 +841,12 @@ class InlineMove extends ConsumerWidget {
 
     final indexText = branch.position.ply.isOdd
         ? TextSpan(
-            text: '${(branch.position.ply / 2).ceil()}.',
+            text: '${(branch.position.ply / 2).ceil()}. ',
             style: indexTextStyle,
           )
         : (lineInfo.startLine
             ? TextSpan(
-                text: '${(branch.position.ply / 2).ceil()}…',
+                text: '${(branch.position.ply / 2).ceil()}… ',
                 style: indexTextStyle,
               )
             : null);
@@ -897,7 +897,6 @@ class InlineMove extends ConsumerWidget {
             children: [
               if (indexText != null) ...[
                 indexText,
-                const WidgetSpan(child: SizedBox(width: 3)),
               ],
               TextSpan(
                 text: moveWithNag,

--- a/lib/src/view/analysis/tree_view.dart
+++ b/lib/src/view/analysis/tree_view.dart
@@ -253,7 +253,6 @@ List<InlineSpan> _buildInlineSideLine({
   required _PgnTreeViewParams params,
 }) {
   textStyle = textStyle.copyWith(
-    fontStyle: FontStyle.italic,
     fontSize: textStyle.fontSize != null ? textStyle.fontSize! - 2.0 : null,
   );
 
@@ -931,7 +930,10 @@ List<TextSpan> comments(
         .map(
           (comment) => TextSpan(
             text: comment.text,
-            style: textStyle.copyWith(fontSize: textStyle.fontSize! - 2.0),
+            style: textStyle.copyWith(
+              fontSize: textStyle.fontSize! - 2.0,
+              fontStyle: FontStyle.italic,
+            ),
           ),
         )
         .toList();

--- a/lib/src/view/analysis/tree_view.dart
+++ b/lib/src/view/analysis/tree_view.dart
@@ -282,7 +282,7 @@ List<InlineSpan> _buildInlineSideLine({
             node,
             parent: i == 0 ? parent : sidelineNodes[i - 1],
             lineInfo: (
-              type: LineType.inlineSideline,
+              type: _LineType.inlineSideline,
               startLine: i == 0 || sidelineNodes[i - 1].hasTextComment
             ),
             pathToNode: pathToNode,
@@ -306,19 +306,27 @@ const _baseTextStyle = TextStyle(
   height: 1.5,
 );
 
-enum LineType {
+/// The different types of lines (move sequences) that are displayed in the tree view.
+enum _LineType {
+  /// (A part of) the game's main line.
   mainline,
+
+  /// A sideline branching off the main line or a parent sideline.
+  /// Each sideline is rendered on a new line and indented.
   sideline,
+
+  /// A short sideline without any branching, displayed in parantheses inline with it's parent line.
   inlineSideline,
 }
 
-typedef LineInfo = ({LineType type, bool startLine});
+/// Metadata about a move's role in the tree view.
+typedef _LineInfo = ({_LineType type, bool startLine});
 
 List<InlineSpan> moveWithComment(
   ViewBranch branch, {
   required ViewNode parent,
   required TextStyle textStyle,
-  required LineInfo lineInfo,
+  required _LineInfo lineInfo,
   required UciPath pathToNode,
   required _PgnTreeViewParams params,
   GlobalKey? moveKey,
@@ -373,7 +381,7 @@ class _SideLinePart extends ConsumerWidget {
         nodes.first,
         parent: parent,
         lineInfo: (
-          type: LineType.sideline,
+          type: _LineType.sideline,
           startLine: true,
         ),
         moveKey: firstMoveKey,
@@ -388,7 +396,7 @@ class _SideLinePart extends ConsumerWidget {
               node.children.first,
               parent: node,
               lineInfo: (
-                type: LineType.sideline,
+                type: _LineType.sideline,
                 startLine: node.hasTextComment,
               ),
               pathToNode: path,
@@ -452,7 +460,7 @@ class _MainLinePart extends ConsumerWidget {
                     mainlineNode,
                     parent: node,
                     lineInfo: (
-                      type: LineType.mainline,
+                      type: _LineType.mainline,
                       startLine: i == 0 || (node as ViewBranch).hasTextComment,
                     ),
                     pathToNode: path,
@@ -735,7 +743,7 @@ class InlineMove extends ConsumerWidget {
 
   final TextStyle textStyle;
 
-  final LineInfo lineInfo;
+  final _LineInfo lineInfo;
 
   final _PgnTreeViewParams params;
 
@@ -756,7 +764,7 @@ class InlineMove extends ConsumerWidget {
       fontFamily: moveFontFamily,
       fontWeight: isCurrentMove
           ? FontWeight.bold
-          : lineInfo.type == LineType.inlineSideline
+          : lineInfo.type == _LineType.inlineSideline
               ? FontWeight.normal
               : FontWeight.w600,
     );
@@ -803,7 +811,7 @@ class InlineMove extends ConsumerWidget {
             path: path,
             parent: parent,
             branch: branch,
-            isSideline: lineInfo.type != LineType.mainline,
+            isSideline: lineInfo.type != _LineType.mainline,
           ),
         );
       },

--- a/lib/src/view/analysis/tree_view.dart
+++ b/lib/src/view/analysis/tree_view.dart
@@ -386,7 +386,6 @@ List<InlineSpan> _buildInlineSideLine({
           ],
           ..._moveWithComment(
             node,
-            parent: i == 0 ? parent : sidelineNodes[i - 1],
             lineInfo: (
               type: _LineType.inlineSideline,
               startLine: i == 0 || sidelineNodes[i - 1].hasTextComment
@@ -430,7 +429,6 @@ typedef _LineInfo = ({_LineType type, bool startLine});
 
 List<InlineSpan> _moveWithComment(
   ViewBranch branch, {
-  required ViewNode parent,
   required TextStyle textStyle,
   required _LineInfo lineInfo,
   required UciPath pathToNode,
@@ -442,7 +440,6 @@ List<InlineSpan> _moveWithComment(
       alignment: PlaceholderAlignment.middle,
       child: InlineMove(
         branch: branch,
-        parent: parent,
         lineInfo: lineInfo,
         path: pathToNode + branch.id,
         key: moveKey,
@@ -460,15 +457,12 @@ List<InlineSpan> _moveWithComment(
 class _SideLinePart extends ConsumerWidget {
   _SideLinePart(
     this.nodes, {
-    required this.parent,
     required this.initialPath,
     required this.firstMoveKey,
     required this.params,
   }) : assert(nodes.isNotEmpty);
 
   final List<ViewBranch> nodes;
-
-  final ViewNode parent;
 
   final UciPath initialPath;
 
@@ -487,7 +481,6 @@ class _SideLinePart extends ConsumerWidget {
     final moves = [
       ..._moveWithComment(
         nodes.first,
-        parent: parent,
         lineInfo: (
           type: _LineType.sideline,
           startLine: true,
@@ -502,7 +495,6 @@ class _SideLinePart extends ConsumerWidget {
           final moves = [
             ..._moveWithComment(
               node.children.first,
-              parent: node,
               lineInfo: (
                 type: _LineType.sideline,
                 startLine: node.hasTextComment,
@@ -566,7 +558,6 @@ class _MainLinePart extends ConsumerWidget {
                 final moves = [
                   _moveWithComment(
                     mainlineNode,
-                    parent: node,
                     lineInfo: (
                       type: _LineType.mainline,
                       startLine: i == 0 || (node as ViewBranch).hasTextComment,
@@ -630,7 +621,6 @@ class _SideLines extends StatelessWidget {
       children: [
         _SideLinePart(
           sidelineNodes.toList(),
-          parent: parent,
           firstMoveKey: firstMoveKey,
           initialPath: initialPath,
           params: params,
@@ -834,7 +824,6 @@ Color? _textColor(
 class InlineMove extends ConsumerWidget {
   const InlineMove({
     required this.branch,
-    required this.parent,
     required this.path,
     required this.textStyle,
     required this.lineInfo,
@@ -842,7 +831,6 @@ class InlineMove extends ConsumerWidget {
     required this.params,
   });
 
-  final ViewNode parent;
   final ViewBranch branch;
   final UciPath path;
 
@@ -914,7 +902,6 @@ class InlineMove extends ConsumerWidget {
                 ? '${(ply / 2).ceil()}. $moveWithNag'
                 : '${(ply / 2).ceil()}... $moveWithNag',
             path: path,
-            parent: parent,
             branch: branch,
             isSideline: lineInfo.type != _LineType.mainline,
           ),
@@ -959,7 +946,6 @@ class _MoveContextMenu extends ConsumerWidget {
   const _MoveContextMenu({
     required this.title,
     required this.path,
-    required this.parent,
     required this.branch,
     required this.isSideline,
     required this.notifier,
@@ -967,7 +953,6 @@ class _MoveContextMenu extends ConsumerWidget {
 
   final String title;
   final UciPath path;
-  final ViewNode parent;
   final ViewBranch branch;
   final bool isSideline;
   final AnalysisController notifier;

--- a/lib/src/view/analysis/tree_view.dart
+++ b/lib/src/view/analysis/tree_view.dart
@@ -741,35 +741,32 @@ class _IndentedSideLinesState extends State<_IndentedSideLines> {
 
     final padding = widget.nesting < 6 ? 12.0 : 0.0;
 
-    // Without the RepaintBoundary, the CustomPaint would continuously repaint when the view is scrolled
-    return RepaintBoundary(
-      child: Padding(
-        padding: EdgeInsets.only(left: padding),
-        child: CustomPaint(
-          painter: _IndentPainter(
-            sideLineStartPositions: _sideLineStartPositions,
-            color: _textColor(context, 0.6)!,
-            padding: padding,
-          ),
-          child: Column(
-            key: _columnKey,
-            crossAxisAlignment: CrossAxisAlignment.start,
-            children: [
-              ...sideLineWidgets,
-              if (_hasHiddenLines())
-                GestureDetector(
-                  child: Icon(
-                    Icons.add_box,
-                    color: _textColor(context, 0.6),
-                    key: _keys.last,
-                    size: _baseTextStyle.fontSize! + 5,
-                  ),
-                  onTap: () {
-                    widget.params.notifier.expandVariations(widget.initialPath);
-                  },
+    return Padding(
+      padding: EdgeInsets.only(left: padding),
+      child: CustomPaint(
+        painter: _IndentPainter(
+          sideLineStartPositions: _sideLineStartPositions,
+          color: _textColor(context, 0.6)!,
+          padding: padding,
+        ),
+        child: Column(
+          key: _columnKey,
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            ...sideLineWidgets,
+            if (_hasHiddenLines())
+              GestureDetector(
+                child: Icon(
+                  Icons.add_box,
+                  color: _textColor(context, 0.6),
+                  key: _keys.last,
+                  size: _baseTextStyle.fontSize! + 5,
                 ),
-            ],
-          ),
+                onTap: () {
+                  widget.params.notifier.expandVariations(widget.initialPath);
+                },
+              ),
+          ],
         ),
       ),
     );

--- a/lib/src/view/analysis/tree_view.dart
+++ b/lib/src/view/analysis/tree_view.dart
@@ -674,6 +674,8 @@ class _IndentedSideLinesState extends State<_IndentedSideLines> {
         .toList();
 
     final padding = widget.nesting < 6 ? 12.0 : 0.0;
+
+    // Without the RepaintBoundary, the CustomPaint would continuously repaint when the view is scrolled
     return RepaintBoundary(
       child: Padding(
         padding: EdgeInsets.only(left: padding),

--- a/lib/src/view/analysis/tree_view.dart
+++ b/lib/src/view/analysis/tree_view.dart
@@ -228,11 +228,13 @@ typedef _Subtree = ({
 });
 
 class _PgnTreeViewState extends State<_PgnTreeView> {
-  /// Caches the result of [_mainlineParts] to avoid recalculating it on every rebuild.
+  /// Caches the result of [_mainlineParts], it only needs to be recalculated when the root changes,
+  /// but not when `params.pathToCurrentMove` changes.
   List<List<ViewNode>> mainlineParts = [];
 
-  /// Caches the top-level subtrees, where each subtree is a [_MainLinePart] and its sidelines.
-  /// Building the whole tree is expensive, so we cache the subtrees that did not change when the current move changes.
+  /// Caches the top-level subtrees obtained from the last `build()` method, where each subtree is a [_MainLinePart] and its sidelines.
+  /// Building the whole tree is expensive, so we cache the subtrees that did not change when the current move changes,
+  /// the framework will then skip the `build()` of each subtree since the widget reference is the same.
   List<_Subtree> subtrees = [];
 
   UciPath _mainlinePartOfCurrentPath() {

--- a/lib/src/view/analysis/tree_view.dart
+++ b/lib/src/view/analysis/tree_view.dart
@@ -139,7 +139,7 @@ class _InlineTreeViewState extends ConsumerState<AnalysisTreeView> {
               shouldShowComments: shouldShowComments,
               currentMoveKey: currentMoveKey,
               currentPath: currentPath,
-              notifier: () => ref.read(ctrlProvider.notifier),
+              notifier: ref.read(ctrlProvider.notifier),
             ),
           ),
         ),
@@ -155,7 +155,7 @@ typedef _PgnTreeViewParams = ({
   bool shouldShowAnnotations,
   bool shouldShowComments,
   GlobalKey currentMoveKey,
-  AnalysisController Function() notifier,
+  AnalysisController notifier,
 });
 
 /// True if the side line has no branching and is less than 6 moves deep.
@@ -699,9 +699,7 @@ class _IndentedSideLinesState extends State<_IndentedSideLines> {
                     size: _baseTextStyle.fontSize! + 5,
                   ),
                   onTap: () {
-                    widget.params
-                        .notifier()
-                        .expandVariations(widget.initialPath);
+                    widget.params.notifier.expandVariations(widget.initialPath);
                   },
                 ),
             ],
@@ -798,7 +796,7 @@ class InlineMove extends ConsumerWidget {
     return AdaptiveInkWell(
       key: isCurrentMove ? params.currentMoveKey : null,
       borderRadius: borderRadius,
-      onTap: () => params.notifier().userJump(path),
+      onTap: () => params.notifier.userJump(path),
       onLongPress: () {
         showAdaptiveBottomSheet<void>(
           context: context,
@@ -868,7 +866,7 @@ class _MoveContextMenu extends ConsumerWidget {
   final ViewNode parent;
   final ViewBranch branch;
   final bool isSideline;
-  final AnalysisController Function() notifier;
+  final AnalysisController notifier;
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
@@ -951,23 +949,23 @@ class _MoveContextMenu extends ConsumerWidget {
           BottomSheetContextMenuAction(
             icon: Icons.subtitles_off,
             child: Text(context.l10n.collapseVariations),
-            onPressed: () => notifier().collapseVariations(path),
+            onPressed: () => notifier.collapseVariations(path),
           ),
           BottomSheetContextMenuAction(
             icon: Icons.expand_less,
             child: Text(context.l10n.promoteVariation),
-            onPressed: () => notifier().promoteVariation(path, false),
+            onPressed: () => notifier.promoteVariation(path, false),
           ),
           BottomSheetContextMenuAction(
             icon: Icons.check,
             child: Text(context.l10n.makeMainLine),
-            onPressed: () => notifier().promoteVariation(path, true),
+            onPressed: () => notifier.promoteVariation(path, true),
           ),
         ],
         BottomSheetContextMenuAction(
           icon: Icons.delete,
           child: Text(context.l10n.deleteFromHere),
-          onPressed: () => notifier().deleteFromHere(path),
+          onPressed: () => notifier.deleteFromHere(path),
         ),
       ],
     );

--- a/lib/src/view/analysis/tree_view.dart
+++ b/lib/src/view/analysis/tree_view.dart
@@ -500,11 +500,11 @@ class _SideLines extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    final sidelineNodes = [
-      firstNode,
-      if (!_hasNonInlineSideLine(firstNode))
-        ...firstNode.mainline.takeWhile((node) => !_hasNonInlineSideLine(node)),
-    ];
+    final sidelineNodes = [firstNode];
+    while (sidelineNodes.last.children.isNotEmpty &&
+        !_hasNonInlineSideLine(sidelineNodes.last)) {
+      sidelineNodes.add(sidelineNodes.last.children.first);
+    }
 
     final children =
         sidelineNodes.last.children.whereNot((node) => node.isHidden);

--- a/lib/src/view/analysis/tree_view.dart
+++ b/lib/src/view/analysis/tree_view.dart
@@ -171,7 +171,9 @@ bool _hasNonInlineSideLine(ViewNode node) =>
     (node.children.length == 2 && !_displaySideLineAsInline(node.children[1]));
 
 Iterable<List<ViewNode>> _mainlineParts(ViewRoot root) =>
-    [root, ...root.mainline].splitAfter(_hasNonInlineSideLine);
+    [root, ...root.mainline]
+        .splitAfter(_hasNonInlineSideLine)
+        .takeWhile((nodes) => nodes.firstOrNull?.children.isNotEmpty == true);
 
 class _PgnTreeView extends StatefulWidget {
   const _PgnTreeView({

--- a/lib/src/view/analysis/tree_view.dart
+++ b/lib/src/view/analysis/tree_view.dart
@@ -148,8 +148,8 @@ class _InlineTreeViewState extends ConsumerState<AnalysisTreeView> {
   }
 }
 
-// A group of parameters that are passed through various parts of the tree view
-// and ultimately evaluated in the InlineMove widget. Grouped in this record to improve readability.
+/// A group of parameters that are passed through various parts of the tree view
+/// and ultimately evaluated in the InlineMove widget. Grouped in this record to improve readability.
 typedef _PgnTreeViewParams = ({
   UciPath currentPath,
   bool shouldShowAnnotations,

--- a/lib/src/view/analysis/tree_view.dart
+++ b/lib/src/view/analysis/tree_view.dart
@@ -433,6 +433,9 @@ List<InlineSpan> _moveWithComment(
   required _LineInfo lineInfo,
   required UciPath pathToNode,
   required _PgnTreeViewParams params,
+
+  /// Key that will be assigned to the move text. We use this to track the position of the first move of
+  /// a sideline, see [_SideLinePart.firstMoveKey]
   GlobalKey? moveKey,
 }) {
   return [
@@ -466,6 +469,8 @@ class _SideLinePart extends ConsumerWidget {
 
   final UciPath initialPath;
 
+  /// The key that will be assigned to the first move in this sideline.
+  /// This is needed so that the indent guidelines can be drawn correctly.
   final GlobalKey firstMoveKey;
 
   final _PgnTreeViewParams params;
@@ -528,6 +533,7 @@ class _SideLinePart extends ConsumerWidget {
   }
 }
 
+/// A part of the mainline that will be rendered on the same line. See [_mainlineParts].
 class _MainLinePart extends ConsumerWidget {
   const _MainLinePart({
     required this.initialPath,
@@ -589,8 +595,10 @@ class _MainLinePart extends ConsumerWidget {
   }
 }
 
-class _SideLines extends StatelessWidget {
-  const _SideLines({
+/// A sideline where the moves are rendered on the same line (see [_SideLinePart]) until further branching is encountered,
+/// at which point the children sidelines are rendered on new lines and indented (see [_IndentedSideLines]).
+class _SideLine extends StatelessWidget {
+  const _SideLine({
     required this.firstNode,
     required this.parent,
     required this.firstMoveKey,
@@ -682,6 +690,8 @@ class _IndentPainter extends CustomPainter {
   }
 }
 
+/// Displays one ore more sidelines indented on their own line and adds indent guides.
+/// If there are hidden lines, a button is displayed to expand them.
 class _IndentedSideLines extends StatefulWidget {
   const _IndentedSideLines(
     this.sideLines, {
@@ -760,7 +770,7 @@ class _IndentedSideLinesState extends State<_IndentedSideLines> {
   Widget build(BuildContext context) {
     final sideLineWidgets = _visibleSideLines()
         .mapIndexed(
-          (i, firstSidelineNode) => _SideLines(
+          (i, firstSidelineNode) => _SideLine(
             firstNode: firstSidelineNode,
             parent: widget.parent,
             firstMoveKey: _keys[i],

--- a/test/view/analysis/analysis_screen_test.dart
+++ b/test/view/analysis/analysis_screen_test.dart
@@ -47,10 +47,17 @@ void main() {
 
       expect(find.byType(Chessboard), findsOneWidget);
       expect(find.byType(PieceWidget), findsNWidgets(25));
-      final currentMove = find.widgetWithText(InlineMove, 'Qe1#');
+      final currentMove = find.textContaining('Qe1#');
       expect(currentMove, findsOneWidget);
       expect(
-        tester.widgetList<InlineMove>(currentMove).any((e) => e.isCurrentMove),
+        tester
+            .widget<InlineMove>(
+              find.ancestor(
+                of: currentMove,
+                matching: find.byType(InlineMove),
+              ),
+            )
+            .isCurrentMove,
         isTrue,
       );
     });
@@ -92,10 +99,17 @@ void main() {
       await tester.tap(find.byKey(const Key('goto-previous')));
       await tester.pumpAndSettle();
 
-      final currentMove = find.widgetWithText(InlineMove, 'Kc1');
+      final currentMove = find.textContaining('Kc1');
       expect(currentMove, findsOneWidget);
       expect(
-        tester.widgetList<InlineMove>(currentMove).any((e) => e.isCurrentMove),
+        tester
+            .widget<InlineMove>(
+              find.ancestor(
+                of: currentMove,
+                matching: find.byType(InlineMove),
+              ),
+            )
+            .isCurrentMove,
         isTrue,
       );
     });

--- a/test/view/analysis/analysis_screen_test.dart
+++ b/test/view/analysis/analysis_screen_test.dart
@@ -187,7 +187,7 @@ void main() {
       testWidgets('displays long sideline on its own line', (tester) async {
         await buildTree(
           tester,
-          '1. e4 e5 (1... d5 2. exd5 Qxd5 3. Nc3 Qd8 4. d4 Nf6) Nc3 *',
+          '1. e4 e5 (1... d5 2. exd5 Qxd5 3. Nc3 Qd8 4. d4 Nf6) 2. Nc3 *',
         );
 
         expectSameLine(tester, ['1. e4', 'e5']);

--- a/test/view/analysis/analysis_screen_test.dart
+++ b/test/view/analysis/analysis_screen_test.dart
@@ -2,7 +2,7 @@ import 'dart:convert';
 
 import 'package:chessground/chessground.dart';
 import 'package:dartchess/dartchess.dart';
-import 'package:flutter/foundation.dart';
+import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:lichess_mobile/src/model/analysis/analysis_controller.dart';
 import 'package:lichess_mobile/src/model/common/chess.dart';
@@ -112,6 +112,146 @@ void main() {
             .isCurrentMove,
         isTrue,
       );
+    });
+
+    group('Analysis Tree View', () {
+      Future<void> buildTree(
+        WidgetTester tester,
+        String pgn,
+      ) async {
+        final app = await makeTestProviderScopeApp(
+          tester,
+          home: AnalysisScreen(
+            pgnOrId: pgn,
+            options: const AnalysisOptions(
+              isLocalEvaluationAllowed: false,
+              variant: Variant.standard,
+              orientation: Side.white,
+              opening: opening,
+              id: standaloneAnalysisId,
+            ),
+          ),
+        );
+
+        await tester.pumpWidget(app);
+      }
+
+      Text parentText(WidgetTester tester, String move) {
+        return tester.widget<Text>(
+          find.ancestor(
+            of: find.text(move),
+            matching: find.byType(Text),
+          ),
+        );
+      }
+
+      void expectSameLine(WidgetTester tester, Iterable<String> moves) {
+        final line = parentText(tester, moves.first);
+
+        for (final move in moves.skip(1)) {
+          final moveText = find.text(move);
+          expect(moveText, findsOneWidget);
+          expect(
+            parentText(tester, move),
+            line,
+          );
+        }
+      }
+
+      void expectDifferentLines(
+        WidgetTester tester,
+        List<String> moves,
+      ) {
+        for (int i = 0; i < moves.length; i++) {
+          for (int j = i + 1; j < moves.length; j++) {
+            expect(
+              parentText(tester, moves[i]),
+              isNot(parentText(tester, moves[j])),
+            );
+          }
+        }
+      }
+
+      testWidgets('displays short sideline as inline', (tester) async {
+        await buildTree(tester, '1. e4 e5 (1... d5 2. exd5) 2. Nf3 *');
+
+        final mainline = find.ancestor(
+          of: find.text('1. e4'),
+          matching: find.byType(Text),
+        );
+        expect(mainline, findsOneWidget);
+
+        expectSameLine(tester, ['1. e4', 'e5', '1… d5', '2. exd5', '2. Nf3']);
+      });
+
+      testWidgets('displays long sideline on its own line', (tester) async {
+        await buildTree(
+          tester,
+          '1. e4 e5 (1... d5 2. exd5 Qxd5 3. Nc3 Qd8 4. d4 Nf6) Nc3 *',
+        );
+
+        expectSameLine(tester, ['1. e4', 'e5']);
+        expectSameLine(
+          tester,
+          ['1… d5', '2. exd5', 'Qxd5', '3. Nc3', 'Qd8', '4. d4', 'Nf6'],
+        );
+        expectSameLine(tester, ['2. Nc3']);
+
+        expectDifferentLines(tester, ['1. e4', '1… d5', '2. Nc3']);
+      });
+
+      testWidgets('displays sideline with branching on its own line',
+          (tester) async {
+        await buildTree(tester, '1. e4 e5 (1... d5 2. exd5 (2. Nc3)) *');
+
+        expectSameLine(tester, ['1. e4', 'e5']);
+
+        // 2nd branch is rendered inline again
+        expectSameLine(tester, ['1… d5', '2. exd5', '2. Nc3']);
+
+        expectDifferentLines(tester, ['1. e4', '1… d5']);
+      });
+
+      testWidgets('multiple sidelines', (tester) async {
+        await buildTree(
+          tester,
+          '1. e4 e5 (1... d5 2. exd5) (1... Nf6 2. e5) 2. Nf3 Nc6 (2... a5) *',
+        );
+
+        expectSameLine(tester, ['1. e4', 'e5']);
+        expectSameLine(tester, ['1… d5', '2. exd5']);
+        expectSameLine(tester, ['1… Nf6', '2. e5']);
+        expectSameLine(tester, ['2. Nf3', 'Nc6', '2… a5']);
+
+        expectDifferentLines(tester, ['1. e4', '1… d5', '1… Nf6', '2. Nf3']);
+      });
+
+      testWidgets('collapses lines with nesting > 2', (tester) async {
+        await buildTree(
+          tester,
+          '1. e4 e5 (1... d5 2. Nc3 (2. h4 h5 (2... Nc6 3. d3) (2... Qd7))) *',
+        );
+
+        expectSameLine(tester, ['1. e4', 'e5']);
+        expectSameLine(tester, ['1… d5']);
+        expectSameLine(tester, ['2. Nc3']);
+        expectSameLine(tester, ['2. h4']);
+
+        expect(find.text('2… h5'), findsNothing);
+        expect(find.text('2… Nc6'), findsNothing);
+        expect(find.text('3. d3'), findsNothing);
+        expect(find.text('2… Qd7'), findsNothing);
+
+        // sidelines with nesting > 2 are collapsed -> expand them
+        expect(find.byIcon(Icons.add_box), findsOneWidget);
+
+        await tester.tap(find.byIcon(Icons.add_box));
+        await tester.pumpAndSettle();
+
+        expectSameLine(tester, ['2… h5']);
+        expectSameLine(tester, ['2… Nc6', '3. d3']);
+        expectSameLine(tester, ['2… Qd7']);
+      });
     });
   });
 }


### PR DESCRIPTION
Especially for heavily commented PGNs this is now much more readable. We're also more consistent with the website now. I added screenhots for comparison below.

I know this is a rather big refactoring, and the recursive nature of this stuff is quite complex, so let me know if anything is unclear. 

I also made a few style adaptions to be a bit more consistent with the the Web UI, but I don't have any strong opinions here, feel free to tweak the styling again after merging.

(Left: Before, Right: This PR)

<p float="left">
  <img src="https://github.com/user-attachments/assets/e21cddc0-8800-4cae-9fcf-7ff53d8cb1ff" width="350" />
  <img src="https://github.com/user-attachments/assets/1e8ca7c3-70cb-4dfa-a64c-d018dfad9dab" width="350" /> 
</p>

lichess.org for comparison:

![Screenshot_2024-09-28_11-23-42](https://github.com/user-attachments/assets/961991a0-5f7e-4690-8f2c-4ce3434f3e16)

