### PR TITLE
feature: share option in the broadcast game screen

### DIFF
--- a/lib/src/model/game/game_share_service.dart
+++ b/lib/src/model/game/game_share_service.dart
@@ -69,7 +69,7 @@ class GameShareService {
         .read(defaultClientProvider)
         .get(
           Uri.parse(
-            '$kLichessCDNHost/export/fen.gif?fen=${Uri.encodeComponent(fen)}&color=${orientation.name}${lastMove != null ? '&lastMove=${lastMove.uci}' : ''}&theme=${boardTheme.name}&piece=${pieceTheme.name}',
+            '$kLichessCDNHost/export/fen.gif?fen=${Uri.encodeComponent(fen)}&color=${orientation.name}${lastMove != null ? '&lastMove=${lastMove.uci}' : ''}&theme=${boardTheme.gifApiName}&piece=${pieceTheme.name}',
           ),
         )
         .timeout(const Duration(seconds: 1));
@@ -91,6 +91,35 @@ class GameShareService {
         .get(
           Uri.parse(
             '$kLichessCDNHost/game/export/gif/${orientation.name}/$id.gif?theme=${boardTheme.gifApiName}&piece=${pieceTheme.name}',
+          ),
+        )
+        .timeout(const Duration(seconds: 1));
+    if (resp.statusCode != 200) {
+      throw Exception('Failed to get GIF');
+    }
+    return XFile.fromData(resp.bodyBytes, mimeType: 'image/gif');
+  }
+
+  /// Fetches the GIF animation of a study chapter.
+  Future<XFile> chapterGif(
+    StringId id,
+    StringId chapterId,
+  ) async {
+    final boardPreferences = _ref.read(boardPreferencesProvider);
+    final boardTheme = boardPreferences.boardTheme == BoardTheme.system
+        ? BoardTheme.brown
+        : boardPreferences.boardTheme;
+    final pieceTheme = boardPreferences.pieceSet;
+
+    final resp = await _ref
+        .read(lichessClientProvider)
+        .get(
+          lichessUri(
+            '/study/$id/$chapterId.gif',
+            {
+              'theme': boardTheme.gifApiName,
+              'piece': pieceTheme.name,
+            },
           ),
         )
         .timeout(const Duration(seconds: 1));

--- a/lib/src/model/study/study_repository.dart
+++ b/lib/src/model/study/study_repository.dart
@@ -5,13 +5,11 @@ import 'package:fast_immutable_collections/fast_immutable_collections.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:http/http.dart';
 import 'package:lichess_mobile/src/model/common/id.dart';
-import 'package:lichess_mobile/src/model/settings/board_preferences.dart';
 import 'package:lichess_mobile/src/model/study/study.dart';
 import 'package:lichess_mobile/src/model/study/study_filter.dart';
 import 'package:lichess_mobile/src/model/study/study_list_paginator.dart';
 import 'package:lichess_mobile/src/network/http.dart';
 import 'package:riverpod_annotation/riverpod_annotation.dart';
-import 'package:share_plus/share_plus.dart';
 
 part 'study_repository.g.dart';
 
@@ -103,33 +101,5 @@ class StudyRepository {
     );
 
     return utf8.decode(pgnBytes);
-  }
-
-  /// Fetches the GIF animation of a study chapter.
-  Future<XFile> chapterGif(
-    StudyId id,
-    StudyChapterId chapterId,
-  ) async {
-    final boardPreferences = ref.read(boardPreferencesProvider);
-    final boardTheme = boardPreferences.boardTheme == BoardTheme.system
-        ? BoardTheme.brown
-        : boardPreferences.boardTheme;
-    final pieceTheme = boardPreferences.pieceSet;
-
-    final resp = await client
-        .get(
-          lichessUri(
-            '/study/$id/$chapterId.gif',
-            {
-              'theme': boardTheme.gifApiName,
-              'piece': pieceTheme.name,
-            },
-          ),
-        )
-        .timeout(const Duration(seconds: 1));
-    if (resp.statusCode != 200) {
-      throw Exception('Failed to get GIF');
-    }
-    return XFile.fromData(resp.bodyBytes, mimeType: 'image/gif');
   }
 }

--- a/lib/src/view/broadcast/broadcast_boards_tab.dart
+++ b/lib/src/view/broadcast/broadcast_boards_tab.dart
@@ -26,9 +26,11 @@ const _kPlayerWidgetPadding = EdgeInsets.symmetric(vertical: 5.0);
 class BroadcastBoardsTab extends ConsumerWidget {
   const BroadcastBoardsTab({
     required this.roundId,
+    required this.broadcastTitle,
   });
 
   final BroadcastRoundId roundId;
+  final String broadcastTitle;
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
@@ -58,14 +60,18 @@ class BroadcastBoardsTab extends ConsumerWidget {
             : BroadcastPreview(
                 games: value.games.values.toIList(),
                 roundId: roundId,
-                title: value.round.name,
+                broadcastTitle: broadcastTitle,
+                roundTitle: value.round.name,
               ),
         AsyncError(:final error) => SliverFillRemaining(
             child: Center(
               child: Text('Could not load broadcast: $error'),
             ),
           ),
-        _ => BroadcastPreview.loading(roundId: roundId),
+        _ => BroadcastPreview.loading(
+            roundId: roundId,
+            broadcastTitle: broadcastTitle,
+          ),
       },
     );
   }
@@ -75,17 +81,20 @@ class BroadcastPreview extends StatelessWidget {
   const BroadcastPreview({
     required this.roundId,
     required this.games,
-    required this.title,
+    required this.broadcastTitle,
+    required this.roundTitle,
   });
 
   const BroadcastPreview.loading({
     required this.roundId,
+    required this.broadcastTitle,
   })  : games = null,
-        title = null;
+        roundTitle = null;
 
   final BroadcastRoundId roundId;
   final IList<BroadcastGame>? games;
-  final String? title;
+  final String broadcastTitle;
+  final String? roundTitle;
 
   @override
   Widget build(BuildContext context) {
@@ -113,7 +122,7 @@ class BroadcastPreview extends StatelessWidget {
       delegate: SliverChildBuilderDelegate(
         childCount: games == null ? numberLoadingBoards : games!.length,
         (context, index) {
-          if (games == null || title == null) {
+          if (games == null || roundTitle == null) {
             return ShimmerLoading(
               isLoading: true,
               child: BoardThumbnail.loading(
@@ -132,11 +141,12 @@ class BroadcastPreview extends StatelessWidget {
             onTap: () {
               pushPlatformRoute(
                 context,
-                title: title,
+                title: roundTitle,
                 builder: (context) => BroadcastGameScreen(
                   roundId: roundId,
                   gameId: game.id,
-                  title: title!,
+                  broadcastTitle: broadcastTitle,
+                  roundTitle: roundTitle!,
                 ),
               );
             },

--- a/lib/src/view/broadcast/broadcast_game_bottom_bar.dart
+++ b/lib/src/view/broadcast/broadcast_game_bottom_bar.dart
@@ -1,20 +1,31 @@
 import 'package:flutter/cupertino.dart';
+import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:lichess_mobile/src/model/broadcast/broadcast_game_controller.dart';
+import 'package:lichess_mobile/src/model/broadcast/broadcast_repository.dart';
 import 'package:lichess_mobile/src/model/common/id.dart';
+import 'package:lichess_mobile/src/model/game/game_share_service.dart';
+import 'package:lichess_mobile/src/network/http.dart';
 import 'package:lichess_mobile/src/utils/l10n_context.dart';
+import 'package:lichess_mobile/src/utils/share.dart';
+import 'package:lichess_mobile/src/widgets/adaptive_action_sheet.dart';
 import 'package:lichess_mobile/src/widgets/bottom_bar.dart';
 import 'package:lichess_mobile/src/widgets/bottom_bar_button.dart';
 import 'package:lichess_mobile/src/widgets/buttons.dart';
+import 'package:lichess_mobile/src/widgets/feedback.dart';
 
 class BroadcastGameBottomBar extends ConsumerWidget {
   const BroadcastGameBottomBar({
     required this.roundId,
     required this.gameId,
+    required this.broadcastTitle,
+    required this.roundTitle,
   });
 
   final BroadcastRoundId roundId;
   final BroadcastGameId gameId;
+  final String broadcastTitle;
+  final String roundTitle;
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
@@ -23,6 +34,82 @@ class BroadcastGameBottomBar extends ConsumerWidget {
 
     return BottomBar(
       children: [
+        BottomBarButton(
+          label: context.l10n.menu,
+          onTap: () {
+            showAdaptiveActionSheet<void>(
+              context: context,
+              actions: [
+                BottomSheetAction(
+                  makeLabel: (context) => Text(context.l10n.mobileShareGameURL),
+                  onPressed: (context) async {
+                    launchShareDialog(
+                      context,
+                      uri: lichessUri(
+                        '/broadcast/${broadcastTitle.toLowerCase().replaceAll(' ', '-')}/${roundTitle.toLowerCase().replaceAll(' ', '-')}/$roundId/$gameId',
+                      ),
+                    );
+                  },
+                ),
+                BottomSheetAction(
+                  makeLabel: (context) => Text(context.l10n.mobileShareGamePGN),
+                  onPressed: (context) async {
+                    try {
+                      final pgn = await ref.withClient(
+                        (client) => BroadcastRepository(client)
+                            .getGamePgn(roundId, gameId),
+                      );
+                      if (context.mounted) {
+                        launchShareDialog(
+                          context,
+                          text: pgn,
+                        );
+                      }
+                    } catch (e) {
+                      if (context.mounted) {
+                        showPlatformSnackbar(
+                          context,
+                          'Failed to get PGN',
+                          type: SnackBarType.error,
+                        );
+                      }
+                    }
+                  },
+                ),
+                BottomSheetAction(
+                  makeLabel: (context) => const Text('GIF'),
+                  onPressed: (_) async {
+                    try {
+                      final gif =
+                          await ref.read(gameShareServiceProvider).chapterGif(
+                                roundId,
+                                gameId,
+                              );
+                      if (context.mounted) {
+                        launchShareDialog(
+                          context,
+                          files: [gif],
+                        );
+                      }
+                    } catch (e) {
+                      debugPrint(e.toString());
+                      if (context.mounted) {
+                        showPlatformSnackbar(
+                          context,
+                          'Failed to get GIF',
+                          type: SnackBarType.error,
+                        );
+                      }
+                    }
+                  },
+                ),
+              ],
+            );
+          },
+          icon: Theme.of(context).platform == TargetPlatform.iOS
+              ? CupertinoIcons.share
+              : Icons.share,
+        ),
         BottomBarButton(
           label: context.l10n.flipBoard,
           onTap: () {

--- a/lib/src/view/broadcast/broadcast_game_screen.dart
+++ b/lib/src/view/broadcast/broadcast_game_screen.dart
@@ -33,12 +33,14 @@ import 'package:lichess_mobile/src/widgets/platform_scaffold.dart';
 class BroadcastGameScreen extends ConsumerStatefulWidget {
   final BroadcastRoundId roundId;
   final BroadcastGameId gameId;
-  final String title;
+  final String broadcastTitle;
+  final String roundTitle;
 
   const BroadcastGameScreen({
     required this.roundId,
     required this.gameId,
-    required this.title,
+    required this.broadcastTitle,
+    required this.roundTitle,
   });
 
   @override
@@ -80,7 +82,11 @@ class _BroadcastGameScreenState extends ConsumerState<BroadcastGameScreen>
 
     return PlatformScaffold(
       appBar: PlatformAppBar(
-        title: Text(widget.title, overflow: TextOverflow.ellipsis, maxLines: 1),
+        title: Text(
+          widget.roundTitle,
+          overflow: TextOverflow.ellipsis,
+          maxLines: 1,
+        ),
         actions: [
           AppBarAnalysisTabIndicator(
             tabs: tabs,
@@ -104,8 +110,13 @@ class _BroadcastGameScreenState extends ConsumerState<BroadcastGameScreen>
         ],
       ),
       body: switch (broadcastGameState) {
-        AsyncData() =>
-          _Body(widget.roundId, widget.gameId, tabController: _tabController),
+        AsyncData() => _Body(
+            widget.roundId,
+            widget.gameId,
+            widget.broadcastTitle,
+            widget.roundTitle,
+            tabController: _tabController,
+          ),
         AsyncError(:final error) => Center(
             child: Text('Cannot load broadcast game: $error'),
           ),
@@ -116,10 +127,18 @@ class _BroadcastGameScreenState extends ConsumerState<BroadcastGameScreen>
 }
 
 class _Body extends ConsumerWidget {
-  const _Body(this.roundId, this.gameId, {required this.tabController});
+  const _Body(
+    this.roundId,
+    this.gameId,
+    this.broadcastTitle,
+    this.roundTitle, {
+    required this.tabController,
+  });
 
   final BroadcastRoundId roundId;
   final BroadcastGameId gameId;
+  final String broadcastTitle;
+  final String roundTitle;
   final TabController tabController;
 
   @override
@@ -183,7 +202,12 @@ class _Body extends ConsumerWidget {
                   .onUserMove,
             )
           : null,
-      bottomBar: BroadcastGameBottomBar(roundId: roundId, gameId: gameId),
+      bottomBar: BroadcastGameBottomBar(
+        roundId: roundId,
+        gameId: gameId,
+        broadcastTitle: broadcastTitle,
+        roundTitle: roundTitle,
+      ),
       children: [
         _OpeningExplorerTab(roundId, gameId),
         BroadcastGameTreeView(roundId, gameId),

--- a/lib/src/view/broadcast/broadcast_round_screen.dart
+++ b/lib/src/view/broadcast/broadcast_round_screen.dart
@@ -147,6 +147,7 @@ class _BroadcastRoundScreenState extends ConsumerState<BroadcastRoundScreen>
                             sliver: BroadcastBoardsTab(
                               roundId:
                                   _selectedRoundId ?? tournament.defaultRoundId,
+                              broadcastTitle: widget.broadcast.title,
                             ),
                           ),
                         _CupertinoView.players => _TabView(
@@ -196,6 +197,7 @@ class _BroadcastRoundScreenState extends ConsumerState<BroadcastRoundScreen>
                     _TabView(
                       sliver: BroadcastBoardsTab(
                         roundId: _selectedRoundId ?? tournament.defaultRoundId,
+                        broadcastTitle: widget.broadcast.title,
                       ),
                     ),
                     _TabView(

--- a/lib/src/view/study/study_screen.dart
+++ b/lib/src/view/study/study_screen.dart
@@ -330,7 +330,7 @@ class _StudyMenu extends ConsumerWidget {
                     onPressed: (_) async {
                       try {
                         final gif =
-                            await ref.read(studyRepositoryProvider).chapterGif(
+                            await ref.read(gameShareServiceProvider).chapterGif(
                                   state.study.id,
                                   state.study.chapter.id,
                                 );


### PR DESCRIPTION
Adds share URL, download PGN and GIF Options to the broadcast game screen

**Preview**:
 
[broadcasts-share.webm](https://github.com/user-attachments/assets/51b197dc-2753-43b5-a94c-b488aaa21237)

**Remarks**:
- I refactored the GIF functionality from study into `game_share_service` and reused it for broadcasts.
- The broadcast name and round name are not necessary for the URL, but I believe including them is better, as it helps to humanly read the URL.
- I decided against adding the screenshot position option. I can implement it if you think its needed, but I think this feature is unnecessary on mobile devices.


