### PR TITLE
Add blink effect to next button based on game step cursor

### DIFF
--- a/lib/src/view/game/game_body.dart
+++ b/lib/src/view/game/game_body.dart
@@ -603,6 +603,7 @@ class _GameBottomBar extends ConsumerWidget {
                 label: context.l10n.next,
                 icon: CupertinoIcons.chevron_forward,
                 showTooltip: false,
+                blink: gameState.stepCursor != gameState.game.steps.length - 1,
               ),
             ),
           ];

--- a/lib/src/view/game/game_body.dart
+++ b/lib/src/view/game/game_body.dart
@@ -603,7 +603,9 @@ class _GameBottomBar extends ConsumerWidget {
                 label: context.l10n.next,
                 icon: CupertinoIcons.chevron_forward,
                 showTooltip: false,
-                blink: gameState.stepCursor != gameState.game.steps.length - 1,
+                invertBackground:
+                    gameState.stepCursor != gameState.game.steps.length - 1 &&
+                    gameState.game.sideToMove == gameState.game.youAre,
               ),
             ),
           ];


### PR DESCRIPTION
Issue: https://github.com/lichess-org/mobile/issues/755
This PR adds a blink effect to the next button when the user is not at the latest move during game reviews.

| before | after | lichess.org |
|---------|---------|---------|
| ![Screenshot_1737730675](https://github.com/user-attachments/assets/a42896a5-09e8-4078-a741-c4234e509694) | ![untitled](https://github.com/user-attachments/assets/f87130e8-66a7-4f4e-8241-aca58ee51a55) | ![Screen-Recording-2025-01-24-at-18 22 39](https://github.com/user-attachments/assets/a116a21b-eff0-4729-be5c-16c3fb1d0292) |
