### PR TITLE
Edit profile page changes, closes The biography resets when reducing the keyboard #1245

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -38,3 +38,6 @@ doc/api/
 
 # FVM Version Cache
 .fvm/
+
+# VS Code
+.vscode/

--- a/lib/src/view/account/edit_profile_screen.dart
+++ b/lib/src/view/account/edit_profile_screen.dart
@@ -29,10 +29,7 @@ class EditProfileScreen extends StatelessWidget {
   Widget build(BuildContext context) {
     return PlatformScaffold(
       appBar: PlatformAppBar(title: Text(context.l10n.editProfile)),
-      body: PopScope(
-        canPop: false,
-        child: _Body(),
-      ),
+      body: PopScope(canPop: false, child: _Body()),
     );
   }
 }
@@ -287,14 +284,12 @@ class _NumericField extends StatefulWidget {
   final int? initialValue;
   final String formKey;
   final String? Function(int?)? validator;
-  final TextInputAction textInputAction;
   final Map<String, dynamic> formData;
   const _NumericField({
     required this.label,
     required this.initialValue,
     required this.formKey,
     required this.validator,
-    this.textInputAction = TextInputAction.next,
     required this.formData,
   });
 
@@ -346,7 +341,6 @@ class __NumericFieldState extends State<_NumericField> {
                 ),
                 materialDecoration:
                     field.errorText != null ? InputDecoration(errorText: field.errorText) : null,
-                textInputAction: widget.textInputAction,
 
                 onChanged: (value) {
                   field.didChange(int.tryParse(value));

--- a/lib/src/view/account/edit_profile_screen.dart
+++ b/lib/src/view/account/edit_profile_screen.dart
@@ -16,6 +16,11 @@ import 'package:lichess_mobile/src/widgets/platform_scaffold.dart';
 import 'package:result_extensions/result_extensions.dart';
 
 final _countries = countries.values.toList();
+final _cupertinoTextFieldDecoration = BoxDecoration(
+  color: CupertinoColors.tertiarySystemBackground,
+  border: Border.all(color: CupertinoColors.systemGrey4, width: 1),
+  borderRadius: BorderRadius.circular(8),
+);
 
 class EditProfileScreen extends StatelessWidget {
   const EditProfileScreen({super.key});
@@ -24,7 +29,10 @@ class EditProfileScreen extends StatelessWidget {
   Widget build(BuildContext context) {
     return PlatformScaffold(
       appBar: PlatformAppBar(title: Text(context.l10n.editProfile)),
-      body: _Body(),
+      body: PopScope(
+        canPop: false,
+        child: _Body(),
+      ),
     );
   }
 }
@@ -38,14 +46,20 @@ class _Body extends ConsumerWidget {
         if (data == null) {
           return Center(child: Text(context.l10n.mobileMustBeLoggedIn));
         }
-        return Padding(
-          padding: Styles.bodyPadding,
-          child: ListView(
-            children: [
-              Text(context.l10n.allInformationIsPublicAndOptional),
-              const SizedBox(height: 16),
-              _EditProfileForm(data),
-            ],
+        return GestureDetector(
+          onTap: () => FocusScope.of(context).unfocus(),
+          child: Padding(
+            padding: Styles.bodyPadding.copyWith(top: 0, bottom: 0),
+            child: ListView(
+              keyboardDismissBehavior: ScrollViewKeyboardDismissBehavior.onDrag,
+              children: [
+                SizedBox(height: Styles.bodyPadding.top),
+                Text(context.l10n.allInformationIsPublicAndOptional),
+                const SizedBox(height: 16),
+                _EditProfileForm(data),
+                SizedBox(height: Styles.bodyPadding.bottom),
+              ],
+            ),
           ),
         );
       },
@@ -82,30 +96,24 @@ class _EditProfileFormState extends ConsumerState<_EditProfileForm> {
     'links': null,
   };
 
-  final _cupertinoTextFieldDecoration = BoxDecoration(
-    color: CupertinoColors.tertiarySystemBackground,
-    border: Border.all(color: CupertinoColors.systemGrey4, width: 1),
-    borderRadius: BorderRadius.circular(8),
-  );
-
   Future<void>? _pendingSaveProfile;
 
   @override
   Widget build(BuildContext context) {
     final String? initialLinks = widget.user.profile?.links?.map((e) => e.url).join('\r\n');
-
     return Form(
       key: _formKey,
       child: Column(
         children: [
-          _textField(
+          _TextField(
             label: context.l10n.biography,
             initialValue: widget.user.profile?.bio,
             formKey: 'bio',
-            controller: TextEditingController(text: widget.user.profile?.bio),
+            formData: _formData,
             description: context.l10n.biographyDescription,
             maxLength: 400,
             maxLines: 6,
+            textInputAction: TextInputAction.newline,
           ),
           Padding(
             padding: const EdgeInsets.only(bottom: 16.0),
@@ -147,25 +155,26 @@ class _EditProfileFormState extends ConsumerState<_EditProfileForm> {
               },
             ),
           ),
-          _textField(
+          _TextField(
             label: context.l10n.location,
             initialValue: widget.user.profile?.location,
-            controller: TextEditingController(text: widget.user.profile?.location),
+            formData: _formData,
             formKey: 'location',
             maxLength: 80,
           ),
-          _textField(
+          _TextField(
             label: context.l10n.realName,
             initialValue: widget.user.profile?.realName,
             formKey: 'realName',
-            controller: TextEditingController(text: widget.user.profile?.realName),
+            formData: _formData,
             maxLength: 20,
           ),
-          _numericField(
+
+          _NumericField(
             label: context.l10n.xRating('FIDE'),
             initialValue: widget.user.profile?.fideRating,
             formKey: 'fideRating',
-            controller: TextEditingController(text: widget.user.profile?.fideRating?.toString()),
+            formData: _formData,
             validator: (value) {
               if (value != null && (value < 1400 || value > 3000)) {
                 return 'Rating must be between 1400 and 3000';
@@ -173,11 +182,11 @@ class _EditProfileFormState extends ConsumerState<_EditProfileForm> {
               return null;
             },
           ),
-          _numericField(
+          _NumericField(
             label: context.l10n.xRating('USCF'),
             initialValue: widget.user.profile?.uscfRating,
             formKey: 'uscfRating',
-            controller: TextEditingController(text: widget.user.profile?.uscfRating?.toString()),
+            formData: _formData,
             validator: (value) {
               if (value != null && (value < 100 || value > 3000)) {
                 return 'Rating must be between 100 and 3000';
@@ -185,12 +194,11 @@ class _EditProfileFormState extends ConsumerState<_EditProfileForm> {
               return null;
             },
           ),
-          _numericField(
+          _NumericField(
             label: context.l10n.xRating('ECF'),
             initialValue: widget.user.profile?.ecfRating,
             formKey: 'ecfRating',
-            controller: TextEditingController(text: widget.user.profile?.ecfRating?.toString()),
-            textInputAction: TextInputAction.done,
+            formData: _formData,
             validator: (value) {
               if (value != null && (value < 0 || value > 3000)) {
                 return 'Rating must be between 0 and 3000';
@@ -198,11 +206,11 @@ class _EditProfileFormState extends ConsumerState<_EditProfileForm> {
               return null;
             },
           ),
-          _textField(
+          _TextField(
             label: context.l10n.socialMediaLinks,
             initialValue: initialLinks,
             formKey: 'links',
-            controller: TextEditingController(text: initialLinks),
+            formData: _formData,
             maxLength: 3000,
             maxLines: 4,
             textInputAction: TextInputAction.newline,
@@ -257,6 +265,7 @@ class _EditProfileFormState extends ConsumerState<_EditProfileForm> {
                                       context.l10n.success,
                                       type: SnackBarType.success,
                                     );
+                                    Navigator.of(context).pop();
                                   }
                                 },
                               );
@@ -271,89 +280,60 @@ class _EditProfileFormState extends ConsumerState<_EditProfileForm> {
       ),
     );
   }
+}
 
-  Widget _textField({
-    required String label,
-    required String? initialValue,
-    required String formKey,
-    required TextEditingController controller,
-    String? description,
-    int? maxLength,
-    int? maxLines,
-    TextInputAction textInputAction = TextInputAction.next,
-  }) {
-    return Padding(
-      padding: const EdgeInsets.only(bottom: 16.0),
-      child: FormField<String>(
-        initialValue: initialValue,
-        onSaved: (value) {
-          _formData[formKey] = value;
-        },
-        builder: (FormFieldState<String> field) {
-          return Column(
-            crossAxisAlignment: CrossAxisAlignment.start,
-            children: [
-              Text(label, style: Styles.formLabel),
-              const SizedBox(height: 6.0),
-              AdaptiveTextField(
-                maxLength: maxLength,
-                maxLines: maxLines,
-                cupertinoDecoration: _cupertinoTextFieldDecoration.copyWith(
-                  border: Border.all(
-                    color:
-                        field.errorText == null
-                            ? CupertinoColors.systemGrey4
-                            : context.lichessColors.error,
-                    width: 1,
-                  ),
-                ),
-                materialDecoration:
-                    field.errorText != null ? InputDecoration(errorText: field.errorText) : null,
-                textInputAction: textInputAction,
-                controller: controller,
-                onChanged: (value) {
-                  field.didChange(value.trim());
-                },
-              ),
-              if (description != null) ...[
-                const SizedBox(height: 6.0),
-                Text(description, style: Styles.formDescription),
-              ],
-              if (Theme.of(context).platform == TargetPlatform.iOS && field.errorText != null)
-                Padding(
-                  padding: const EdgeInsets.only(top: 6.0),
-                  child: Text(field.errorText!, style: Styles.formError),
-                ),
-            ],
-          );
-        },
-      ),
-    );
+class _NumericField extends StatefulWidget {
+  final String label;
+  final int? initialValue;
+  final String formKey;
+  final String? Function(int?)? validator;
+  final TextInputAction textInputAction;
+  final Map<String, dynamic> formData;
+  const _NumericField({
+    required this.label,
+    required this.initialValue,
+    required this.formKey,
+    required this.validator,
+    this.textInputAction = TextInputAction.next,
+    required this.formData,
+  });
+
+  @override
+  State<_NumericField> createState() => __NumericFieldState();
+}
+
+class __NumericFieldState extends State<_NumericField> {
+  final _controller = TextEditingController();
+  @override
+  void initState() {
+    _controller.text = widget.initialValue?.toString() ?? '';
+    super.initState();
   }
 
-  Widget _numericField({
-    required String label,
-    required int? initialValue,
-    required String formKey,
-    required TextEditingController controller,
-    required String? Function(int?)? validator,
-    TextInputAction textInputAction = TextInputAction.next,
-  }) {
+  @override
+  void dispose() {
+    _controller.dispose();
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
     return Padding(
       padding: const EdgeInsets.only(bottom: 16.0),
       child: FormField<int>(
-        initialValue: initialValue,
+        initialValue: widget.initialValue,
         onSaved: (value) {
-          _formData[formKey] = value;
+          widget.formData[widget.formKey] = value;
         },
-        validator: validator,
+        validator: widget.validator,
         builder: (FormFieldState<int> field) {
           return Column(
             crossAxisAlignment: CrossAxisAlignment.start,
             children: [
-              Text(label, style: Styles.formLabel),
+              Text(widget.label, style: Styles.formLabel),
               const SizedBox(height: 6.0),
               AdaptiveTextField(
+                controller: _controller,
                 keyboardType: TextInputType.number,
                 cupertinoDecoration: _cupertinoTextFieldDecoration.copyWith(
                   border: Border.all(
@@ -366,12 +346,103 @@ class _EditProfileFormState extends ConsumerState<_EditProfileForm> {
                 ),
                 materialDecoration:
                     field.errorText != null ? InputDecoration(errorText: field.errorText) : null,
-                textInputAction: textInputAction,
-                controller: controller,
+                textInputAction: widget.textInputAction,
+
                 onChanged: (value) {
                   field.didChange(int.tryParse(value));
                 },
               ),
+              if (Theme.of(context).platform == TargetPlatform.iOS && field.errorText != null)
+                Padding(
+                  padding: const EdgeInsets.only(top: 6.0),
+                  child: Text(field.errorText!, style: Styles.formError),
+                ),
+            ],
+          );
+        },
+      ),
+    );
+  }
+}
+
+class _TextField extends StatefulWidget {
+  final String label;
+  final String? initialValue;
+  final String formKey;
+  final String? description;
+  final int? maxLength;
+  final int? maxLines;
+  final Map<String, dynamic> formData;
+  final TextInputAction textInputAction;
+  const _TextField({
+    required this.label,
+    required this.initialValue,
+    required this.formKey,
+    required this.formData,
+    this.description,
+    this.maxLength,
+    this.maxLines,
+    this.textInputAction = TextInputAction.next,
+  });
+
+  @override
+  State<_TextField> createState() => __TextFieldState();
+}
+
+class __TextFieldState extends State<_TextField> {
+  final _controller = TextEditingController();
+  @override
+  void initState() {
+    super.initState();
+    _controller.text = widget.initialValue ?? '';
+  }
+
+  @override
+  void dispose() {
+    _controller.dispose();
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Padding(
+      padding: const EdgeInsets.only(bottom: 16.0),
+      child: FormField<String>(
+        initialValue: widget.initialValue,
+        onSaved: (value) {
+          widget.formData[widget.formKey] = value?.trim();
+        },
+
+        builder: (FormFieldState<String> field) {
+          return Column(
+            crossAxisAlignment: CrossAxisAlignment.start,
+            children: [
+              Text(widget.label, style: Styles.formLabel),
+              const SizedBox(height: 6.0),
+              AdaptiveTextField(
+                maxLength: widget.maxLength,
+                maxLines: widget.maxLines,
+                controller: _controller,
+                cupertinoDecoration: _cupertinoTextFieldDecoration.copyWith(
+                  border: Border.all(
+                    color:
+                        field.errorText == null
+                            ? CupertinoColors.systemGrey4
+                            : context.lichessColors.error,
+                    width: 1,
+                  ),
+                ),
+                materialDecoration:
+                    field.errorText != null ? InputDecoration(errorText: field.errorText) : null,
+                textInputAction: widget.textInputAction,
+                onChanged: (value) {
+                  field.didChange(value.trim());
+                },
+              ),
+              if (widget.description != null) ...[
+                const SizedBox(height: 6.0),
+                Text(widget.description!, style: Styles.formDescription),
+              ],
               if (Theme.of(context).platform == TargetPlatform.iOS && field.errorText != null)
                 Padding(
                   padding: const EdgeInsets.only(top: 6.0),


### PR DESCRIPTION
Changes made to the edit profile page include:
 * Removed padding from top and bottom outside ListView and added padding inside ListView.
 * Added scroll behavior and GestureDetector to hide keyboard.
 * Refactored to use widgets instead of functions for performance.
     * Each field owns it controller ensuing dispose is called.
     * closes #1245
 * Made screen pop on successful save.
 * trimmed all text fields before upload.
 * added PopScope to reduce accidental data loss.
Some kind of dialog should be displayed before exiting, but that will require changing the appbar and I haven't quite figured out all the custom widgets to maintain native feel.