### PR TITLE
Fix overflow for tablets

### DIFF
--- a/lib/src/view/analysis/analysis_layout.dart
+++ b/lib/src/view/analysis/analysis_layout.dart
@@ -13,6 +13,7 @@ typedef BoardBuilder = Widget Function(
   BuildContext context,
   double boardSize,
   BorderRadius? boardRadius,
+  Orientation orientation,
 );
 
 typedef EngineGaugeBuilder = Widget Function(
@@ -177,6 +178,7 @@ class AnalysisLayout extends StatelessWidget {
                                     context,
                                     boardSize,
                                     isTablet ? tabletBoardRadius : null,
+                                    Orientation.landscape,
                                   ),
                                   if (engineGaugeBuilder != null) ...[
                                     const SizedBox(width: 4.0),
@@ -259,6 +261,7 @@ class AnalysisLayout extends StatelessWidget {
                               context,
                               boardSize,
                               isTablet ? tabletBoardRadius : null,
+                              Orientation.portrait,
                             ),
                           ),
                           Expanded(

--- a/lib/src/view/analysis/analysis_screen.dart
+++ b/lib/src/view/analysis/analysis_screen.dart
@@ -182,7 +182,8 @@ class _Body extends ConsumerWidget {
 
     return AnalysisLayout(
       tabController: controller,
-      boardBuilder: (context, boardSize, borderRadius) => AnalysisBoard(
+      boardBuilder: (context, boardSize, borderRadius, orientation) =>
+          AnalysisBoard(
         options,
         boardSize,
         borderRadius: borderRadius,

--- a/lib/src/view/broadcast/broadcast_game_screen.dart
+++ b/lib/src/view/broadcast/broadcast_game_screen.dart
@@ -101,12 +101,13 @@ class _Body extends ConsumerWidget {
     return DefaultTabController(
       length: 1,
       child: AnalysisLayout(
-        boardBuilder: (context, boardSize, borderRadius) =>
+        boardBuilder: (context, boardSize, borderRadius, orientation) =>
             _BroadcastBoardWithHeaders(
           roundId,
           gameId,
           boardSize,
           borderRadius,
+          orientation,
         ),
         engineGaugeBuilder: isLocalEvaluationEnabled && showEvaluationGauge
             ? (context, orientation) {
@@ -150,12 +151,14 @@ class _BroadcastBoardWithHeaders extends ConsumerWidget {
   final BroadcastGameId gameId;
   final double size;
   final BorderRadius? borderRadius;
+  final Orientation orientation;
 
   const _BroadcastBoardWithHeaders(
     this.roundId,
     this.gameId,
     this.size,
     this.borderRadius,
+    this.orientation,
   );
 
   @override
@@ -172,7 +175,8 @@ class _BroadcastBoardWithHeaders extends ConsumerWidget {
             bottomRight: Radius.zero,
           ),
         ),
-        _BroadcastBoard(roundId, gameId, size, borderRadius != null),
+        _BroadcastBoard(
+            roundId, gameId, size, borderRadius != null, orientation),
         _PlayerWidget(
           roundId: roundId,
           gameId: gameId,
@@ -194,12 +198,14 @@ class _BroadcastBoard extends ConsumerStatefulWidget {
     this.gameId,
     this.boardSize,
     this.hasShadow,
+    this.orientation,
   );
 
   final BroadcastRoundId roundId;
   final BroadcastGameId gameId;
   final double boardSize;
   final bool hasShadow;
+  final Orientation orientation;
 
   @override
   ConsumerState<_BroadcastBoard> createState() => _BroadcastBoardState();
@@ -238,7 +244,10 @@ class _BroadcastBoardState extends ConsumerState<_BroadcastBoard> {
         : ISet();
 
     return Chessboard(
-      size: widget.boardSize,
+      size: switch (widget.orientation) {
+        Orientation.portrait => widget.boardSize,
+        Orientation.landscape => widget.boardSize - 2 * 30,
+      },
       fen: broadcastAnalysisState.position.fen,
       lastMove: broadcastAnalysisState.lastMove as NormalMove?,
       orientation: broadcastAnalysisState.pov,

--- a/lib/src/view/study/study_screen.dart
+++ b/lib/src/view/study/study_screen.dart
@@ -221,7 +221,8 @@ class _Body extends ConsumerWidget {
       return DefaultTabController(
         length: 1,
         child: AnalysisLayout(
-          boardBuilder: (context, boardSize, borderRadius) => SizedBox.square(
+          boardBuilder: (context, boardSize, borderRadius, orientation) =>
+              SizedBox.square(
             dimension: boardSize,
             child: Center(
               child: Text(
@@ -249,7 +250,8 @@ class _Body extends ConsumerWidget {
     return DefaultTabController(
       length: 1,
       child: AnalysisLayout(
-        boardBuilder: (context, boardSize, borderRadius) => _StudyBoard(
+        boardBuilder: (context, boardSize, borderRadius, orientation) =>
+            _StudyBoard(
           id: id,
           boardSize: boardSize,
           borderRadius: borderRadius,


### PR DESCRIPTION
There is an overflow because of the board headers on broadcast game screen when using landscape orientation.

I am still thinking about the way to solve this issue because the board size depends on the height of the headers

![Screenshot_1732871399](https://github.com/user-attachments/assets/8de8261a-ce3f-42b7-a7d4-7916932ba5c4)

Looks like there is also an issue with spacing. There is a lot of blank space between move list and board.