### PR TITLE
fix: off-by-one error in tree view caching logic

### DIFF
--- a/lib/src/widgets/pgn.dart
+++ b/lib/src/widgets/pgn.dart
@@ -361,9 +361,15 @@ class _PgnTreeViewState extends State<_PgnTreeView> {
           }
 
           final mainlinePartOfCurrentPath = _mainlinePartOfCurrentPath();
+          final currentMoveIsOnMainline =
+              mainlinePartOfCurrentPath == widget.params.pathToCurrentMove;
+
           final containsCurrentMove =
-              mainlinePartOfCurrentPath.size > mainlineInitialPath.size &&
-              mainlinePartOfCurrentPath.size <= path.size;
+              currentMoveIsOnMainline
+                  ? mainlinePartOfCurrentPath.size > mainlineInitialPath.size &&
+                      mainlinePartOfCurrentPath.size <= path.size
+                  : mainlinePartOfCurrentPath.size >= mainlineInitialPath.size &&
+                      mainlinePartOfCurrentPath.size < path.size;
 
           if (fullRebuild || subtrees[i].containsCurrentMove || containsCurrentMove) {
             // Skip the first node which is the continuation of the mainline

--- a/test/view/analysis/analysis_screen_test.dart
+++ b/test/view/analysis/analysis_screen_test.dart
@@ -357,6 +357,34 @@ void main() {
       // second mainline part has not changed since the current move is not part of it
       expect(identical(secondMainlinePartOnMoveE5, secondMainlinePartOnMoveE4), isTrue);
     });
+
+    testWidgets(
+      'Select first move of sideline if mainline part has only one move (regression test)',
+      (tester) async {
+        /// Will be rendered as:
+        /// -------------------
+        /// 1. e4
+        /// |- 1. d4
+        /// |- 1. c4
+        /// -------------------
+        await buildTree(tester, '1. e4 (1. d4) (1. c4)');
+
+        await tester.tap(find.text('1. d4'));
+        // need to wait for current move change debounce delay
+        await tester.pumpAndSettle(const Duration(milliseconds: 200));
+
+        final e4NodeBeforeTap = parentText(tester, '1. e4');
+
+        await tester.tap(find.text('1. c4'));
+        // need to wait for current move change debounce delay
+        await tester.pumpAndSettle(const Duration(milliseconds: 200));
+
+        final e4NodeAfterTap = parentText(tester, '1. e4');
+
+        // There was a bug where the subtree would not be rebuilt here
+        expect(e4NodeBeforeTap, isNot(e4NodeAfterTap));
+      },
+    );
   });
 }
 


### PR DESCRIPTION
This bug only occurs if a mainline part consists of a single move - In that case, tapping a move in one of its sidelines will not invalidate the subtree cache, leading to the "current move" highlight not being updated.

Demonstration of the bug:

[bug.webm](https://github.com/user-attachments/assets/5969786d-c8d9-47c4-9b5f-975dd8f38d1c)


With this PR:

[fix.webm](https://github.com/user-attachments/assets/2a019d0c-9b18-445c-adea-b81c0f81a6c2)
