### PR TITLE
fix inconsistent font size in puzzle's ratingDiff

### DIFF
--- a/lib/src/view/puzzle/puzzle_session_widget.dart
+++ b/lib/src/view/puzzle/puzzle_session_widget.dart
@@ -221,7 +221,7 @@ class _SessionItem extends StatelessWidget {
                     child: Padding(
                       padding: const EdgeInsets.all(2.0),
                       child: FittedBox(
-                        fit: BoxFit.cover,
+                        fit: BoxFit.fitHeight,
                         child: Text(
                           attempt!.ratingDiffString!,
                           maxLines: 1,


### PR DESCRIPTION
Hi,

not familiar with flutter but I think this small change can close this bug #1090 
please test and if you have suggestion please let me know

before
![Screenshot_20241209_161924 before](https://github.com/user-attachments/assets/27e18a3b-a277-442b-95fa-d6fae2b16b27)


after
![Screenshot_20241209_161858 after](https://github.com/user-attachments/assets/9daafd9d-f2a1-4a8f-a2d1-eed16457fd75)

