### PR TITLE
Tweak watch tab

### DIFF
--- a/lib/src/view/watch/watch_tab_screen.dart
+++ b/lib/src/view/watch/watch_tab_screen.dart
@@ -220,6 +220,9 @@ class _BroadcastWidget extends ConsumerWidget {
   Widget build(BuildContext context, WidgetRef ref) {
     return broadcastList.when(
       data: (data) {
+        if (data.active.isEmpty && data.past.isEmpty) {
+          return const SizedBox.shrink();
+        }
         return ListSection(
           hasLeading: true,
           header: Text(context.l10n.broadcastBroadcasts),


### PR DESCRIPTION
Don't show section title for broadcast when there is no items to make it consistent with the two others sections.

![Screenshot_1735828026](https://github.com/user-attachments/assets/58e2196b-ee4c-4035-a891-6e07cfce7026)
