### PR TITLE
Increase move list height in tablet/landscape view

### DIFF
--- a/lib/src/widgets/board_table.dart
+++ b/lib/src/widgets/board_table.dart
@@ -264,7 +264,7 @@ class _BoardTableState extends ConsumerState<BoardTable> {
                         crossAxisAlignment: CrossAxisAlignment.stretch,
                         mainAxisAlignment: MainAxisAlignment.spaceAround,
                         children: [
-                          Flexible(child: widget.topTable),
+                          widget.topTable,
                           if (!widget.zenMode && slicedMoves != null)
                             Expanded(
                               child: Padding(
@@ -279,14 +279,8 @@ class _BoardTableState extends ConsumerState<BoardTable> {
                               ),
                             )
                           else
-                            // same height as [MoveList]
-                            const Expanded(
-                              child: Padding(
-                                padding: EdgeInsets.all(16.0),
-                                child: SizedBox(height: 40),
-                              ),
-                            ),
-                          Flexible(child: widget.bottomTable),
+                            const Spacer(),
+                          widget.bottomTable,
                         ],
                       ),
                     ),


### PR DESCRIPTION
Partially fixes #585, the bottom bar is still at the very bottom, but we at least use the space on the right hand side more efficiently now.

Before:

![Screenshot_1730458251](https://github.com/user-attachments/assets/eb97d9ec-549e-48d4-9257-d165d35616b3)

After:

![Screenshot_1730458271](https://github.com/user-attachments/assets/25dd1f88-acd8-4a96-8227-e53d1c9d4d2c)

This also affects all other screens that use `BoardTable`, but I think it looks nice, for example puzzle streak:

Before:

![Screenshot_1730458340](https://github.com/user-attachments/assets/3a6a8aa0-7f6b-48e0-a206-eccfe45768fd)


After:

![Screenshot_1730458306](https://github.com/user-attachments/assets/8cf4d87c-e15a-4916-87e0-d88f08dcda1e)
