### PR TITLE
Added Bluesky to social links

### DIFF
--- a/lib/src/model/user/profile.dart
+++ b/lib/src/model/user/profile.dart
@@ -101,6 +101,7 @@ enum LinkSite {
     ]),
   ),
   twitter('Twitter', IListConst(['twitter.com'])),
+  bluesky('Bluesky', IListConst(['bsky.app'])),
   facebook('Facebook', IListConst(['facebook.com'])),
   instagram('Instagram', IListConst(['instagram.com'])),
   youtube('YouTube', IListConst(['youtube.com'])),


### PR DESCRIPTION
Added Bluesky to the `LinkSite` enum, hopefully I did everything correctly! 
This should ideally designate bsky.app links as links to Bluesky instead of showing the URL. 