### PR TITLE
fix: creation of gif api

### DIFF
--- a/lib/src/model/game/game_share_service.dart
+++ b/lib/src/model/game/game_share_service.dart
@@ -81,13 +81,16 @@ class GameShareService {
 
   /// Fetches the GIF animation of a game.
   Future<XFile> gameGif(GameId id, Side orientation) async {
-    final boardTheme = _ref.read(boardPreferencesProvider).boardTheme;
-    final pieceTheme = _ref.read(boardPreferencesProvider).pieceSet;
+    final boardPreferences = _ref.read(boardPreferencesProvider);
+    final boardTheme = boardPreferences.boardTheme == BoardTheme.system
+        ? BoardTheme.brown
+        : boardPreferences.boardTheme;
+    final pieceTheme = boardPreferences.pieceSet;
     final resp = await _ref
         .read(defaultClientProvider)
         .get(
           Uri.parse(
-            '$kLichessCDNHost/game/export/gif/${orientation.name}/$id.gif?theme=${boardTheme.name}&piece=${pieceTheme.name}',
+            '$kLichessCDNHost/game/export/gif/${orientation.name}/$id.gif?theme=${boardTheme.gifApiName}&piece=${pieceTheme.name}',
           ),
         )
         .timeout(const Duration(seconds: 1));

--- a/lib/src/model/settings/board_preferences.dart
+++ b/lib/src/model/settings/board_preferences.dart
@@ -223,34 +223,35 @@ enum ShapeColor {
 
 /// The chessboard theme.
 enum BoardTheme {
-  system('System'),
-  blue('Blue'),
-  blue2('Blue2'),
-  blue3('Blue3'),
-  blueMarble('Blue Marble'),
-  canvas('Canvas'),
-  wood('Wood'),
-  wood2('Wood2'),
-  wood3('Wood3'),
-  wood4('Wood4'),
-  maple('Maple'),
-  maple2('Maple 2'),
-  brown('Brown'),
-  leather('Leather'),
-  green('Green'),
-  marble('Marble'),
-  greenPlastic('Green Plastic'),
-  grey('Grey'),
-  metal('Metal'),
-  olive('Olive'),
-  newspaper('Newspaper'),
-  purpleDiag('Purple-Diag'),
-  pinkPyramid('Pink'),
-  horsey('Horsey');
+  system('System', 'system'),
+  blue('Blue', 'blue'),
+  blue2('Blue 2', 'blue2'),
+  blue3('Blue 3', 'blue3'),
+  blueMarble('Blue Marble', 'blue-marble'),
+  canvas('Canvas', 'canvas'),
+  wood('Wood', 'wood'),
+  wood2('Wood 2', 'wood2'),
+  wood3('Wood 3', 'wood3'),
+  wood4('Wood 4', 'wood4'),
+  maple('Maple', 'maple'),
+  maple2('Maple 2', 'maple2'),
+  brown('Brown', 'brown'),
+  leather('Leather', 'leather'),
+  green('Green', 'green'),
+  marble('Marble', 'marble'),
+  greenPlastic('Green Plastic', 'green-plastic'),
+  grey('Grey', 'grey'),
+  metal('Metal', 'metal'),
+  olive('Olive', 'olive'),
+  newspaper('Newspaper', 'newspaper'),
+  purpleDiag('Purple-Diag', 'purple-diag'),
+  pinkPyramid('Pink', 'pink'),
+  horsey('Horsey', 'horsey');
 
   final String label;
+  final String gifApiName;
 
-  const BoardTheme(this.label);
+  const BoardTheme(this.label, this.gifApiName);
 
   ChessboardColorScheme get colors {
     switch (this) {

--- a/lib/src/model/study/study_repository.dart
+++ b/lib/src/model/study/study_repository.dart
@@ -1,6 +1,5 @@
 import 'dart:convert';
 
-import 'package:dartchess/dartchess.dart';
 import 'package:deep_pick/deep_pick.dart';
 import 'package:fast_immutable_collections/fast_immutable_collections.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
@@ -110,16 +109,19 @@ class StudyRepository {
   Future<XFile> chapterGif(
     StudyId id,
     StudyChapterId chapterId,
-    Side orientation,
   ) async {
-    final boardTheme = ref.read(boardPreferencesProvider).boardTheme;
-    final pieceTheme = ref.read(boardPreferencesProvider).pieceSet;
+    final boardPreferences = ref.read(boardPreferencesProvider);
+    final boardTheme = boardPreferences.boardTheme == BoardTheme.system
+        ? BoardTheme.brown
+        : boardPreferences.boardTheme;
+    final pieceTheme = boardPreferences.pieceSet;
+
     final resp = await client
         .get(
           lichessUri(
             '/study/$id/$chapterId.gif',
             {
-              'theme': boardTheme.name,
+              'theme': boardTheme.gifApiName,
               'piece': pieceTheme.name,
             },
           ),

--- a/lib/src/view/study/study_screen.dart
+++ b/lib/src/view/study/study_screen.dart
@@ -333,7 +333,6 @@ class _StudyMenu extends ConsumerWidget {
                             await ref.read(studyRepositoryProvider).chapterGif(
                                   state.study.id,
                                   state.study.chapter.id,
-                                  state.pov,
                                 );
                         if (context.mounted) {
                           launchShareDialog(


### PR DESCRIPTION
Fixes two bugs related to the GIF creation process:
- Creating a GIF from studies while the current board theme was set to "system" did not work. It now defaults to brown.
- Sometimes depending on the current theme, the board theme preferences were not respected due to a different naming in the GIF-API . This issue affected GIF creation for games (it defaulted to brown instead of the user prefs) and studies (GIFs were not created at all).

Also, I changed the labels of the board themes to include spaces, e.g., Blue2 → Blue 2.
