### PR TITLE
Tweak analysis layout

### DIFF
--- a/lib/src/view/analysis/analysis_layout.dart
+++ b/lib/src/view/analysis/analysis_layout.dart
@@ -176,7 +176,7 @@ class AnalysisLayout extends StatelessWidget {
                                   boardBuilder(
                                     context,
                                     boardSize,
-                                    isTablet ? tabletBoardRadius : null,
+                                    tabletBoardRadius,
                                   ),
                                   if (engineGaugeBuilder != null) ...[
                                     const SizedBox(width: 4.0),


### PR DESCRIPTION
In orientation landscape, we already know that this is a tablet so we don't need to check for it.

We also are not checking if it is a tablet for the padding so I think this commit makes the code more consistent.