### PR TITLE
Use a global cache to preload chess pieces

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -27,6 +27,8 @@ Future<void> main() async {
   await lichessBinding.preloadSharedPreferences();
   await lichessBinding.preloadData();
 
+  await preloadPieceImages();
+
   await setupFirstLaunch();
 
   await SoundService.initialize();

--- a/lib/src/init.dart
+++ b/lib/src/init.dart
@@ -9,6 +9,7 @@ import 'package:lichess_mobile/src/db/secure_storage.dart';
 import 'package:lichess_mobile/src/model/settings/board_preferences.dart';
 import 'package:lichess_mobile/src/model/settings/preferences.dart';
 import 'package:lichess_mobile/src/network/socket.dart';
+import 'package:lichess_mobile/src/utils/chessboard.dart';
 import 'package:lichess_mobile/src/utils/color_palette.dart';
 import 'package:lichess_mobile/src/utils/screen.dart';
 import 'package:lichess_mobile/src/utils/string.dart';
@@ -42,6 +43,22 @@ Future<void> setupFirstLaunch() async {
 
     await prefs.setBool('first_run', false);
   }
+}
+
+Future<void> preloadPieceImages() async {
+  final prefs = LichessBinding.instance.sharedPreferences;
+  final storedPrefs = prefs.getString(PrefCategory.board.storageKey);
+  BoardPrefs boardPrefs = BoardPrefs.defaults;
+  if (storedPrefs != null) {
+    try {
+      boardPrefs =
+          BoardPrefs.fromJson(jsonDecode(storedPrefs) as Map<String, dynamic>);
+    } catch (e) {
+      _logger.warning('Failed to decode board preferences: $e');
+    }
+  }
+
+  await precachePieceImages(boardPrefs.pieceSet);
 }
 
 /// Display setup on Android.

--- a/lib/src/model/auth/auth_controller.dart
+++ b/lib/src/model/auth/auth_controller.dart
@@ -46,13 +46,13 @@ class AuthController extends _$AuthController {
     final appAuth = ref.read(appAuthProvider);
 
     try {
+      await ref.read(notificationServiceProvider).unregister();
       await ref.withClient(
         (client) => AuthRepository(client, appAuth).signOut(),
       );
-      ref.read(notificationServiceProvider).unregister();
-      // force reconnect to the current socket
-      ref.read(socketPoolProvider).currentClient.connect();
       await ref.read(authSessionProvider.notifier).delete();
+      // force reconnect to the current socket
+      await ref.read(socketPoolProvider).currentClient.connect();
       state = const AsyncValue.data(null);
     } catch (e, st) {
       state = AsyncValue.error(e, st);

--- a/lib/src/model/settings/board_preferences.dart
+++ b/lib/src/model/settings/board_preferences.dart
@@ -151,11 +151,7 @@ class BoardPrefs with _$BoardPrefs implements SerializablePreferences {
   }
 
   factory BoardPrefs.fromJson(Map<String, dynamic> json) {
-    try {
-      return _$BoardPrefsFromJson(json);
-    } catch (_) {
-      return defaults;
-    }
+    return _$BoardPrefsFromJson(json);
   }
 
   Duration get pieceAnimationDuration =>

--- a/lib/src/utils/chessboard.dart
+++ b/lib/src/utils/chessboard.dart
@@ -1,0 +1,23 @@
+import 'package:chessground/chessground.dart';
+import 'package:flutter/widgets.dart';
+
+/// Preload piece images from the specified [PieceSet] into Chessground's image cache.
+///
+/// This method clears the cache before loading the images.
+Future<void> precachePieceImages(PieceSet pieceSet) async {
+  try {
+    final devicePixelRatio = WidgetsBinding
+            .instance.platformDispatcher.implicitView?.devicePixelRatio ??
+        1.0;
+
+    ChessgroundImages.instance.clear();
+
+    for (final asset in pieceSet.assets.values) {
+      await ChessgroundImages.instance
+          .load(asset, devicePixelRatio: devicePixelRatio);
+      debugPrint('Preloaded piece image: ${asset.assetName}');
+    }
+  } catch (e) {
+    debugPrint('Failed to preload piece images: $e');
+  }
+}

--- a/lib/src/view/puzzle/puzzle_feedback_widget.dart
+++ b/lib/src/view/puzzle/puzzle_feedback_widget.dart
@@ -29,7 +29,8 @@ class PuzzleFeedbackWidget extends ConsumerWidget {
         ref.watch(boardPreferencesProvider.select((state) => state.boardTheme));
     final brightness = ref.watch(currentBrightnessProvider);
 
-    final piece = state.pov == Side.white ? kWhiteKingKind : kBlackKingKind;
+    final piece =
+        state.pov == Side.white ? PieceKind.whiteKing : PieceKind.blackKing;
     final asset = pieceSet.assets[piece]!;
 
     switch (state.mode) {

--- a/lib/src/view/settings/piece_set_screen.dart
+++ b/lib/src/view/settings/piece_set_screen.dart
@@ -4,104 +4,106 @@ import 'package:flutter/cupertino.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:lichess_mobile/src/model/settings/board_preferences.dart';
+import 'package:lichess_mobile/src/utils/chessboard.dart';
 import 'package:lichess_mobile/src/utils/l10n_context.dart';
 import 'package:lichess_mobile/src/widgets/list.dart';
-import 'package:lichess_mobile/src/widgets/platform.dart';
+import 'package:lichess_mobile/src/widgets/platform_scaffold.dart';
 
-class PieceSetScreen extends StatelessWidget {
+class PieceSetScreen extends ConsumerStatefulWidget {
   const PieceSetScreen({super.key});
 
   @override
-  Widget build(BuildContext context) {
-    return PlatformWidget(
-      androidBuilder: _androidBuilder,
-      iosBuilder: _iosBuilder,
-    );
-  }
-
-  Widget _androidBuilder(BuildContext context) {
-    return Scaffold(
-      appBar: AppBar(title: Text(context.l10n.pieceSet)),
-      body: _Body(),
-    );
-  }
-
-  Widget _iosBuilder(BuildContext context) {
-    return CupertinoPageScaffold(
-      navigationBar: const CupertinoNavigationBar(),
-      child: _Body(),
-    );
-  }
+  ConsumerState<PieceSetScreen> createState() => _PieceSetScreenState();
 }
 
-class _Body extends ConsumerWidget {
+class _PieceSetScreenState extends ConsumerState<PieceSetScreen> {
+  bool isLoading = false;
+
+  Future<void> onChanged(PieceSet? value) async {
+    if (value != null) {
+      ref.read(boardPreferencesProvider.notifier).setPieceSet(value);
+      setState(() {
+        isLoading = true;
+      });
+      try {
+        await precachePieceImages(value);
+      } finally {
+        setState(() {
+          isLoading = false;
+        });
+      }
+    }
+  }
+
+  List<AssetImage> getPieceImages(PieceSet set) {
+    return [
+      set.assets[PieceKind.whiteKing]!,
+      set.assets[PieceKind.blackQueen]!,
+      set.assets[PieceKind.whiteRook]!,
+      set.assets[PieceKind.blackBishop]!,
+      set.assets[PieceKind.whiteKnight]!,
+      set.assets[PieceKind.blackPawn]!,
+    ];
+  }
+
   @override
-  Widget build(BuildContext context, WidgetRef ref) {
+  Widget build(BuildContext context) {
     final boardPrefs = ref.watch(boardPreferencesProvider);
 
-    List<AssetImage> getPieceImages(PieceSet set) {
-      return [
-        set.assets[kWhiteKingKind]!,
-        set.assets[kBlackQueenKind]!,
-        set.assets[kWhiteRookKind]!,
-        set.assets[kBlackBishopKind]!,
-        set.assets[kWhiteKnightKind]!,
-        set.assets[kBlackPawnKind]!,
-      ];
-    }
-
-    void onChanged(PieceSet? value) => ref
-        .read(boardPreferencesProvider.notifier)
-        .setPieceSet(value ?? PieceSet.cburnett);
-
-    return SafeArea(
-      child: ListView.separated(
-        itemCount: PieceSet.values.length,
-        separatorBuilder: (_, __) => PlatformDivider(
-          height: 1,
-          // on iOS: 14 (default indent) + 16 (padding)
-          indent:
-              Theme.of(context).platform == TargetPlatform.iOS ? 14 + 16 : null,
-          color: Theme.of(context).platform == TargetPlatform.iOS
-              ? null
-              : Colors.transparent,
-        ),
-        itemBuilder: (context, index) {
-          final set = PieceSet.values[index];
-          return PlatformListTile(
-            trailing: boardPrefs.pieceSet == set
-                ? Theme.of(context).platform == TargetPlatform.android
-                    ? const Icon(Icons.check)
-                    : Icon(
-                        CupertinoIcons.check_mark_circled_solid,
-                        color: CupertinoTheme.of(context).primaryColor,
-                      )
+    return PlatformScaffold(
+      appBar: PlatformAppBar(
+        title: Text(context.l10n.pieceSet),
+        actions: [
+          if (isLoading) const PlatformAppBarLoadingIndicator(),
+        ],
+      ),
+      body: SafeArea(
+        child: ListView.separated(
+          itemCount: PieceSet.values.length,
+          separatorBuilder: (_, __) => PlatformDivider(
+            height: 1,
+            // on iOS: 14 (default indent) + 16 (padding)
+            indent: Theme.of(context).platform == TargetPlatform.iOS
+                ? 14 + 16
                 : null,
-            title: Text(set.label),
-            subtitle: ConstrainedBox(
-              constraints: const BoxConstraints(
-                maxWidth: 264,
-              ),
-              child: Stack(
-                children: [
-                  boardPrefs.boardTheme.thumbnail,
-                  Row(
-                    children: getPieceImages(set)
-                        .map(
-                          (img) => Image(
+            color: Theme.of(context).platform == TargetPlatform.iOS
+                ? null
+                : Colors.transparent,
+          ),
+          itemBuilder: (context, index) {
+            final pieceSet = PieceSet.values[index];
+            return PlatformListTile(
+              trailing: boardPrefs.pieceSet == pieceSet
+                  ? Theme.of(context).platform == TargetPlatform.android
+                      ? const Icon(Icons.check)
+                      : Icon(
+                          CupertinoIcons.check_mark_circled_solid,
+                          color: CupertinoTheme.of(context).primaryColor,
+                        )
+                  : null,
+              title: Text(pieceSet.label),
+              subtitle: ConstrainedBox(
+                constraints: const BoxConstraints(maxWidth: 264),
+                child: Stack(
+                  children: [
+                    boardPrefs.boardTheme.thumbnail,
+                    Row(
+                      children: [
+                        for (final img in getPieceImages(pieceSet))
+                          Image(
                             image: img,
                             height: 44,
                           ),
-                        )
-                        .toList(),
-                  ),
-                ],
+                      ],
+                    ),
+                  ],
+                ),
               ),
-            ),
-            onTap: () => onChanged(set),
-            selected: boardPrefs.pieceSet == set,
-          );
-        },
+              onTap: isLoading ? null : () => onChanged(pieceSet),
+              selected: boardPrefs.pieceSet == pieceSet,
+            );
+          },
+        ),
       ),
     );
   }

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -194,10 +194,10 @@ packages:
     dependency: "direct main"
     description:
       name: chessground
-      sha256: "3267db8b04e0857761c40eab5895c556a885263388386f0f26b85d61401a1e05"
+      sha256: "93d7c7c8e6c049dd9ee99aa158520c6ae6e1d81aedae1dc0dbca93a5113fba9e"
       url: "https://pub.dev"
     source: hosted
-    version: "5.1.1"
+    version: "5.2.0"
   ci:
     dependency: transitive
     description:
@@ -346,10 +346,10 @@ packages:
     dependency: "direct main"
     description:
       name: dartchess
-      sha256: f07896a6c29f169ce21b44429c0ff8057d58cd4f9b17b35c5ffc8a1b2cfc4f23
+      sha256: "9ce59d164b5ddf87fdb3cbe118015674f2f241e33b0891cec1e9f30b68a81b26"
       url: "https://pub.dev"
     source: hosted
-    version: "0.8.0"
+    version: "0.9.0"
   dbus:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -11,14 +11,14 @@ dependencies:
   app_settings: ^5.1.1
   async: ^2.10.0
   cached_network_image: ^3.2.2
-  chessground: ^5.1.1
+  chessground: ^5.2.0
   collection: ^1.17.0
   connectivity_plus: ^6.0.2
   cronet_http: ^1.3.1
   crypto: ^3.0.3
   cupertino_http: ^1.1.0
   cupertino_icons: ^1.0.2
-  dartchess: ^0.8.0
+  dartchess: ^0.9.0
   deep_pick: ^1.0.0
   device_info_plus: ^10.1.0
   dynamic_color: ^1.6.9


### PR DESCRIPTION
The goal is to bypass the default flutter `ImageCache` and `Image` widgets which can lead to unexpected reloading of images, causing a "blink" effect.

Closes #236 

Probably fixes #1055 (I could not reproduce to ensure it)
Probably fixes #1027 

Incidentally fixes a failing test in `auth_controller_test.dart` that aroused in CI at the time of this PR.