### PR TITLE
Add flutter lints

### DIFF
--- a/analysis_options.yaml
+++ b/analysis_options.yaml
@@ -7,8 +7,8 @@
 
 # The following lines activate a set of recommended lints.
 include:
-  - package:lint/strict.yaml
   - package:flutter_lints/flutter.yaml
+  - package:lint/strict.yaml
 
 analyzer:
   language:

--- a/analysis_options.yaml
+++ b/analysis_options.yaml
@@ -5,9 +5,10 @@
 # IDEs (https://dart.dev/tools#ides-and-editors). The analyzer can also be
 # invoked from the command line by running `flutter analyze`.
 
-# The following line activates a set of recommended lints for Flutter apps,
-# packages, and plugins designed to encourage good coding practices.
-include: package:lint/strict.yaml
+# The following lines activate a set of recommended lints.
+include:
+  - package:lint/strict.yaml
+  - package:flutter_lints/flutter.yaml
 
 analyzer:
   language:

--- a/lib/src/model/game/archived_game.dart
+++ b/lib/src/model/game/archived_game.dart
@@ -56,7 +56,7 @@ class ArchivedGame with _$ArchivedGame, BaseGame, IndexableSteps implements Base
   /// Create an archived game from the lichess api.
   ///
   /// Currently, those endpoints are supported:
-  /// - GET /game/export/<id>
+  /// - GET /game/export/\<id\>
   factory ArchivedGame.fromServerJson(Map<String, dynamic> json) {
     return _archivedGameFromPick(pick(json).required());
   }
@@ -88,7 +88,7 @@ typedef LightArchivedGameWithPov = ({LightArchivedGame game, Side pov});
 ///
 /// This is commonly used to display a list of games.
 /// Lichess endpoints that return this data:
-/// - GET /api/games/user/<userId>
+/// - GET /api/games/user/\<userId\>
 /// - GET /api/games/export/_ids
 @Freezed(fromJson: true, toJson: true)
 class LightArchivedGame with _$LightArchivedGame {

--- a/lib/src/model/game/playable_game.dart
+++ b/lib/src/model/game/playable_game.dart
@@ -66,8 +66,8 @@ class PlayableGame with _$PlayableGame, BaseGame, IndexableSteps implements Base
   ///
   /// Currently, those endpoints are supported:
   /// - GET /api/mobile/my-games
-  /// - player game socket (/play/<gameFullId>/v6) 'full' event
-  /// - watcher game socket (/watch/<gameId>/<side>/v6) 'full' event
+  /// - player game socket (/play/\<gameFullId\>/v6) 'full' event
+  /// - watcher game socket (/watch/<\gameId\>/<\side\>/v6) 'full' event
   factory PlayableGame.fromServerJson(Map<String, dynamic> json) {
     return _playableGameFromPick(pick(json).required());
   }

--- a/lib/src/utils/focus_detector.dart
+++ b/lib/src/utils/focus_detector.dart
@@ -49,7 +49,7 @@ class FocusDetector extends StatefulWidget {
   final Widget child;
 
   @override
-  _FocusDetectorState createState() => _FocusDetectorState();
+  State<FocusDetector> createState() => _FocusDetectorState();
 }
 
 class _FocusDetectorState extends State<FocusDetector> with WidgetsBindingObserver {

--- a/lib/src/view/account/profile_screen.dart
+++ b/lib/src/view/account/profile_screen.dart
@@ -62,7 +62,7 @@ class ProfileScreen extends ConsumerWidget {
 }
 
 class AccountPerfCards extends ConsumerWidget {
-  const AccountPerfCards({this.padding});
+  const AccountPerfCards({super.key, this.padding});
 
   final EdgeInsetsGeometry? padding;
 

--- a/lib/src/view/analysis/analysis_board.dart
+++ b/lib/src/view/analysis/analysis_board.dart
@@ -16,7 +16,7 @@ import 'package:lichess_mobile/src/widgets/pgn.dart';
 class AnalysisBoard extends ConsumerStatefulWidget {
   const AnalysisBoard(
     this.options,
-    this.boardSize, {
+    this.boardSize, {super.key, 
     this.borderRadius,
     this.enableDrawingShapes = true,
     this.shouldReplaceChildOnUserMove = false,

--- a/lib/src/view/analysis/analysis_board.dart
+++ b/lib/src/view/analysis/analysis_board.dart
@@ -16,7 +16,8 @@ import 'package:lichess_mobile/src/widgets/pgn.dart';
 class AnalysisBoard extends ConsumerStatefulWidget {
   const AnalysisBoard(
     this.options,
-    this.boardSize, {super.key, 
+    this.boardSize, {
+    super.key,
     this.borderRadius,
     this.enableDrawingShapes = true,
     this.shouldReplaceChildOnUserMove = false,

--- a/lib/src/view/analysis/analysis_screen.dart
+++ b/lib/src/view/analysis/analysis_screen.dart
@@ -33,7 +33,7 @@ import 'package:logging/logging.dart';
 final _logger = Logger('AnalysisScreen');
 
 class AnalysisScreen extends ConsumerStatefulWidget {
-  const AnalysisScreen({required this.options, this.enableDrawingShapes = true});
+  const AnalysisScreen({super.key, required this.options, this.enableDrawingShapes = true});
 
   final AnalysisOptions options;
 

--- a/lib/src/view/analysis/analysis_settings.dart
+++ b/lib/src/view/analysis/analysis_settings.dart
@@ -13,7 +13,7 @@ import 'package:lichess_mobile/src/widgets/platform_scaffold.dart';
 import 'package:lichess_mobile/src/widgets/settings.dart';
 
 class AnalysisSettings extends ConsumerWidget {
-  const AnalysisSettings(this.options);
+  const AnalysisSettings(this.options, {super.key});
 
   final AnalysisOptions options;
 

--- a/lib/src/view/analysis/analysis_share_screen.dart
+++ b/lib/src/view/analysis/analysis_share_screen.dart
@@ -17,7 +17,7 @@ import 'package:lichess_mobile/src/widgets/platform_scaffold.dart';
 final _dateFormatter = DateFormat('yyyy.MM.dd');
 
 class AnalysisShareScreen extends StatelessWidget {
-  const AnalysisShareScreen({required this.options});
+  const AnalysisShareScreen({super.key, required this.options});
 
   final AnalysisOptions options;
 

--- a/lib/src/view/analysis/server_analysis.dart
+++ b/lib/src/view/analysis/server_analysis.dart
@@ -17,7 +17,7 @@ import 'package:lichess_mobile/src/widgets/buttons.dart';
 import 'package:lichess_mobile/src/widgets/feedback.dart';
 
 class ServerAnalysisSummary extends ConsumerWidget {
-  const ServerAnalysisSummary(this.options);
+  const ServerAnalysisSummary(this.options, {super.key});
 
   final AnalysisOptions options;
 
@@ -295,7 +295,7 @@ class _SummaryPlayerName extends StatelessWidget {
 }
 
 class AcplChart extends ConsumerWidget {
-  const AcplChart(this.options);
+  const AcplChart(this.options, {super.key});
 
   final AnalysisOptions options;
 

--- a/lib/src/view/analysis/tree_view.dart
+++ b/lib/src/view/analysis/tree_view.dart
@@ -7,7 +7,7 @@ import 'package:lichess_mobile/src/widgets/pgn.dart';
 const kOpeningHeaderHeight = 32.0;
 
 class AnalysisTreeView extends ConsumerWidget {
-  const AnalysisTreeView(this.options);
+  const AnalysisTreeView(this.options, {super.key});
 
   final AnalysisOptions options;
 

--- a/lib/src/view/broadcast/broadcast_boards_tab.dart
+++ b/lib/src/view/broadcast/broadcast_boards_tab.dart
@@ -24,7 +24,8 @@ const _kPlayerWidgetPadding = EdgeInsets.symmetric(vertical: 5.0);
 
 /// A tab that displays the live games of a broadcast round.
 class BroadcastBoardsTab extends ConsumerWidget {
-  const BroadcastBoardsTab({super.key, 
+  const BroadcastBoardsTab({
+    super.key,
     required this.tournamentId,
     required this.roundId,
     required this.tournamentSlug,
@@ -79,7 +80,8 @@ class BroadcastBoardsTab extends ConsumerWidget {
 }
 
 class BroadcastPreview extends StatelessWidget {
-  const BroadcastPreview({super.key, 
+  const BroadcastPreview({
+    super.key,
     required this.tournamentId,
     required this.roundId,
     required this.games,

--- a/lib/src/view/broadcast/broadcast_boards_tab.dart
+++ b/lib/src/view/broadcast/broadcast_boards_tab.dart
@@ -24,7 +24,7 @@ const _kPlayerWidgetPadding = EdgeInsets.symmetric(vertical: 5.0);
 
 /// A tab that displays the live games of a broadcast round.
 class BroadcastBoardsTab extends ConsumerWidget {
-  const BroadcastBoardsTab({
+  const BroadcastBoardsTab({super.key, 
     required this.tournamentId,
     required this.roundId,
     required this.tournamentSlug,
@@ -79,7 +79,7 @@ class BroadcastBoardsTab extends ConsumerWidget {
 }
 
 class BroadcastPreview extends StatelessWidget {
-  const BroadcastPreview({
+  const BroadcastPreview({super.key, 
     required this.tournamentId,
     required this.roundId,
     required this.games,
@@ -88,7 +88,7 @@ class BroadcastPreview extends StatelessWidget {
     required this.roundSlug,
   });
 
-  const BroadcastPreview.loading()
+  const BroadcastPreview.loading({super.key})
     : tournamentId = const BroadcastTournamentId(''),
       roundId = const BroadcastRoundId(''),
       games = null,

--- a/lib/src/view/broadcast/broadcast_game_bottom_bar.dart
+++ b/lib/src/view/broadcast/broadcast_game_bottom_bar.dart
@@ -15,7 +15,7 @@ import 'package:lichess_mobile/src/widgets/buttons.dart';
 import 'package:lichess_mobile/src/widgets/feedback.dart';
 
 class BroadcastGameBottomBar extends ConsumerWidget {
-  const BroadcastGameBottomBar({
+  const BroadcastGameBottomBar({super.key, 
     required this.roundId,
     required this.gameId,
     this.tournamentSlug,

--- a/lib/src/view/broadcast/broadcast_game_bottom_bar.dart
+++ b/lib/src/view/broadcast/broadcast_game_bottom_bar.dart
@@ -15,7 +15,8 @@ import 'package:lichess_mobile/src/widgets/buttons.dart';
 import 'package:lichess_mobile/src/widgets/feedback.dart';
 
 class BroadcastGameBottomBar extends ConsumerWidget {
-  const BroadcastGameBottomBar({super.key, 
+  const BroadcastGameBottomBar({
+    super.key,
     required this.roundId,
     required this.gameId,
     this.tournamentSlug,

--- a/lib/src/view/broadcast/broadcast_game_screen.dart
+++ b/lib/src/view/broadcast/broadcast_game_screen.dart
@@ -39,7 +39,8 @@ class BroadcastGameScreen extends ConsumerStatefulWidget {
   final String? roundSlug;
   final String? title;
 
-  const BroadcastGameScreen({super.key, 
+  const BroadcastGameScreen({
+    super.key,
     required this.tournamentId,
     required this.roundId,
     required this.gameId,

--- a/lib/src/view/broadcast/broadcast_game_screen.dart
+++ b/lib/src/view/broadcast/broadcast_game_screen.dart
@@ -39,7 +39,7 @@ class BroadcastGameScreen extends ConsumerStatefulWidget {
   final String? roundSlug;
   final String? title;
 
-  const BroadcastGameScreen({
+  const BroadcastGameScreen({super.key, 
     required this.tournamentId,
     required this.roundId,
     required this.gameId,

--- a/lib/src/view/broadcast/broadcast_game_settings.dart
+++ b/lib/src/view/broadcast/broadcast_game_settings.dart
@@ -14,7 +14,7 @@ import 'package:lichess_mobile/src/widgets/platform_scaffold.dart';
 import 'package:lichess_mobile/src/widgets/settings.dart';
 
 class BroadcastGameSettings extends ConsumerWidget {
-  const BroadcastGameSettings(this.roundId, this.gameId);
+  const BroadcastGameSettings(this.roundId, this.gameId, {super.key});
 
   final BroadcastRoundId roundId;
   final BroadcastGameId gameId;

--- a/lib/src/view/broadcast/broadcast_game_tree_view.dart
+++ b/lib/src/view/broadcast/broadcast_game_tree_view.dart
@@ -8,7 +8,7 @@ import 'package:lichess_mobile/src/widgets/pgn.dart';
 const kOpeningHeaderHeight = 32.0;
 
 class BroadcastGameTreeView extends ConsumerWidget {
-  const BroadcastGameTreeView(this.roundId, this.gameId);
+  const BroadcastGameTreeView(this.roundId, this.gameId, {super.key});
 
   final BroadcastRoundId roundId;
   final BroadcastGameId gameId;

--- a/lib/src/view/broadcast/broadcast_list_screen.dart
+++ b/lib/src/view/broadcast/broadcast_list_screen.dart
@@ -281,7 +281,7 @@ class BroadcastCard extends StatefulWidget {
   final ImageColorWorker worker;
   final double aspectRatio;
 
-  const BroadcastCard.loading({required this.worker, required this.aspectRatio})
+  const BroadcastCard.loading({super.key, required this.worker, required this.aspectRatio})
     : broadcast = const Broadcast(
         tour: BroadcastTournamentData(
           id: BroadcastTournamentId(''),

--- a/lib/src/view/broadcast/broadcast_player_results_screen.dart
+++ b/lib/src/view/broadcast/broadcast_player_results_screen.dart
@@ -27,8 +27,9 @@ class BroadcastPlayerResultsScreen extends StatelessWidget {
     this.tournamentId,
     this.playerId,
     this.playerTitle,
-    this.playerName,
-  );
+    this.playerName, {
+    super.key,
+  });
 
   @override
   Widget build(BuildContext context) {

--- a/lib/src/view/broadcast/broadcast_player_widget.dart
+++ b/lib/src/view/broadcast/broadcast_player_widget.dart
@@ -3,7 +3,7 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:lichess_mobile/src/styles/styles.dart';
 
 class BroadcastPlayerWidget extends ConsumerWidget {
-  const BroadcastPlayerWidget({
+  const BroadcastPlayerWidget({super.key, 
     this.federation,
     required this.title,
     required this.name,

--- a/lib/src/view/broadcast/broadcast_player_widget.dart
+++ b/lib/src/view/broadcast/broadcast_player_widget.dart
@@ -3,7 +3,8 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:lichess_mobile/src/styles/styles.dart';
 
 class BroadcastPlayerWidget extends ConsumerWidget {
-  const BroadcastPlayerWidget({super.key, 
+  const BroadcastPlayerWidget({
+    super.key,
     this.federation,
     required this.title,
     required this.name,

--- a/lib/src/view/broadcast/broadcast_players_tab.dart
+++ b/lib/src/view/broadcast/broadcast_players_tab.dart
@@ -16,7 +16,7 @@ import 'package:lichess_mobile/src/widgets/progression_widget.dart';
 
 /// A tab that displays the players participating in a broadcast tournament.
 class BroadcastPlayersTab extends ConsumerWidget {
-  const BroadcastPlayersTab({required this.tournamentId});
+  const BroadcastPlayersTab({super.key, required this.tournamentId});
 
   final BroadcastTournamentId tournamentId;
 
@@ -52,7 +52,7 @@ const _kTableRowPadding = EdgeInsets.symmetric(
 const _kHeaderTextStyle = TextStyle(fontWeight: FontWeight.bold, overflow: TextOverflow.ellipsis);
 
 class PlayersList extends ConsumerStatefulWidget {
-  const PlayersList(this.players, this.tournamentId);
+  const PlayersList(this.players, this.tournamentId, {super.key});
 
   final IList<BroadcastPlayerExtended> players;
   final BroadcastTournamentId tournamentId;

--- a/lib/src/view/broadcast/broadcast_round_screen.dart
+++ b/lib/src/view/broadcast/broadcast_round_screen.dart
@@ -23,10 +23,10 @@ import 'package:lichess_mobile/src/widgets/shimmer.dart';
 class BroadcastRoundScreen extends ConsumerStatefulWidget {
   final Broadcast broadcast;
 
-  const BroadcastRoundScreen({required this.broadcast});
+  const BroadcastRoundScreen({super.key, required this.broadcast});
 
   @override
-  _BroadcastRoundScreenState createState() => _BroadcastRoundScreenState();
+  ConsumerState<BroadcastRoundScreen> createState() => _BroadcastRoundScreenState();
 }
 
 enum _CupertinoView { overview, boards, players }

--- a/lib/src/view/clock/custom_clock_settings.dart
+++ b/lib/src/view/clock/custom_clock_settings.dart
@@ -10,7 +10,12 @@ import 'package:lichess_mobile/src/widgets/list.dart';
 import 'package:lichess_mobile/src/widgets/non_linear_slider.dart';
 
 class CustomClockSettings extends StatefulWidget {
-  const CustomClockSettings({super.key, required this.onSubmit, required this.player, required this.clock});
+  const CustomClockSettings({
+    super.key,
+    required this.onSubmit,
+    required this.player,
+    required this.clock,
+  });
 
   final Side player;
   final TimeIncrement clock;

--- a/lib/src/view/clock/custom_clock_settings.dart
+++ b/lib/src/view/clock/custom_clock_settings.dart
@@ -10,7 +10,7 @@ import 'package:lichess_mobile/src/widgets/list.dart';
 import 'package:lichess_mobile/src/widgets/non_linear_slider.dart';
 
 class CustomClockSettings extends StatefulWidget {
-  const CustomClockSettings({required this.onSubmit, required this.player, required this.clock});
+  const CustomClockSettings({super.key, required this.onSubmit, required this.player, required this.clock});
 
   final Side player;
   final TimeIncrement clock;

--- a/lib/src/view/coordinate_training/coordinate_display.dart
+++ b/lib/src/view/coordinate_training/coordinate_display.dart
@@ -10,7 +10,7 @@ const double _kCurrCoordOpacity = 0.9;
 const double _kNextCoordOpacity = 0.7;
 
 class CoordinateDisplay extends ConsumerStatefulWidget {
-  const CoordinateDisplay({required this.currentCoord, required this.nextCoord});
+  const CoordinateDisplay({super.key, required this.currentCoord, required this.nextCoord});
 
   final Square currentCoord;
 

--- a/lib/src/view/coordinate_training/coordinate_training_screen.dart
+++ b/lib/src/view/coordinate_training/coordinate_training_screen.dart
@@ -353,7 +353,7 @@ class _Button extends StatelessWidget {
 }
 
 class SettingsBottomSheet extends ConsumerWidget {
-  const SettingsBottomSheet();
+  const SettingsBottomSheet({super.key});
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {

--- a/lib/src/view/engine/engine_depth.dart
+++ b/lib/src/view/engine/engine_depth.dart
@@ -12,7 +12,7 @@ import 'package:lichess_mobile/src/widgets/list.dart';
 import 'package:popover/popover.dart';
 
 class EngineDepth extends ConsumerWidget {
-  const EngineDepth({this.defaultEval});
+  const EngineDepth({super.key, this.defaultEval});
 
   final ClientEval? defaultEval;
 

--- a/lib/src/view/engine/engine_gauge.dart
+++ b/lib/src/view/engine/engine_gauge.dart
@@ -31,7 +31,7 @@ typedef EngineGaugeParams =
     });
 
 class EngineGauge extends ConsumerWidget {
-  const EngineGauge({required this.displayMode, required this.params});
+  const EngineGauge({super.key, required this.displayMode, required this.params});
 
   final EngineGaugeDisplayMode displayMode;
 

--- a/lib/src/view/engine/engine_lines.dart
+++ b/lib/src/view/engine/engine_lines.dart
@@ -11,7 +11,7 @@ import 'package:lichess_mobile/src/view/engine/engine_gauge.dart';
 import 'package:lichess_mobile/src/widgets/buttons.dart';
 
 class EngineLines extends ConsumerWidget {
-  const EngineLines({required this.onTapMove, required this.clientEval, required this.isGameOver});
+  const EngineLines({super.key, required this.onTapMove, required this.clientEval, required this.isGameOver});
   final void Function(NormalMove move) onTapMove;
   final ClientEval? clientEval;
   final bool isGameOver;
@@ -49,9 +49,9 @@ class EngineLines extends ConsumerWidget {
 }
 
 class Engineline extends ConsumerWidget {
-  const Engineline(this.onTapMove, this.fromPosition, this.pvData);
+  const Engineline(this.onTapMove, this.fromPosition, this.pvData, {super.key});
 
-  const Engineline.empty()
+  const Engineline.empty({super.key})
     : onTapMove = null,
       pvData = const PvData(moves: IListConst([])),
       fromPosition = Chess.initial;

--- a/lib/src/view/engine/engine_lines.dart
+++ b/lib/src/view/engine/engine_lines.dart
@@ -11,7 +11,12 @@ import 'package:lichess_mobile/src/view/engine/engine_gauge.dart';
 import 'package:lichess_mobile/src/widgets/buttons.dart';
 
 class EngineLines extends ConsumerWidget {
-  const EngineLines({super.key, required this.onTapMove, required this.clientEval, required this.isGameOver});
+  const EngineLines({
+    super.key,
+    required this.onTapMove,
+    required this.clientEval,
+    required this.isGameOver,
+  });
   final void Function(NormalMove move) onTapMove;
   final ClientEval? clientEval;
   final bool isGameOver;

--- a/lib/src/view/game/game_body.dart
+++ b/lib/src/view/game/game_body.dart
@@ -46,7 +46,7 @@ import 'package:lichess_mobile/src/widgets/yes_no_dialog.dart';
 /// Handles the immersive mode through focus detection, and the pop scope to
 /// prevent the user from going back to the previous screen.
 class GameBody extends ConsumerWidget {
-  const GameBody({
+  const GameBody({super.key, 
     required this.id,
     required this.whiteClockKey,
     required this.blackClockKey,

--- a/lib/src/view/game/game_body.dart
+++ b/lib/src/view/game/game_body.dart
@@ -46,7 +46,8 @@ import 'package:lichess_mobile/src/widgets/yes_no_dialog.dart';
 /// Handles the immersive mode through focus detection, and the pop scope to
 /// prevent the user from going back to the previous screen.
 class GameBody extends ConsumerWidget {
-  const GameBody({super.key, 
+  const GameBody({
+    super.key,
     required this.id,
     required this.whiteClockKey,
     required this.blackClockKey,

--- a/lib/src/view/game/game_list_tile.dart
+++ b/lib/src/view/game/game_list_tile.dart
@@ -29,7 +29,8 @@ final _dateFormatter = DateFormat.yMMMd().add_Hm();
 
 /// A list tile that shows game info.
 class GameListTile extends StatelessWidget {
-  const GameListTile({super.key, 
+  const GameListTile({
+    super.key,
     required this.game,
     required this.mySide,
     required this.opponentTitle,

--- a/lib/src/view/game/game_list_tile.dart
+++ b/lib/src/view/game/game_list_tile.dart
@@ -29,7 +29,7 @@ final _dateFormatter = DateFormat.yMMMd().add_Hm();
 
 /// A list tile that shows game info.
 class GameListTile extends StatelessWidget {
-  const GameListTile({
+  const GameListTile({super.key, 
     required this.game,
     required this.mySide,
     required this.opponentTitle,
@@ -359,7 +359,7 @@ class _ContextMenu extends ConsumerWidget {
 
 /// A list tile that shows extended game info including a result icon and analysis icon.
 class ExtendedGameListTile extends StatelessWidget {
-  const ExtendedGameListTile({required this.item, this.userId, this.padding});
+  const ExtendedGameListTile({super.key, required this.item, this.userId, this.padding});
 
   final LightArchivedGameWithPov item;
   final UserId? userId;

--- a/lib/src/view/game/game_loading_board.dart
+++ b/lib/src/view/game/game_loading_board.dart
@@ -15,7 +15,7 @@ import 'package:lichess_mobile/src/widgets/platform.dart';
 import 'package:lichess_mobile/src/widgets/user_full_name.dart';
 
 class LobbyScreenLoadingContent extends StatelessWidget {
-  const LobbyScreenLoadingContent(this.seek, this.cancelGameCreation);
+  const LobbyScreenLoadingContent(this.seek, this.cancelGameCreation, {super.key});
 
   final GameSeek seek;
   final Future<void> Function() cancelGameCreation;
@@ -92,7 +92,7 @@ class LobbyScreenLoadingContent extends StatelessWidget {
 }
 
 class ChallengeLoadingContent extends StatelessWidget {
-  const ChallengeLoadingContent(this.challenge, this.cancelChallenge);
+  const ChallengeLoadingContent(this.challenge, this.cancelChallenge, {super.key});
 
   final ChallengeRequest challenge;
   final Future<void> Function() cancelChallenge;
@@ -188,7 +188,7 @@ class StandaloneGameLoadingBoard extends StatelessWidget {
 }
 
 class LoadGameError extends StatelessWidget {
-  const LoadGameError(this.errorMessage);
+  const LoadGameError(this.errorMessage, {super.key});
 
   final String errorMessage;
 
@@ -226,7 +226,7 @@ class LoadGameError extends StatelessWidget {
 
 /// A board that shows a message that a challenge has been declined.
 class ChallengeDeclinedBoard extends StatelessWidget {
-  const ChallengeDeclinedBoard({required this.declineReason, required this.challenge});
+  const ChallengeDeclinedBoard({super.key, required this.declineReason, required this.challenge});
 
   final String declineReason;
   final Challenge challenge;

--- a/lib/src/view/game/game_player.dart
+++ b/lib/src/view/game/game_player.dart
@@ -311,7 +311,7 @@ class _MoveExpirationState extends ConsumerState<MoveExpiration> {
 }
 
 class MaterialDifferenceDisplay extends StatelessWidget {
-  const MaterialDifferenceDisplay({
+  const MaterialDifferenceDisplay({super.key, 
     required this.materialDiff,
     this.materialDifferenceFormat = MaterialDifferenceFormat.materialDifference,
   });

--- a/lib/src/view/game/game_player.dart
+++ b/lib/src/view/game/game_player.dart
@@ -311,7 +311,8 @@ class _MoveExpirationState extends ConsumerState<MoveExpiration> {
 }
 
 class MaterialDifferenceDisplay extends StatelessWidget {
-  const MaterialDifferenceDisplay({super.key, 
+  const MaterialDifferenceDisplay({
+    super.key,
     required this.materialDiff,
     this.materialDifferenceFormat = MaterialDifferenceFormat.materialDifference,
   });

--- a/lib/src/view/game/game_screen.dart
+++ b/lib/src/view/game/game_screen.dart
@@ -56,13 +56,13 @@ class GameScreen extends ConsumerStatefulWidget {
   /// The date of the last move played in the game. If null, the game is in progress.
   final DateTime? lastMoveAt;
 
-  _GameSource get source {
+  GameSource get source {
     if (initialGameId != null) {
-      return _GameSource.game;
+      return GameSource.game;
     } else if (challenge != null) {
-      return _GameSource.challenge;
+      return GameSource.challenge;
     } else {
-      return _GameSource.lobby;
+      return GameSource.lobby;
     }
   }
 
@@ -70,7 +70,7 @@ class GameScreen extends ConsumerStatefulWidget {
   ConsumerState<GameScreen> createState() => _GameScreenState();
 }
 
-enum _GameSource { lobby, challenge, game }
+enum GameSource { lobby, challenge, game }
 
 class _GameScreenState extends ConsumerState<GameScreen> with RouteAware {
   final _whiteClockKey = GlobalKey(debugLabel: 'whiteClockOnGameScreen');
@@ -94,7 +94,7 @@ class _GameScreenState extends ConsumerState<GameScreen> with RouteAware {
 
   @override
   void didPop() {
-    if (mounted && (widget.source == _GameSource.lobby || widget.source == _GameSource.challenge)) {
+    if (mounted && (widget.source == GameSource.lobby || widget.source == GameSource.challenge)) {
       ref.invalidate(myRecentGamesProvider);
       ref.invalidate(accountProvider);
     }
@@ -126,7 +126,7 @@ class _GameScreenState extends ConsumerState<GameScreen> with RouteAware {
                         ref.read(provider.notifier).loadGame(id);
                       },
                       onNewOpponentCallback: (game) {
-                        if (widget.source == _GameSource.lobby) {
+                        if (widget.source == GameSource.lobby) {
                           ref.read(provider.notifier).newOpponent();
                         } else {
                           final savedSetup = ref.read(gameSetupPreferencesProvider);

--- a/lib/src/view/game/message_screen.dart
+++ b/lib/src/view/game/message_screen.dart
@@ -19,7 +19,7 @@ class MessageScreen extends ConsumerStatefulWidget {
   final Widget title;
   final LightUser? me;
 
-  const MessageScreen({required this.id, required this.title, this.me});
+  const MessageScreen({super.key, required this.id, required this.title, this.me});
 
   @override
   ConsumerState<ConsumerStatefulWidget> createState() => _MessageScreenState();

--- a/lib/src/view/home/home_tab_screen.dart
+++ b/lib/src/view/home/home_tab_screen.dart
@@ -741,7 +741,7 @@ class _OfflineCorrespondencePreview extends ConsumerWidget {
 }
 
 class PreviewGameList<T> extends StatelessWidget {
-  const PreviewGameList({
+  const PreviewGameList({super.key, 
     required this.list,
     required this.builder,
     required this.moreScreenBuilder,

--- a/lib/src/view/home/home_tab_screen.dart
+++ b/lib/src/view/home/home_tab_screen.dart
@@ -741,7 +741,8 @@ class _OfflineCorrespondencePreview extends ConsumerWidget {
 }
 
 class PreviewGameList<T> extends StatelessWidget {
-  const PreviewGameList({super.key, 
+  const PreviewGameList({
+    super.key,
     required this.list,
     required this.builder,
     required this.moreScreenBuilder,

--- a/lib/src/view/opening_explorer/opening_explorer_screen.dart
+++ b/lib/src/view/opening_explorer/opening_explorer_screen.dart
@@ -24,7 +24,7 @@ import 'package:lichess_mobile/src/widgets/platform.dart';
 const _kTabletBoardRadius = BorderRadius.all(Radius.circular(4.0));
 
 class OpeningExplorerScreen extends ConsumerWidget {
-  const OpeningExplorerScreen({required this.options});
+  const OpeningExplorerScreen({super.key, required this.options});
 
   final AnalysisOptions options;
 

--- a/lib/src/view/opening_explorer/opening_explorer_settings.dart
+++ b/lib/src/view/opening_explorer/opening_explorer_settings.dart
@@ -13,7 +13,7 @@ import 'package:lichess_mobile/src/widgets/adaptive_bottom_sheet.dart';
 import 'package:lichess_mobile/src/widgets/list.dart';
 
 class OpeningExplorerSettings extends ConsumerWidget {
-  const OpeningExplorerSettings();
+  const OpeningExplorerSettings({super.key});
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {

--- a/lib/src/view/opening_explorer/opening_explorer_view.dart
+++ b/lib/src/view/opening_explorer/opening_explorer_view.dart
@@ -19,7 +19,7 @@ import 'package:lichess_mobile/src/widgets/shimmer.dart';
 ///
 /// Network requests are debounced and cached to avoid unnecessary requests.
 class OpeningExplorerView extends ConsumerStatefulWidget {
-  const OpeningExplorerView({
+  const OpeningExplorerView({super.key, 
     required this.position,
     required this.onMoveSelected,
     this.opening,

--- a/lib/src/view/opening_explorer/opening_explorer_view.dart
+++ b/lib/src/view/opening_explorer/opening_explorer_view.dart
@@ -19,7 +19,8 @@ import 'package:lichess_mobile/src/widgets/shimmer.dart';
 ///
 /// Network requests are debounced and cached to avoid unnecessary requests.
 class OpeningExplorerView extends ConsumerStatefulWidget {
-  const OpeningExplorerView({super.key, 
+  const OpeningExplorerView({
+    super.key,
     required this.position,
     required this.onMoveSelected,
     this.opening,

--- a/lib/src/view/opening_explorer/opening_explorer_widgets.dart
+++ b/lib/src/view/opening_explorer/opening_explorer_widgets.dart
@@ -72,7 +72,7 @@ class OpeningNameHeader extends StatelessWidget {
 
 /// Table of moves for the opening explorer.
 class OpeningExplorerMoveTable extends ConsumerWidget {
-  const OpeningExplorerMoveTable({
+  const OpeningExplorerMoveTable({super.key, 
     required this.moves,
     required this.whiteWins,
     required this.draws,
@@ -81,7 +81,7 @@ class OpeningExplorerMoveTable extends ConsumerWidget {
     this.isIndexing = false,
   }) : _isLoading = false;
 
-  const OpeningExplorerMoveTable.loading()
+  const OpeningExplorerMoveTable.loading({super.key})
     : _isLoading = true,
       moves = const IListConst([]),
       whiteWins = 0,
@@ -274,7 +274,7 @@ class OpeningExplorerMoveTable extends ConsumerWidget {
 }
 
 class IndexingIndicator extends StatefulWidget {
-  const IndexingIndicator();
+  const IndexingIndicator({super.key});
 
   @override
   State<IndexingIndicator> createState() => _IndexingIndicatorState();

--- a/lib/src/view/opening_explorer/opening_explorer_widgets.dart
+++ b/lib/src/view/opening_explorer/opening_explorer_widgets.dart
@@ -72,7 +72,8 @@ class OpeningNameHeader extends StatelessWidget {
 
 /// Table of moves for the opening explorer.
 class OpeningExplorerMoveTable extends ConsumerWidget {
-  const OpeningExplorerMoveTable({super.key, 
+  const OpeningExplorerMoveTable({
+    super.key,
     required this.moves,
     required this.whiteWins,
     required this.draws,

--- a/lib/src/view/over_the_board/configure_over_the_board_game.dart
+++ b/lib/src/view/over_the_board/configure_over_the_board_game.dart
@@ -154,7 +154,7 @@ void showConfigureDisplaySettings(BuildContext context) {
 }
 
 class OverTheBoardDisplaySettings extends ConsumerWidget {
-  const OverTheBoardDisplaySettings();
+  const OverTheBoardDisplaySettings({super.key});
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {

--- a/lib/src/view/play/create_challenge_screen.dart
+++ b/lib/src/view/play/create_challenge_screen.dart
@@ -31,7 +31,7 @@ import 'package:lichess_mobile/src/widgets/non_linear_slider.dart';
 import 'package:lichess_mobile/src/widgets/platform_scaffold.dart';
 
 class CreateChallengeScreen extends StatelessWidget {
-  const CreateChallengeScreen(this.user);
+  const CreateChallengeScreen(this.user, {super.key});
 
   final LightUser user;
 

--- a/lib/src/view/play/create_custom_game_screen.dart
+++ b/lib/src/view/play/create_custom_game_screen.dart
@@ -37,7 +37,7 @@ import 'package:lichess_mobile/src/widgets/platform.dart';
 enum _ViewMode { create, challenges }
 
 class CreateCustomGameScreen extends StatelessWidget {
-  const CreateCustomGameScreen();
+  const CreateCustomGameScreen({super.key});
 
   @override
   Widget build(BuildContext context) {

--- a/lib/src/view/play/create_game_options.dart
+++ b/lib/src/view/play/create_game_options.dart
@@ -14,7 +14,7 @@ import 'package:lichess_mobile/src/widgets/list.dart';
 
 /// A widget that displays the options for creating a game.
 class CreateGameOptions extends ConsumerWidget {
-  const CreateGameOptions();
+  const CreateGameOptions({super.key});
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {

--- a/lib/src/view/play/online_bots_screen.dart
+++ b/lib/src/view/play/online_bots_screen.dart
@@ -37,7 +37,7 @@ final _onlineBotsProvider = FutureProvider.autoDispose<IList<User>>((ref) async 
 });
 
 class OnlineBotsScreen extends StatelessWidget {
-  const OnlineBotsScreen();
+  const OnlineBotsScreen({super.key});
 
   @override
   Widget build(BuildContext context) {

--- a/lib/src/view/play/play_screen.dart
+++ b/lib/src/view/play/play_screen.dart
@@ -7,7 +7,7 @@ import 'package:lichess_mobile/src/view/play/quick_game_button.dart';
 import 'package:lichess_mobile/src/widgets/platform_scaffold.dart';
 
 class PlayScreen extends StatelessWidget {
-  const PlayScreen();
+  const PlayScreen({super.key});
 
   @override
   Widget build(BuildContext context) {

--- a/lib/src/view/play/quick_game_button.dart
+++ b/lib/src/view/play/quick_game_button.dart
@@ -15,7 +15,7 @@ import 'package:lichess_mobile/src/widgets/adaptive_bottom_sheet.dart';
 import 'package:lichess_mobile/src/widgets/buttons.dart';
 
 class QuickGameButton extends ConsumerWidget {
-  const QuickGameButton();
+  const QuickGameButton({super.key});
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {

--- a/lib/src/view/play/quick_game_matrix.dart
+++ b/lib/src/view/play/quick_game_matrix.dart
@@ -16,7 +16,7 @@ import 'package:lichess_mobile/src/widgets/buttons.dart';
 const _kMatrixSpacing = 4.0;
 
 class QuickGameMatrix extends StatelessWidget {
-  const QuickGameMatrix();
+  const QuickGameMatrix({super.key});
 
   @override
   Widget build(BuildContext context) {

--- a/lib/src/view/puzzle/dashboard_screen.dart
+++ b/lib/src/view/puzzle/dashboard_screen.dart
@@ -36,11 +36,13 @@ class _Body extends ConsumerWidget {
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
-    return ListView(children: [PuzzleDashboardWidget()]);
+    return ListView(children: const [PuzzleDashboardWidget()]);
   }
 }
 
 class PuzzleDashboardWidget extends ConsumerWidget {
+  const PuzzleDashboardWidget({super.key});
+
   @override
   Widget build(BuildContext context, WidgetRef ref) {
     final puzzleDashboard = ref.watch(puzzleDashboardProvider(ref.watch(daysProvider).days));
@@ -157,7 +159,7 @@ class PuzzleDashboardWidget extends ConsumerWidget {
 }
 
 class PuzzleChart extends StatelessWidget {
-  const PuzzleChart(this.puzzleData);
+  const PuzzleChart(this.puzzleData, {super.key});
 
   final List<PuzzleDashboardData> puzzleData;
 
@@ -192,7 +194,7 @@ class PuzzleChart extends StatelessWidget {
 }
 
 class DaysSelector extends ConsumerWidget {
-  const DaysSelector();
+  const DaysSelector({super.key});
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {

--- a/lib/src/view/puzzle/puzzle_feedback_widget.dart
+++ b/lib/src/view/puzzle/puzzle_feedback_widget.dart
@@ -11,7 +11,7 @@ import 'package:lichess_mobile/src/utils/string.dart';
 import 'package:lichess_mobile/src/view/account/rating_pref_aware.dart';
 
 class PuzzleFeedbackWidget extends ConsumerWidget {
-  const PuzzleFeedbackWidget({required this.puzzle, required this.state, required this.onStreak});
+  const PuzzleFeedbackWidget({super.key, required this.puzzle, required this.state, required this.onStreak});
 
   final Puzzle puzzle;
   final PuzzleState state;

--- a/lib/src/view/puzzle/puzzle_feedback_widget.dart
+++ b/lib/src/view/puzzle/puzzle_feedback_widget.dart
@@ -11,7 +11,12 @@ import 'package:lichess_mobile/src/utils/string.dart';
 import 'package:lichess_mobile/src/view/account/rating_pref_aware.dart';
 
 class PuzzleFeedbackWidget extends ConsumerWidget {
-  const PuzzleFeedbackWidget({super.key, required this.puzzle, required this.state, required this.onStreak});
+  const PuzzleFeedbackWidget({
+    super.key,
+    required this.puzzle,
+    required this.state,
+    required this.onStreak,
+  });
 
   final Puzzle puzzle;
   final PuzzleState state;

--- a/lib/src/view/puzzle/puzzle_history_screen.dart
+++ b/lib/src/view/puzzle/puzzle_history_screen.dart
@@ -63,7 +63,7 @@ class PuzzleHistoryPreview extends ConsumerWidget {
 
 /// A screen that displays the full puzzle history.
 class PuzzleHistoryScreen extends StatelessWidget {
-  const PuzzleHistoryScreen();
+  const PuzzleHistoryScreen({super.key});
 
   @override
   Widget build(BuildContext context) {
@@ -179,7 +179,7 @@ class _BodyState extends ConsumerState<_Body> {
 }
 
 class PuzzleHistoryBoard extends ConsumerWidget {
-  const PuzzleHistoryBoard(this.puzzle, this.boardWidth);
+  const PuzzleHistoryBoard(this.puzzle, this.boardWidth, {super.key});
 
   final PuzzleHistoryEntry puzzle;
   final double boardWidth;

--- a/lib/src/view/puzzle/puzzle_session_widget.dart
+++ b/lib/src/view/puzzle/puzzle_session_widget.dart
@@ -14,7 +14,11 @@ import 'package:lichess_mobile/src/utils/screen.dart';
 import 'package:lichess_mobile/src/view/account/rating_pref_aware.dart';
 
 class PuzzleSessionWidget extends ConsumerStatefulWidget {
-  const PuzzleSessionWidget({super.key, required this.initialPuzzleContext, required this.ctrlProvider});
+  const PuzzleSessionWidget({
+    super.key,
+    required this.initialPuzzleContext,
+    required this.ctrlProvider,
+  });
 
   final PuzzleContext initialPuzzleContext;
   final PuzzleControllerProvider ctrlProvider;

--- a/lib/src/view/puzzle/puzzle_session_widget.dart
+++ b/lib/src/view/puzzle/puzzle_session_widget.dart
@@ -14,7 +14,7 @@ import 'package:lichess_mobile/src/utils/screen.dart';
 import 'package:lichess_mobile/src/view/account/rating_pref_aware.dart';
 
 class PuzzleSessionWidget extends ConsumerStatefulWidget {
-  const PuzzleSessionWidget({required this.initialPuzzleContext, required this.ctrlProvider});
+  const PuzzleSessionWidget({super.key, required this.initialPuzzleContext, required this.ctrlProvider});
 
   final PuzzleContext initialPuzzleContext;
   final PuzzleControllerProvider ctrlProvider;

--- a/lib/src/view/puzzle/puzzle_tab_screen.dart
+++ b/lib/src/view/puzzle/puzzle_tab_screen.dart
@@ -456,7 +456,7 @@ class _PuzzleMenu extends ConsumerWidget {
 }
 
 class PuzzleHistoryWidget extends ConsumerWidget {
-  const PuzzleHistoryWidget({this.showHeader = true});
+  const PuzzleHistoryWidget({super.key, this.showHeader = true});
 
   final bool showHeader;
 

--- a/lib/src/view/puzzle/storm_clock.dart
+++ b/lib/src/view/puzzle/storm_clock.dart
@@ -8,12 +8,12 @@ import 'package:lichess_mobile/src/styles/styles.dart';
 const _kClockFontSize = 26.0;
 
 class StormClockWidget extends StatefulWidget {
-  const StormClockWidget({required this.clock});
+  const StormClockWidget({super.key, required this.clock});
 
   final StormClock clock;
 
   @override
-  _ClockState createState() => _ClockState();
+  State<StormClockWidget> createState() => _ClockState();
 }
 
 class _ClockState extends State<StormClockWidget> with SingleTickerProviderStateMixin {

--- a/lib/src/view/study/study_bottom_bar.dart
+++ b/lib/src/view/study/study_bottom_bar.dart
@@ -14,7 +14,7 @@ import 'package:lichess_mobile/src/widgets/buttons.dart';
 import 'package:lichess_mobile/src/widgets/list.dart';
 
 class StudyBottomBar extends ConsumerWidget {
-  const StudyBottomBar({required this.id});
+  const StudyBottomBar({super.key, required this.id});
 
   final StudyId id;
 

--- a/lib/src/view/study/study_gamebook.dart
+++ b/lib/src/view/study/study_gamebook.dart
@@ -8,7 +8,7 @@ import 'package:lichess_mobile/src/widgets/buttons.dart';
 import 'package:url_launcher/url_launcher.dart';
 
 class StudyGamebook extends StatelessWidget {
-  const StudyGamebook(this.id);
+  const StudyGamebook(this.id, {super.key});
 
   final StudyId id;
 

--- a/lib/src/view/study/study_screen.dart
+++ b/lib/src/view/study/study_screen.dart
@@ -39,7 +39,7 @@ import 'package:logging/logging.dart';
 final _logger = Logger('StudyScreen');
 
 class StudyScreen extends ConsumerWidget {
-  const StudyScreen({required this.id});
+  const StudyScreen({super.key, required this.id});
 
   final StudyId id;
 

--- a/lib/src/view/study/study_settings.dart
+++ b/lib/src/view/study/study_settings.dart
@@ -15,7 +15,7 @@ import 'package:lichess_mobile/src/widgets/platform_scaffold.dart';
 import 'package:lichess_mobile/src/widgets/settings.dart';
 
 class StudySettings extends ConsumerWidget {
-  const StudySettings(this.id);
+  const StudySettings(this.id, {super.key});
 
   final StudyId id;
 

--- a/lib/src/view/study/study_tree_view.dart
+++ b/lib/src/view/study/study_tree_view.dart
@@ -11,7 +11,7 @@ import 'package:lichess_mobile/src/widgets/pgn.dart';
 const kNextChapterButtonHeight = 32.0;
 
 class StudyTreeView extends ConsumerWidget {
-  const StudyTreeView(this.id);
+  const StudyTreeView(this.id, {super.key});
 
   final StudyId id;
 

--- a/lib/src/view/user/leaderboard_screen.dart
+++ b/lib/src/view/user/leaderboard_screen.dart
@@ -82,7 +82,7 @@ class _Body extends ConsumerWidget {
 ///
 /// Optionaly Provide the [perfIcon] for the Variant of the List
 class LeaderboardListTile extends StatelessWidget {
-  const LeaderboardListTile({required this.user, this.perfIcon});
+  const LeaderboardListTile({super.key, required this.user, this.perfIcon});
   final LeaderboardUser user;
   final IconData? perfIcon;
 

--- a/lib/src/view/user/leaderboard_widget.dart
+++ b/lib/src/view/user/leaderboard_widget.dart
@@ -13,6 +13,8 @@ import 'package:lichess_mobile/src/widgets/shimmer.dart';
 ///
 /// The title routes to a Leaderboard Screen with the top 10 players for each perf.
 class LeaderboardWidget extends ConsumerWidget {
+  const LeaderboardWidget({super.key});
+
   @override
   Widget build(BuildContext context, WidgetRef ref) {
     final leaderboardState = ref.watch(top1Provider);

--- a/lib/src/view/user/player_screen.dart
+++ b/lib/src/view/user/player_screen.dart
@@ -51,7 +51,7 @@ class _Body extends ConsumerWidget {
       children: [
         const Padding(padding: Styles.bodySectionPadding, child: _SearchButton()),
         if (session != null) _OnlineFriendsWidget(),
-        RatingPrefAware(child: LeaderboardWidget()),
+        const RatingPrefAware(child: LeaderboardWidget()),
       ],
     );
   }

--- a/lib/src/view/user/search_screen.dart
+++ b/lib/src/view/user/search_screen.dart
@@ -17,7 +17,7 @@ import 'package:lichess_mobile/src/widgets/user_list_tile.dart';
 const _kSaveHistoryDebouncTimer = Duration(seconds: 2);
 
 class SearchScreen extends ConsumerStatefulWidget {
-  const SearchScreen({this.onUserTap});
+  const SearchScreen({super.key, this.onUserTap});
 
   final void Function(LightUser)? onUserTap;
 

--- a/lib/src/view/user/user_activity.dart
+++ b/lib/src/view/user/user_activity.dart
@@ -285,7 +285,7 @@ class _ResultBox extends StatelessWidget {
 }
 
 class BriefGameResultBox extends StatelessWidget {
-  const BriefGameResultBox({required this.win, required this.draw, required this.loss});
+  const BriefGameResultBox({super.key, required this.win, required this.draw, required this.loss});
 
   final int win;
   final int draw;

--- a/lib/src/view/user/user_profile.dart
+++ b/lib/src/view/user/user_profile.dart
@@ -23,7 +23,7 @@ import 'package:url_launcher/url_launcher.dart';
 const _userNameStyle = TextStyle(fontSize: 20, fontWeight: FontWeight.w500);
 
 class UserProfileWidget extends ConsumerWidget {
-  const UserProfileWidget({required this.user, this.bioMaxLines = 10});
+  const UserProfileWidget({super.key, required this.user, this.bioMaxLines = 10});
 
   final User user;
 

--- a/lib/src/view/watch/streamer_screen.dart
+++ b/lib/src/view/watch/streamer_screen.dart
@@ -10,7 +10,7 @@ import 'package:lichess_mobile/src/widgets/platform.dart';
 import 'package:url_launcher/url_launcher.dart';
 
 class StreamerScreen extends StatelessWidget {
-  const StreamerScreen({required this.streamers});
+  const StreamerScreen({super.key, required this.streamers});
 
   final IList<Streamer> streamers;
 
@@ -59,7 +59,7 @@ class StreamerScreen extends StatelessWidget {
 }
 
 class StreamerListTile extends StatelessWidget {
-  const StreamerListTile({
+  const StreamerListTile({super.key, 
     required this.streamer,
     this.showSubtitle = false,
     this.maxSubtitleLines = 1,

--- a/lib/src/view/watch/streamer_screen.dart
+++ b/lib/src/view/watch/streamer_screen.dart
@@ -59,7 +59,8 @@ class StreamerScreen extends StatelessWidget {
 }
 
 class StreamerListTile extends StatelessWidget {
-  const StreamerListTile({super.key, 
+  const StreamerListTile({
+    super.key,
     required this.streamer,
     this.showSubtitle = false,
     this.maxSubtitleLines = 1,

--- a/lib/src/view/watch/watch_tab_screen.dart
+++ b/lib/src/view/watch/watch_tab_screen.dart
@@ -64,7 +64,7 @@ class WatchTabScreen extends ConsumerStatefulWidget {
   const WatchTabScreen({super.key});
 
   @override
-  _WatchScreenState createState() => _WatchScreenState();
+  ConsumerState<WatchTabScreen> createState() => _WatchScreenState();
 }
 
 class _WatchScreenState extends ConsumerState<WatchTabScreen> {

--- a/lib/src/widgets/adaptive_bottom_sheet.dart
+++ b/lib/src/widgets/adaptive_bottom_sheet.dart
@@ -47,7 +47,7 @@ Future<T?> showAdaptiveBottomSheet<T>({
 ///
 /// This is meant for content that mostly fits on the screen, not for long lists.
 class BottomSheetScrollableContainer extends StatelessWidget {
-  const BottomSheetScrollableContainer({
+  const BottomSheetScrollableContainer({super.key, 
     required this.children,
     this.padding = const EdgeInsets.only(bottom: 16.0),
     this.scrollController,
@@ -70,7 +70,7 @@ class BottomSheetScrollableContainer extends StatelessWidget {
 }
 
 class BottomSheetContextMenuAction extends StatelessWidget {
-  const BottomSheetContextMenuAction({
+  const BottomSheetContextMenuAction({super.key, 
     required this.child,
     this.icon,
     this.onPressed,

--- a/lib/src/widgets/adaptive_bottom_sheet.dart
+++ b/lib/src/widgets/adaptive_bottom_sheet.dart
@@ -47,7 +47,8 @@ Future<T?> showAdaptiveBottomSheet<T>({
 ///
 /// This is meant for content that mostly fits on the screen, not for long lists.
 class BottomSheetScrollableContainer extends StatelessWidget {
-  const BottomSheetScrollableContainer({super.key, 
+  const BottomSheetScrollableContainer({
+    super.key,
     required this.children,
     this.padding = const EdgeInsets.only(bottom: 16.0),
     this.scrollController,
@@ -70,7 +71,8 @@ class BottomSheetScrollableContainer extends StatelessWidget {
 }
 
 class BottomSheetContextMenuAction extends StatelessWidget {
-  const BottomSheetContextMenuAction({super.key, 
+  const BottomSheetContextMenuAction({
+    super.key,
     required this.child,
     this.icon,
     this.onPressed,

--- a/lib/src/widgets/board_carousel_item.dart
+++ b/lib/src/widgets/board_carousel_item.dart
@@ -12,7 +12,8 @@ import 'package:lichess_mobile/src/widgets/platform.dart';
 const _kBoardCarouselItemMargin = EdgeInsets.symmetric(vertical: 8.0, horizontal: 6.0);
 
 class BoardCarouselItem extends ConsumerWidget {
-  const BoardCarouselItem({super.key, 
+  const BoardCarouselItem({
+    super.key,
     required this.orientation,
     required this.fen,
     required this.description,

--- a/lib/src/widgets/board_carousel_item.dart
+++ b/lib/src/widgets/board_carousel_item.dart
@@ -12,7 +12,7 @@ import 'package:lichess_mobile/src/widgets/platform.dart';
 const _kBoardCarouselItemMargin = EdgeInsets.symmetric(vertical: 8.0, horizontal: 6.0);
 
 class BoardCarouselItem extends ConsumerWidget {
-  const BoardCarouselItem({
+  const BoardCarouselItem({super.key, 
     required this.orientation,
     required this.fen,
     required this.description,

--- a/lib/src/widgets/board_preview.dart
+++ b/lib/src/widgets/board_preview.dart
@@ -9,7 +9,7 @@ import 'package:lichess_mobile/src/styles/styles.dart';
 
 /// A board preview with a description.
 class SmallBoardPreview extends ConsumerStatefulWidget {
-  const SmallBoardPreview({
+  const SmallBoardPreview({super.key, 
     required this.orientation,
     required this.fen,
     required this.description,
@@ -18,7 +18,7 @@ class SmallBoardPreview extends ConsumerStatefulWidget {
     this.onTap,
   }) : _showLoadingPlaceholder = false;
 
-  const SmallBoardPreview.loading({this.padding})
+  const SmallBoardPreview.loading({super.key, this.padding})
     : orientation = Side.white,
       fen = kEmptyFEN,
       lastMove = null,

--- a/lib/src/widgets/board_preview.dart
+++ b/lib/src/widgets/board_preview.dart
@@ -9,7 +9,8 @@ import 'package:lichess_mobile/src/styles/styles.dart';
 
 /// A board preview with a description.
 class SmallBoardPreview extends ConsumerStatefulWidget {
-  const SmallBoardPreview({super.key, 
+  const SmallBoardPreview({
+    super.key,
     required this.orientation,
     required this.fen,
     required this.description,

--- a/lib/src/widgets/board_table.dart
+++ b/lib/src/widgets/board_table.dart
@@ -49,7 +49,8 @@ class BoardTable extends ConsumerStatefulWidget {
        );
 
   /// Creates an empty board table (useful for loading).
-  const BoardTable.empty({super.key, 
+  const BoardTable.empty({
+    super.key,
     this.showMoveListPlaceholder = false,
     this.showEngineGaugePlaceholder = false,
     this.errorMessage,

--- a/lib/src/widgets/board_table.dart
+++ b/lib/src/widgets/board_table.dart
@@ -49,7 +49,7 @@ class BoardTable extends ConsumerStatefulWidget {
        );
 
   /// Creates an empty board table (useful for loading).
-  const BoardTable.empty({
+  const BoardTable.empty({super.key, 
     this.showMoveListPlaceholder = false,
     this.showEngineGaugePlaceholder = false,
     this.errorMessage,

--- a/lib/src/widgets/board_thumbnail.dart
+++ b/lib/src/widgets/board_thumbnail.dart
@@ -8,6 +8,7 @@ import 'package:lichess_mobile/src/model/settings/board_preferences.dart';
 /// A board thumbnail widget
 class BoardThumbnail extends ConsumerStatefulWidget {
   const BoardThumbnail({
+    super.key,
     required this.size,
     required this.orientation,
     required this.fen,
@@ -18,7 +19,7 @@ class BoardThumbnail extends ConsumerStatefulWidget {
     this.animationDuration,
   });
 
-  const BoardThumbnail.loading({required this.size, this.header, this.footer})
+  const BoardThumbnail.loading({super.key, required this.size, this.header, this.footer})
     : orientation = Side.white,
       fen = kInitialFEN,
       lastMove = null,
@@ -49,7 +50,7 @@ class BoardThumbnail extends ConsumerStatefulWidget {
   final Duration? animationDuration;
 
   @override
-  _BoardThumbnailState createState() => _BoardThumbnailState();
+  ConsumerState<BoardThumbnail> createState() => _BoardThumbnailState();
 }
 
 class _BoardThumbnailState extends ConsumerState<BoardThumbnail> {

--- a/lib/src/widgets/bottom_bar.dart
+++ b/lib/src/widgets/bottom_bar.dart
@@ -6,13 +6,13 @@ import 'package:lichess_mobile/src/constants.dart';
 ///
 /// The height of the bar is always [kBottomBarHeight].
 class BottomBar extends StatelessWidget {
-  const BottomBar({
+  const BottomBar({super.key, 
     required this.children,
     this.mainAxisAlignment = MainAxisAlignment.spaceAround,
     this.expandChildren = true,
   });
 
-  const BottomBar.empty()
+  const BottomBar.empty({super.key})
     : children = const [],
       expandChildren = true,
       mainAxisAlignment = MainAxisAlignment.spaceAround;

--- a/lib/src/widgets/bottom_bar.dart
+++ b/lib/src/widgets/bottom_bar.dart
@@ -6,7 +6,8 @@ import 'package:lichess_mobile/src/constants.dart';
 ///
 /// The height of the bar is always [kBottomBarHeight].
 class BottomBar extends StatelessWidget {
-  const BottomBar({super.key, 
+  const BottomBar({
+    super.key,
     required this.children,
     this.mainAxisAlignment = MainAxisAlignment.spaceAround,
     this.expandChildren = true,

--- a/lib/src/widgets/buttons.dart
+++ b/lib/src/widgets/buttons.dart
@@ -338,6 +338,7 @@ class AdaptiveInkWell extends StatelessWidget {
 /// `onTap` callback should be handled by the child widget.
 class RepeatButton extends StatefulWidget {
   const RepeatButton({
+    super.key,
     required this.onLongPress,
     required this.child,
     this.triggerDelays = const [
@@ -362,7 +363,7 @@ class RepeatButton extends StatefulWidget {
   final Duration holdDelay;
 
   @override
-  _RepeatButtonState createState() => _RepeatButtonState();
+  State<RepeatButton> createState() => _RepeatButtonState();
 }
 
 class _RepeatButtonState extends State<RepeatButton> {
@@ -418,6 +419,7 @@ class _RepeatButtonState extends State<RepeatButton> {
 /// Will use [IconButton] on Android and [CupertinoIconButton] on iOS.
 class PlatformIconButton extends StatelessWidget {
   const PlatformIconButton({
+    super.key,
     required this.icon,
     required this.semanticsLabel,
     required this.onTap,

--- a/lib/src/widgets/expanded_section.dart
+++ b/lib/src/widgets/expanded_section.dart
@@ -4,10 +4,10 @@ class ExpandedSection extends StatefulWidget {
   final Widget child;
   final bool expand;
 
-  const ExpandedSection({this.expand = false, required this.child});
+  const ExpandedSection({super.key, this.expand = false, required this.child});
 
   @override
-  _ExpandedSectionState createState() => _ExpandedSectionState();
+  State<ExpandedSection> createState() => _ExpandedSectionState();
 }
 
 class _ExpandedSectionState extends State<ExpandedSection> with SingleTickerProviderStateMixin {

--- a/lib/src/widgets/feedback.dart
+++ b/lib/src/widgets/feedback.dart
@@ -66,7 +66,7 @@ class LagIndicator extends StatelessWidget {
 }
 
 class ConnectivityBanner extends ConsumerWidget {
-  const ConnectivityBanner();
+  const ConnectivityBanner({super.key});
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
@@ -230,7 +230,7 @@ class CupertinoSnackBar extends StatelessWidget {
   final TextStyle? textStyle;
   final Color? backgroundColor;
 
-  const CupertinoSnackBar({required this.message, this.textStyle, this.backgroundColor});
+  const CupertinoSnackBar({super.key, required this.message, this.textStyle, this.backgroundColor});
 
   @override
   Widget build(BuildContext context) {

--- a/lib/src/widgets/filter.dart
+++ b/lib/src/widgets/filter.dart
@@ -10,7 +10,8 @@ enum FilterType {
 
 /// Displays a row of choices that can be selected or deselected.
 class Filter<T extends Enum> extends StatelessWidget {
-  const Filter({super.key, 
+  const Filter({
+    super.key,
     this.filterName,
     required this.filterType,
     required this.choices,

--- a/lib/src/widgets/filter.dart
+++ b/lib/src/widgets/filter.dart
@@ -10,7 +10,7 @@ enum FilterType {
 
 /// Displays a row of choices that can be selected or deselected.
 class Filter<T extends Enum> extends StatelessWidget {
-  const Filter({
+  const Filter({super.key, 
     this.filterName,
     required this.filterType,
     required this.choices,

--- a/lib/src/widgets/list.dart
+++ b/lib/src/widgets/list.dart
@@ -207,7 +207,8 @@ class ListSection extends StatelessWidget {
 /// Useful to show a divider between [PlatformListTile] widgets when using the
 /// [ListView.separated] constructor.
 class PlatformDivider extends StatelessWidget {
-  const PlatformDivider({super.key, 
+  const PlatformDivider({
+    super.key,
     this.height,
     this.thickness,
     this.indent,

--- a/lib/src/widgets/list.dart
+++ b/lib/src/widgets/list.dart
@@ -22,7 +22,7 @@ class ListSection extends StatelessWidget {
     this.cupertinoClipBehavior = Clip.hardEdge,
   }) : _isLoading = false;
 
-  ListSection.loading({required int itemsNumber, bool header = false, this.margin})
+  ListSection.loading({super.key, required int itemsNumber, bool header = false, this.margin})
     : children = [for (int i = 0; i < itemsNumber; i++) const SizedBox.shrink()],
       headerTrailing = null,
       header = header ? const SizedBox.shrink() : null,
@@ -207,7 +207,7 @@ class ListSection extends StatelessWidget {
 /// Useful to show a divider between [PlatformListTile] widgets when using the
 /// [ListView.separated] constructor.
 class PlatformDivider extends StatelessWidget {
-  const PlatformDivider({
+  const PlatformDivider({super.key, 
     this.height,
     this.thickness,
     this.indent,

--- a/lib/src/widgets/move_list.dart
+++ b/lib/src/widgets/move_list.dart
@@ -14,7 +14,8 @@ const _kMoveListHeight = 40.0;
 enum MoveListType { inline, stacked }
 
 class MoveList extends ConsumerStatefulWidget {
-  const MoveList({super.key, 
+  const MoveList({
+    super.key,
     required this.type,
     required this.slicedMoves,
     required this.currentMoveIndex,

--- a/lib/src/widgets/move_list.dart
+++ b/lib/src/widgets/move_list.dart
@@ -14,7 +14,7 @@ const _kMoveListHeight = 40.0;
 enum MoveListType { inline, stacked }
 
 class MoveList extends ConsumerStatefulWidget {
-  const MoveList({
+  const MoveList({super.key, 
     required this.type,
     required this.slicedMoves,
     required this.currentMoveIndex,
@@ -161,7 +161,7 @@ class _MoveListState extends ConsumerState<MoveList> {
 }
 
 class InlineMoveCount extends StatelessWidget {
-  const InlineMoveCount({required this.count, required this.pieceNotation, this.color});
+  const InlineMoveCount({super.key, required this.count, required this.pieceNotation, this.color});
 
   final PieceNotation pieceNotation;
   final int count;
@@ -226,7 +226,7 @@ class InlineMoveItem extends StatelessWidget {
 }
 
 class StackedMoveCount extends StatelessWidget {
-  const StackedMoveCount({required this.count});
+  const StackedMoveCount({super.key, required this.count});
 
   final int count;
 

--- a/lib/src/widgets/pgn.dart
+++ b/lib/src/widgets/pgn.dart
@@ -92,6 +92,7 @@ abstract class PgnTreeNotifier {
 /// Similarly, a [_SideLinePart] contains the moves sequence of a sideline where each node has only one child.
 class DebouncedPgnTreeView extends ConsumerStatefulWidget {
   const DebouncedPgnTreeView({
+    super.key,
     required this.root,
     required this.currentPath,
     this.broadcastLivePath,
@@ -233,7 +234,7 @@ class _DebouncedPgnTreeViewState extends ConsumerState<DebouncedPgnTreeView> {
 /// and ultimately evaluated in the [InlineMove] widget.
 ///
 /// Grouped in this record to improve readability.
-typedef _PgnTreeViewParams =
+typedef PgnTreeViewParams =
     ({
       /// Path to the currently selected move in the tree.
       UciPath pathToCurrentMove,
@@ -277,7 +278,7 @@ bool _displaySideLineAsInline(ViewBranch node, [int depth = 0]) {
 }
 
 /// Returns whether this node has a sideline that should not be displayed inline.
-bool _hasNonInlineSideLine(ViewNode node, _PgnTreeViewParams params) {
+bool _hasNonInlineSideLine(ViewNode node, PgnTreeViewParams params) {
   final children = _filteredChildren(node, params.shouldShowComputerVariations);
   return children.length > 2 || (children.length == 2 && !_displaySideLineAsInline(children[1]));
 }
@@ -285,7 +286,7 @@ bool _hasNonInlineSideLine(ViewNode node, _PgnTreeViewParams params) {
 /// Splits the mainline into parts, where each part is a sequence of moves that are displayed on the same line.
 ///
 /// A part ends when a mainline node has a sideline that should not be displayed inline.
-Iterable<List<ViewNode>> _mainlineParts(ViewRoot root, _PgnTreeViewParams params) =>
+Iterable<List<ViewNode>> _mainlineParts(ViewRoot root, PgnTreeViewParams params) =>
     [root, ...root.mainline]
         .splitAfter((n) => _hasNonInlineSideLine(n, params))
         .takeWhile((nodes) => nodes.firstOrNull?.children.isNotEmpty == true);
@@ -299,7 +300,7 @@ class _PgnTreeView extends StatefulWidget {
   /// Comments associated with the root node
   final IList<PgnComment>? rootComments;
 
-  final _PgnTreeViewParams params;
+  final PgnTreeViewParams params;
 
   @override
   State<_PgnTreeView> createState() => _PgnTreeViewState();
@@ -452,7 +453,7 @@ List<InlineSpan> _buildInlineSideLine({
   required UciPath initialPath,
   required TextStyle textStyle,
   required bool followsComment,
-  required _PgnTreeViewParams params,
+  required PgnTreeViewParams params,
 }) {
   textStyle = textStyle.copyWith(
     fontSize: textStyle.fontSize != null ? textStyle.fontSize! - 2.0 : null,
@@ -507,14 +508,14 @@ enum _LineType {
 }
 
 /// Metadata about a move's role in the tree view.
-typedef _LineInfo = ({_LineType type, bool startLine, UciPath pathToLine});
+typedef LineInfo = ({_LineType type, bool startLine, UciPath pathToLine});
 
 List<InlineSpan> _moveWithComment(
   ViewBranch branch, {
   required TextStyle textStyle,
-  required _LineInfo lineInfo,
+  required LineInfo lineInfo,
   required UciPath pathToNode,
-  required _PgnTreeViewParams params,
+  required PgnTreeViewParams params,
 
   /// Optional [GlobalKey] that will be assigned to the [InlineMove] widget.
   ///
@@ -559,7 +560,7 @@ class _SideLinePart extends ConsumerWidget {
   /// This is needed so that the indent guidelines can be drawn correctly.
   final GlobalKey firstMoveKey;
 
-  final _PgnTreeViewParams params;
+  final PgnTreeViewParams params;
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
@@ -626,7 +627,7 @@ class _MainLinePart extends ConsumerWidget {
 
   final List<ViewNode> nodes;
 
-  final _PgnTreeViewParams params;
+  final PgnTreeViewParams params;
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
@@ -696,7 +697,7 @@ class _SideLine extends StatelessWidget {
   final ViewNode parent;
   final GlobalKey firstMoveKey;
   final UciPath initialPath;
-  final _PgnTreeViewParams params;
+  final PgnTreeViewParams params;
   final int nesting;
 
   List<ViewBranch> _getSidelinePartNodes() {
@@ -801,7 +802,7 @@ class _IndentedSideLines extends StatefulWidget {
 
   final UciPath initialPath;
 
-  final _PgnTreeViewParams params;
+  final PgnTreeViewParams params;
 
   final int nesting;
 
@@ -953,9 +954,9 @@ class InlineMove extends ConsumerWidget {
 
   final TextStyle textStyle;
 
-  final _LineInfo lineInfo;
+  final LineInfo lineInfo;
 
-  final _PgnTreeViewParams params;
+  final PgnTreeViewParams params;
 
   static const borderRadius = BorderRadius.all(Radius.circular(4.0));
 
@@ -1065,7 +1066,7 @@ class _MoveContextMenu extends ConsumerWidget {
   final String title;
   final UciPath path;
   final ViewBranch branch;
-  final _LineInfo lineInfo;
+  final LineInfo lineInfo;
   final PgnTreeNotifier notifier;
 
   @override

--- a/lib/src/widgets/platform_search_bar.dart
+++ b/lib/src/widgets/platform_search_bar.dart
@@ -4,7 +4,7 @@ import 'package:lichess_mobile/src/widgets/platform.dart';
 
 /// Displays a [SearchBar] on Android and a [CupertinoSearchTextField] on iOS.
 class PlatformSearchBar extends StatelessWidget {
-  const PlatformSearchBar({
+  const PlatformSearchBar({super.key, 
     this.controller,
     this.hintText,
     this.autoFocus = false,

--- a/lib/src/widgets/platform_search_bar.dart
+++ b/lib/src/widgets/platform_search_bar.dart
@@ -4,7 +4,8 @@ import 'package:lichess_mobile/src/widgets/platform.dart';
 
 /// Displays a [SearchBar] on Android and a [CupertinoSearchTextField] on iOS.
 class PlatformSearchBar extends StatelessWidget {
-  const PlatformSearchBar({super.key, 
+  const PlatformSearchBar({
+    super.key,
     this.controller,
     this.hintText,
     this.autoFocus = false,

--- a/lib/src/widgets/progression_widget.dart
+++ b/lib/src/widgets/progression_widget.dart
@@ -8,7 +8,7 @@ class ProgressionWidget extends StatelessWidget {
   final int progress;
   final double fontSize;
 
-  const ProgressionWidget(this.progress, {this.fontSize = 20});
+  const ProgressionWidget(this.progress, {super.key, this.fontSize = 20});
 
   @override
   Widget build(BuildContext context) {

--- a/lib/src/widgets/settings.dart
+++ b/lib/src/widgets/settings.dart
@@ -95,7 +95,8 @@ class SwitchSettingTile extends StatelessWidget {
 }
 
 class SliderSettingsTile extends StatefulWidget {
-  const SliderSettingsTile({super.key, 
+  const SliderSettingsTile({
+    super.key,
     this.icon,
     required this.value,
     required this.values,

--- a/lib/src/widgets/settings.dart
+++ b/lib/src/widgets/settings.dart
@@ -95,7 +95,7 @@ class SwitchSettingTile extends StatelessWidget {
 }
 
 class SliderSettingsTile extends StatefulWidget {
-  const SliderSettingsTile({
+  const SliderSettingsTile({super.key, 
     this.icon,
     required this.value,
     required this.values,

--- a/lib/src/widgets/stat_card.dart
+++ b/lib/src/widgets/stat_card.dart
@@ -9,7 +9,8 @@ const _defaultValueFontSize = 18.0;
 
 class StatCard extends StatelessWidget {
   const StatCard(
-    this.stat, {super.key, 
+    this.stat, {
+    super.key,
     this.child,
     this.value,
     this.padding,

--- a/lib/src/widgets/stat_card.dart
+++ b/lib/src/widgets/stat_card.dart
@@ -9,7 +9,7 @@ const _defaultValueFontSize = 18.0;
 
 class StatCard extends StatelessWidget {
   const StatCard(
-    this.stat, {
+    this.stat, {super.key, 
     this.child,
     this.value,
     this.padding,
@@ -66,7 +66,7 @@ class StatCard extends StatelessWidget {
 class StatCardRow extends StatelessWidget {
   final List<StatCard> cards;
 
-  const StatCardRow(this.cards);
+  const StatCardRow(this.cards, {super.key});
 
   @override
   Widget build(BuildContext context) {

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -579,6 +579,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "6.0.0"
+  flutter_lints:
+    dependency: "direct dev"
+    description:
+      name: flutter_lints
+      sha256: "5398f14efa795ffb7a33e9b6a08798b26a180edac4ad7db3f231e40f82ce11e1"
+      url: "https://pub.dev"
+    source: hosted
+    version: "5.0.0"
   flutter_local_notifications:
     dependency: "direct main"
     description:
@@ -891,6 +899,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "2.3.0"
+  lints:
+    dependency: transitive
+    description:
+      name: lints
+      sha256: c35bb79562d980e9a453fc715854e1ed39e24e7d0297a880ef54e17f9874a9d7
+      url: "https://pub.dev"
+    source: hosted
+    version: "5.1.1"
   logging:
     dependency: "direct main"
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -82,6 +82,7 @@ dev_dependencies:
   build_runner: ^2.3.2
   custom_lint: ^0.7.0
   fake_async: ^1.3.1
+  flutter_lints: ^5.0.0
   flutter_test:
     sdk: flutter
   freezed: ^2.3.4

--- a/test/view/user/leaderboard_widget_test.dart
+++ b/test/view/user/leaderboard_widget_test.dart
@@ -21,7 +21,7 @@ void main() {
       final SemanticsHandle handle = tester.ensureSemantics();
       final app = await makeTestProviderScopeApp(
         tester,
-        home: Column(children: [LeaderboardWidget()]),
+        home: const Column(children: [LeaderboardWidget()]),
         overrides: [lichessClientProvider.overrideWith((ref) => LichessClient(client, ref))],
       );
 


### PR DESCRIPTION
The rules that required fixes :
- library_private_types_in_public_api
- unintended_html_in_doc_comment
- use_key_in_widget_constructors
- prefer_const_literals_to_create_immutables 
- prefer_const_constructors

I am not sure if we really want to add this set of rules because some of them seem to especially address to packages like unintended_html_in_doc_comment, use_key_in_widget_constructors, library_private_types_in_public_api. However I think it is still interesting to keep the rules on const.

So I see two options, We can either add manually the two rules on const constructor or add the flutter set of rules and remove the ones that seem specific to Flutter packages.