### PR TITLE
Add chapter numbers to study overview

### DIFF
--- a/lib/src/view/study/study_bottom_bar.dart
+++ b/lib/src/view/study/study_bottom_bar.dart
@@ -292,7 +292,10 @@ class _StudyChaptersMenuState extends ConsumerState<_StudyChaptersMenu> {
         for (final chapter in state.study.chapters)
           PlatformListTile(
             key: chapter.id == state.currentChapter.id ? currentChapterKey : null,
-            title: Text(chapter.name, maxLines: 2),
+            title: Text(
+              'Chapter ${state.study.chapters.indexOf(chapter) + 1}: ${chapter.name}',
+              maxLines: 2,
+            ),
             onTap: () {
               ref.read(studyControllerProvider(widget.id).notifier).goToChapter(chapter.id);
               Navigator.of(context).pop();

--- a/lib/src/view/study/study_screen.dart
+++ b/lib/src/view/study/study_screen.dart
@@ -178,7 +178,7 @@ class _StudyScreenState extends ConsumerState<_StudyScreen> with TickerProviderS
     return PlatformScaffold(
       appBar: PlatformAppBar(
         title: AutoSizeText(
-          widget.studyState.currentChapterTitle,
+          'Chapter ${widget.studyState.study.chapters.indexOf(widget.studyState.currentChapterMeta) + 1}: ${widget.studyState.currentChapterTitle}',
           maxLines: 2,
           minFontSize: 14,
           overflow: TextOverflow.ellipsis,


### PR DESCRIPTION
Add chapter numbers to the chapter titles in the study overview.

* **lib/src/view/study/study_screen.dart**
  - Update the `_StudyScreen` widget to include chapter numbers in the chapter titles.
  - Modify the `_StudyScreenLoader` widget to display chapter numbers in the chapter titles.

* **lib/src/view/study/study_bottom_bar.dart**
  - Add chapter numbers to the chapter list in the `_StudyChaptersMenu` widget.
  - Update the `_ChapterButton` widget to include chapter numbers in the chapter titles.

