### PR TITLE
Fix iOS broadcast test

### DIFF
--- a/lib/src/view/broadcast/broadcast_list_screen.dart
+++ b/lib/src/view/broadcast/broadcast_list_screen.dart
@@ -197,7 +197,7 @@ class _BodyState extends ConsumerState<_Body> {
         slivers: [
           for (final section in sections)
             SliverMainAxisGroup(
-              key: ValueKey(section),
+              key: ValueKey(section.$1),
               slivers: [
                 if (section.$3.isNotEmpty)
                   if (Theme.of(context).platform == TargetPlatform.iOS)

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -1054,14 +1054,6 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "2.0.0"
-  mockito:
-    dependency: transitive
-    description:
-      name: mockito
-      sha256: f99d8d072e249f719a5531735d146d8cf04c580d93920b04de75bef6dfb2daf6
-      url: "https://pub.dev"
-    source: hosted
-    version: "5.4.5"
   mocktail:
     dependency: "direct dev"
     description:
@@ -1070,14 +1062,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.0.4"
-  network_image_mock:
+  mocktail_image_network:
     dependency: "direct dev"
     description:
-      name: network_image_mock
-      sha256: "855cdd01d42440e0cffee0d6c2370909fc31b3bcba308a59829f24f64be42db7"
+      name: mocktail_image_network
+      sha256: a1fccbba780343517cfc552e0af2b3834d8bdb8f9f55a746c4d495ed1a8d50d6
       url: "https://pub.dev"
     source: hosted
-    version: "2.1.1"
+    version: "1.2.0"
   nm:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -92,7 +92,7 @@ dev_dependencies:
   json_serializable: ^6.5.4
   lint: ^2.0.1
   mocktail: ^1.0.0
-  network_image_mock: ^2.1.1
+  mocktail_image_network: ^1.2.0
   riverpod_generator: ^2.1.0
   riverpod_lint: ^2.3.3
   sqflite_common_ffi: ^2.2.3

--- a/test/view/broadcast/broadcast_list_screen_test.dart
+++ b/test/view/broadcast/broadcast_list_screen_test.dart
@@ -69,7 +69,6 @@ void main() {
       });
     });
 
-    // TODO: Fix test for iOS
     testWidgets('Scroll broadcast tournament screen', variant: kPlatformVariant, (tester) async {
       await mockNetworkImagesFor(() async {
         final app = await makeTestProviderScopeApp(
@@ -90,7 +89,7 @@ void main() {
         // Wait for broadcast tournaments to load
         await tester.pump(const Duration(milliseconds: 100));
 
-        await tester.scrollUntilVisible(find.text('Past broadcasts'), 100.0);
+        await tester.scrollUntilVisible(find.byKey(const ValueKey('past')), 100.0);
       });
     });
   });

--- a/test/view/broadcast/broadcast_list_screen_test.dart
+++ b/test/view/broadcast/broadcast_list_screen_test.dart
@@ -7,7 +7,6 @@ import 'package:lichess_mobile/src/model/broadcast/broadcast_providers.dart';
 import 'package:lichess_mobile/src/network/http.dart';
 import 'package:lichess_mobile/src/utils/image.dart';
 import 'package:lichess_mobile/src/view/broadcast/broadcast_list_screen.dart';
-import 'package:network_image_mock/network_image_mock.dart';
 
 import '../../test_helpers.dart';
 import '../../test_provider_scope.dart';
@@ -46,51 +45,47 @@ final client = MockClient((request) {
 void main() {
   group('BroadcastListScreen', () {
     testWidgets('Displays broadcast tournament screen', variant: kPlatformVariant, (tester) async {
-      await mockNetworkImagesFor(() async {
-        final app = await makeTestProviderScopeApp(
-          tester,
-          home: const BroadcastListScreen(),
-          overrides: [
-            lichessClientProvider.overrideWith((ref) => LichessClient(client, ref)),
-            broadcastImageWorkerFactoryProvider.overrideWith(
-              (ref) => FakeBroadcastImageWorkerFactory(),
-            ),
-          ],
-        );
+      final app = await makeTestProviderScopeApp(
+        tester,
+        home: const BroadcastListScreen(),
+        overrides: [
+          lichessClientProvider.overrideWith((ref) => LichessClient(client, ref)),
+          broadcastImageWorkerFactoryProvider.overrideWith(
+            (ref) => FakeBroadcastImageWorkerFactory(),
+          ),
+        ],
+      );
 
-        await tester.pumpWidget(app);
+      await tester.pumpWidget(app);
 
-        expect(find.byType(CircularProgressIndicator), findsOneWidget);
+      expect(find.byType(CircularProgressIndicator), findsOneWidget);
 
-        // Wait for broadcast tournaments to load
-        await tester.pump(const Duration(milliseconds: 100));
+      // Load the broadcast tournaments
+      await tester.pump();
 
-        expect(find.byType(BroadcastListTile), findsAtLeast(1));
-      });
+      expect(find.byType(BroadcastListTile), findsAtLeast(1));
     });
 
     testWidgets('Scroll broadcast tournament screen', variant: kPlatformVariant, (tester) async {
-      await mockNetworkImagesFor(() async {
-        final app = await makeTestProviderScopeApp(
-          tester,
-          home: const BroadcastListScreen(),
-          overrides: [
-            lichessClientProvider.overrideWith((ref) => LichessClient(client, ref)),
-            broadcastImageWorkerFactoryProvider.overrideWith(
-              (ref) => FakeBroadcastImageWorkerFactory(),
-            ),
-          ],
-        );
+      final app = await makeTestProviderScopeApp(
+        tester,
+        home: const BroadcastListScreen(),
+        overrides: [
+          lichessClientProvider.overrideWith((ref) => LichessClient(client, ref)),
+          broadcastImageWorkerFactoryProvider.overrideWith(
+            (ref) => FakeBroadcastImageWorkerFactory(),
+          ),
+        ],
+      );
 
-        await tester.pumpWidget(app);
+      await tester.pumpWidget(app);
 
-        expect(find.byType(CircularProgressIndicator), findsOneWidget);
+      expect(find.byType(CircularProgressIndicator), findsOneWidget);
 
-        // Wait for broadcast tournaments to load
-        await tester.pump(const Duration(milliseconds: 100));
+      // Load the broadcast tournaments
+      await tester.pump();
 
-        await tester.scrollUntilVisible(find.byKey(const ValueKey('past')), 100.0);
-      });
+      await tester.scrollUntilVisible(find.byKey(const ValueKey('past')), 100.0);
     });
   });
 }

--- a/test/view/broadcast/broadcast_list_screen_test.dart
+++ b/test/view/broadcast/broadcast_list_screen_test.dart
@@ -46,7 +46,7 @@ final client = MockClient((request) {
 void main() {
   group('BroadcastListScreen', () {
     testWidgets('Displays broadcast tournament screen', variant: kPlatformVariant, (tester) async {
-      mockNetworkImagesFor(() async {
+      await mockNetworkImagesFor(() async {
         final app = await makeTestProviderScopeApp(
           tester,
           home: const BroadcastListScreen(),
@@ -62,15 +62,16 @@ void main() {
 
         expect(find.byType(CircularProgressIndicator), findsOneWidget);
 
-        // wait for broadcast tournaments to load
+        // Wait for broadcast tournaments to load
         await tester.pump(const Duration(milliseconds: 100));
 
         expect(find.byType(BroadcastListTile), findsAtLeast(1));
       });
     });
 
+    // TODO: Fix test for iOS
     testWidgets('Scroll broadcast tournament screen', variant: kPlatformVariant, (tester) async {
-      mockNetworkImagesFor(() async {
+      await mockNetworkImagesFor(() async {
         final app = await makeTestProviderScopeApp(
           tester,
           home: const BroadcastListScreen(),
@@ -86,7 +87,7 @@ void main() {
 
         expect(find.byType(CircularProgressIndicator), findsOneWidget);
 
-        // wait for broadcast tournaments to load
+        // Wait for broadcast tournaments to load
         await tester.pump(const Duration(milliseconds: 100));
 
         await tester.scrollUntilVisible(find.text('Past broadcasts'), 100.0);

--- a/test/view/broadcast/broadcast_round_screen_test.dart
+++ b/test/view/broadcast/broadcast_round_screen_test.dart
@@ -7,7 +7,7 @@ import 'package:lichess_mobile/src/model/common/id.dart';
 import 'package:lichess_mobile/src/network/http.dart';
 import 'package:lichess_mobile/src/view/broadcast/broadcast_round_screen.dart';
 import 'package:lichess_mobile/src/widgets/board_thumbnail.dart';
-import 'package:network_image_mock/network_image_mock.dart';
+import 'package:mocktail_image_network/mocktail_image_network.dart';
 
 import '../../test_helpers.dart';
 import '../../test_provider_scope.dart';
@@ -119,55 +119,53 @@ void main() {
     testWidgets('Test overview tab with an upcoming tournament', variant: kPlatformVariant, (
       tester,
     ) async {
-      await mockNetworkImagesFor(() async {
-        final client = MockClient((request) {
-          if (request.url.path == '/api/broadcast/KnP1dgul') {
-            return mockResponse(
-              _upcomingTournamentResponse,
-              200,
-              headers: {'content-type': 'application/json; charset=utf-8'},
-            );
-          }
-          if (request.url.path == '/api/broadcast/-/-/UN587WBI') {
-            return mockResponse(
-              _upcomingRoundResponse,
-              200,
-              headers: {'content-type': 'application/json; charset=utf-8'},
-            );
-          }
-          return mockResponse('', 404);
-        });
-
-        final app = await makeTestProviderScopeApp(
-          tester,
-          home: BroadcastRoundScreen(broadcast: _upcomingBroadcast),
-          overrides: [lichessClientProvider.overrideWith((ref) => LichessClient(client, ref))],
-        );
-
-        await tester.pumpWidget(app);
-
-        expect(find.byType(CircularProgressIndicator), findsOneWidget);
-
-        // Load the tournament
-        await tester.pump();
-
-        expect(find.byType(CircularProgressIndicator), findsOneWidget);
-
-        // Load the overview
-        await tester.pump();
-
-        final startsAt = DateTime.fromMillisecondsSinceEpoch(1736526600000);
-        final endsAt = DateTime.fromMillisecondsSinceEpoch(1737189000000);
-        final f = DateFormat.MMMd();
-
-        expect(find.text('${f.format(startsAt)} - ${f.format(endsAt)}'), findsOneWidget);
-        expect(find.text('9-round Swiss'), findsOneWidget);
-        expect(find.text('90 min + 30 sec / move'), findsOneWidget);
-        expect(find.text('Seville, Spain'), findsOneWidget);
-        expect(find.text('Xu, Bonelli, Jacobson'), findsOneWidget);
-        expect(find.text('Official website'), findsOneWidget);
-        expect(find.text('Standings'), findsOneWidget);
+      final client = MockClient((request) {
+        if (request.url.path == '/api/broadcast/KnP1dgul') {
+          return mockResponse(
+            _upcomingTournamentResponse,
+            200,
+            headers: {'content-type': 'application/json; charset=utf-8'},
+          );
+        }
+        if (request.url.path == '/api/broadcast/-/-/UN587WBI') {
+          return mockResponse(
+            _upcomingRoundResponse,
+            200,
+            headers: {'content-type': 'application/json; charset=utf-8'},
+          );
+        }
+        return mockResponse('', 404);
       });
+
+      final app = await makeTestProviderScopeApp(
+        tester,
+        home: BroadcastRoundScreen(broadcast: _upcomingBroadcast),
+        overrides: [lichessClientProvider.overrideWith((ref) => LichessClient(client, ref))],
+      );
+
+      await tester.pumpWidget(app);
+
+      expect(find.byType(CircularProgressIndicator), findsOneWidget);
+
+      // Load the tournament
+      await tester.pump();
+
+      expect(find.byType(CircularProgressIndicator), findsOneWidget);
+
+      // Load the overview
+      await mockNetworkImages(() => tester.pump());
+
+      final startsAt = DateTime.fromMillisecondsSinceEpoch(1736526600000);
+      final endsAt = DateTime.fromMillisecondsSinceEpoch(1737189000000);
+      final f = DateFormat.MMMd();
+
+      expect(find.text('${f.format(startsAt)} - ${f.format(endsAt)}'), findsOneWidget);
+      expect(find.text('9-round Swiss'), findsOneWidget);
+      expect(find.text('90 min + 30 sec / move'), findsOneWidget);
+      expect(find.text('Seville, Spain'), findsOneWidget);
+      expect(find.text('Xu, Bonelli, Jacobson'), findsOneWidget);
+      expect(find.text('Official website'), findsOneWidget);
+      expect(find.text('Standings'), findsOneWidget);
     });
 
     testWidgets('Test clocks are ticking with a live round', variant: kPlatformVariant, (

--- a/test/view/broadcast/broadcast_round_screen_test.dart
+++ b/test/view/broadcast/broadcast_round_screen_test.dart
@@ -119,7 +119,7 @@ void main() {
     testWidgets('Test overview tab with an upcoming tournament', variant: kPlatformVariant, (
       tester,
     ) async {
-      mockNetworkImagesFor(() async {
+      await mockNetworkImagesFor(() async {
         final client = MockClient((request) {
           if (request.url.path == '/api/broadcast/KnP1dgul') {
             return mockResponse(


### PR DESCRIPTION
The test for iOS is failing because the finder in `scrollUntilVisible` needs to match a single element and for iOS there are two text widgets that appears with _Completed_ so I don't know how to fix this test. Maybe we can just remove it or make a separate test for Android and iOS ?

![20250116_12h29m31s_grim](https://github.com/user-attachments/assets/0fbc7767-fa81-4519-b7e6-d34cd3d460c7)
