### PR TITLE
feat: add option to show variation arrows in analysis

### DIFF
--- a/lib/src/model/analysis/analysis_controller.dart
+++ b/lib/src/model/analysis/analysis_controller.dart
@@ -763,7 +763,7 @@ class AnalysisCurrentNode with _$AnalysisCurrentNode {
 
   const factory AnalysisCurrentNode({
     required Position position,
-    required bool hasChild,
+    required List<Move> children,
     required bool isRoot,
     SanMove? sanMove,
     Opening? opening,
@@ -774,13 +774,16 @@ class AnalysisCurrentNode with _$AnalysisCurrentNode {
     IList<int>? nags,
   }) = _AnalysisCurrentNode;
 
+  bool get hasChild => children.isNotEmpty;
+
   factory AnalysisCurrentNode.fromNode(Node node) {
+    final children = node.children.map((n) => n.sanMove.move).toList();
     if (node is Branch) {
       return AnalysisCurrentNode(
         sanMove: node.sanMove,
         position: node.position,
         isRoot: node is Root,
-        hasChild: node.children.isNotEmpty,
+        children: children,
         opening: node.opening,
         eval: node.eval,
         lichessAnalysisComments: IList(node.lichessAnalysisComments),
@@ -791,7 +794,7 @@ class AnalysisCurrentNode with _$AnalysisCurrentNode {
     } else {
       return AnalysisCurrentNode(
         position: node.position,
-        hasChild: node.children.isNotEmpty,
+        children: children,
         isRoot: node is Root,
         opening: node.opening,
         eval: node.eval,

--- a/lib/src/model/analysis/analysis_preferences.dart
+++ b/lib/src/model/analysis/analysis_preferences.dart
@@ -64,6 +64,14 @@ class AnalysisPreferences extends _$AnalysisPreferences {
     );
   }
 
+  Future<void> toggleShowVariationArrows() {
+    return _save(
+      state.copyWith(
+        showVariationArrows: !state.showVariationArrows,
+      ),
+    );
+  }
+
   Future<void> setNumEvalLines(int numEvalLines) {
     assert(numEvalLines >= 1 && numEvalLines <= 3);
     return _save(
@@ -100,6 +108,7 @@ class AnalysisPrefState with _$AnalysisPrefState {
     required bool enableLocalEvaluation,
     required bool showEvaluationGauge,
     required bool showBestMoveArrow,
+    required bool showVariationArrows,
     required bool showAnnotations,
     required bool showPgnComments,
     @Assert('numEvalLines >= 1 && numEvalLines <= 3') required int numEvalLines,
@@ -111,6 +120,7 @@ class AnalysisPrefState with _$AnalysisPrefState {
     enableLocalEvaluation: true,
     showEvaluationGauge: true,
     showBestMoveArrow: true,
+    showVariationArrows: true,
     showAnnotations: true,
     showPgnComments: true,
     numEvalLines: 2,

--- a/lib/src/view/analysis/analysis_settings.dart
+++ b/lib/src/view/analysis/analysis_settings.dart
@@ -108,6 +108,13 @@ class AnalysisSettings extends ConsumerWidget {
               : null,
         ),
         SwitchSettingTile(
+          title: Text(context.l10n.showVariationArrows),
+          value: prefs.showVariationArrows,
+          onChanged: (value) => ref
+              .read(analysisPreferencesProvider.notifier)
+              .toggleShowVariationArrows(),
+        ),
+        SwitchSettingTile(
           title: Text(context.l10n.evaluationGauge),
           value: prefs.showEvaluationGauge,
           onChanged: (value) => ref


### PR DESCRIPTION
Mainly for study, but can be helpful for analysis as well (the website also has this option for analysis)

Open questions:

- [ ] Color choice - The mainline should be highlighted more. The website uses a blue shadow for the mainline arrow, but we could also do something different of course
- [ ] What happens if engine evaluation is enabled and the best move is also the mainline move? The website has a special arrow color for this (blue with white shadow)

![Screenshot_1727818512](https://github.com/user-attachments/assets/0ecd6e07-0e3d-4a15-a505-1487582c37b3)