### PR TITLE
feat: add study screen

### DIFF
--- a/lib/src/model/analysis/analysis_controller.dart
+++ b/lib/src/model/analysis/analysis_controller.dart
@@ -271,7 +271,11 @@ class AnalysisController extends _$AnalysisController
   @override
   void expandVariations(UciPath path) {
     final node = _root.nodeAt(path);
-    for (final child in node.children) {
+
+    final childrenToShow =
+        _root.isOnMainline(path) ? node.children.skip(1) : node.children;
+
+    for (final child in childrenToShow) {
       child.isHidden = false;
       for (final grandChild in child.children) {
         grandChild.isHidden = false;

--- a/lib/src/model/settings/preferences_storage.dart
+++ b/lib/src/model/settings/preferences_storage.dart
@@ -18,6 +18,7 @@ enum PrefCategory {
   home('preferences.home'),
   board('preferences.board'),
   analysis('preferences.analysis'),
+  study('preferences.study'),
   overTheBoard('preferences.overTheBoard'),
   challenge('preferences.challenge'),
   gameSetup('preferences.gameSetup'),

--- a/lib/src/model/study/study_controller.dart
+++ b/lib/src/model/study/study_controller.dart
@@ -33,6 +33,17 @@ class StudyController extends _$StudyController implements PgnTreeNotifier {
 
   Timer? _startEngineEvalTimer;
 
+  @override
+  Future<StudyState> build(StudyId id) async {
+    final evaluationService = ref.watch(evaluationServiceProvider);
+    ref.onDispose(() {
+      _startEngineEvalTimer?.cancel();
+      _engineEvalDebounce.dispose();
+      evaluationService.disposeEngine();
+    });
+    return _fetchChapter(id);
+  }
+
   Future<void> nextChapter() async {
     if (state.hasValue) {
       final chapters = state.requireValue.study.chapters;
@@ -131,17 +142,6 @@ class StudyController extends _$StudyController implements PgnTreeNotifier {
     }
 
     return studyState;
-  }
-
-  @override
-  Future<StudyState> build(StudyId id) async {
-    final evaluationService = ref.watch(evaluationServiceProvider);
-    ref.onDispose(() {
-      _startEngineEvalTimer?.cancel();
-      _engineEvalDebounce.dispose();
-      evaluationService.disposeEngine();
-    });
-    return _fetchChapter(id);
   }
 
   EvaluationContext _evaluationContext(Variant variant) => EvaluationContext(

--- a/lib/src/model/study/study_controller.dart
+++ b/lib/src/model/study/study_controller.dart
@@ -248,7 +248,11 @@ class StudyController extends _$StudyController implements PgnTreeNotifier {
     if (!state.hasValue) return;
 
     final node = _root.nodeAt(path);
-    for (final child in node.children) {
+
+    final childrenToShow =
+        _root.isOnMainline(path) ? node.children.skip(1) : node.children;
+
+    for (final child in childrenToShow) {
       child.isHidden = false;
       for (final grandChild in child.children) {
         grandChild.isHidden = false;

--- a/lib/src/model/study/study_controller.dart
+++ b/lib/src/model/study/study_controller.dart
@@ -68,6 +68,8 @@ class StudyController extends _$StudyController implements PgnTreeNotifier {
     final variant = study.chapter.setup.variant;
     final orientation = study.chapter.setup.orientation;
 
+    // Some studies have illegal starting positions. This is usually the case for introductory chapters.
+    // We do not treat this as an error, but display a static board instead.
     try {
       _root = Root.fromPgnGame(game);
     } on PositionSetupException {

--- a/lib/src/model/study/study_controller.dart
+++ b/lib/src/model/study/study_controller.dart
@@ -1,0 +1,622 @@
+import 'dart:async';
+
+import 'package:chessground/chessground.dart';
+import 'package:collection/collection.dart';
+import 'package:dartchess/dartchess.dart';
+import 'package:fast_immutable_collections/fast_immutable_collections.dart';
+import 'package:freezed_annotation/freezed_annotation.dart';
+import 'package:lichess_mobile/src/model/analysis/analysis_preferences.dart';
+import 'package:lichess_mobile/src/model/common/chess.dart';
+import 'package:lichess_mobile/src/model/common/eval.dart';
+import 'package:lichess_mobile/src/model/common/id.dart';
+import 'package:lichess_mobile/src/model/common/node.dart';
+import 'package:lichess_mobile/src/model/common/service/move_feedback.dart';
+import 'package:lichess_mobile/src/model/common/service/sound_service.dart';
+import 'package:lichess_mobile/src/model/common/uci.dart';
+import 'package:lichess_mobile/src/model/engine/evaluation_service.dart';
+import 'package:lichess_mobile/src/model/engine/work.dart';
+import 'package:lichess_mobile/src/model/study/study.dart';
+import 'package:lichess_mobile/src/model/study/study_repository.dart';
+import 'package:lichess_mobile/src/utils/rate_limit.dart';
+import 'package:lichess_mobile/src/view/engine/engine_gauge.dart';
+import 'package:lichess_mobile/src/widgets/pgn.dart';
+import 'package:riverpod_annotation/riverpod_annotation.dart';
+
+part 'study_controller.freezed.dart';
+part 'study_controller.g.dart';
+
+@riverpod
+class StudyController extends _$StudyController implements PgnTreeNotifier {
+  late Root _root;
+
+  final _engineEvalDebounce = Debouncer(const Duration(milliseconds: 150));
+
+  Timer? _startEngineEvalTimer;
+
+  Future<void> nextChapter() async {
+    if (state.hasValue) {
+      final chapters = state.requireValue.study.chapters;
+      final currentChapterIndex = chapters.indexWhere(
+        (chapter) => chapter.id == state.requireValue.study.chapter.id,
+      );
+      goToChapter(chapters[currentChapterIndex + 1].id);
+    }
+  }
+
+  Future<void> goToChapter(StudyChapterId chapterId) async {
+    state = const AsyncValue.loading();
+    state = AsyncValue.data(
+      await _fetchChapter(
+        state.requireValue.study.id,
+        chapterId: chapterId,
+      ),
+    );
+  }
+
+  Future<StudyState> _fetchChapter(
+    StudyId id, {
+    StudyChapterId? chapterId,
+  }) async {
+    final (study, pgn) = await ref
+        .read(studyRepositoryProvider)
+        .getStudy(id: id, chapterId: chapterId);
+
+    final game = PgnGame.parsePgn(pgn);
+
+    final rootComments = IList(game.comments.map((c) => PgnComment.fromPgn(c)));
+
+    final variant = study.chapter.setup.variant;
+    final orientation = study.chapter.setup.orientation;
+
+    try {
+      _root = Root.fromPgnGame(game);
+    } on PositionSetupException {
+      return StudyState(
+        variant: variant,
+        study: study,
+        currentPath: UciPath.empty,
+        isOnMainline: true,
+        root: null,
+        currentNode: StudyCurrentNode.illegalPosition(),
+        pgnRootComments: rootComments,
+        pov: orientation,
+        isLocalEvaluationAllowed: false,
+        isLocalEvaluationEnabled: false,
+        pgn: pgn,
+      );
+    }
+
+    // don't use ref.watch here: we don't want to invalidate state when the
+    // analysis preferences change
+    final prefs = ref.read(analysisPreferencesProvider);
+
+    const currentPath = UciPath.empty;
+    Move? lastMove;
+
+    final studyState = StudyState(
+      variant: variant,
+      study: study,
+      currentPath: currentPath,
+      isOnMainline: true,
+      root: _root.view,
+      currentNode: StudyCurrentNode.fromNode(_root),
+      pgnRootComments: rootComments,
+      lastMove: lastMove,
+      pov: orientation,
+      isLocalEvaluationAllowed:
+          study.chapter.features.computer && !study.chapter.gamebook,
+      isLocalEvaluationEnabled: prefs.enableLocalEvaluation,
+      pgn: pgn,
+    );
+
+    final evaluationService = ref.watch(evaluationServiceProvider);
+    if (studyState.isEngineAvailable) {
+      await evaluationService.disposeEngine();
+
+      evaluationService
+          .initEngine(
+        _evaluationContext(studyState.variant),
+        options: EvaluationOptions(
+          multiPv: prefs.numEvalLines,
+          cores: prefs.numEngineCores,
+        ),
+      )
+          .then((_) {
+        _startEngineEvalTimer = Timer(const Duration(milliseconds: 250), () {
+          _startEngineEval();
+        });
+      });
+    }
+
+    return studyState;
+  }
+
+  @override
+  Future<StudyState> build(StudyId id) async {
+    final evaluationService = ref.watch(evaluationServiceProvider);
+    ref.onDispose(() {
+      _startEngineEvalTimer?.cancel();
+      _engineEvalDebounce.dispose();
+      evaluationService.disposeEngine();
+    });
+    return _fetchChapter(id);
+  }
+
+  EvaluationContext _evaluationContext(Variant variant) => EvaluationContext(
+        variant: variant,
+        initialPosition: _root.position,
+      );
+
+  void onUserMove(NormalMove move) {
+    if (!state.hasValue || state.requireValue.position == null) return;
+
+    if (!state.requireValue.position!.isLegal(move)) return;
+
+    if (isPromotionPawnMove(state.requireValue.position!, move)) {
+      state = AsyncValue.data(state.requireValue.copyWith(promotionMove: move));
+      return;
+    }
+
+    final (newPath, isNewNode) =
+        _root.addMoveAt(state.requireValue.currentPath, move);
+    if (newPath != null) {
+      _setPath(
+        newPath,
+        shouldRecomputeRootView: isNewNode,
+        shouldForceShowVariation: true,
+      );
+    }
+  }
+
+  void onPromotionSelection(Role? role) {
+    final state = this.state.valueOrNull;
+    if (state == null) return;
+
+    if (role == null) {
+      this.state = AsyncValue.data(state.copyWith(promotionMove: null));
+      return;
+    }
+    final promotionMove = state.promotionMove;
+    if (promotionMove != null) {
+      final promotion = promotionMove.withPromotion(role);
+      onUserMove(promotion);
+    }
+  }
+
+  void showGamebookSolution() {
+    onUserMove(state.requireValue.currentNode.children.first as NormalMove);
+  }
+
+  void userNext() {
+    final state = this.state.valueOrNull;
+    if (state!.currentNode.children.isEmpty) return;
+    _setPath(
+      state.currentPath + _root.nodeAt(state.currentPath).children.first.id,
+      replaying: true,
+    );
+  }
+
+  void jumpToNthNodeOnMainline(int n) {
+    UciPath path = _root.mainlinePath;
+    while (!path.penultimate.isEmpty) {
+      path = path.penultimate;
+    }
+    Node? node = _root.nodeAt(path);
+    int count = 0;
+
+    while (node != null && count < n) {
+      if (node.children.isNotEmpty) {
+        path = path + node.children.first.id;
+        node = _root.nodeAt(path);
+        count++;
+      } else {
+        break;
+      }
+    }
+
+    if (node != null) {
+      userJump(path);
+    }
+  }
+
+  void toggleBoard() {
+    final state = this.state.valueOrNull;
+    if (state != null) {
+      this.state = AsyncValue.data(state.copyWith(pov: state.pov.opposite));
+    }
+  }
+
+  void userPrevious() {
+    if (state.hasValue) {
+      _setPath(state.requireValue.currentPath.penultimate, replaying: true);
+    }
+  }
+
+  void reset() {
+    if (state.hasValue) {
+      _setPath(UciPath.empty);
+    }
+  }
+
+  @override
+  void userJump(UciPath path) {
+    _setPath(path);
+  }
+
+  @override
+  void expandVariations(UciPath path) {
+    if (!state.hasValue) return;
+
+    final node = _root.nodeAt(path);
+    for (final child in node.children) {
+      child.isHidden = false;
+      for (final grandChild in child.children) {
+        grandChild.isHidden = false;
+      }
+    }
+    state = AsyncValue.data(state.requireValue.copyWith(root: _root.view));
+  }
+
+  @override
+  void collapseVariations(UciPath path) {
+    if (!state.hasValue) return;
+
+    final node = _root.nodeAt(path);
+
+    for (final child in node.children) {
+      child.isHidden = true;
+    }
+
+    state = AsyncValue.data(state.requireValue.copyWith(root: _root.view));
+  }
+
+  @override
+  void promoteVariation(UciPath path, bool toMainline) {
+    final state = this.state.valueOrNull;
+    if (state == null) return;
+    _root.promoteAt(path, toMainline: toMainline);
+    this.state = AsyncValue.data(
+      state.copyWith(
+        isOnMainline: _root.isOnMainline(state.currentPath),
+        root: _root.view,
+      ),
+    );
+  }
+
+  @override
+  void deleteFromHere(UciPath path) {
+    if (!state.hasValue) return;
+
+    _root.deleteAt(path);
+    _setPath(path.penultimate, shouldRecomputeRootView: true);
+  }
+
+  Future<void> toggleLocalEvaluation() async {
+    if (!state.hasValue) return;
+
+    ref
+        .read(analysisPreferencesProvider.notifier)
+        .toggleEnableLocalEvaluation();
+
+    state = AsyncValue.data(
+      state.requireValue.copyWith(
+        isLocalEvaluationEnabled: !state.requireValue.isLocalEvaluationEnabled,
+      ),
+    );
+
+    if (state.requireValue.isEngineAvailable) {
+      final prefs = ref.read(analysisPreferencesProvider);
+      await ref.read(evaluationServiceProvider).initEngine(
+            _evaluationContext(state.requireValue.variant),
+            options: EvaluationOptions(
+              multiPv: prefs.numEvalLines,
+              cores: prefs.numEngineCores,
+            ),
+          );
+      _startEngineEval();
+    } else {
+      _stopEngineEval();
+      ref.read(evaluationServiceProvider).disposeEngine();
+    }
+  }
+
+  void setNumEvalLines(int numEvalLines) {
+    if (!state.hasValue) return;
+
+    ref
+        .read(analysisPreferencesProvider.notifier)
+        .setNumEvalLines(numEvalLines);
+
+    ref.read(evaluationServiceProvider).setOptions(
+          EvaluationOptions(
+            multiPv: numEvalLines,
+            cores: ref.read(analysisPreferencesProvider).numEngineCores,
+          ),
+        );
+
+    _root.updateAll((node) => node.eval = null);
+
+    state = AsyncValue.data(
+      state.requireValue.copyWith(
+        currentNode: StudyCurrentNode.fromNode(
+          _root.nodeAt(state.requireValue.currentPath),
+        ),
+      ),
+    );
+
+    _startEngineEval();
+  }
+
+  void setEngineCores(int numEngineCores) {
+    ref
+        .read(analysisPreferencesProvider.notifier)
+        .setEngineCores(numEngineCores);
+
+    ref.read(evaluationServiceProvider).setOptions(
+          EvaluationOptions(
+            multiPv: ref.read(analysisPreferencesProvider).numEvalLines,
+            cores: numEngineCores,
+          ),
+        );
+
+    _startEngineEval();
+  }
+
+  void _setPath(
+    UciPath path, {
+    bool shouldForceShowVariation = false,
+    bool shouldRecomputeRootView = false,
+    bool replaying = false,
+  }) {
+    final state = this.state.valueOrNull;
+    if (state == null) return;
+
+    final pathChange = state.currentPath != path;
+    final currentNode = _root.nodeAt(path);
+
+    // always show variation if the user plays a move
+    if (shouldForceShowVariation &&
+        currentNode is Branch &&
+        currentNode.isHidden) {
+      _root.updateAt(path, (node) {
+        if (node is Branch) node.isHidden = false;
+      });
+    }
+
+    // root view is only used to display move list, so we need to
+    // recompute the root view only when the nodelist length changes
+    // or a variation is hidden/shown
+    final rootView = shouldForceShowVariation || shouldRecomputeRootView
+        ? _root.view
+        : state.root;
+
+    final isForward = path.size > state.currentPath.size;
+    if (currentNode is Branch) {
+      if (!replaying) {
+        if (isForward) {
+          final isCheck = currentNode.sanMove.isCheck;
+          if (currentNode.sanMove.isCapture) {
+            ref
+                .read(moveFeedbackServiceProvider)
+                .captureFeedback(check: isCheck);
+          } else {
+            ref.read(moveFeedbackServiceProvider).moveFeedback(check: isCheck);
+          }
+        }
+      } else if (isForward) {
+        final soundService = ref.read(soundServiceProvider);
+        if (currentNode.sanMove.isCapture) {
+          soundService.play(Sound.capture);
+        } else {
+          soundService.play(Sound.move);
+        }
+      }
+
+      this.state = AsyncValue.data(
+        state.copyWith(
+          currentPath: path,
+          isOnMainline: _root.isOnMainline(path),
+          currentNode: StudyCurrentNode.fromNode(currentNode),
+          lastMove: currentNode.sanMove.move,
+          promotionMove: null,
+          root: rootView,
+        ),
+      );
+    } else {
+      this.state = AsyncValue.data(
+        state.copyWith(
+          currentPath: path,
+          isOnMainline: _root.isOnMainline(path),
+          currentNode: StudyCurrentNode.fromNode(currentNode),
+          lastMove: null,
+          promotionMove: null,
+          root: rootView,
+        ),
+      );
+    }
+
+    if (pathChange) {
+      _debouncedStartEngineEval();
+    }
+  }
+
+  void _startEngineEval() {
+    final state = this.state.valueOrNull;
+    if (state == null || !state.isEngineAvailable) return;
+
+    ref
+        .read(evaluationServiceProvider)
+        .start(
+          state.currentPath,
+          _root.branchesOn(state.currentPath).map(Step.fromNode),
+          // Note: AnalysisController passes _root.eval as initialPositionEval here,
+          // but for studies this leads to false positive cache hits when switching between chapters.
+          shouldEmit: (work) => work.path == state.currentPath,
+        )
+        ?.forEach(
+          (t) => _root.updateAt(t.$1.path, (node) => node.eval = t.$2),
+        );
+  }
+
+  void _debouncedStartEngineEval() {
+    _engineEvalDebounce(() {
+      _startEngineEval();
+    });
+  }
+
+  void _stopEngineEval() {
+    ref.read(evaluationServiceProvider).stop();
+
+    if (!state.hasValue) return;
+
+    // update the current node with last cached eval
+    state = AsyncValue.data(
+      state.requireValue.copyWith(
+        currentNode: StudyCurrentNode.fromNode(
+          _root.nodeAt(state.requireValue.currentPath),
+        ),
+      ),
+    );
+  }
+}
+
+@freezed
+class StudyState with _$StudyState {
+  const StudyState._();
+
+  const factory StudyState({
+    required Study study,
+    required String pgn,
+
+    /// The variant of the current chapter
+    required Variant variant,
+
+    /// Immutable view of the whole tree. Null if the chapter's starting position is illegal.
+    required ViewRoot? root,
+
+    /// The current node in the study tree view.
+    ///
+    /// This is an immutable copy of the actual [Node] at the `currentPath`.
+    /// We don't want to use [Node.view] here because it'd copy the whole tree
+    /// under the current node and it's expensive.
+    required StudyCurrentNode currentNode,
+
+    /// The path to the current node in the analysis view.
+    required UciPath currentPath,
+
+    /// Whether the current path is on the mainline.
+    required bool isOnMainline,
+
+    /// The side to display the board from.
+    required Side pov,
+
+    /// Whether local evaluation is allowed for this study.
+    required bool isLocalEvaluationAllowed,
+
+    /// Whether the user has enabled local evaluation.
+    required bool isLocalEvaluationEnabled,
+
+    /// The last move played.
+    Move? lastMove,
+
+    /// Possible promotion move to be played.
+    NormalMove? promotionMove,
+
+    /// The PGN root comments of the study
+    IList<PgnComment>? pgnRootComments,
+  }) = _StudyState;
+
+  IMap<Square, ISet<Square>> get validMoves => currentNode.position != null
+      ? makeLegalMoves(currentNode.position!)
+      : const IMap.empty();
+
+  /// Whether the engine is available for evaluation
+  bool get isEngineAvailable =>
+      isLocalEvaluationAllowed &&
+      engineSupportedVariants.contains(variant) &&
+      isLocalEvaluationEnabled;
+
+  EngineGaugeParams? get engineGaugeParams => isEngineAvailable
+      ? (
+          orientation: pov,
+          isLocalEngineAvailable: isEngineAvailable,
+          position: position!,
+          savedEval: currentNode.eval,
+        )
+      : null;
+
+  Position? get position => currentNode.position;
+  StudyChapter get currentChapter => study.chapter;
+  bool get canGoNext => currentNode.children.isNotEmpty;
+  bool get canGoBack => currentPath.size > UciPath.empty.size;
+
+  String get currentChapterTitle => study.chapters
+      .firstWhere(
+        (chapter) => chapter.id == currentChapter.id,
+      )
+      .name;
+  bool get hasNextChapter => study.chapter.id != study.chapters.last.id;
+
+  bool get isAtEndOfChapter => isOnMainline && currentNode.children.isEmpty;
+
+  bool get isAtStartOfChapter => currentPath.isEmpty;
+
+  bool get isIntroductoryChapter =>
+      currentNode.isRoot && currentNode.children.isEmpty;
+
+  IList<PgnCommentShape> get pgnShapes => IList(
+        (currentNode.isRoot ? pgnRootComments : currentNode.comments)
+            ?.map((comment) => comment.shapes)
+            .flattened,
+      );
+
+  PlayerSide get playerSide => PlayerSide.both;
+}
+
+@freezed
+class StudyCurrentNode with _$StudyCurrentNode {
+  const StudyCurrentNode._();
+
+  const factory StudyCurrentNode({
+    // Null if the chapter's starting position is illegal.
+    required Position? position,
+    required List<Move> children,
+    required bool isRoot,
+    SanMove? sanMove,
+    IList<PgnComment>? startingComments,
+    IList<PgnComment>? comments,
+    IList<int>? nags,
+    ClientEval? eval,
+  }) = _StudyCurrentNode;
+
+  factory StudyCurrentNode.illegalPosition() {
+    return const StudyCurrentNode(
+      position: null,
+      children: [],
+      isRoot: true,
+    );
+  }
+
+  factory StudyCurrentNode.fromNode(Node node) {
+    final children = node.children.map((n) => n.sanMove.move).toList();
+    if (node is Branch) {
+      return StudyCurrentNode(
+        sanMove: node.sanMove,
+        position: node.position,
+        isRoot: false,
+        children: children,
+        eval: node.eval,
+        startingComments: IList(node.startingComments),
+        comments: IList(node.comments),
+        nags: IList(node.nags),
+      );
+    } else {
+      return StudyCurrentNode(
+        position: node.position,
+        children: children,
+        eval: node.eval,
+        isRoot: true,
+      );
+    }
+  }
+}

--- a/lib/src/model/study/study_preferences.dart
+++ b/lib/src/model/study/study_preferences.dart
@@ -1,0 +1,51 @@
+import 'package:freezed_annotation/freezed_annotation.dart';
+import 'package:lichess_mobile/src/model/settings/preferences_storage.dart';
+import 'package:riverpod_annotation/riverpod_annotation.dart';
+
+part 'study_preferences.freezed.dart';
+part 'study_preferences.g.dart';
+
+@riverpod
+class StudyPreferences extends _$StudyPreferences
+    with PreferencesStorage<StudyPrefs> {
+  // ignore: avoid_public_notifier_properties
+  @override
+  final prefCategory = PrefCategory.study;
+
+  // ignore: avoid_public_notifier_properties
+  @override
+  StudyPrefs get defaults => StudyPrefs.defaults;
+
+  @override
+  StudyPrefs fromJson(Map<String, dynamic> json) => StudyPrefs.fromJson(json);
+
+  @override
+  StudyPrefs build() {
+    return fetch();
+  }
+
+  Future<void> toggleShowVariationArrows() {
+    return save(
+      state.copyWith(
+        showVariationArrows: !state.showVariationArrows,
+      ),
+    );
+  }
+}
+
+@Freezed(fromJson: true, toJson: true)
+class StudyPrefs with _$StudyPrefs implements Serializable {
+  const StudyPrefs._();
+
+  const factory StudyPrefs({
+    required bool showVariationArrows,
+  }) = _StudyPrefs;
+
+  static const defaults = StudyPrefs(
+    showVariationArrows: false,
+  );
+
+  factory StudyPrefs.fromJson(Map<String, dynamic> json) {
+    return _$StudyPrefsFromJson(json);
+  }
+}

--- a/lib/src/view/study/study_bottom_bar.dart
+++ b/lib/src/view/study/study_bottom_bar.dart
@@ -36,7 +36,7 @@ class StudyBottomBar extends ConsumerWidget {
           child: BottomBarButton(
             key: const ValueKey('goto-previous'),
             onTap: onGoBack,
-            label: 'Previous',
+            label: context.l10n.studyBack,
             showLabel: true,
             icon: CupertinoIcons.chevron_back,
             showTooltip: false,
@@ -47,7 +47,7 @@ class StudyBottomBar extends ConsumerWidget {
               ? ref.read(studyControllerProvider(id).notifier).nextChapter
               : null,
           icon: Icons.play_arrow,
-          label: 'Next chapter',
+          label: context.l10n.studyNextChapter,
           showLabel: true,
           blink: !state.isIntroductoryChapter &&
               state.isAtEndOfChapter &&
@@ -59,7 +59,7 @@ class StudyBottomBar extends ConsumerWidget {
             key: const ValueKey('goto-next'),
             icon: CupertinoIcons.chevron_forward,
             onTap: onGoForward,
-            label: context.l10n.next,
+            label: context.l10n.studyNext,
             showLabel: true,
             showTooltip: false,
           ),

--- a/lib/src/view/study/study_bottom_bar.dart
+++ b/lib/src/view/study/study_bottom_bar.dart
@@ -1,0 +1,70 @@
+import 'package:flutter/cupertino.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:lichess_mobile/src/model/common/id.dart';
+import 'package:lichess_mobile/src/model/study/study_controller.dart';
+import 'package:lichess_mobile/src/utils/l10n_context.dart';
+import 'package:lichess_mobile/src/widgets/bottom_bar.dart';
+import 'package:lichess_mobile/src/widgets/bottom_bar_button.dart';
+import 'package:lichess_mobile/src/widgets/buttons.dart';
+
+class StudyBottomBar extends ConsumerWidget {
+  const StudyBottomBar({
+    required this.id,
+  });
+
+  final StudyId id;
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final state = ref.watch(studyControllerProvider(id)).valueOrNull;
+    if (state == null) {
+      return const BottomBar(children: []);
+    }
+
+    final onGoForward = state.canGoNext
+        ? ref.read(studyControllerProvider(id).notifier).userNext
+        : null;
+    final onGoBack = state.canGoBack
+        ? ref.read(studyControllerProvider(id).notifier).userPrevious
+        : null;
+
+    return BottomBar(
+      children: [
+        RepeatButton(
+          onLongPress: onGoBack,
+          child: BottomBarButton(
+            key: const ValueKey('goto-previous'),
+            onTap: onGoBack,
+            label: 'Previous',
+            showLabel: true,
+            icon: CupertinoIcons.chevron_back,
+            showTooltip: false,
+          ),
+        ),
+        BottomBarButton(
+          onTap: state.hasNextChapter
+              ? ref.read(studyControllerProvider(id).notifier).nextChapter
+              : null,
+          icon: Icons.play_arrow,
+          label: 'Next chapter',
+          showLabel: true,
+          blink: !state.isIntroductoryChapter &&
+              state.isAtEndOfChapter &&
+              state.hasNextChapter,
+        ),
+        RepeatButton(
+          onLongPress: onGoForward,
+          child: BottomBarButton(
+            key: const ValueKey('goto-next'),
+            icon: CupertinoIcons.chevron_forward,
+            onTap: onGoForward,
+            label: context.l10n.next,
+            showLabel: true,
+            showTooltip: false,
+          ),
+        ),
+      ],
+    );
+  }
+}

--- a/lib/src/view/study/study_screen.dart
+++ b/lib/src/view/study/study_screen.dart
@@ -14,7 +14,6 @@ import 'package:lichess_mobile/src/model/settings/board_preferences.dart';
 import 'package:lichess_mobile/src/model/study/study_controller.dart';
 import 'package:lichess_mobile/src/model/study/study_preferences.dart';
 import 'package:lichess_mobile/src/utils/l10n_context.dart';
-import 'package:lichess_mobile/src/utils/navigation.dart';
 import 'package:lichess_mobile/src/utils/screen.dart';
 import 'package:lichess_mobile/src/view/engine/engine_gauge.dart';
 import 'package:lichess_mobile/src/view/engine/engine_lines.dart';
@@ -96,20 +95,21 @@ class _ChapterButton extends ConsumerWidget {
     return state == null
         ? const SizedBox.shrink()
         : AppBarIconButton(
-            onPressed: () => pushPlatformRoute(
-              context,
-              builder: (context) {
-                return _StudyChaptersScreen(id: id);
-              },
+            onPressed: () => showAdaptiveBottomSheet<void>(
+              context: context,
+              showDragHandle: true,
+              isDismissible: true,
+              builder: (_) => _StudyChaptersMenu(id: id),
             ),
+            // TODO mobile l10n
             semanticsLabel: 'Chapters',
             icon: const Icon(Icons.menu_book),
           );
   }
 }
 
-class _StudyChaptersScreen extends ConsumerWidget {
-  const _StudyChaptersScreen({
+class _StudyChaptersMenu extends ConsumerWidget {
+  const _StudyChaptersMenu({
     required this.id,
   });
 
@@ -131,36 +131,39 @@ class _StudyChaptersScreen extends ConsumerWidget {
       }
     });
 
-    return PlatformScaffold(
-      appBar: const PlatformAppBar(
-        // TODO mobile l10n
-        title: Text('Chapters'),
-      ),
-      body: SafeArea(
-        child: ListView(
-          children: [
-            ChoicePicker(
-              notchedTile: true,
-              choices: state.study.chapters.unlock,
-              selectedItem: state.study.chapters.firstWhere(
-                (chapter) => chapter.id == state.currentChapter.id,
-              ),
-              titleBuilder: (chapter) => Text(
-                chapter.name,
-                key: chapter.id == state.study.chapter.id
-                    ? currentChapterKey
-                    : null,
-              ),
-              onSelectedItemChanged: (chapter) {
-                ref.read(studyControllerProvider(id).notifier).goToChapter(
-                      chapter.id,
-                    );
-                Navigator.of(context).pop();
-              },
-            ),
-          ],
+    return Column(
+      children: [
+        Text(
+          context.l10n.studyNbChapters(state.study.chapters.length),
+          style: const TextStyle(fontSize: 18, fontWeight: FontWeight.bold),
         ),
-      ),
+        const SizedBox(height: 10),
+        Expanded(
+          child: ListView(
+            children: [
+              ChoicePicker(
+                notchedTile: true,
+                choices: state.study.chapters.unlock,
+                selectedItem: state.study.chapters.firstWhere(
+                  (chapter) => chapter.id == state.currentChapter.id,
+                ),
+                titleBuilder: (chapter) => Text(
+                  chapter.name,
+                  key: chapter.id == state.study.chapter.id
+                      ? currentChapterKey
+                      : null,
+                ),
+                onSelectedItemChanged: (chapter) {
+                  ref.read(studyControllerProvider(id).notifier).goToChapter(
+                        chapter.id,
+                      );
+                  Navigator.of(context).pop();
+                },
+              ),
+            ],
+          ),
+        ),
+      ],
     );
   }
 }

--- a/lib/src/view/study/study_screen.dart
+++ b/lib/src/view/study/study_screen.dart
@@ -1,6 +1,35 @@
-import 'package:flutter/widgets.dart';
+import 'package:chessground/chessground.dart';
+import 'package:collection/collection.dart';
+import 'package:dartchess/dartchess.dart';
+import 'package:fast_immutable_collections/fast_immutable_collections.dart';
+import 'package:flutter/cupertino.dart';
+import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:lichess_mobile/src/constants.dart';
+import 'package:lichess_mobile/src/model/analysis/analysis_preferences.dart';
+import 'package:lichess_mobile/src/model/common/chess.dart';
+import 'package:lichess_mobile/src/model/common/eval.dart';
 import 'package:lichess_mobile/src/model/common/id.dart';
+import 'package:lichess_mobile/src/model/engine/evaluation_service.dart';
+import 'package:lichess_mobile/src/model/settings/board_preferences.dart';
+import 'package:lichess_mobile/src/model/study/study_controller.dart';
+import 'package:lichess_mobile/src/model/study/study_preferences.dart';
+import 'package:lichess_mobile/src/utils/l10n_context.dart';
+import 'package:lichess_mobile/src/utils/screen.dart';
+import 'package:lichess_mobile/src/view/engine/engine_gauge.dart';
+import 'package:lichess_mobile/src/view/engine/engine_lines.dart';
+import 'package:lichess_mobile/src/view/study/study_bottom_bar.dart';
+import 'package:lichess_mobile/src/view/study/study_settings.dart';
+import 'package:lichess_mobile/src/view/study/study_tree_view.dart';
+import 'package:lichess_mobile/src/widgets/adaptive_bottom_sheet.dart';
+import 'package:lichess_mobile/src/widgets/buttons.dart';
+import 'package:lichess_mobile/src/widgets/list.dart';
+import 'package:lichess_mobile/src/widgets/pgn.dart';
+import 'package:lichess_mobile/src/widgets/platform.dart';
+import 'package:lichess_mobile/src/widgets/platform_scaffold.dart';
+import 'package:logging/logging.dart';
+
+final _logger = Logger('StudyScreen');
 
 class StudyScreen extends ConsumerWidget {
   const StudyScreen({
@@ -11,6 +40,443 @@ class StudyScreen extends ConsumerWidget {
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
-    return const SizedBox.shrink();
+    final state = ref.watch(studyControllerProvider(id));
+
+    return state.when(
+      data: (state) {
+        return PlatformScaffold(
+          appBar: PlatformAppBar(
+            title: FittedBox(
+              fit: BoxFit.scaleDown,
+              child: Text(state.currentChapterTitle),
+            ),
+            actions: [
+              AppBarIconButton(
+                onPressed: () => showAdaptiveBottomSheet<void>(
+                  context: context,
+                  isScrollControlled: true,
+                  showDragHandle: true,
+                  isDismissible: true,
+                  builder: (_) => StudySettings(id),
+                ),
+                semanticsLabel: context.l10n.settingsSettings,
+                icon: const Icon(Icons.settings),
+              ),
+              _ChapterButton(id: id),
+            ],
+          ),
+          body: _Body(id: id),
+        );
+      },
+      loading: () {
+        return const PlatformScaffold(
+          appBar: PlatformAppBar(
+            title: Text(''),
+          ),
+          body: Center(child: CircularProgressIndicator()),
+        );
+      },
+      error: (error, st) {
+        _logger.severe('Cannot load study: $error', st);
+        Navigator.of(context).pop();
+        return const SizedBox.shrink();
+      },
+    );
+  }
+}
+
+class _ChapterButton extends ConsumerWidget {
+  const _ChapterButton({required this.id});
+
+  final StudyId id;
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final state = ref.watch(studyControllerProvider(id)).valueOrNull;
+    return state == null
+        ? const SizedBox.shrink()
+        : AppBarIconButton(
+            onPressed: () => showAdaptiveDialog<void>(
+              context: context,
+              builder: (context) {
+                return SimpleDialog(
+                  title: const Text('Chapters'),
+                  children: [
+                    SizedBox(
+                      height: MediaQuery.of(context).size.height * 0.8,
+                      width: MediaQuery.of(context).size.width * 0.8,
+                      child: ListView.separated(
+                        itemBuilder: (context, index) {
+                          final chapter = state.study.chapters[index];
+                          final selected =
+                              chapter.id == state.currentChapter.id;
+                          final checkedIcon = Theme.of(context).platform ==
+                                  TargetPlatform.android
+                              ? const Icon(Icons.check)
+                              : Icon(
+                                  CupertinoIcons.check_mark_circled_solid,
+                                  color:
+                                      CupertinoTheme.of(context).primaryColor,
+                                );
+                          return PlatformListTile(
+                            selected: selected,
+                            trailing: selected ? checkedIcon : null,
+                            title: Text(chapter.name),
+                            onTap: () {
+                              ref
+                                  .read(studyControllerProvider(id).notifier)
+                                  .goToChapter(
+                                    chapter.id,
+                                  );
+                              Navigator.of(context).pop();
+                            },
+                          );
+                        },
+                        separatorBuilder: (_, __) => const PlatformDivider(
+                          height: 1,
+                        ),
+                        itemCount: state.study.chapters.length,
+                      ),
+                    ),
+                  ],
+                );
+              },
+            ),
+            semanticsLabel: 'Chapters',
+            icon: const Icon(Icons.menu_book),
+          );
+  }
+}
+
+class _Body extends ConsumerWidget {
+  const _Body({
+    required this.id,
+  });
+
+  final StudyId id;
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    return SafeArea(
+      child: Column(
+        children: [
+          Expanded(
+            child: LayoutBuilder(
+              builder: (context, constraints) {
+                final defaultBoardSize = constraints.biggest.shortestSide;
+                final isTablet = isTabletOrLarger(context);
+                final remainingHeight =
+                    constraints.maxHeight - defaultBoardSize;
+                final isSmallScreen =
+                    remainingHeight < kSmallRemainingHeightLeftBoardThreshold;
+                final boardSize = isTablet || isSmallScreen
+                    ? defaultBoardSize - kTabletBoardTableSidePadding * 2
+                    : defaultBoardSize;
+
+                final landscape = constraints.biggest.aspectRatio > 1;
+
+                final engineGaugeParams = ref.watch(
+                  studyControllerProvider(id)
+                      .select((state) => state.valueOrNull?.engineGaugeParams),
+                );
+
+                final currentNode = ref.watch(
+                  studyControllerProvider(id)
+                      .select((state) => state.requireValue.currentNode),
+                );
+
+                final engineLines = EngineLines(
+                  clientEval: currentNode.eval,
+                  isGameOver: currentNode.position?.isGameOver ?? false,
+                  onTapMove: ref
+                      .read(
+                        studyControllerProvider(id).notifier,
+                      )
+                      .onUserMove,
+                );
+
+                final showEvaluationGauge = ref.watch(
+                  analysisPreferencesProvider
+                      .select((value) => value.showEvaluationGauge),
+                );
+
+                final engineGauge =
+                    showEvaluationGauge && engineGaugeParams != null
+                        ? EngineGauge(
+                            params: engineGaugeParams,
+                            displayMode: landscape
+                                ? EngineGaugeDisplayMode.vertical
+                                : EngineGaugeDisplayMode.horizontal,
+                          )
+                        : null;
+
+                return landscape
+                    ? Row(
+                        mainAxisSize: MainAxisSize.max,
+                        children: [
+                          Padding(
+                            padding: EdgeInsets.all(
+                              isTablet ? kTabletBoardTableSidePadding : 0.0,
+                            ),
+                            child: Row(
+                              children: [
+                                _StudyBoard(
+                                  id: id,
+                                  boardSize: boardSize,
+                                  isTablet: isTablet,
+                                ),
+                                if (engineGauge != null) ...[
+                                  const SizedBox(width: 4.0),
+                                  engineGauge,
+                                ],
+                              ],
+                            ),
+                          ),
+                          Flexible(
+                            fit: FlexFit.loose,
+                            child: Column(
+                              mainAxisAlignment: MainAxisAlignment.start,
+                              children: [
+                                if (engineGaugeParams != null) engineLines,
+                                Expanded(
+                                  child: PlatformCard(
+                                    clipBehavior: Clip.hardEdge,
+                                    borderRadius: const BorderRadius.all(
+                                      Radius.circular(4.0),
+                                    ),
+                                    margin: const EdgeInsets.all(
+                                      kTabletBoardTableSidePadding,
+                                    ),
+                                    semanticContainer: false,
+                                    child: StudyTreeView(id),
+                                  ),
+                                ),
+                              ],
+                            ),
+                          ),
+                        ],
+                      )
+                    : Column(
+                        mainAxisAlignment: MainAxisAlignment.center,
+                        mainAxisSize: MainAxisSize.max,
+                        crossAxisAlignment: CrossAxisAlignment.center,
+                        children: [
+                          Padding(
+                            padding: EdgeInsets.all(
+                              isTablet ? kTabletBoardTableSidePadding : 0.0,
+                            ),
+                            child: Column(
+                              children: [
+                                if (engineGauge != null) ...[
+                                  engineGauge,
+                                  engineLines,
+                                ],
+                                _StudyBoard(
+                                  id: id,
+                                  boardSize: boardSize,
+                                  isTablet: isTablet,
+                                ),
+                              ],
+                            ),
+                          ),
+                          Expanded(
+                            child: Padding(
+                              padding: isTablet
+                                  ? const EdgeInsets.symmetric(
+                                      horizontal: kTabletBoardTableSidePadding,
+                                    )
+                                  : EdgeInsets.zero,
+                              child: StudyTreeView(id),
+                            ),
+                          ),
+                        ],
+                      );
+              },
+            ),
+          ),
+          StudyBottomBar(id: id),
+        ],
+      ),
+    );
+  }
+}
+
+extension on PgnCommentShape {
+  Shape get chessground {
+    final shapeColor = switch (color) {
+      CommentShapeColor.green => ShapeColor.green,
+      CommentShapeColor.red => ShapeColor.red,
+      CommentShapeColor.blue => ShapeColor.blue,
+      CommentShapeColor.yellow => ShapeColor.yellow,
+    };
+    return from != to
+        ? Arrow(
+            color: shapeColor.color,
+            orig: from,
+            dest: to,
+          )
+        : Circle(color: shapeColor.color, orig: from);
+  }
+}
+
+class _StudyBoard extends ConsumerStatefulWidget {
+  const _StudyBoard({
+    required this.id,
+    required this.boardSize,
+    required this.isTablet,
+  });
+
+  final StudyId id;
+
+  final double boardSize;
+
+  final bool isTablet;
+
+  @override
+  ConsumerState<_StudyBoard> createState() => _StudyBoardState();
+}
+
+class _StudyBoardState extends ConsumerState<_StudyBoard> {
+  ISet<Shape> userShapes = ISet();
+
+  @override
+  Widget build(BuildContext context) {
+    // Clear shapes when switching to a new chapter.
+    // This avoids "leftover" shapes from the previous chapter when the engine has not evaluated the new position yet.
+    ref.listen(
+        studyControllerProvider(widget.id).select((state) => state.hasValue),
+        (prev, next) {
+      if (prev != next) {
+        setState(() {
+          userShapes = ISet();
+        });
+      }
+    });
+    final boardPrefs = ref.watch(boardPreferencesProvider);
+
+    final studyState =
+        ref.watch(studyControllerProvider(widget.id)).requireValue;
+
+    final currentNode = studyState.currentNode;
+    final position = currentNode.position;
+
+    final showVariationArrows = ref.watch(
+          studyPreferencesProvider.select(
+            (prefs) => prefs.showVariationArrows,
+          ),
+        ) &&
+        currentNode.children.length > 1;
+
+    final pgnShapes = ISet(
+      studyState.pgnShapes.map((shape) => shape.chessground),
+    );
+
+    final variationArrows = ISet<Shape>(
+      showVariationArrows
+          ? currentNode.children.mapIndexed((i, move) {
+              final color = Colors.white.withValues(alpha: i == 0 ? 0.9 : 0.5);
+              return Arrow(
+                color: color,
+                orig: (move as NormalMove).from,
+                dest: move.to,
+              );
+            }).toList()
+          : [],
+    );
+
+    final showAnnotationsOnBoard = ref.watch(
+      analysisPreferencesProvider.select((value) => value.showAnnotations),
+    );
+
+    final showBestMoveArrow = ref.watch(
+      analysisPreferencesProvider.select(
+        (value) => value.showBestMoveArrow,
+      ),
+    );
+    final bestMoves = ref.watch(
+      engineEvaluationProvider.select((s) => s.eval?.bestMoves),
+    );
+    final ISet<Shape> bestMoveShapes =
+        showBestMoveArrow && studyState.isEngineAvailable && bestMoves != null
+            ? computeBestMoveShapes(
+                bestMoves,
+                currentNode.position!.turn,
+                boardPrefs.pieceSet.assets,
+              )
+            : ISet();
+
+    final sanMove = currentNode.sanMove;
+    final annotation = makeAnnotation(studyState.currentNode.nags);
+
+    return Chessboard(
+      size: widget.boardSize,
+      settings: boardPrefs.toBoardSettings().copyWith(
+            borderRadius: widget.isTablet
+                ? const BorderRadius.all(Radius.circular(4.0))
+                : BorderRadius.zero,
+            boxShadow: widget.isTablet ? boardShadows : const <BoxShadow>[],
+            drawShape: DrawShapeOptions(
+              enable: true,
+              onCompleteShape: _onCompleteShape,
+              onClearShapes: _onClearShapes,
+              newShapeColor: boardPrefs.shapeColor.color,
+            ),
+          ),
+      fen: studyState.position?.board.fen ??
+          studyState.study.currentChapterMeta.fen ??
+          kInitialFEN,
+      lastMove: studyState.lastMove as NormalMove?,
+      orientation: studyState.pov,
+      shapes: pgnShapes
+          .union(userShapes)
+          .union(variationArrows)
+          .union(bestMoveShapes),
+      annotations:
+          showAnnotationsOnBoard && sanMove != null && annotation != null
+              ? altCastles.containsKey(sanMove.move.uci)
+                  ? IMap({
+                      Move.parse(altCastles[sanMove.move.uci]!)!.to: annotation,
+                    })
+                  : IMap({sanMove.move.to: annotation})
+              : null,
+      game: position != null
+          ? GameData(
+              playerSide: studyState.playerSide,
+              isCheck: position.isCheck,
+              sideToMove: position.turn,
+              validMoves: makeLegalMoves(position),
+              promotionMove: studyState.promotionMove,
+              onMove: (move, {isDrop, captured}) {
+                ref
+                    .read(studyControllerProvider(widget.id).notifier)
+                    .onUserMove(move);
+              },
+              onPromotionSelection: (role) {
+                ref
+                    .read(studyControllerProvider(widget.id).notifier)
+                    .onPromotionSelection(role);
+              },
+            )
+          : null,
+    );
+  }
+
+  void _onCompleteShape(Shape shape) {
+    if (userShapes.any((element) => element == shape)) {
+      setState(() {
+        userShapes = userShapes.remove(shape);
+      });
+      return;
+    } else {
+      setState(() {
+        userShapes = userShapes.add(shape);
+      });
+    }
+  }
+
+  void _onClearShapes() {
+    setState(() {
+      userShapes = ISet();
+    });
   }
 }

--- a/lib/src/view/study/study_screen.dart
+++ b/lib/src/view/study/study_screen.dart
@@ -77,8 +77,9 @@ class StudyScreen extends ConsumerWidget {
       },
       error: (error, st) {
         _logger.severe('Cannot load study: $error', st);
-        Navigator.of(context).pop();
-        return const SizedBox.shrink();
+        return Center(
+          child: Text('Cannot load study: $error'),
+        );
       },
     );
   }

--- a/lib/src/view/study/study_screen.dart
+++ b/lib/src/view/study/study_screen.dart
@@ -102,8 +102,8 @@ class _ChapterButton extends ConsumerWidget {
               isDismissible: true,
               builder: (_) => _StudyChaptersMenu(id: id),
             ),
-            // TODO mobile l10n
-            semanticsLabel: 'Chapters',
+            semanticsLabel:
+                context.l10n.studyNbChapters(state.study.chapters.length),
             icon: const Icon(Icons.menu_book),
           );
   }

--- a/lib/src/view/study/study_settings.dart
+++ b/lib/src/view/study/study_settings.dart
@@ -1,0 +1,153 @@
+import 'package:flutter/cupertino.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:lichess_mobile/src/model/analysis/analysis_preferences.dart';
+import 'package:lichess_mobile/src/model/common/id.dart';
+import 'package:lichess_mobile/src/model/engine/evaluation_service.dart';
+import 'package:lichess_mobile/src/model/settings/general_preferences.dart';
+import 'package:lichess_mobile/src/model/study/study_controller.dart';
+import 'package:lichess_mobile/src/model/study/study_preferences.dart';
+import 'package:lichess_mobile/src/utils/l10n_context.dart';
+import 'package:lichess_mobile/src/widgets/adaptive_bottom_sheet.dart';
+import 'package:lichess_mobile/src/widgets/list.dart';
+import 'package:lichess_mobile/src/widgets/non_linear_slider.dart';
+import 'package:lichess_mobile/src/widgets/settings.dart';
+
+class StudySettings extends ConsumerWidget {
+  const StudySettings(this.id);
+
+  final StudyId id;
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final studyController = studyControllerProvider(id);
+
+    final isLocalEvaluationAllowed = ref.watch(
+      studyController.select((s) => s.requireValue.isLocalEvaluationAllowed),
+    );
+    final isEngineAvailable = ref.watch(
+      studyController.select((s) => s.requireValue.isEngineAvailable),
+    );
+
+    final analysisPrefs = ref.watch(analysisPreferencesProvider);
+    final studyPrefs = ref.watch(studyPreferencesProvider);
+    final isSoundEnabled = ref.watch(
+      generalPreferencesProvider.select((pref) => pref.isSoundEnabled),
+    );
+
+    return BottomSheetScrollableContainer(
+      children: [
+        SwitchSettingTile(
+          title: Text(context.l10n.toggleLocalEvaluation),
+          value: analysisPrefs.enableLocalEvaluation,
+          onChanged: isLocalEvaluationAllowed
+              ? (_) {
+                  ref.read(studyController.notifier).toggleLocalEvaluation();
+                }
+              : null,
+        ),
+        PlatformListTile(
+          title: Text.rich(
+            TextSpan(
+              text: '${context.l10n.multipleLines}: ',
+              style: const TextStyle(
+                fontWeight: FontWeight.normal,
+              ),
+              children: [
+                TextSpan(
+                  style: const TextStyle(
+                    fontWeight: FontWeight.bold,
+                    fontSize: 18,
+                  ),
+                  text: analysisPrefs.numEvalLines.toString(),
+                ),
+              ],
+            ),
+          ),
+          subtitle: NonLinearSlider(
+            value: analysisPrefs.numEvalLines,
+            values: const [1, 2, 3],
+            onChangeEnd: isEngineAvailable
+                ? (value) => ref
+                    .read(studyController.notifier)
+                    .setNumEvalLines(value.toInt())
+                : null,
+          ),
+        ),
+        if (maxEngineCores > 1)
+          PlatformListTile(
+            title: Text.rich(
+              TextSpan(
+                text: '${context.l10n.cpus}: ',
+                style: const TextStyle(
+                  fontWeight: FontWeight.normal,
+                ),
+                children: [
+                  TextSpan(
+                    style: const TextStyle(
+                      fontWeight: FontWeight.bold,
+                      fontSize: 18,
+                    ),
+                    text: analysisPrefs.numEngineCores.toString(),
+                  ),
+                ],
+              ),
+            ),
+            subtitle: NonLinearSlider(
+              value: analysisPrefs.numEngineCores,
+              values: List.generate(maxEngineCores, (index) => index + 1),
+              onChangeEnd: isEngineAvailable
+                  ? (value) => ref
+                      .read(studyController.notifier)
+                      .setEngineCores(value.toInt())
+                  : null,
+            ),
+          ),
+        SwitchSettingTile(
+          title: Text(context.l10n.bestMoveArrow),
+          value: analysisPrefs.showBestMoveArrow,
+          onChanged: isEngineAvailable
+              ? (value) => ref
+                  .read(analysisPreferencesProvider.notifier)
+                  .toggleShowBestMoveArrow()
+              : null,
+        ),
+        SwitchSettingTile(
+          title: Text(context.l10n.showVariationArrows),
+          value: studyPrefs.showVariationArrows,
+          onChanged: (value) => ref
+              .read(studyPreferencesProvider.notifier)
+              .toggleShowVariationArrows(),
+        ),
+        SwitchSettingTile(
+          title: Text(context.l10n.evaluationGauge),
+          value: analysisPrefs.showEvaluationGauge,
+          onChanged: (value) => ref
+              .read(analysisPreferencesProvider.notifier)
+              .toggleShowEvaluationGauge(),
+        ),
+        SwitchSettingTile(
+          title: Text(context.l10n.toggleGlyphAnnotations),
+          value: analysisPrefs.showAnnotations,
+          onChanged: (_) => ref
+              .read(analysisPreferencesProvider.notifier)
+              .toggleAnnotations(),
+        ),
+        SwitchSettingTile(
+          title: Text(context.l10n.mobileShowComments),
+          value: analysisPrefs.showPgnComments,
+          onChanged: (_) => ref
+              .read(analysisPreferencesProvider.notifier)
+              .togglePgnComments(),
+        ),
+        SwitchSettingTile(
+          title: Text(context.l10n.sound),
+          value: isSoundEnabled,
+          onChanged: (value) {
+            ref.read(generalPreferencesProvider.notifier).toggleSoundEnabled();
+          },
+        ),
+      ],
+    );
+  }
+}

--- a/lib/src/view/study/study_tree_view.dart
+++ b/lib/src/view/study/study_tree_view.dart
@@ -1,0 +1,60 @@
+import 'package:dartchess/dartchess.dart';
+import 'package:fast_immutable_collections/fast_immutable_collections.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:lichess_mobile/src/model/common/id.dart';
+import 'package:lichess_mobile/src/model/common/node.dart';
+import 'package:lichess_mobile/src/model/study/study_controller.dart';
+import 'package:lichess_mobile/src/widgets/pgn.dart';
+
+const kNextChapterButtonHeight = 32.0;
+
+class StudyTreeView extends ConsumerWidget {
+  const StudyTreeView(
+    this.id,
+  );
+
+  final StudyId id;
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final root = ref.watch(
+          studyControllerProvider(id)
+              .select((value) => value.requireValue.root),
+        ) ??
+        // If root is null, the study chapter's position is illegal.
+        // We still want to display the root comments though, so create a dummy root.
+        const ViewRoot(position: Chess.initial, children: IList.empty());
+
+    final currentPath = ref.watch(
+      studyControllerProvider(id)
+          .select((value) => value.requireValue.currentPath),
+    );
+
+    final pgnRootComments = ref.watch(
+      studyControllerProvider(id)
+          .select((value) => value.requireValue.pgnRootComments),
+    );
+
+    return CustomScrollView(
+      slivers: [
+        SliverFillRemaining(
+          hasScrollBody: false,
+          child: Column(
+            crossAxisAlignment: CrossAxisAlignment.start,
+            children: [
+              Expanded(
+                child: DebouncedPgnTreeView(
+                  root: root,
+                  currentPath: currentPath,
+                  pgnRootComments: pgnRootComments,
+                  notifier: ref.read(studyControllerProvider(id).notifier),
+                ),
+              ),
+            ],
+          ),
+        ),
+      ],
+    );
+  }
+}

--- a/lib/src/view/tools/tools_tab_screen.dart
+++ b/lib/src/view/tools/tools_tab_screen.dart
@@ -6,6 +6,7 @@ import 'package:lichess_mobile/src/model/analysis/analysis_controller.dart';
 import 'package:lichess_mobile/src/model/common/chess.dart';
 import 'package:lichess_mobile/src/navigation.dart';
 import 'package:lichess_mobile/src/network/connectivity.dart';
+import 'package:lichess_mobile/src/styles/lichess_icons.dart';
 import 'package:lichess_mobile/src/styles/styles.dart';
 import 'package:lichess_mobile/src/utils/l10n_context.dart';
 import 'package:lichess_mobile/src/utils/navigation.dart';
@@ -14,6 +15,7 @@ import 'package:lichess_mobile/src/view/board_editor/board_editor_screen.dart';
 import 'package:lichess_mobile/src/view/clock/clock_screen.dart';
 import 'package:lichess_mobile/src/view/coordinate_training/coordinate_training_screen.dart';
 import 'package:lichess_mobile/src/view/opening_explorer/opening_explorer_screen.dart';
+import 'package:lichess_mobile/src/view/study/study_list_screen.dart';
 import 'package:lichess_mobile/src/view/tools/load_position_screen.dart';
 import 'package:lichess_mobile/src/widgets/feedback.dart';
 import 'package:lichess_mobile/src/widgets/list.dart';
@@ -175,6 +177,16 @@ class _Body extends ConsumerWidget {
                     )
                 : null,
           ),
+          if (isOnline)
+            _ToolsButton(
+              icon: LichessIcons.study,
+              title: context.l10n.studyMenu,
+              onTap: () => pushPlatformRoute(
+                context,
+                builder: (context) => const StudyListScreen(),
+                rootNavigator: true,
+              ),
+            ),
           _ToolsButton(
             icon: Icons.edit_outlined,
             title: context.l10n.boardEditor,

--- a/test/view/study/study_screen_test.dart
+++ b/test/view/study/study_screen_test.dart
@@ -1,0 +1,237 @@
+import 'package:chessground/chessground.dart';
+import 'package:dartchess/dartchess.dart';
+import 'package:fast_immutable_collections/fast_immutable_collections.dart';
+import 'package:flutter/widgets.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:lichess_mobile/src/model/common/chess.dart';
+import 'package:lichess_mobile/src/model/common/id.dart';
+import 'package:lichess_mobile/src/model/study/study.dart';
+import 'package:lichess_mobile/src/model/study/study_repository.dart';
+import 'package:lichess_mobile/src/view/study/study_screen.dart';
+import 'package:mocktail/mocktail.dart';
+
+import '../../test_helpers.dart';
+import '../../test_provider_scope.dart';
+
+class MockStudyRepository extends Mock implements StudyRepository {}
+
+const testId = StudyId('test-id');
+
+StudyChapter makeChapter({
+  required StudyChapterId id,
+  Side orientation = Side.white,
+  bool gamebook = false,
+}) {
+  return StudyChapter(
+    id: id,
+    setup: StudyChapterSetup(
+      id: null,
+      orientation: orientation,
+      variant: Variant.standard,
+      fromFen: null,
+    ),
+    conceal: null,
+    features: (computer: false, explorer: false),
+    gamebook: gamebook,
+    practise: false,
+  );
+}
+
+Study makeStudy({
+  StudyChapter? chapter,
+  IList<StudyChapterMeta>? chapters,
+  IList<String?> hints = const IList.empty(),
+  IList<String?> deviationComments = const IList.empty(),
+}) {
+  chapter = chapter ?? makeChapter(id: const StudyChapterId('1'));
+  return Study(
+    id: testId,
+    name: '',
+    liked: false,
+    likes: 0,
+    ownerId: null,
+    features: (cloneable: false, chat: false, sticky: false),
+    topics: const IList.empty(),
+    chapters: chapters ??
+        IList([StudyChapterMeta(id: chapter.id, name: '', fen: null)]),
+    chapter: chapter,
+    hints: hints,
+    deviationComments: deviationComments,
+  );
+}
+
+void main() {
+  group('Study screen', () {
+    testWidgets('Displays PGN moves and comments', (WidgetTester tester) async {
+      final mockRepository = MockStudyRepository();
+
+      when(() => mockRepository.getStudy(id: testId)).thenAnswer(
+        (_) async =>
+            (makeStudy(), '{root comment} 1. e4 {wow} e5 {such chess}'),
+      );
+
+      final app = await makeTestProviderScopeApp(
+        tester,
+        home: const StudyScreen(id: testId),
+        overrides: [
+          studyRepositoryProvider.overrideWith(
+            (ref) => mockRepository,
+          ),
+        ],
+      );
+      await tester.pumpWidget(app);
+      await tester.pumpAndSettle();
+
+      expect(find.text('root comment'), findsOneWidget);
+      expect(find.text('1. e4'), findsOneWidget);
+      expect(find.textContaining('wow'), findsOneWidget);
+      expect(find.textContaining('e5'), findsOneWidget);
+      expect(find.textContaining('such chess'), findsOneWidget);
+    });
+
+    testWidgets('Switch between chapters', (WidgetTester tester) async {
+      final mockRepository = MockStudyRepository();
+
+      final studyChapter1 = makeStudy(
+        chapter: makeChapter(id: const StudyChapterId('1')),
+        chapters: IList(const [
+          StudyChapterMeta(
+            id: StudyChapterId('1'),
+            name: 'Chapter 1',
+            fen: null,
+          ),
+          StudyChapterMeta(
+            id: StudyChapterId('2'),
+            name: 'Chapter 2',
+            fen: null,
+          ),
+        ]),
+      );
+
+      final studyChapter2 = studyChapter1.copyWith(
+        chapter: makeChapter(id: const StudyChapterId('2')),
+      );
+
+      when(() => mockRepository.getStudy(id: testId)).thenAnswer(
+        (_) async => (studyChapter1, '{pgn 1}'),
+      );
+      when(
+        () => mockRepository.getStudy(
+          id: testId,
+          chapterId: const StudyChapterId('1'),
+        ),
+      ).thenAnswer(
+        (_) async => (studyChapter1, '{pgn 1}'),
+      );
+      when(
+        () => mockRepository.getStudy(
+          id: testId,
+          chapterId: const StudyChapterId('2'),
+        ),
+      ).thenAnswer(
+        (_) async => (studyChapter2, '{pgn 2}'),
+      );
+
+      final app = await makeTestProviderScopeApp(
+        tester,
+        home: const StudyScreen(id: testId),
+        overrides: [
+          studyRepositoryProvider.overrideWith(
+            (ref) => mockRepository,
+          ),
+        ],
+      );
+      await tester.pumpWidget(app);
+      await tester.pumpAndSettle();
+
+      expect(find.text('Chapter 1'), findsOneWidget);
+      expect(find.text('Chapter 2'), findsNothing);
+
+      expect(find.text('pgn 1'), findsOneWidget);
+      expect(find.text('pgn 2'), findsNothing);
+
+      // 2nd press should not have any effect, we're already at the last chapter
+      await tester.tap(find.text('Next chapter'));
+      await tester.pumpAndSettle();
+      await tester.tap(find.text('Next chapter'));
+      await tester.pumpAndSettle();
+
+      expect(find.text('Chapter 1'), findsNothing);
+      expect(find.text('Chapter 2'), findsOneWidget);
+
+      expect(find.text('pgn 1'), findsNothing);
+      expect(find.text('pgn 2'), findsOneWidget);
+
+      // Open chapter selection dialog
+      await tester.tap(find.byTooltip('Chapters'));
+      await tester.pumpAndSettle();
+
+      expect(
+        find.descendant(
+          of: find.byType(ListView),
+          matching: find.text('Chapter 1'),
+        ),
+        findsOneWidget,
+      );
+      expect(
+        find.descendant(
+          of: find.byType(ListView),
+          matching: find.text('Chapter 2'),
+        ),
+        findsOneWidget,
+      );
+
+      await tester.tap(find.text('Chapter 1'));
+      await tester.pumpAndSettle();
+
+      expect(find.text('Chapter 1'), findsOneWidget);
+      expect(find.text('Chapter 2'), findsNothing);
+
+      expect(find.text('pgn 1'), findsOneWidget);
+      expect(find.text('pgn 2'), findsNothing);
+    });
+
+    testWidgets('Can play moves for both sides', (WidgetTester tester) async {
+      final mockRepository = MockStudyRepository();
+      when(() => mockRepository.getStudy(id: testId)).thenAnswer(
+        (_) async => (
+          makeStudy(
+            chapter: makeChapter(
+              id: const StudyChapterId('1'),
+              orientation: Side.black,
+            ),
+          ),
+          ''
+        ),
+      );
+
+      final app = await makeTestProviderScopeApp(
+        tester,
+        home: const StudyScreen(id: testId),
+        overrides: [
+          studyRepositoryProvider.overrideWith(
+            (ref) => mockRepository,
+          ),
+        ],
+      );
+      await tester.pumpWidget(app);
+      await tester.pumpAndSettle();
+
+      final boardRect = tester.getRect(find.byType(Chessboard));
+      await playMove(tester, boardRect, 'e2', 'e4', orientation: Side.black);
+      await tester.pumpAndSettle();
+
+      expect(find.byKey(const Key('whitepawn-e2')), findsNothing);
+      expect(find.byKey(const Key('whitepawn-e4')), findsOneWidget);
+
+      await playMove(tester, boardRect, 'e7', 'e5', orientation: Side.black);
+      await tester.pumpAndSettle();
+
+      expect(find.byKey(const Key('blackpawn-e5')), findsNothing);
+      expect(find.byKey(const Key('blackpawn-e7')), findsOneWidget);
+
+      expect(find.text('1. e4'), findsOneWidget);
+      expect(find.text('e5'), findsOneWidget);
+    });
+  });
+}

--- a/test/view/study/study_screen_test.dart
+++ b/test/view/study/study_screen_test.dart
@@ -168,7 +168,7 @@ void main() {
       expect(find.text('pgn 2'), findsOneWidget);
 
       // Open chapter selection dialog
-      await tester.tap(find.byTooltip('Chapters'));
+      await tester.tap(find.byTooltip('2 Chapters'));
       // Wait for dialog to open
       await tester.pumpAndSettle();
 

--- a/test/view/study/study_screen_test.dart
+++ b/test/view/study/study_screen_test.dart
@@ -80,6 +80,8 @@ void main() {
         ],
       );
       await tester.pumpWidget(app);
+
+      // Wait for study to load
       await tester.pumpAndSettle();
 
       expect(find.text('root comment'), findsOneWidget);
@@ -142,6 +144,7 @@ void main() {
         ],
       );
       await tester.pumpWidget(app);
+      // Wait for study to load
       await tester.pumpAndSettle();
 
       expect(find.text('Chapter 1'), findsOneWidget);
@@ -152,8 +155,10 @@ void main() {
 
       // 2nd press should not have any effect, we're already at the last chapter
       await tester.tap(find.text('Next chapter'));
+      // Wait for next chapter to load
       await tester.pumpAndSettle();
       await tester.tap(find.text('Next chapter'));
+      // Wait for next chapter to load (even though it shouldn't)
       await tester.pumpAndSettle();
 
       expect(find.text('Chapter 1'), findsNothing);
@@ -164,6 +169,7 @@ void main() {
 
       // Open chapter selection dialog
       await tester.tap(find.byTooltip('Chapters'));
+      // Wait for dialog to open
       await tester.pumpAndSettle();
 
       expect(
@@ -182,6 +188,7 @@ void main() {
       );
 
       await tester.tap(find.text('Chapter 1'));
+      // Wait for chapter to load
       await tester.pumpAndSettle();
 
       expect(find.text('Chapter 1'), findsOneWidget);
@@ -215,17 +222,16 @@ void main() {
         ],
       );
       await tester.pumpWidget(app);
+      // Wait for study to load
       await tester.pumpAndSettle();
 
       final boardRect = tester.getRect(find.byType(Chessboard));
       await playMove(tester, boardRect, 'e2', 'e4', orientation: Side.black);
-      await tester.pumpAndSettle();
 
       expect(find.byKey(const Key('e2-whitepawn')), findsNothing);
       expect(find.byKey(const Key('e4-whitepawn')), findsOneWidget);
 
       await playMove(tester, boardRect, 'e7', 'e5', orientation: Side.black);
-      await tester.pumpAndSettle();
 
       expect(find.byKey(const Key('e5-blackpawn')), findsOneWidget);
       expect(find.byKey(const Key('e7-blackpawn')), findsNothing);

--- a/test/view/study/study_screen_test.dart
+++ b/test/view/study/study_screen_test.dart
@@ -221,14 +221,14 @@ void main() {
       await playMove(tester, boardRect, 'e2', 'e4', orientation: Side.black);
       await tester.pumpAndSettle();
 
-      expect(find.byKey(const Key('whitepawn-e2')), findsNothing);
-      expect(find.byKey(const Key('whitepawn-e4')), findsOneWidget);
+      expect(find.byKey(const Key('e2-whitepawn')), findsNothing);
+      expect(find.byKey(const Key('e4-whitepawn')), findsOneWidget);
 
       await playMove(tester, boardRect, 'e7', 'e5', orientation: Side.black);
       await tester.pumpAndSettle();
 
-      expect(find.byKey(const Key('blackpawn-e5')), findsNothing);
-      expect(find.byKey(const Key('blackpawn-e7')), findsOneWidget);
+      expect(find.byKey(const Key('e5-blackpawn')), findsOneWidget);
+      expect(find.byKey(const Key('e7-blackpawn')), findsNothing);
 
       expect(find.text('1. e4'), findsOneWidget);
       expect(find.text('e5'), findsOneWidget);


### PR DESCRIPTION
Feature set is the same as the old app for now, I'll add support for interactive studies in another PR.

Chat is also missing for now, I'll have to figure out how to use the websocket for that.

@veloce The build fails because this PR depends on some of the other study PRs, namely https://github.com/lichess-org/mobile/pull/1109 https://github.com/lichess-org/mobile/pull/1077 and https://github.com/lichess-org/mobile/pull/990. If you want to try out the whole feature, it's probably easiest to create a local branch based on this PR and then rebase it onto the other ones.

[study_screen.webm](https://github.com/user-attachments/assets/7722124a-f554-4619-aa3e-7f91fd7d4463)
