### PR TITLE
fix: 1263 puzzle streak reset when app is terminated

### DIFF
--- a/lib/src/model/puzzle/puzzle_controller.dart
+++ b/lib/src/model/puzzle/puzzle_controller.dart
@@ -240,7 +240,9 @@ class PuzzleController extends _$PuzzleController {
   }
 
   void _saveCurrentStreakLocally() {
+    if(state.streak != null) {
     ref.read(streakStorageProvider(initialContext.userId)).saveActiveStreak(state.streak!);
+    }
   }
 
   void _sendStreakResult() {

--- a/lib/src/model/puzzle/puzzle_controller.dart
+++ b/lib/src/model/puzzle/puzzle_controller.dart
@@ -232,13 +232,14 @@ class PuzzleController extends _$PuzzleController {
     return nextPuzzle;
   }
 
-  void loadPuzzle(PuzzleContext nextContext, {PuzzleStreak? nextStreak}) {
+  void onLoadPuzzle(PuzzleContext nextContext, {PuzzleStreak? nextStreak}) {
     ref.read(evaluationServiceProvider).disposeEngine();
 
     state = _loadNewContext(nextContext, nextStreak ?? state.streak);
+    _saveCurrentStreakLocally();
   }
 
-  void saveStreakResultLocally() {
+  void _saveCurrentStreakLocally() {
     ref.read(streakStorageProvider(initialContext.userId)).saveActiveStreak(state.streak!);
   }
 
@@ -341,7 +342,7 @@ class PuzzleController extends _$PuzzleController {
       if (next != null &&
           result == PuzzleResult.win &&
           ref.read(puzzlePreferencesProvider).autoNext) {
-        loadPuzzle(next);
+        onLoadPuzzle(next);
       }
     } else {
       // one fail and streak is over
@@ -366,7 +367,7 @@ class PuzzleController extends _$PuzzleController {
               if (nextContext != null) {
                 await Future<void>.delayed(const Duration(milliseconds: 250));
                 soundService.play(Sound.confirmation);
-                loadPuzzle(
+                onLoadPuzzle(
                   nextContext,
                   nextStreak: state.streak!.copyWith(index: state.streak!.index + 1),
                 );

--- a/lib/src/model/puzzle/puzzle_controller.dart
+++ b/lib/src/model/puzzle/puzzle_controller.dart
@@ -240,8 +240,8 @@ class PuzzleController extends _$PuzzleController {
   }
 
   void _saveCurrentStreakLocally() {
-    if(state.streak != null) {
-    ref.read(streakStorageProvider(initialContext.userId)).saveActiveStreak(state.streak!);
+    if (state.streak != null) {
+      ref.read(streakStorageProvider(initialContext.userId)).saveActiveStreak(state.streak!);
     }
   }
 

--- a/lib/src/view/puzzle/puzzle_screen.dart
+++ b/lib/src/view/puzzle/puzzle_screen.dart
@@ -411,7 +411,7 @@ class _BottomBar extends ConsumerWidget {
           BottomBarButton(
             onTap:
                 puzzleState.mode == PuzzleMode.view && puzzleState.nextContext != null
-                    ? () => ref.read(ctrlProvider.notifier).loadPuzzle(puzzleState.nextContext!)
+                    ? () => ref.read(ctrlProvider.notifier).onLoadPuzzle(puzzleState.nextContext!)
                     : null,
             highlighted: true,
             label: context.l10n.puzzleContinueTraining,
@@ -533,7 +533,7 @@ class _DifficultySelector extends ConsumerWidget {
                                 .read(ctrlProvider.notifier)
                                 .changeDifficulty(selectedDifficulty);
                             if (context.mounted && nextContext != null) {
-                              ref.read(ctrlProvider.notifier).loadPuzzle(nextContext);
+                              ref.read(ctrlProvider.notifier).onLoadPuzzle(nextContext);
                             }
                           });
                         },

--- a/lib/src/view/puzzle/puzzle_session_widget.dart
+++ b/lib/src/view/puzzle/puzzle_session_widget.dart
@@ -107,7 +107,7 @@ class PuzzleSessionWidgetState extends ConsumerState<PuzzleSessionWidget> {
                                     puzzle: puzzle,
                                   );
 
-                                  ref.read(widget.ctrlProvider.notifier).loadPuzzle(nextContext);
+                                  ref.read(widget.ctrlProvider.notifier).onLoadPuzzle(nextContext);
                                 } finally {
                                   if (mounted) {
                                     setState(() {

--- a/lib/src/view/puzzle/streak_screen.dart
+++ b/lib/src/view/puzzle/streak_screen.dart
@@ -192,10 +192,7 @@ class _Body extends ConsumerWidget {
               (context) => YesNoDialog(
                 title: Text(context.l10n.mobileAreYouSure),
                 content: const Text('No worries, your score will be saved locally.'),
-                onYes: () {
-                  ref.read(ctrlProvider.notifier).saveStreakResultLocally();
-                  return Navigator.of(context).pop(true);
-                },
+                onYes: () => Navigator.of(context).pop(true),
                 onNo: () => Navigator.of(context).pop(false),
               ),
         );
@@ -345,7 +342,7 @@ class _RetryFetchPuzzleDialog extends ConsumerWidget {
           if (data != null) {
             ref
                 .read(ctrlProvider.notifier)
-                .loadPuzzle(
+                .onLoadPuzzle(
                   data,
                   nextStreak: state.streak!.copyWith(index: state.streak!.index + 1),
                 );


### PR DESCRIPTION
 https://github.com/lichess-org/mobile/issues/1263 

Fix: Puzzle streak reset when app is terminated #1263

Change:
- Instead of saving the result only when the user leaves the screen, it is now saved after a puzzle is loaded.


Result:

https://github.com/user-attachments/assets/a40337f8-1976-44ef-b8da-b49468d50949

