### PR TITLE
Fix: Correspondence confirm move behavior #1329

### DIFF
--- a/lib/src/view/game/game_body.dart
+++ b/lib/src/view/game/game_body.dart
@@ -118,6 +118,7 @@ class GameBody extends ConsumerWidget {
           materialDifferenceFormat: boardPreferences.materialDifferenceFormat,
           timeToMove: gameState.game.sideToMove == Side.black ? gameState.timeToMove : null,
           mePlaying: youAre == Side.black,
+          canGoForward: gameState.canGoForward, 
           zenMode: gameState.isZenModeActive,
           clockPosition: boardPreferences.clockPosition,
           confirmMoveCallbacks:
@@ -167,6 +168,7 @@ class GameBody extends ConsumerWidget {
           materialDifferenceFormat: boardPreferences.materialDifferenceFormat,
           timeToMove: gameState.game.sideToMove == Side.white ? gameState.timeToMove : null,
           mePlaying: youAre == Side.white,
+          canGoForward: gameState.canGoForward, 
           zenMode: gameState.isZenModeActive,
           clockPosition: boardPreferences.clockPosition,
           confirmMoveCallbacks:

--- a/lib/src/view/game/game_player.dart
+++ b/lib/src/view/game/game_player.dart
@@ -35,6 +35,7 @@ class GamePlayer extends StatelessWidget {
     this.timeToMove,
     this.shouldLinkToUserProfile = true,
     this.mePlaying = false,
+    this.canGoForward= false,
     this.zenMode = false,
     this.clockPosition = ClockPosition.right,
     super.key,
@@ -52,6 +53,7 @@ class GamePlayer extends StatelessWidget {
 
   final bool shouldLinkToUserProfile;
   final bool mePlaying;
+  final bool canGoForward;
   final bool zenMode;
   final ClockPosition clockPosition;
 
@@ -164,7 +166,7 @@ class GamePlayer extends StatelessWidget {
       crossAxisAlignment: CrossAxisAlignment.center,
       children: [
         if (clock != null && clockPosition == ClockPosition.left) Flexible(flex: 3, child: clock!),
-        if (mePlaying && confirmMoveCallbacks != null)
+        if (mePlaying && confirmMoveCallbacks != null && canGoForward ==false)
           Expanded(
             flex: 7,
             child: Padding(


### PR DESCRIPTION
Fixes bug #1329 

Confirm move dialog does not disappeared when back arrow is pressed to visualize previous positions (it disappears correctly in web app).  It's a problem not only related to correspondence chess, but to all time controls  where "Move confirmation" preference is set.

To fix it, an additional condition is added (in GamePlayer widget) to show the ConfirmMove widget:  'canGoForward ==false' (the same condition used to disable the forward button).  To achieve this, an additional parameter 'canGoForward' is added to the GamePlayer widget constructor..