### PR TITLE
Improve documentation on setting a dev environment

### DIFF
--- a/lib/src/network/http.dart
+++ b/lib/src/network/http.dart
@@ -38,7 +38,9 @@ const _maxCacheSize = 2 * 1024 * 1024;
 
 /// Creates a Uri pointing to lichess server with the given unencoded path and query parameters.
 Uri lichessUri(String unencodedPath, [Map<String, dynamic>? queryParameters]) =>
-    kLichessHost.startsWith('localhost')
+    kLichessHost.startsWith('localhost') ||
+            kLichessHost.startsWith('10.') ||
+            kLichessHost.startsWith('192.168.')
         ? Uri.http(kLichessHost, unencodedPath, queryParameters)
         : Uri.https(kLichessHost, unencodedPath, queryParameters);
 

--- a/lib/src/network/socket.dart
+++ b/lib/src/network/socket.dart
@@ -48,7 +48,9 @@ final socketGlobalStream = _globalStreamController.stream;
 
 /// Creates a WebSocket URI for the lichess server.
 Uri lichessWSUri(String unencodedPath, [Map<String, String>? queryParameters]) =>
-    kLichessWSHost.startsWith('localhost')
+    kLichessWSHost.startsWith('localhost') ||
+            kLichessWSHost.startsWith('10.') ||
+            kLichessWSHost.startsWith('192.168.')
         ? Uri(
           scheme: 'ws',
           host: kLichessWSHost.split(':')[0],


### PR DESCRIPTION
## Changes

- completed the android emulator troubleshooting section
- added the section on setting up a real device
- moved the When using a manually installed lila server and When using lila-docker sections that were in Setting up the emulators to the Run section
- changed the content of When using lila-docker
- moved some part of Local lila server (manual installation) to Run and also small changes to Run

I also changed the scheme when using a private ip address for the host so that you can connect to a local lila from your android phone without using `adb reverse`.