### PR TITLE
fix: use Chessboard instead of ChessboardEditor for coordinate training

### DIFF
--- a/lib/src/view/coordinate_training/coordinate_training_screen.dart
+++ b/lib/src/view/coordinate_training/coordinate_training_screen.dart
@@ -431,9 +431,9 @@ class _TrainingBoardState extends ConsumerState<_TrainingBoard> {
         Stack(
           alignment: Alignment.center,
           children: [
-            ChessboardEditor(
+            Chessboard.fixed(
               size: widget.boardSize,
-              pieces: readFen(trainingPrefs.showPieces ? kInitialFEN : kEmptyFEN),
+              fen: trainingPrefs.showPieces ? kInitialFEN : kEmptyFEN,
               squareHighlights: widget.squareHighlights,
               orientation: widget.orientation,
               settings: boardPrefs.toBoardSettings().copyWith(
@@ -444,8 +444,7 @@ class _TrainingBoardState extends ConsumerState<_TrainingBoard> {
                         : BorderRadius.zero,
                 boxShadow: widget.isTablet ? boardShadows : const <BoxShadow>[],
               ),
-              pointerMode: EditorPointerMode.edit,
-              onEditedSquare: (square) {
+              onTouchedSquare: (square) {
                 if (trainingState.trainingActive && trainingPrefs.mode == TrainingMode.findSquare) {
                   widget.onGuess(square);
                 }

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -202,10 +202,10 @@ packages:
     dependency: "direct main"
     description:
       name: chessground
-      sha256: "5cf1a5bcd95c2c043ebfb1c88775b3d05b3332908ae4bbd528f32a8003129850"
+      sha256: "40330af2661f8fb58877b8e6e97130f494a628b114840668994ee5d426880ee4"
       url: "https://pub.dev"
     source: hosted
-    version: "6.2.3"
+    version: "6.3.0"
   ci:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -14,7 +14,7 @@ dependencies:
   async: ^2.10.0
   auto_size_text: ^3.0.0
   cached_network_image: ^3.2.2
-  chessground: ^6.2.3
+  chessground: ^6.3.0
   clock: ^1.1.1
   collection: ^1.17.0
   connectivity_plus: ^6.0.2

--- a/test/view/coordinate_training/coordinate_training_screen_test.dart
+++ b/test/view/coordinate_training/coordinate_training_screen_test.dart
@@ -3,10 +3,12 @@ import 'package:dartchess/dartchess.dart';
 import 'package:flutter/widgets.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
+import 'package:lichess_mobile/src/model/common/game.dart';
 import 'package:lichess_mobile/src/model/coordinate_training/coordinate_training_controller.dart';
 import 'package:lichess_mobile/src/model/coordinate_training/coordinate_training_preferences.dart';
 import 'package:lichess_mobile/src/view/coordinate_training/coordinate_training_screen.dart';
 
+import '../../test_helpers.dart';
 import '../../test_provider_scope.dart';
 
 void main() {
@@ -18,13 +20,11 @@ void main() {
       await tester.tap(find.text('Start Training'));
       await tester.pumpAndSettle();
 
-      final container = ProviderScope.containerOf(tester.element(find.byType(ChessboardEditor)));
+      final container = ProviderScope.containerOf(tester.element(find.byType(Chessboard)));
       final controllerProvider = coordinateTrainingControllerProvider;
 
       final trainingPrefsNotifier = container.read(coordinateTrainingPreferencesProvider.notifier);
       trainingPrefsNotifier.setMode(TrainingMode.findSquare);
-      // This way all squares can be found via find.byKey(ValueKey('${square.name}-empty'))
-      trainingPrefsNotifier.setShowPieces(false);
       await tester.pumpAndSettle();
 
       expect(container.read(controllerProvider).score, 0);
@@ -41,24 +41,22 @@ void main() {
       final app = await makeTestProviderScopeApp(tester, home: const CoordinateTrainingScreen());
       await tester.pumpWidget(app);
 
+      final container = ProviderScope.containerOf(tester.element(find.byType(Chessboard)));
+      final trainingPrefsNotifier = container.read(coordinateTrainingPreferencesProvider.notifier);
+      trainingPrefsNotifier.setMode(TrainingMode.findSquare);
+      trainingPrefsNotifier.setSideChoice(SideChoice.white);
+
       await tester.tap(find.text('Start Training'));
       await tester.pumpAndSettle();
 
-      final container = ProviderScope.containerOf(tester.element(find.byType(ChessboardEditor)));
       final controllerProvider = coordinateTrainingControllerProvider;
-
-      final trainingPrefsNotifier = container.read(coordinateTrainingPreferencesProvider.notifier);
-      trainingPrefsNotifier.setMode(TrainingMode.findSquare);
-      // This way all squares can be found via find.byKey(ValueKey('${square.name}-empty'))
-      trainingPrefsNotifier.setShowPieces(false);
-      await tester.pumpAndSettle();
 
       final currentCoord = container.read(controllerProvider).currentCoord;
       final nextCoord = container.read(controllerProvider).nextCoord;
 
       final wrongCoord = Square.values[(currentCoord! + 1) % Square.values.length];
 
-      await tester.tap(find.byKey(ValueKey('${wrongCoord.name}-empty')));
+      await tester.tapAt(squareOffset(wrongCoord, tester.getRect(find.byType(Chessboard))));
       await tester.pump();
 
       expect(container.read(controllerProvider).score, 0);
@@ -76,22 +74,21 @@ void main() {
       final app = await makeTestProviderScopeApp(tester, home: const CoordinateTrainingScreen());
       await tester.pumpWidget(app);
 
-      await tester.tap(find.text('Start Training'));
-      await tester.pumpAndSettle();
-
-      final container = ProviderScope.containerOf(tester.element(find.byType(ChessboardEditor)));
-      final controllerProvider = coordinateTrainingControllerProvider;
-
+      final container = ProviderScope.containerOf(tester.element(find.byType(Chessboard)));
       final trainingPrefsNotifier = container.read(coordinateTrainingPreferencesProvider.notifier);
       trainingPrefsNotifier.setMode(TrainingMode.findSquare);
-      // This way all squares can be found via find.byKey(ValueKey('${square.name}-empty'))
-      trainingPrefsNotifier.setShowPieces(false);
+      trainingPrefsNotifier.setSideChoice(SideChoice.white);
+
+      final controllerProvider = coordinateTrainingControllerProvider;
+
+      await tester.tap(find.text('Start Training'));
       await tester.pumpAndSettle();
 
       final currentCoord = container.read(controllerProvider).currentCoord;
       final nextCoord = container.read(controllerProvider).nextCoord;
 
-      await tester.tap(find.byKey(ValueKey('${currentCoord!.name}-empty')));
+      await tester.tapAt(squareOffset(currentCoord!, tester.getRect(find.byType(Chessboard))));
+
       await tester.pump();
 
       expect(find.byKey(ValueKey('${currentCoord.name}-highlight')), findsOneWidget);


### PR DESCRIPTION
Fixes #1017

Needs https://github.com/lichess-org/flutter-chessground/pull/66