### PR TITLE
Tweak broadcast game screen ui

### DIFF
--- a/lib/src/view/broadcast/broadcast_game_screen.dart
+++ b/lib/src/view/broadcast/broadcast_game_screen.dart
@@ -346,7 +346,7 @@ class _PlayerWidget extends ConsumerWidget {
             Card(
               margin: EdgeInsets.zero,
               shape: _makePlayerWidgetBorder(
-                position: widgetPosition,
+                widgetPosition: widgetPosition,
                 borderRadius: borderRadius,
                 hasLeftBorderRadius: true,
               ),
@@ -374,7 +374,7 @@ class _PlayerWidget extends ConsumerWidget {
             child: Card(
               margin: EdgeInsets.zero,
               shape: _makePlayerWidgetBorder(
-                position: widgetPosition,
+                widgetPosition: widgetPosition,
                 borderRadius: borderRadius,
                 hasLeftBorderRadius: !game.isOver,
                 hasRightBorderRadius: clock == null,
@@ -443,7 +443,7 @@ class _PlayerWidget extends ConsumerWidget {
                   : null,
               margin: EdgeInsets.zero,
               shape: _makePlayerWidgetBorder(
-                position: widgetPosition,
+                widgetPosition: widgetPosition,
                 borderRadius: borderRadius,
                 hasRightBorderRadius: true,
               ),
@@ -505,7 +505,7 @@ class _Clock extends StatelessWidget {
 
 ShapeBorder _makePlayerWidgetBorder({
   required BorderRadius? borderRadius,
-  required _PlayerWidgetPosition position,
+  required _PlayerWidgetPosition widgetPosition,
   bool hasLeftBorderRadius = false,
   bool hasRightBorderRadius = false,
 }) {
@@ -514,7 +514,7 @@ ShapeBorder _makePlayerWidgetBorder({
   if (!hasLeftBorderRadius && !hasRightBorderRadius) return const Border();
 
   return RoundedRectangleBorder(
-    borderRadius: switch (position) {
+    borderRadius: switch (widgetPosition) {
       _PlayerWidgetPosition.top => borderRadius.copyWith(
           topLeft: hasLeftBorderRadius ? null : Radius.zero,
           topRight: hasRightBorderRadius ? null : Radius.zero,

--- a/lib/src/view/broadcast/broadcast_game_screen.dart
+++ b/lib/src/view/broadcast/broadcast_game_screen.dart
@@ -314,7 +314,7 @@ class _PlayerWidget extends ConsumerWidget {
   final BroadcastGameId gameId;
   final double width;
   final _PlayerWidgetPosition widgetPosition;
-  final BorderRadiusGeometry? borderRadius;
+  final BorderRadius? borderRadius;
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
@@ -345,8 +345,10 @@ class _PlayerWidget extends ConsumerWidget {
           if (game.isOver)
             Card(
               margin: EdgeInsets.zero,
-              shape: RoundedRectangleBorder(
-                borderRadius: borderRadius ?? BorderRadius.zero,
+              shape: _makePlayerWidgetBorder(
+                position: widgetPosition,
+                borderRadius: borderRadius,
+                hasLeftBorderRadius: true,
               ),
               child: Padding(
                 padding: const EdgeInsets.symmetric(
@@ -371,8 +373,11 @@ class _PlayerWidget extends ConsumerWidget {
           Expanded(
             child: Card(
               margin: EdgeInsets.zero,
-              shape: RoundedRectangleBorder(
-                borderRadius: borderRadius ?? BorderRadius.zero,
+              shape: _makePlayerWidgetBorder(
+                position: widgetPosition,
+                borderRadius: borderRadius,
+                hasLeftBorderRadius: !game.isOver,
+                hasRightBorderRadius: clock == null,
               ),
               child: Padding(
                 padding:
@@ -437,8 +442,10 @@ class _PlayerWidget extends ConsumerWidget {
                       : Theme.of(context).colorScheme.secondaryContainer
                   : null,
               margin: EdgeInsets.zero,
-              shape: RoundedRectangleBorder(
-                borderRadius: borderRadius ?? BorderRadius.zero,
+              shape: _makePlayerWidgetBorder(
+                position: widgetPosition,
+                borderRadius: borderRadius,
+                hasRightBorderRadius: true,
               ),
               child: Padding(
                 padding:
@@ -494,4 +501,32 @@ class _Clock extends StatelessWidget {
       ),
     );
   }
+}
+
+ShapeBorder _makePlayerWidgetBorder({
+  required BorderRadius? borderRadius,
+  required _PlayerWidgetPosition position,
+  bool hasLeftBorderRadius = false,
+  bool hasRightBorderRadius = false,
+}) {
+  if (borderRadius == null) return const Border();
+
+  if (!hasLeftBorderRadius && !hasRightBorderRadius) return const Border();
+
+  return RoundedRectangleBorder(
+    borderRadius: switch (position) {
+      _PlayerWidgetPosition.top => borderRadius.copyWith(
+          topLeft: hasLeftBorderRadius ? null : Radius.zero,
+          topRight: hasRightBorderRadius ? null : Radius.zero,
+          bottomLeft: Radius.zero,
+          bottomRight: Radius.zero,
+        ),
+      _PlayerWidgetPosition.bottom => borderRadius.copyWith(
+          topLeft: Radius.zero,
+          topRight: Radius.zero,
+          bottomLeft: hasLeftBorderRadius ? null : Radius.zero,
+          bottomRight: hasRightBorderRadius ? null : Radius.zero,
+        ),
+    },
+  );
 }


### PR DESCRIPTION
This pull request add border radius to the whole player widget and not on every card widget. I think it looks better this way.

Before

![20241129_16h19m30s_grim](https://github.com/user-attachments/assets/6cc47bac-f95d-46bd-af33-6a3a19fbae47)

After

![20241129_16h21m42s_grim](https://github.com/user-attachments/assets/9eb00d0a-957c-461a-b1e5-7ffc68961dd5)

Note: I increase the radius for the screenshots to see the difference