### PR TITLE
Fix CI tests 

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -24,6 +24,9 @@ jobs:
           channel: beta
       - run: flutter doctor -v
 
+      - name: Install requirements for sqflite_common_ffi package
+        run: sudo apt-get -y install libsqlite3-0 libsqlite3-dev
+
       - name: Install dependencies
         run: flutter pub get
 


### PR DESCRIPTION
Fix CI tests by installing SQlite dependencies on Ubuntu that are required for Dart package sqflite_common_ffi