### PR TITLE
Revert shimmer changes

### DIFF
--- a/lib/src/view/broadcast/broadcast_boards_tab.dart
+++ b/lib/src/view/broadcast/broadcast_boards_tab.dart
@@ -14,7 +14,6 @@ import 'package:lichess_mobile/src/view/broadcast/broadcast_game_screen.dart';
 import 'package:lichess_mobile/src/view/broadcast/broadcast_player_widget.dart';
 import 'package:lichess_mobile/src/widgets/board_thumbnail.dart';
 import 'package:lichess_mobile/src/widgets/clock.dart';
-import 'package:lichess_mobile/src/widgets/shimmer.dart';
 
 // height of 1.0 is important because we need to determine the height of the text
 // to calculate the height of the header and footer of the board
@@ -88,6 +87,7 @@ class BroadcastPreview extends StatelessWidget {
     required this.roundSlug,
   });
 
+  // A circular progress indicator is used instead of shimmers currently
   const BroadcastPreview.loading()
     : tournamentId = const BroadcastTournamentId(''),
       roundId = const BroadcastRoundId(''),
@@ -131,13 +131,10 @@ class BroadcastPreview extends StatelessWidget {
         childCount: games == null ? numberLoadingBoards : games!.length,
         (context, index) {
           if (games == null) {
-            return ShimmerLoading(
-              isLoading: true,
-              child: BoardThumbnail.loading(
-                size: boardWidth,
-                header: _PlayerWidgetLoading(width: boardWidth),
-                footer: _PlayerWidgetLoading(width: boardWidth),
-              ),
+            return BoardThumbnail.loading(
+              size: boardWidth,
+              header: _PlayerWidgetLoading(width: boardWidth),
+              footer: _PlayerWidgetLoading(width: boardWidth),
             );
           }
 

--- a/lib/src/view/broadcast/broadcast_round_screen.dart
+++ b/lib/src/view/broadcast/broadcast_round_screen.dart
@@ -18,7 +18,6 @@ import 'package:lichess_mobile/src/widgets/bottom_bar.dart';
 import 'package:lichess_mobile/src/widgets/buttons.dart';
 import 'package:lichess_mobile/src/widgets/list.dart';
 import 'package:lichess_mobile/src/widgets/platform.dart';
-import 'package:lichess_mobile/src/widgets/shimmer.dart';
 
 class BroadcastRoundScreen extends ConsumerStatefulWidget {
   final Broadcast broadcast;
@@ -257,17 +256,15 @@ class _TabView extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    return Shimmer(
-      child: CustomScrollView(
-        slivers: [
-          if (cupertinoTabSwitcher != null)
-            SliverPadding(
-              padding: Styles.bodyPadding + EdgeInsets.only(top: MediaQuery.paddingOf(context).top),
-              sliver: SliverToBoxAdapter(child: cupertinoTabSwitcher),
-            ),
-          sliver,
-        ],
-      ),
+    return CustomScrollView(
+      slivers: [
+        if (cupertinoTabSwitcher != null)
+          SliverPadding(
+            padding: Styles.bodyPadding + EdgeInsets.only(top: MediaQuery.paddingOf(context).top),
+            sliver: SliverToBoxAdapter(child: cupertinoTabSwitcher),
+          ),
+        sliver,
+      ],
     );
   }
 }

--- a/lib/src/widgets/shimmer.dart
+++ b/lib/src/widgets/shimmer.dart
@@ -118,14 +118,10 @@ class _ShimmerLoadingState extends State<ShimmerLoading> {
     }
     final shimmerSize = shimmer.size;
     final gradient = shimmer.gradient;
-    final renderObject = context.findRenderObject();
-    final offsetWithinShimmer =
-        renderObject != null
-            ? shimmer.getDescendantOffset(
-              // ignore: cast_nullable_to_non_nullable
-              descendant: renderObject as RenderBox,
-            )
-            : Offset.zero;
+    final offsetWithinShimmer = shimmer.getDescendantOffset(
+      // ignore: cast_nullable_to_non_nullable
+      descendant: context.findRenderObject() as RenderBox,
+    );
 
     return ShaderMask(
       blendMode: BlendMode.srcATop,


### PR DESCRIPTION
Revert changes of `shimmer.dart` and remove the shimmers widget in broadcast that are not currently used and causes `pumpAndSettle` in tests to time out