### PR TITLE
Theme fixes

### DIFF
--- a/build.yaml
+++ b/build.yaml
@@ -13,6 +13,7 @@ targets:
       riverpod_generator:
         generate_for:
           - lib/src/localizations.dart
+          - lib/src/theme.dart
           - lib/src/model/**/*.dart
           - lib/src/network/*.dart
           - lib/src/db/*.dart

--- a/docs/coding_style.md
+++ b/docs/coding_style.md
@@ -60,7 +60,7 @@ PlatformWidget(
 ```
 
 > [!TIP]
-> The codebase already has some common platform-aware widgets that you can use, for example `PlatformThemedScaffold`,
+> The codebase already has some common platform-aware widgets that you can use, for example `PlatformScaffold`,
 > `PlatformAppBar`, `PlatformListTile`, ...
 
 ## Writing UI code

--- a/docs/coding_style.md
+++ b/docs/coding_style.md
@@ -60,7 +60,7 @@ PlatformWidget(
 ```
 
 > [!TIP]
-> The codebase already has some common platform-aware widgets that you can use, for example `PlatformScaffold`,
+> The codebase already has some common platform-aware widgets that you can use, for example `PlatformThemedScaffold`,
 > `PlatformAppBar`, `PlatformListTile`, ...
 
 ## Writing UI code

--- a/lib/src/app.dart
+++ b/lib/src/app.dart
@@ -156,7 +156,7 @@ class _AppState extends ConsumerState<Application> {
           (settings) =>
               settings.name != null ? resolveAppLinkUri(context, Uri.parse(settings.name!)) : null,
       onGenerateInitialRoutes: (initialRoute) {
-        final homeRoute = createPlatformRoute(context, screen: const BottomNavScaffold());
+        final homeRoute = buildScreenRoute<void>(context, screen: const BottomNavScaffold());
         return <Route<dynamic>?>[
           homeRoute,
           resolveAppLinkUri(context, Uri.parse(initialRoute)),

--- a/lib/src/app.dart
+++ b/lib/src/app.dart
@@ -1,7 +1,5 @@
-import 'package:flex_color_scheme/flex_color_scheme.dart';
 import 'package:flutter/cupertino.dart';
 import 'package:flutter/material.dart';
-import 'package:flutter/services.dart' show SystemUiOverlayStyle;
 import 'package:flutter_native_splash/flutter_native_splash.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:lichess_mobile/l10n/l10n.dart';
@@ -125,42 +123,36 @@ class _AppState extends ConsumerState<Application> {
     final isIOS = Theme.of(context).platform == TargetPlatform.iOS;
     final remainingHeight = estimateRemainingHeightLeftBoard(context);
 
-    return AnnotatedRegion<SystemUiOverlayStyle>(
-      value: FlexColorScheme.themedSystemNavigationBar(
-        context,
-        systemNavBarStyle: FlexSystemNavBarStyle.transparent,
+    return MaterialApp(
+      localizationsDelegates: AppLocalizations.localizationsDelegates,
+      supportedLocales: kSupportedLocales,
+      onGenerateTitle: (BuildContext context) => 'lichess.org',
+      locale: generalPrefs.locale,
+      theme: themeLight.copyWith(
+        navigationBarTheme: NavigationBarTheme.of(
+          context,
+        ).copyWith(height: remainingHeight < kSmallRemainingHeightLeftBoardThreshold ? 60 : null),
       ),
-      child: MaterialApp(
-        localizationsDelegates: AppLocalizations.localizationsDelegates,
-        supportedLocales: kSupportedLocales,
-        onGenerateTitle: (BuildContext context) => 'lichess.org',
-        locale: generalPrefs.locale,
-        theme: themeLight.copyWith(
-          navigationBarTheme: NavigationBarTheme.of(
-            context,
-          ).copyWith(height: remainingHeight < kSmallRemainingHeightLeftBoardThreshold ? 60 : null),
-        ),
-        darkTheme: themeDark.copyWith(
-          navigationBarTheme: NavigationBarTheme.of(
-            context,
-          ).copyWith(height: remainingHeight < kSmallRemainingHeightLeftBoardThreshold ? 60 : null),
-          extensions: [lichessCustomColors.harmonized(themeDark.colorScheme)],
-        ),
-        themeMode: switch (generalPrefs.themeMode) {
-          BackgroundThemeMode.light => ThemeMode.light,
-          BackgroundThemeMode.dark => ThemeMode.dark,
-          BackgroundThemeMode.system => ThemeMode.system,
-        },
-        builder:
-            isIOS
-                ? (context, child) => IconTheme.merge(
-                  data: IconThemeData(color: CupertinoTheme.of(context).textTheme.textStyle.color),
-                  child: Material(color: Colors.transparent, child: child),
-                )
-                : null,
-        home: const FullScreenBackgroundTheme(child: BottomNavScaffold()),
-        navigatorObservers: [rootNavPageRouteObserver],
+      darkTheme: themeDark.copyWith(
+        navigationBarTheme: NavigationBarTheme.of(
+          context,
+        ).copyWith(height: remainingHeight < kSmallRemainingHeightLeftBoardThreshold ? 60 : null),
+        extensions: [lichessCustomColors.harmonized(themeDark.colorScheme)],
       ),
+      themeMode: switch (generalPrefs.themeMode) {
+        BackgroundThemeMode.light => ThemeMode.light,
+        BackgroundThemeMode.dark => ThemeMode.dark,
+        BackgroundThemeMode.system => ThemeMode.system,
+      },
+      builder:
+          isIOS
+              ? (context, child) => IconTheme.merge(
+                data: IconThemeData(color: CupertinoTheme.of(context).textTheme.textStyle.color),
+                child: Material(color: Colors.transparent, child: child),
+              )
+              : null,
+      home: const FullScreenBackgroundTheme(child: BottomNavScaffold()),
+      navigatorObservers: [rootNavPageRouteObserver],
     );
   }
 }

--- a/lib/src/app.dart
+++ b/lib/src/app.dart
@@ -11,17 +11,15 @@ import 'package:lichess_mobile/src/model/challenge/challenge_service.dart';
 import 'package:lichess_mobile/src/model/common/preloaded_data.dart';
 import 'package:lichess_mobile/src/model/correspondence/correspondence_service.dart';
 import 'package:lichess_mobile/src/model/notifications/notification_service.dart';
-import 'package:lichess_mobile/src/model/settings/board_preferences.dart';
 import 'package:lichess_mobile/src/model/settings/general_preferences.dart';
 import 'package:lichess_mobile/src/navigation.dart';
 import 'package:lichess_mobile/src/network/connectivity.dart';
 import 'package:lichess_mobile/src/network/http.dart';
 import 'package:lichess_mobile/src/network/socket.dart';
-import 'package:lichess_mobile/src/styles/lichess_colors.dart';
 import 'package:lichess_mobile/src/styles/styles.dart';
 import 'package:lichess_mobile/src/theme.dart';
-import 'package:lichess_mobile/src/utils/color_palette.dart' show getDynamicColorSchemes;
 import 'package:lichess_mobile/src/utils/screen.dart';
+import 'package:lichess_mobile/src/widgets/background_theme.dart';
 
 /// Application initialization and main entry point.
 class AppInitializationScreen extends ConsumerWidget {
@@ -122,118 +120,10 @@ class _AppState extends ConsumerState<Application> {
   @override
   Widget build(BuildContext context) {
     final generalPrefs = ref.watch(generalPreferencesProvider);
+    final (light: themeLight, dark: themeDark) = ref.watch(applicationThemeProvider);
 
-    final boardTheme = ref.watch(boardPreferencesProvider.select((state) => state.boardTheme));
-    final isTablet = isTabletOrLarger(context);
     final isIOS = Theme.of(context).platform == TargetPlatform.iOS;
     final remainingHeight = estimateRemainingHeightLeftBoard(context);
-    final systemScheme = getDynamicColorSchemes();
-    final hasSystemColors = systemScheme != null && generalPrefs.systemColors == true;
-
-    final defaultLight = ColorScheme.fromSeed(seedColor: boardTheme.colors.darkSquare);
-    final defaultDark = ColorScheme.fromSeed(
-      seedColor: boardTheme.colors.darkSquare,
-      brightness: Brightness.dark,
-    );
-
-    final themeLight =
-        hasSystemColors
-            ? ThemeData.from(colorScheme: systemScheme.light)
-            : ThemeData.from(colorScheme: defaultLight);
-    // : FlexThemeData.light(
-    //   colors: AppTheme.lightColors,
-    //   surfaceMode: FlexSurfaceMode.highScaffoldLowSurface,
-    //   blendLevel: 10,
-    //   swapLegacyOnMaterial3: !hasSystemColors,
-    //   useMaterial3ErrorColors: true,
-    //   cupertinoOverrideTheme: const CupertinoThemeData(applyThemeToAll: true),
-    //   appBarStyle: isIOS ? null : FlexAppBarStyle.scaffoldBackground,
-    // );
-
-    // Defined in 2 steps to allow for a different scaffold background color.
-    final darkFlexScheme = FlexColorScheme.dark(
-      colors: AppTheme.darkColors,
-      surfaceMode: FlexSurfaceMode.highSurfaceLowScaffold,
-      blendLevel: 10,
-    );
-    final themeDark =
-        hasSystemColors
-            ? ThemeData.from(colorScheme: systemScheme.dark)
-            : ThemeData.from(colorScheme: defaultDark);
-    // : FlexThemeData.dark(
-    //   colors: AppTheme.darkColors,
-    //   // swapColors: !hasSystemColors,
-    //   swapLegacyOnMaterial3: !hasSystemColors,
-    //   useMaterial3ErrorColors: !hasSystemColors,
-    //   surfaceMode: FlexSurfaceMode.highSurfaceLowScaffold,
-    //   blendLevel: 15,
-    //   cupertinoOverrideTheme: const CupertinoThemeData(applyThemeToAll: true),
-    //   scaffoldBackground:
-    //       darkFlexScheme.scaffoldBackground != null
-    //           ? lighten(darkFlexScheme.scaffoldBackground!, 0.1)
-    //           : null,
-    //   appBarStyle: isIOS ? null : FlexAppBarStyle.scaffoldBackground,
-    // );
-
-    const cupertinoTitleColor = CupertinoDynamicColor.withBrightness(
-      color: Color(0xFF000000),
-      darkColor: Color(0xFFF5F5F5),
-    );
-
-    final lightCupertino = CupertinoThemeData(
-      applyThemeToAll: true,
-      primaryColor: themeLight.colorScheme.primary,
-      primaryContrastingColor: themeLight.colorScheme.onPrimary,
-      brightness: Brightness.light,
-      scaffoldBackgroundColor: darken(themeLight.scaffoldBackgroundColor, 0.05),
-      barBackgroundColor: themeLight.colorScheme.surface.withValues(alpha: isTablet ? 1.0 : 0.9),
-      textTheme: const CupertinoThemeData().textTheme.copyWith(
-        primaryColor: themeLight.colorScheme.primary,
-        textStyle: const CupertinoThemeData().textTheme.textStyle.copyWith(
-          color: themeLight.colorScheme.onSurface,
-        ),
-        navTitleTextStyle: const CupertinoThemeData().textTheme.navTitleTextStyle.copyWith(
-          color: themeLight.colorScheme.onSurface,
-        ),
-        navLargeTitleTextStyle: const CupertinoThemeData().textTheme.navLargeTitleTextStyle
-            .copyWith(color: themeLight.colorScheme.onSurface),
-      ),
-    );
-
-    final darkCupertino = CupertinoThemeData(
-      applyThemeToAll: true,
-      primaryColor: themeDark.colorScheme.primary,
-      primaryContrastingColor: themeDark.colorScheme.onPrimary,
-      brightness: Brightness.dark,
-      scaffoldBackgroundColor: themeDark.scaffoldBackgroundColor,
-      barBackgroundColor: themeDark.colorScheme.surface.withValues(alpha: isTablet ? 1.0 : 0.9),
-      textTheme: const CupertinoThemeData().textTheme.copyWith(
-        primaryColor: themeDark.colorScheme.primary,
-        textStyle: const CupertinoThemeData().textTheme.textStyle.copyWith(
-          color: themeDark.colorScheme.onSurface,
-        ),
-        navTitleTextStyle: const CupertinoThemeData().textTheme.navTitleTextStyle.copyWith(
-          color: themeDark.colorScheme.onSurface,
-        ),
-        navLargeTitleTextStyle: const CupertinoThemeData().textTheme.navLargeTitleTextStyle
-            .copyWith(color: themeDark.colorScheme.onSurface),
-      ),
-    );
-
-    // The high blend theme is used only for the navigation bar in light mode.
-    final highBlendThemeLight = FlexThemeData.light(
-      colors: AppTheme.lightColors,
-      surfaceMode: FlexSurfaceMode.highBackgroundLowScaffold,
-      blendLevel: 20,
-    );
-
-    final floatingActionButtonTheme =
-        hasSystemColors
-            ? null
-            : FloatingActionButtonThemeData(
-              backgroundColor: themeLight.colorScheme.primaryFixedDim,
-              foregroundColor: themeLight.colorScheme.onPrimaryFixed,
-            );
 
     return AnnotatedRegion<SystemUiOverlayStyle>(
       value: FlexColorScheme.themedSystemNavigationBar(
@@ -246,47 +136,14 @@ class _AppState extends ConsumerState<Application> {
         onGenerateTitle: (BuildContext context) => 'lichess.org',
         locale: generalPrefs.locale,
         theme: themeLight.copyWith(
-          cupertinoOverrideTheme: lightCupertino,
-          splashFactory: isIOS ? NoSplash.splashFactory : null,
-          textTheme: isIOS ? Typography.blackCupertino : null,
-          listTileTheme:
-              isIOS
-                  ? ListTileTheme.of(context).copyWith(
-                    titleTextStyle: lightCupertino.textTheme.textStyle,
-                    subtitleTextStyle: lightCupertino.textTheme.textStyle,
-                    leadingAndTrailingTextStyle: lightCupertino.textTheme.textStyle,
-                  )
-                  : null,
-          menuTheme: isIOS ? Styles.cupertinoAnchorMenuTheme : null,
-          navigationBarTheme: NavigationBarTheme.of(context).copyWith(
-            height: remainingHeight < kSmallRemainingHeightLeftBoardThreshold ? 60 : null,
-            // backgroundColor: hasSystemColors ? null : highBlendThemeLight.colorScheme.surface,
-            // indicatorColor:
-            //     hasSystemColors
-            //         ? null
-            //         : darken(highBlendThemeLight.colorScheme.secondaryContainer, 0.05),
-            // elevation: 3,
-          ),
-          extensions: [lichessCustomColors.harmonized(themeLight.colorScheme)],
+          navigationBarTheme: NavigationBarTheme.of(
+            context,
+          ).copyWith(height: remainingHeight < kSmallRemainingHeightLeftBoardThreshold ? 60 : null),
         ),
         darkTheme: themeDark.copyWith(
-          cupertinoOverrideTheme: darkCupertino,
-          splashFactory: isIOS ? NoSplash.splashFactory : null,
-          textTheme: isIOS ? Typography.whiteCupertino : null,
-          listTileTheme:
-              isIOS
-                  ? ListTileTheme.of(context).copyWith(
-                    titleTextStyle: darkCupertino.textTheme.textStyle,
-                    subtitleTextStyle: darkCupertino.textTheme.textStyle,
-                    leadingAndTrailingTextStyle: darkCupertino.textTheme.textStyle,
-                  )
-                  : null,
-          // floatingActionButtonTheme: floatingActionButtonTheme,
-          menuTheme: isIOS ? Styles.cupertinoAnchorMenuTheme : null,
-          navigationBarTheme: NavigationBarTheme.of(context).copyWith(
-            height: remainingHeight < kSmallRemainingHeightLeftBoardThreshold ? 60 : null,
-            // backgroundColor: hasSystemColors ? null : themeDark.colorScheme.surface,
-          ),
+          navigationBarTheme: NavigationBarTheme.of(
+            context,
+          ).copyWith(height: remainingHeight < kSmallRemainingHeightLeftBoardThreshold ? 60 : null),
           extensions: [lichessCustomColors.harmonized(themeDark.colorScheme)],
         ),
         themeMode: switch (generalPrefs.themeMode) {
@@ -298,13 +155,10 @@ class _AppState extends ConsumerState<Application> {
             isIOS
                 ? (context, child) => IconTheme.merge(
                   data: IconThemeData(color: CupertinoTheme.of(context).textTheme.textStyle.color),
-                  child: DefaultTextStyle.merge(
-                    style: CupertinoTheme.of(context).textTheme.textStyle,
-                    child: Material(color: Colors.transparent, child: child),
-                  ),
+                  child: Material(color: Colors.transparent, child: child),
                 )
                 : null,
-        home: const BottomNavScaffold(),
+        home: const FullScreenBackgroundTheme(child: BottomNavScaffold()),
         navigatorObservers: [rootNavPageRouteObserver],
       ),
     );

--- a/lib/src/app.dart
+++ b/lib/src/app.dart
@@ -140,11 +140,14 @@ class _AppState extends ConsumerState<Application> {
         ).copyWith(height: remainingHeight < kSmallRemainingHeightLeftBoardThreshold ? 60 : null),
         extensions: [lichessCustomColors.harmonized(themeDark.colorScheme)],
       ),
-      themeMode: switch (generalPrefs.themeMode) {
-        BackgroundThemeMode.light => ThemeMode.light,
-        BackgroundThemeMode.dark => ThemeMode.dark,
-        BackgroundThemeMode.system => ThemeMode.system,
-      },
+      themeMode:
+          generalPrefs.isForcedDarkMode
+              ? ThemeMode.dark
+              : switch (generalPrefs.themeMode) {
+                BackgroundThemeMode.light => ThemeMode.light,
+                BackgroundThemeMode.dark => ThemeMode.dark,
+                BackgroundThemeMode.system => ThemeMode.system,
+              },
       builder:
           isIOS
               ? (context, child) => IconTheme.merge(

--- a/lib/src/app.dart
+++ b/lib/src/app.dart
@@ -17,7 +17,7 @@ import 'package:lichess_mobile/src/network/socket.dart';
 import 'package:lichess_mobile/src/styles/styles.dart';
 import 'package:lichess_mobile/src/theme.dart';
 import 'package:lichess_mobile/src/utils/screen.dart';
-import 'package:lichess_mobile/src/widgets/background_theme.dart';
+import 'package:lichess_mobile/src/widgets/background.dart';
 
 /// Application initialization and main entry point.
 class AppInitializationScreen extends ConsumerWidget {
@@ -151,7 +151,7 @@ class _AppState extends ConsumerState<Application> {
                 child: Material(color: Colors.transparent, child: child),
               )
               : null,
-      home: const FullScreenBackgroundTheme(child: BottomNavScaffold()),
+      home: const FullScreenBackground(child: BottomNavScaffold()),
       navigatorObservers: [rootNavPageRouteObserver],
     );
   }

--- a/lib/src/app_links.dart
+++ b/lib/src/app_links.dart
@@ -19,13 +19,13 @@ Route<dynamic>? resolveAppLinkUri(BuildContext context, Uri appLinkUri) {
 
   switch (appLinkUri.pathSegments[0]) {
     case 'streak':
-      return createPlatformRoute(context, screen: const StreakScreen());
+      return buildScreenRoute(context, screen: const StreakScreen());
     case 'storm':
-      return createPlatformRoute(context, screen: const StormScreen());
+      return buildScreenRoute(context, screen: const StormScreen());
     case 'study':
-      return createPlatformRoute(context, screen: StudyScreen(id: StudyId(id)));
+      return buildScreenRoute(context, screen: StudyScreen(id: StudyId(id)));
     case 'training':
-      return createPlatformRoute(
+      return buildScreenRoute(
         context,
         screen: PuzzleScreen(angle: PuzzleAngle.fromKey('mix'), puzzleId: PuzzleId(id)),
       );
@@ -34,7 +34,7 @@ Route<dynamic>? resolveAppLinkUri(BuildContext context, Uri appLinkUri) {
         final gameId = GameId(appLinkUri.pathSegments[0]);
         final orientation = appLinkUri.pathSegments.getOrNull(2);
         if (gameId.isValid) {
-          return createPlatformRoute(
+          return buildScreenRoute(
             context,
             screen: ArchivedGameScreen(
               gameId: gameId,

--- a/lib/src/model/challenge/challenge_service.dart
+++ b/lib/src/model/challenge/challenge_service.dart
@@ -13,7 +13,6 @@ import 'package:lichess_mobile/src/model/notifications/notifications.dart';
 import 'package:lichess_mobile/src/navigation.dart';
 import 'package:lichess_mobile/src/network/socket.dart';
 import 'package:lichess_mobile/src/utils/l10n_context.dart';
-import 'package:lichess_mobile/src/utils/navigation.dart';
 import 'package:lichess_mobile/src/view/game/game_screen.dart';
 import 'package:lichess_mobile/src/view/user/challenge_requests_screen.dart';
 import 'package:lichess_mobile/src/widgets/adaptive_action_sheet.dart';
@@ -112,11 +111,10 @@ class ChallengeService {
           rootNavState.popUntil((route) => route.isFirst);
         }
 
-        pushPlatformRoute(
+        Navigator.of(
           context,
           rootNavigator: true,
-          builder: (BuildContext context) => GameScreen(initialGameId: fullId),
-        );
+        ).push(GameScreen.buildRoute(context, initialGameId: fullId));
 
       case 'decline':
         final context = ref.read(currentNavigatorKeyProvider).currentContext;
@@ -144,10 +142,7 @@ class ChallengeService {
         if (navState.canPop()) {
           navState.popUntil((route) => route.isFirst);
         }
-        pushPlatformRoute(
-          context,
-          builder: (BuildContext context) => const ChallengeRequestsScreen(),
-        );
+        Navigator.of(context).push(ChallengeRequestsScreen.buildRoute(context));
     }
   }
 }

--- a/lib/src/model/correspondence/correspondence_service.dart
+++ b/lib/src/model/correspondence/correspondence_service.dart
@@ -19,7 +19,6 @@ import 'package:lichess_mobile/src/model/game/playable_game.dart';
 import 'package:lichess_mobile/src/navigation.dart';
 import 'package:lichess_mobile/src/network/http.dart';
 import 'package:lichess_mobile/src/network/socket.dart';
-import 'package:lichess_mobile/src/utils/navigation.dart';
 import 'package:lichess_mobile/src/view/game/game_screen.dart';
 import 'package:logging/logging.dart';
 import 'package:riverpod_annotation/riverpod_annotation.dart';
@@ -48,11 +47,10 @@ class CorrespondenceService {
       rootNavState.popUntil((route) => route.isFirst);
     }
 
-    pushPlatformRoute(
+    Navigator.of(
       context,
       rootNavigator: true,
-      builder: (_) => GameScreen(initialGameId: fullId),
-    );
+    ).push(GameScreen.buildRoute(context, initialGameId: fullId));
   }
 
   /// Syncs offline correspondence games with the server.

--- a/lib/src/model/settings/board_preferences.dart
+++ b/lib/src/model/settings/board_preferences.dart
@@ -1,6 +1,5 @@
 import 'package:chessground/chessground.dart';
 import 'package:flex_color_scheme/flex_color_scheme.dart';
-import 'package:flutter/cupertino.dart' show CupertinoThemeData;
 import 'package:flutter/material.dart';
 import 'package:freezed_annotation/freezed_annotation.dart';
 import 'package:lichess_mobile/l10n/l10n.dart';
@@ -446,7 +445,7 @@ class BoardBackgroundImage with _$BoardBackgroundImage {
     required String path,
     required Matrix4 transform,
     required bool isBlurred,
-    required ColorScheme darkColors,
+    required Color seedColor,
     required double meanLuminance,
     required double width,
     required double height,
@@ -454,34 +453,22 @@ class BoardBackgroundImage with _$BoardBackgroundImage {
     required double viewportHeight,
   }) = _BoardBackgroundImage;
 
-  static Color getFilterColor(ColorScheme scheme, double meanLuminance) =>
-      scheme.surface.withValues(
-        alpha: switch (meanLuminance) {
-          < 0.2 => 0,
-          < 0.4 => 0.25,
-          < 0.6 => 0.5,
-          _ => 0.8,
-        },
-      );
-
-  static ThemeData getTheme(ColorScheme scheme) => FlexThemeData.dark(
-    colors: FlexSchemeColor(
-      primary: scheme.primary,
-      primaryContainer: scheme.primaryContainer,
-      secondary: scheme.secondary,
-      secondaryContainer: scheme.secondaryContainer,
-      tertiary: scheme.tertiary,
-      tertiaryContainer: scheme.tertiaryContainer,
-      error: scheme.error,
-      errorContainer: scheme.errorContainer,
-    ),
-    cupertinoOverrideTheme: const CupertinoThemeData(applyThemeToAll: true),
-    appBarOpacity: 0.5,
+  static Color getFilterColor(Color surfaceColor, double meanLuminance) => surfaceColor.withValues(
+    alpha: switch (meanLuminance) {
+      < 0.2 => 0,
+      < 0.4 => 0.25,
+      < 0.6 => 0.5,
+      _ => 0.8,
+    },
   );
 
-  ThemeData get theme => getTheme(darkColors);
+  /// Generate a base [ThemeData] from the seed color.
+  static ThemeData getTheme(Color seedColor) => ThemeData.from(
+    colorScheme: ColorScheme.fromSeed(seedColor: seedColor, brightness: Brightness.dark),
+  );
 
-  Color get filterColor => getFilterColor(darkColors, meanLuminance);
+  /// The base theme for the background image.
+  ThemeData get baseTheme => getTheme(seedColor);
 }
 
 class BoardBackgroundImageConverter
@@ -494,30 +481,13 @@ class BoardBackgroundImageConverter
       return null;
     }
 
-    final darkColors = ColorScheme(
-      brightness: Brightness.dark,
-      primary: Color(json['darkPrimary'] as int),
-      onPrimary: Color(json['darkOnPrimary'] as int),
-      primaryContainer: Color(json['darkPrimaryContainer'] as int),
-      secondary: Color(json['darkSecondary'] as int),
-      onSecondary: Color(json['darkOnSecondary'] as int),
-      secondaryContainer: Color(json['darkSecondaryContainer'] as int),
-      tertiary: Color(json['darkTertiary'] as int),
-      tertiaryContainer: Color(json['darkTertiaryContainer'] as int),
-      error: Color(json['darkError'] as int),
-      onError: Color(json['darkOnError'] as int),
-      errorContainer: Color(json['darkErrorContainer'] as int),
-      surface: Color(json['darkSurface'] as int),
-      onSurface: Color(json['darkOnSurface'] as int),
-    );
-
     final transform = json['transform'] as List<dynamic>;
 
     return BoardBackgroundImage(
       path: json['path'] as String,
       transform: Matrix4.fromList(transform.map((e) => (e as num).toDouble()).toList()),
       isBlurred: json['isBlurred'] as bool,
-      darkColors: darkColors,
+      seedColor: Color(json['seedColor'] as int),
       meanLuminance: json['meanLuminance'] as double,
       width: json['width'] as double,
       height: json['height'] as double,
@@ -532,27 +502,11 @@ class BoardBackgroundImageConverter
       return null;
     }
 
-    final Map<String, int> darkColors = {
-      'darkPrimary': object.darkColors.primary.toARGB32(),
-      'darkOnPrimary': object.darkColors.onPrimary.toARGB32(),
-      'darkPrimaryContainer': object.darkColors.primaryContainer.toARGB32(),
-      'darkSecondary': object.darkColors.secondary.toARGB32(),
-      'darkOnSecondary': object.darkColors.onSecondary.toARGB32(),
-      'darkSecondaryContainer': object.darkColors.secondaryContainer.toARGB32(),
-      'darkTertiary': object.darkColors.tertiary.toARGB32(),
-      'darkTertiaryContainer': object.darkColors.tertiaryContainer.toARGB32(),
-      'darkError': object.darkColors.error.toARGB32(),
-      'darkOnError': object.darkColors.onError.toARGB32(),
-      'darkErrorContainer': object.darkColors.errorContainer.toARGB32(),
-      'darkSurface': object.darkColors.surface.toARGB32(),
-      'darkOnSurface': object.darkColors.onSurface.toARGB32(),
-    };
-
     return {
       'path': object.path,
       'transform': object.transform.storage,
       'isBlurred': object.isBlurred,
-      ...darkColors,
+      'seedColor': object.seedColor.toARGB32(),
       'meanLuminance': object.meanLuminance,
       'width': object.width,
       'height': object.height,

--- a/lib/src/model/settings/board_preferences.dart
+++ b/lib/src/model/settings/board_preferences.dart
@@ -1,5 +1,4 @@
 import 'package:chessground/chessground.dart';
-import 'package:flex_color_scheme/flex_color_scheme.dart';
 import 'package:flutter/material.dart';
 import 'package:freezed_annotation/freezed_annotation.dart';
 import 'package:lichess_mobile/l10n/l10n.dart';
@@ -368,26 +367,26 @@ String dragTargetKindLabel(DragTargetKind kind) => switch (kind) {
 };
 
 enum BoardBackgroundTheme {
-  blue(30, 34, FlexScheme.blue, 'Blue'),
-  indigo(30, 34, FlexScheme.indigo, 'indigo'),
-  green(30, 34, FlexScheme.jungle, 'Green'),
-  brown(30, 34, FlexScheme.purpleBrown, 'Brown'),
-  gold(30, 34, FlexScheme.gold, 'Gold'),
-  red(34, 34, FlexScheme.redWine, 'Red'),
-  purple(30, 34, FlexScheme.purpleM3, 'Purple'),
-  teal(30, 34, FlexScheme.tealM3, 'Teal'),
-  lime(30, 34, FlexScheme.limeM3, 'Lime'),
-  mango(30, 34, FlexScheme.mango, 'Mango'),
-  sepia(30, 34, FlexScheme.sepia, 'Sepia');
+  blue(Color.fromARGB(255, 58, 81, 100), 'Blue'),
+  indigo(Color.fromARGB(255, 49, 54, 82), 'indigo'),
+  green(Color.fromARGB(255, 32, 64, 42), 'Green'),
+  brown(Color.fromARGB(255, 67, 52, 54), 'Brown'),
+  gold(Color.fromARGB(255, 95, 68, 38), 'Gold'),
+  red(Color.fromARGB(255, 92, 42, 50), 'Red'),
+  purple(Color.fromARGB(255, 100, 69, 103), 'Purple'),
+  teal(Color.fromARGB(255, 34, 88, 81), 'Teal'),
+  lime(Color.fromARGB(255, 77, 84, 40), 'Lime'),
+  sepia(Color.fromARGB(255, 97, 93, 87), 'Sepia');
 
-  final int lightBlend;
-  final int darkBlend;
-  final FlexScheme scheme;
+  final Color color;
   final String _label;
 
-  const BoardBackgroundTheme(this.lightBlend, this.darkBlend, this.scheme, this._label);
+  const BoardBackgroundTheme(this.color, this._label);
 
   String label(AppLocalizations l10n) => _label;
+
+  /// The base theme for the background color.
+  ThemeData get baseTheme => BoardBackgroundImage.getTheme(color);
 }
 
 @freezed

--- a/lib/src/model/settings/board_preferences.dart
+++ b/lib/src/model/settings/board_preferences.dart
@@ -409,8 +409,6 @@ String dragTargetKindLabel(DragTargetKind kind) => switch (kind) {
 };
 
 enum BoardBackgroundTheme {
-  /// The background theme is based on the chess board
-  board(30, 34),
   blue(30, 34, FlexScheme.blue, 'Blue'),
   indigo(30, 34, FlexScheme.indigo, 'indigo'),
   green(30, 34, FlexScheme.jungle, 'Green'),
@@ -418,17 +416,13 @@ enum BoardBackgroundTheme {
   gold(30, 34, FlexScheme.gold, 'Gold'),
   red(34, 34, FlexScheme.redWine, 'Red'),
   purple(30, 34, FlexScheme.purpleM3, 'Purple'),
-  sepia(28, 34, FlexScheme.sepia, 'Sepia'),
+  teal(30, 34, FlexScheme.tealM3, 'Teal'),
+  lime(30, 34, FlexScheme.limeM3, 'Lime'),
+  mango(30, 34, FlexScheme.mango, 'Mango'),
+  sepia(30, 34, FlexScheme.sepia, 'Sepia'),
 
-  dimBoard(20, 24),
-  dimBlue(20, 24, FlexScheme.blue, 'Blue dim'),
-  dimIndigo(20, 24, FlexScheme.indigo, 'Indigo dim'),
-  dimGreen(20, 24, FlexScheme.jungle, 'Green dim'),
-  dimBrown(20, 24, FlexScheme.purpleBrown, 'Brown dim'),
-  dimGold(20, 24, FlexScheme.gold, 'Gold dim'),
-  dimRed(24, 24, FlexScheme.redWine, 'Red dim'),
-  dimPurple(20, 24, FlexScheme.purpleM3, 'Purple dim'),
-  dimSepia(18, 24, FlexScheme.sepia, 'Sepia dim');
+  /// The background theme is based on the chess board
+  board(30, 34);
 
   final int lightBlend;
   final int darkBlend;
@@ -437,15 +431,10 @@ enum BoardBackgroundTheme {
 
   const BoardBackgroundTheme(this.lightBlend, this.darkBlend, [this.scheme, this._label]);
 
-  String label(AppLocalizations l10n) =>
-      this == BoardBackgroundTheme.board || this == BoardBackgroundTheme.dimBoard
-          ? l10n.board
-          : _label!;
+  String label(AppLocalizations l10n) => this == BoardBackgroundTheme.board ? l10n.board : _label!;
 
   FlexSchemeData getFlexScheme(BoardTheme boardTheme) =>
-      this == BoardBackgroundTheme.board || this == BoardBackgroundTheme.dimBoard
-          ? boardTheme.flexScheme
-          : scheme!.data;
+      this == BoardBackgroundTheme.board ? boardTheme.flexScheme : scheme!.data;
 }
 
 @freezed

--- a/lib/src/model/settings/board_preferences.dart
+++ b/lib/src/model/settings/board_preferences.dart
@@ -306,46 +306,6 @@ enum BoardTheme {
     }
   }
 
-  FlexSchemeData get flexScheme {
-    final lightScheme = SeedColorScheme.fromSeeds(
-      primaryKey: colors.darkSquare,
-      secondaryKey: colors.lightSquare,
-      brightness: Brightness.light,
-    );
-    final darkScheme = SeedColorScheme.fromSeeds(
-      primaryKey: colors.darkSquare,
-      secondaryKey: colors.lightSquare,
-      brightness: Brightness.dark,
-    );
-    return FlexSchemeData(
-      name: 'Chessboard',
-      description: 'Chessboard based theme: $label',
-      light: FlexSchemeColor(
-        primary: lightScheme.primary,
-        primaryContainer: lightScheme.primaryContainer,
-        secondary: lightScheme.secondary,
-        secondaryContainer: lightScheme.secondaryContainer,
-        tertiary: lightScheme.tertiary,
-        tertiaryContainer: lightScheme.tertiaryContainer,
-        error: lightScheme.error,
-        errorContainer: lightScheme.errorContainer,
-      ),
-      dark: FlexSchemeColor(
-        primary: darkScheme.primary,
-        primaryContainer: darkScheme.primaryContainer,
-        primaryLightRef: lightScheme.primary,
-        secondary: darkScheme.secondary,
-        secondaryContainer: darkScheme.secondaryContainer,
-        secondaryLightRef: lightScheme.secondary,
-        tertiary: darkScheme.tertiary,
-        tertiaryContainer: darkScheme.tertiaryContainer,
-        tertiaryLightRef: lightScheme.tertiary,
-        error: darkScheme.error,
-        errorContainer: darkScheme.errorContainer,
-      ),
-    );
-  }
-
   Widget get thumbnail =>
       this == BoardTheme.system
           ? SizedBox(
@@ -418,22 +378,16 @@ enum BoardBackgroundTheme {
   teal(30, 34, FlexScheme.tealM3, 'Teal'),
   lime(30, 34, FlexScheme.limeM3, 'Lime'),
   mango(30, 34, FlexScheme.mango, 'Mango'),
-  sepia(30, 34, FlexScheme.sepia, 'Sepia'),
-
-  /// The background theme is based on the chess board
-  board(30, 34);
+  sepia(30, 34, FlexScheme.sepia, 'Sepia');
 
   final int lightBlend;
   final int darkBlend;
-  final FlexScheme? scheme;
-  final String? _label;
+  final FlexScheme scheme;
+  final String _label;
 
-  const BoardBackgroundTheme(this.lightBlend, this.darkBlend, [this.scheme, this._label]);
+  const BoardBackgroundTheme(this.lightBlend, this.darkBlend, this.scheme, this._label);
 
-  String label(AppLocalizations l10n) => this == BoardBackgroundTheme.board ? l10n.board : _label!;
-
-  FlexSchemeData getFlexScheme(BoardTheme boardTheme) =>
-      this == BoardBackgroundTheme.board ? boardTheme.flexScheme : scheme!.data;
+  String label(AppLocalizations l10n) => _label;
 }
 
 @freezed

--- a/lib/src/model/settings/general_preferences.dart
+++ b/lib/src/model/settings/general_preferences.dart
@@ -144,7 +144,7 @@ enum BackgroundTheme {
   gold(Color.fromARGB(255, 95, 68, 38), 'Gold'),
   red(Color.fromARGB(255, 92, 42, 50), 'Red'),
   purple(Color.fromARGB(255, 100, 69, 103), 'Purple'),
-  teal(Color.fromARGB(255, 34, 88, 81), 'Teal'),
+  // teal(Color.fromARGB(255, 34, 88, 81), 'Teal'),
   lime(Color.fromARGB(255, 77, 84, 40), 'Lime'),
   sepia(Color.fromARGB(255, 97, 93, 87), 'Sepia');
 

--- a/lib/src/model/settings/general_preferences.dart
+++ b/lib/src/model/settings/general_preferences.dart
@@ -66,6 +66,8 @@ class GeneralPreferences extends _$GeneralPreferences with PreferencesStorage<Ge
 
 @Freezed(fromJson: true, toJson: true)
 class GeneralPrefs with _$GeneralPrefs implements Serializable {
+  const GeneralPrefs._();
+
   const factory GeneralPrefs({
     @JsonKey(unknownEnumValue: BackgroundThemeMode.system, defaultValue: BackgroundThemeMode.system)
     required BackgroundThemeMode themeMode,
@@ -100,6 +102,8 @@ class GeneralPrefs with _$GeneralPrefs implements Serializable {
   factory GeneralPrefs.fromJson(Map<String, dynamic> json) {
     return _$GeneralPrefsFromJson(json);
   }
+
+  bool get isForcedDarkMode => backgroundTheme != null || backgroundImage != null;
 }
 
 enum AppThemeSeed {
@@ -138,9 +142,9 @@ enum SoundTheme {
 
 enum BackgroundTheme {
   blue(Color.fromARGB(255, 58, 81, 100), 'Blue'),
-  indigo(Color.fromARGB(255, 49, 54, 82), 'indigo'),
+  indigo(Color.fromARGB(255, 49, 54, 82), 'Indigo'),
   green(Color.fromARGB(255, 32, 64, 42), 'Green'),
-  brown(Color.fromARGB(255, 67, 52, 54), 'Brown'),
+  brown(Color.fromARGB(255, 67, 52, 54), 'Brown purple'),
   gold(Color.fromARGB(255, 95, 68, 38), 'Gold'),
   red(Color.fromARGB(255, 92, 42, 50), 'Red'),
   purple(Color.fromARGB(255, 100, 69, 103), 'Purple'),

--- a/lib/src/styles/styles.dart
+++ b/lib/src/styles/styles.dart
@@ -62,7 +62,11 @@ abstract class Styles {
     final colorScheme = ColorScheme.of(context);
     return brightness == Brightness.light
         ? colorScheme.surfaceContainerLowest
-        : colorScheme.surfaceContainer;
+        : colorScheme.surfaceContainerHigh;
+  }
+
+  static Color backgroundActivated(BuildContext context) {
+    return ColorScheme.of(context).surfaceContainerHighest;
   }
 
   static const _cupertinoDarkLabelColor = Color(0xFFDCDCDC);

--- a/lib/src/styles/styles.dart
+++ b/lib/src/styles/styles.dart
@@ -66,7 +66,10 @@ abstract class Styles {
   }
 
   static Color backgroundActivated(BuildContext context) {
-    return ColorScheme.of(context).surfaceContainerHighest;
+    final brightness = Theme.of(context).brightness;
+    return brightness == Brightness.light
+        ? ColorScheme.of(context).surfaceContainerLow
+        : ColorScheme.of(context).surfaceContainerHighest;
   }
 
   static const _cupertinoDarkLabelColor = Color(0xFFDCDCDC);

--- a/lib/src/theme.dart
+++ b/lib/src/theme.dart
@@ -20,12 +20,12 @@ class ApplicationTheme extends _$ApplicationTheme {
     if (generalPrefs.backgroundTheme == null && generalPrefs.backgroundImage == null) {
       return _makeDefaultTheme(generalPrefs, boardPrefs, isIOS);
     } else if (generalPrefs.backgroundImage != null) {
-      return makeBackgroundImageTheme(
+      return _makeBackgroundImageTheme(
         baseTheme: generalPrefs.backgroundImage!.baseTheme,
         isIOS: isIOS,
       );
     } else {
-      return makeBackgroundImageTheme(
+      return _makeBackgroundImageTheme(
         baseTheme: generalPrefs.backgroundTheme!.baseTheme,
         isIOS: isIOS,
       );
@@ -94,52 +94,66 @@ class ApplicationTheme extends _$ApplicationTheme {
       ),
     );
   }
-}
 
-({ThemeData light, ThemeData dark}) makeBackgroundImageTheme({
-  required ThemeData baseTheme,
-  required bool isIOS,
-}) {
-  final cupertinoTheme = _makeCupertinoBackgroundTheme(
-    baseTheme,
-    brightness: Brightness.dark,
-    transparentScaffold: true,
-  );
+  ({ThemeData light, ThemeData dark}) _makeBackgroundImageTheme({
+    required ThemeData baseTheme,
+    required bool isIOS,
+  }) {
+    final primary = baseTheme.colorScheme.primary;
+    final onPrimary = baseTheme.colorScheme.onPrimary;
+    final cupertinoTheme = CupertinoThemeData(
+      primaryColor: primary,
+      primaryContrastingColor: onPrimary,
+      brightness: Brightness.dark,
+      textTheme: cupertinoTextTheme(baseTheme.colorScheme),
+      scaffoldBackgroundColor: baseTheme.scaffoldBackgroundColor.withValues(alpha: 0),
+      barBackgroundColor: baseTheme.colorScheme.surface.withValues(alpha: 0.5),
+      applyThemeToAll: true,
+    );
 
-  const baseSurfaceAlpha = 0.7;
+    const baseSurfaceAlpha = 0.7;
 
-  final theme = baseTheme.copyWith(
-    colorScheme: baseTheme.colorScheme.copyWith(
-      surface: baseTheme.colorScheme.surface.withValues(alpha: baseSurfaceAlpha),
-      surfaceContainerLowest: baseTheme.colorScheme.surfaceContainerLowest.withValues(
-        alpha: baseSurfaceAlpha,
+    final theme = baseTheme.copyWith(
+      colorScheme: baseTheme.colorScheme.copyWith(
+        surface: baseTheme.colorScheme.surface.withValues(alpha: baseSurfaceAlpha),
+        surfaceContainerLowest: baseTheme.colorScheme.surfaceContainerLowest.withValues(
+          alpha: baseSurfaceAlpha,
+        ),
+        surfaceContainerLow: baseTheme.colorScheme.surfaceContainerLow.withValues(
+          alpha: baseSurfaceAlpha,
+        ),
+        surfaceContainer: baseTheme.colorScheme.surfaceContainer.withValues(
+          alpha: baseSurfaceAlpha,
+        ),
+        surfaceContainerHigh: baseTheme.colorScheme.surfaceContainerHigh.withValues(
+          alpha: baseSurfaceAlpha,
+        ),
+        surfaceContainerHighest: baseTheme.colorScheme.surfaceContainerHighest.withValues(
+          alpha: baseSurfaceAlpha,
+        ),
+        surfaceDim: baseTheme.colorScheme.surfaceDim.withValues(alpha: baseSurfaceAlpha + 1),
+        surfaceBright: baseTheme.colorScheme.surfaceBright.withValues(alpha: baseSurfaceAlpha - 2),
       ),
-      surfaceContainerLow: baseTheme.colorScheme.surfaceContainerLow.withValues(
-        alpha: baseSurfaceAlpha,
+      cupertinoOverrideTheme: cupertinoTheme,
+      listTileTheme: isIOS ? _cupertinoListTileTheme(cupertinoTheme) : null,
+      bottomSheetTheme: BottomSheetThemeData(
+        backgroundColor: baseTheme.colorScheme.surface.withValues(alpha: 0.8),
       ),
-      surfaceContainer: baseTheme.colorScheme.surfaceContainer.withValues(alpha: baseSurfaceAlpha),
-      surfaceContainerHigh: baseTheme.colorScheme.surfaceContainerHigh.withValues(
-        alpha: baseSurfaceAlpha,
+      dialogTheme: DialogTheme(
+        backgroundColor: baseTheme.colorScheme.surface.withValues(alpha: 0.8),
       ),
-      surfaceContainerHighest: baseTheme.colorScheme.surfaceContainerHighest.withValues(
-        alpha: baseSurfaceAlpha,
+      menuTheme: isIOS ? Styles.cupertinoAnchorMenuTheme : null,
+      scaffoldBackgroundColor: baseTheme.scaffoldBackgroundColor.withValues(alpha: 0),
+      appBarTheme: baseTheme.appBarTheme.copyWith(
+        backgroundColor: baseTheme.scaffoldBackgroundColor.withValues(alpha: 0),
       ),
-      surfaceDim: baseTheme.colorScheme.surfaceDim.withValues(alpha: baseSurfaceAlpha + 1),
-      surfaceBright: baseTheme.colorScheme.surfaceBright.withValues(alpha: baseSurfaceAlpha - 2),
-    ),
-    cupertinoOverrideTheme: cupertinoTheme,
-    listTileTheme: isIOS ? _cupertinoListTileTheme(cupertinoTheme) : null,
-    menuTheme: isIOS ? Styles.cupertinoAnchorMenuTheme : null,
-    scaffoldBackgroundColor: baseTheme.scaffoldBackgroundColor.withValues(alpha: 0),
-    appBarTheme: baseTheme.appBarTheme.copyWith(
-      backgroundColor: baseTheme.colorScheme.surfaceContainerLowest.withValues(alpha: 0.5),
-    ),
-    splashFactory: isIOS ? NoSplash.splashFactory : null,
-    textTheme: isIOS ? Typography.whiteCupertino : null,
-    extensions: [lichessCustomColors.harmonized(baseTheme.colorScheme)],
-  );
+      splashFactory: isIOS ? NoSplash.splashFactory : null,
+      textTheme: isIOS ? Typography.whiteCupertino : null,
+      extensions: [lichessCustomColors.harmonized(baseTheme.colorScheme)],
+    );
 
-  return (light: theme, dark: theme);
+    return (light: theme, dark: theme);
+  }
 }
 
 /// Makes a Cupertino text theme based on the given [colors].
@@ -160,25 +174,3 @@ ListTileThemeData _cupertinoListTileTheme(CupertinoThemeData cupertinoTheme) => 
   subtitleTextStyle: cupertinoTheme.textTheme.textStyle,
   leadingAndTrailingTextStyle: cupertinoTheme.textTheme.textStyle,
 );
-
-CupertinoThemeData _makeCupertinoBackgroundTheme(
-  ThemeData theme, {
-  required Brightness brightness,
-  bool transparentScaffold = false,
-}) {
-  final primary = theme.colorScheme.primary;
-  final onPrimary = theme.colorScheme.onPrimary;
-  return CupertinoThemeData(
-    primaryColor: primary,
-    primaryContrastingColor: onPrimary,
-    brightness: brightness,
-    textTheme: cupertinoTextTheme(theme.colorScheme),
-    scaffoldBackgroundColor: theme.scaffoldBackgroundColor.withValues(
-      alpha: transparentScaffold ? 0 : 1,
-    ),
-    barBackgroundColor: theme.colorScheme.surface.withValues(
-      alpha: transparentScaffold ? 0.5 : 0.9,
-    ),
-    applyThemeToAll: true,
-  );
-}

--- a/lib/src/theme.dart
+++ b/lib/src/theme.dart
@@ -1,4 +1,3 @@
-import 'package:flex_color_scheme/flex_color_scheme.dart';
 import 'package:flutter/cupertino.dart';
 import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
@@ -10,7 +9,7 @@ import 'package:riverpod_annotation/riverpod_annotation.dart';
 
 part 'theme.g.dart';
 
-@Riverpod(keepAlive: true)
+@riverpod
 class ApplicationTheme extends _$ApplicationTheme {
   @override
   ({ThemeData light, ThemeData dark}) build() {
@@ -26,9 +25,8 @@ class ApplicationTheme extends _$ApplicationTheme {
         isIOS: isIOS,
       );
     } else {
-      return makeColoredBackgroundTheme(
-        boardPrefs.boardTheme,
-        boardPrefs.backgroundTheme!,
+      return makeBackgroundImageTheme(
+        baseTheme: boardPrefs.backgroundTheme!.baseTheme,
         isIOS: isIOS,
       );
     }
@@ -63,7 +61,7 @@ class ApplicationTheme extends _$ApplicationTheme {
       primaryContrastingColor: themeLight.colorScheme.onPrimary,
       brightness: Brightness.light,
       scaffoldBackgroundColor: darken(themeLight.scaffoldBackgroundColor, 0.05),
-      barBackgroundColor: themeLight.colorScheme.surface.withValues(alpha: 0.8),
+      barBackgroundColor: themeLight.colorScheme.surface.withValues(alpha: 0.9),
       textTheme: _cupertinoTextTheme(themeLight.colorScheme),
     );
 
@@ -73,7 +71,7 @@ class ApplicationTheme extends _$ApplicationTheme {
       primaryContrastingColor: themeDark.colorScheme.onPrimary,
       brightness: Brightness.dark,
       scaffoldBackgroundColor: themeDark.scaffoldBackgroundColor,
-      barBackgroundColor: themeDark.colorScheme.surface.withValues(alpha: 0.8),
+      barBackgroundColor: themeDark.colorScheme.surface.withValues(alpha: 0.9),
       textTheme: _cupertinoTextTheme(themeDark.colorScheme),
     );
 
@@ -98,35 +96,6 @@ class ApplicationTheme extends _$ApplicationTheme {
   }
 }
 
-/// Create a colored background theme based on the provided [BoardTheme] and [BoardBackgroundTheme].
-({ThemeData light, ThemeData dark}) makeColoredBackgroundTheme(
-  BoardTheme boardTheme,
-  BoardBackgroundTheme backgroundTheme, {
-  required bool isIOS,
-}) {
-  final flexScheme = backgroundTheme.scheme.data;
-  final lightTheme = FlexThemeData.light(
-    colors: flexScheme.light,
-    cupertinoOverrideTheme: const CupertinoThemeData(applyThemeToAll: true),
-    surfaceMode: FlexSurfaceMode.highScaffoldLevelSurface,
-    appBarStyle: isIOS ? null : FlexAppBarStyle.scaffoldBackground,
-    blendLevel: backgroundTheme.lightBlend,
-  );
-  final darkTheme = FlexThemeData.dark(
-    colors: flexScheme.dark,
-    surfaceMode: FlexSurfaceMode.highScaffoldLevelSurface,
-    blendLevel: backgroundTheme.darkBlend,
-    cupertinoOverrideTheme: const CupertinoThemeData(applyThemeToAll: true),
-    appBarStyle: isIOS ? null : FlexAppBarStyle.scaffoldBackground,
-  );
-
-  return (
-    light: _makeBackgroundTheme(theme: lightTheme, brightness: Brightness.light, isIOS: isIOS),
-    dark: _makeBackgroundTheme(theme: darkTheme, brightness: Brightness.dark, isIOS: isIOS),
-  );
-}
-
-/// Create a background theme based on the provided [ThemeData] base theme.
 ({ThemeData light, ThemeData dark}) makeBackgroundImageTheme({
   required ThemeData baseTheme,
   required bool isIOS,
@@ -140,29 +109,11 @@ class ApplicationTheme extends _$ApplicationTheme {
   return (light: theme, dark: theme);
 }
 
-CupertinoTextThemeData _cupertinoTextTheme(ColorScheme colors) =>
-    const CupertinoThemeData().textTheme.copyWith(
-      primaryColor: colors.primary,
-      textStyle: const CupertinoThemeData().textTheme.textStyle.copyWith(color: colors.onSurface),
-      navTitleTextStyle: const CupertinoThemeData().textTheme.navTitleTextStyle.copyWith(
-        color: colors.onSurface,
-      ),
-      navLargeTitleTextStyle: const CupertinoThemeData().textTheme.navLargeTitleTextStyle.copyWith(
-        color: colors.onSurface,
-      ),
-    );
-
-ListTileThemeData _cupertinoListTileTheme(CupertinoThemeData cupertinoTheme) => ListTileThemeData(
-  titleTextStyle: cupertinoTheme.textTheme.textStyle,
-  subtitleTextStyle: cupertinoTheme.textTheme.textStyle,
-  leadingAndTrailingTextStyle: cupertinoTheme.textTheme.textStyle,
-);
-
 ThemeData _makeBackgroundTheme({
   required ThemeData theme,
-  required Brightness brightness,
   required bool isIOS,
-  bool transparentScaffold = false,
+  Brightness brightness = Brightness.dark,
+  bool transparentScaffold = true,
 }) {
   final cupertinoTheme = _makeCupertinoBackgroundTheme(
     theme,
@@ -208,7 +159,7 @@ ThemeData _makeBackgroundTheme({
     appBarTheme:
         transparentScaffold
             ? theme.appBarTheme.copyWith(
-              backgroundColor: theme.colorScheme.surfaceContainer.withValues(alpha: 0.0),
+              backgroundColor: theme.colorScheme.surfaceContainerLowest.withValues(alpha: 0.5),
             )
             : null,
     splashFactory: isIOS ? NoSplash.splashFactory : null,
@@ -221,6 +172,24 @@ ThemeData _makeBackgroundTheme({
     extensions: [lichessCustomColors.harmonized(theme.colorScheme)],
   );
 }
+
+CupertinoTextThemeData _cupertinoTextTheme(ColorScheme colors) =>
+    const CupertinoThemeData().textTheme.copyWith(
+      primaryColor: colors.primary,
+      textStyle: const CupertinoThemeData().textTheme.textStyle.copyWith(color: colors.onSurface),
+      navTitleTextStyle: const CupertinoThemeData().textTheme.navTitleTextStyle.copyWith(
+        color: colors.onSurface,
+      ),
+      navLargeTitleTextStyle: const CupertinoThemeData().textTheme.navLargeTitleTextStyle.copyWith(
+        color: colors.onSurface,
+      ),
+    );
+
+ListTileThemeData _cupertinoListTileTheme(CupertinoThemeData cupertinoTheme) => ListTileThemeData(
+  titleTextStyle: cupertinoTheme.textTheme.textStyle,
+  subtitleTextStyle: cupertinoTheme.textTheme.textStyle,
+  leadingAndTrailingTextStyle: cupertinoTheme.textTheme.textStyle,
+);
 
 CupertinoThemeData _makeCupertinoBackgroundTheme(
   ThemeData theme, {
@@ -238,7 +207,7 @@ CupertinoThemeData _makeCupertinoBackgroundTheme(
       alpha: transparentScaffold ? 0 : 1,
     ),
     barBackgroundColor: theme.colorScheme.surface.withValues(
-      alpha: transparentScaffold ? 0.5 : 0.8,
+      alpha: transparentScaffold ? 0.5 : 0.9,
     ),
     applyThemeToAll: true,
   );

--- a/lib/src/theme.dart
+++ b/lib/src/theme.dart
@@ -100,77 +100,46 @@ class ApplicationTheme extends _$ApplicationTheme {
   required ThemeData baseTheme,
   required bool isIOS,
 }) {
-  final theme = _makeBackgroundTheme(
-    theme: baseTheme,
-    brightness: Brightness.dark,
-    isIOS: isIOS,
-    transparentScaffold: true,
-  );
-  return (light: theme, dark: theme);
-}
-
-ThemeData _makeBackgroundTheme({
-  required ThemeData theme,
-  required bool isIOS,
-  Brightness brightness = Brightness.dark,
-  bool transparentScaffold = true,
-}) {
   final cupertinoTheme = _makeCupertinoBackgroundTheme(
-    theme,
-    brightness: brightness,
-    transparentScaffold: transparentScaffold,
+    baseTheme,
+    brightness: Brightness.dark,
+    transparentScaffold: true,
   );
 
   const baseSurfaceAlpha = 0.7;
 
-  return theme.copyWith(
-    colorScheme: theme.colorScheme.copyWith(
-      surface: theme.colorScheme.surface.withValues(
-        alpha: transparentScaffold ? baseSurfaceAlpha : 1,
+  final theme = baseTheme.copyWith(
+    colorScheme: baseTheme.colorScheme.copyWith(
+      surface: baseTheme.colorScheme.surface.withValues(alpha: baseSurfaceAlpha),
+      surfaceContainerLowest: baseTheme.colorScheme.surfaceContainerLowest.withValues(
+        alpha: baseSurfaceAlpha,
       ),
-      surfaceContainerLowest: theme.colorScheme.surfaceContainerLowest.withValues(
-        alpha: transparentScaffold ? baseSurfaceAlpha : 1,
+      surfaceContainerLow: baseTheme.colorScheme.surfaceContainerLow.withValues(
+        alpha: baseSurfaceAlpha,
       ),
-      surfaceContainerLow: theme.colorScheme.surfaceContainerLow.withValues(
-        alpha: transparentScaffold ? baseSurfaceAlpha : 1,
+      surfaceContainer: baseTheme.colorScheme.surfaceContainer.withValues(alpha: baseSurfaceAlpha),
+      surfaceContainerHigh: baseTheme.colorScheme.surfaceContainerHigh.withValues(
+        alpha: baseSurfaceAlpha,
       ),
-      surfaceContainer: theme.colorScheme.surfaceContainer.withValues(
-        alpha: transparentScaffold ? baseSurfaceAlpha : 1,
+      surfaceContainerHighest: baseTheme.colorScheme.surfaceContainerHighest.withValues(
+        alpha: baseSurfaceAlpha,
       ),
-      surfaceContainerHigh: theme.colorScheme.surfaceContainerHigh.withValues(
-        alpha: transparentScaffold ? baseSurfaceAlpha : 1,
-      ),
-      surfaceContainerHighest: theme.colorScheme.surfaceContainerHighest.withValues(
-        alpha: transparentScaffold ? baseSurfaceAlpha : 1,
-      ),
-      surfaceDim: theme.colorScheme.surfaceDim.withValues(
-        alpha: transparentScaffold ? baseSurfaceAlpha + 1 : 1,
-      ),
-      surfaceBright: theme.colorScheme.surfaceBright.withValues(
-        alpha: transparentScaffold ? baseSurfaceAlpha - 2 : 1,
-      ),
+      surfaceDim: baseTheme.colorScheme.surfaceDim.withValues(alpha: baseSurfaceAlpha + 1),
+      surfaceBright: baseTheme.colorScheme.surfaceBright.withValues(alpha: baseSurfaceAlpha - 2),
     ),
     cupertinoOverrideTheme: cupertinoTheme,
     listTileTheme: isIOS ? _cupertinoListTileTheme(cupertinoTheme) : null,
     menuTheme: isIOS ? Styles.cupertinoAnchorMenuTheme : null,
-    scaffoldBackgroundColor: theme.scaffoldBackgroundColor.withValues(
-      alpha: transparentScaffold ? 0 : 1,
+    scaffoldBackgroundColor: baseTheme.scaffoldBackgroundColor.withValues(alpha: 0),
+    appBarTheme: baseTheme.appBarTheme.copyWith(
+      backgroundColor: baseTheme.colorScheme.surfaceContainerLowest.withValues(alpha: 0.5),
     ),
-    appBarTheme:
-        transparentScaffold
-            ? theme.appBarTheme.copyWith(
-              backgroundColor: theme.colorScheme.surfaceContainerLowest.withValues(alpha: 0.5),
-            )
-            : null,
     splashFactory: isIOS ? NoSplash.splashFactory : null,
-    textTheme:
-        isIOS
-            ? brightness == Brightness.light
-                ? Typography.blackCupertino
-                : Typography.whiteCupertino
-            : null,
-    extensions: [lichessCustomColors.harmonized(theme.colorScheme)],
+    textTheme: isIOS ? Typography.whiteCupertino : null,
+    extensions: [lichessCustomColors.harmonized(baseTheme.colorScheme)],
   );
+
+  return (light: theme, dark: theme);
 }
 
 CupertinoTextThemeData _cupertinoTextTheme(ColorScheme colors) =>

--- a/lib/src/theme.dart
+++ b/lib/src/theme.dart
@@ -17,16 +17,16 @@ class ApplicationTheme extends _$ApplicationTheme {
     final boardPrefs = ref.watch(boardPreferencesProvider);
     final isIOS = defaultTargetPlatform == TargetPlatform.iOS;
 
-    if (boardPrefs.backgroundTheme == null && boardPrefs.backgroundImage == null) {
+    if (generalPrefs.backgroundTheme == null && generalPrefs.backgroundImage == null) {
       return _makeDefaultTheme(generalPrefs, boardPrefs, isIOS);
-    } else if (boardPrefs.backgroundImage != null) {
+    } else if (generalPrefs.backgroundImage != null) {
       return makeBackgroundImageTheme(
-        baseTheme: boardPrefs.backgroundImage!.baseTheme,
+        baseTheme: generalPrefs.backgroundImage!.baseTheme,
         isIOS: isIOS,
       );
     } else {
       return makeBackgroundImageTheme(
-        baseTheme: boardPrefs.backgroundTheme!.baseTheme,
+        baseTheme: generalPrefs.backgroundTheme!.baseTheme,
         isIOS: isIOS,
       );
     }

--- a/lib/src/theme.dart
+++ b/lib/src/theme.dart
@@ -62,7 +62,7 @@ class ApplicationTheme extends _$ApplicationTheme {
       brightness: Brightness.light,
       scaffoldBackgroundColor: darken(themeLight.scaffoldBackgroundColor, 0.05),
       barBackgroundColor: themeLight.colorScheme.surface.withValues(alpha: 0.9),
-      textTheme: _cupertinoTextTheme(themeLight.colorScheme),
+      textTheme: cupertinoTextTheme(themeLight.colorScheme),
     );
 
     final darkCupertino = CupertinoThemeData(
@@ -72,7 +72,7 @@ class ApplicationTheme extends _$ApplicationTheme {
       brightness: Brightness.dark,
       scaffoldBackgroundColor: themeDark.scaffoldBackgroundColor,
       barBackgroundColor: themeDark.colorScheme.surface.withValues(alpha: 0.9),
-      textTheme: _cupertinoTextTheme(themeDark.colorScheme),
+      textTheme: cupertinoTextTheme(themeDark.colorScheme),
     );
 
     return (
@@ -142,7 +142,8 @@ class ApplicationTheme extends _$ApplicationTheme {
   return (light: theme, dark: theme);
 }
 
-CupertinoTextThemeData _cupertinoTextTheme(ColorScheme colors) =>
+/// Makes a Cupertino text theme based on the given [colors].
+CupertinoTextThemeData cupertinoTextTheme(ColorScheme colors) =>
     const CupertinoThemeData().textTheme.copyWith(
       primaryColor: colors.primary,
       textStyle: const CupertinoThemeData().textTheme.textStyle.copyWith(color: colors.onSurface),
@@ -171,7 +172,7 @@ CupertinoThemeData _makeCupertinoBackgroundTheme(
     primaryColor: primary,
     primaryContrastingColor: onPrimary,
     brightness: brightness,
-    textTheme: _cupertinoTextTheme(theme.colorScheme),
+    textTheme: cupertinoTextTheme(theme.colorScheme),
     scaffoldBackgroundColor: theme.scaffoldBackgroundColor.withValues(
       alpha: transparentScaffold ? 0 : 1,
     ),

--- a/lib/src/theme.dart
+++ b/lib/src/theme.dart
@@ -1,0 +1,37 @@
+import 'package:flex_color_scheme/flex_color_scheme.dart';
+import 'package:flutter/cupertino.dart';
+import 'package:flutter/material.dart';
+
+// ignore: avoid_classes_with_only_static_members
+abstract final class AppTheme {
+  static const lightColors = FlexSchemeColor(
+    // Custom colors
+    primary: Color(0xFF5F4A45),
+    primaryContainer: Color(0xFFC7BCAC),
+    primaryLightRef: Color(0xFF5F4A45),
+    secondary: Color(0xFFE3B964),
+    secondaryContainer: Color(0xFFFFDE9C),
+    secondaryLightRef: Color(0xFFE3B964),
+    tertiary: Color(0xFFF5E9C9),
+    tertiaryContainer: Color(0xFFFEE7AD),
+    tertiaryLightRef: Color(0xFFF5E9C9),
+    appBarColor: Color(0xFFFFDE9C),
+    error: Color(0xFFB00020),
+    errorContainer: Color(0xFFFFDAD6),
+  );
+
+  static const darkColors = FlexSchemeColor(
+    primary: Color(0xFFF8ECD4),
+    primaryContainer: Color(0xFF705D49),
+    primaryLightRef: Color(0xFF5F4A45),
+    secondary: Color(0xFFEED6A6),
+    secondaryContainer: Color(0xFF8E774F),
+    secondaryLightRef: Color(0xFFE3B964),
+    tertiary: Color(0xFF8D7F7D),
+    tertiaryContainer: Color(0xFF452F2B),
+    tertiaryLightRef: Color(0xFFF5E9C9),
+    appBarColor: Color(0xFFFFDE9C),
+    error: Color(0xFFCF6679),
+    errorContainer: Color(0xFF93000A),
+  );
+}

--- a/lib/src/theme.dart
+++ b/lib/src/theme.dart
@@ -1,37 +1,245 @@
 import 'package:flex_color_scheme/flex_color_scheme.dart';
 import 'package:flutter/cupertino.dart';
+import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
+import 'package:lichess_mobile/src/model/settings/board_preferences.dart';
+import 'package:lichess_mobile/src/model/settings/general_preferences.dart';
+import 'package:lichess_mobile/src/styles/styles.dart';
+import 'package:lichess_mobile/src/utils/color_palette.dart';
+import 'package:riverpod_annotation/riverpod_annotation.dart';
 
-// ignore: avoid_classes_with_only_static_members
-abstract final class AppTheme {
-  static const lightColors = FlexSchemeColor(
-    // Custom colors
-    primary: Color(0xFF5F4A45),
-    primaryContainer: Color(0xFFC7BCAC),
-    primaryLightRef: Color(0xFF5F4A45),
-    secondary: Color(0xFFE3B964),
-    secondaryContainer: Color(0xFFFFDE9C),
-    secondaryLightRef: Color(0xFFE3B964),
-    tertiary: Color(0xFFF5E9C9),
-    tertiaryContainer: Color(0xFFFEE7AD),
-    tertiaryLightRef: Color(0xFFF5E9C9),
-    appBarColor: Color(0xFFFFDE9C),
-    error: Color(0xFFB00020),
-    errorContainer: Color(0xFFFFDAD6),
+part 'theme.g.dart';
+
+@Riverpod(keepAlive: true)
+class ApplicationTheme extends _$ApplicationTheme {
+  @override
+  ({ThemeData light, ThemeData dark}) build() {
+    final generalPrefs = ref.watch(generalPreferencesProvider);
+    final boardPrefs = ref.watch(boardPreferencesProvider);
+    final isIOS = defaultTargetPlatform == TargetPlatform.iOS;
+
+    if (boardPrefs.backgroundTheme == null && boardPrefs.backgroundImage == null) {
+      return _makeDefaultTheme(generalPrefs, boardPrefs, isIOS);
+    } else if (boardPrefs.backgroundImage != null) {
+      return makeBackgroundImageTheme(
+        baseTheme: boardPrefs.backgroundImage!.baseTheme,
+        isIOS: isIOS,
+      );
+    } else {
+      return makeColoredBackgroundTheme(
+        boardPrefs.boardTheme,
+        boardPrefs.backgroundTheme!,
+        isIOS: isIOS,
+      );
+    }
+  }
+
+  ({ThemeData light, ThemeData dark}) _makeDefaultTheme(
+    GeneralPrefs generalPrefs,
+    BoardPrefs boardPrefs,
+    bool isIOS,
+  ) {
+    final boardTheme = boardPrefs.boardTheme;
+    final systemScheme = getDynamicColorSchemes();
+    final hasSystemColors = systemScheme != null && generalPrefs.systemColors == true;
+    final defaultLight = ColorScheme.fromSeed(seedColor: boardTheme.colors.darkSquare);
+    final defaultDark = ColorScheme.fromSeed(
+      seedColor: boardTheme.colors.darkSquare,
+      brightness: Brightness.dark,
+    );
+
+    final themeLight =
+        hasSystemColors
+            ? ThemeData.from(colorScheme: systemScheme.light)
+            : ThemeData.from(colorScheme: defaultLight);
+    final themeDark =
+        hasSystemColors
+            ? ThemeData.from(colorScheme: systemScheme.dark)
+            : ThemeData.from(colorScheme: defaultDark);
+
+    final lightCupertino = CupertinoThemeData(
+      applyThemeToAll: true,
+      primaryColor: themeLight.colorScheme.primary,
+      primaryContrastingColor: themeLight.colorScheme.onPrimary,
+      brightness: Brightness.light,
+      scaffoldBackgroundColor: darken(themeLight.scaffoldBackgroundColor, 0.05),
+      barBackgroundColor: themeLight.colorScheme.surface.withValues(alpha: 0.8),
+      textTheme: _cupertinoTextTheme(themeLight.colorScheme),
+    );
+
+    final darkCupertino = CupertinoThemeData(
+      applyThemeToAll: true,
+      primaryColor: themeDark.colorScheme.primary,
+      primaryContrastingColor: themeDark.colorScheme.onPrimary,
+      brightness: Brightness.dark,
+      scaffoldBackgroundColor: themeDark.scaffoldBackgroundColor,
+      barBackgroundColor: themeDark.colorScheme.surface.withValues(alpha: 0.8),
+      textTheme: _cupertinoTextTheme(themeDark.colorScheme),
+    );
+
+    return (
+      light: themeLight.copyWith(
+        cupertinoOverrideTheme: lightCupertino,
+        splashFactory: isIOS ? NoSplash.splashFactory : null,
+        textTheme: isIOS ? Typography.blackCupertino : null,
+        listTileTheme: isIOS ? _cupertinoListTileTheme(lightCupertino) : null,
+        menuTheme: isIOS ? Styles.cupertinoAnchorMenuTheme : null,
+        extensions: [lichessCustomColors.harmonized(themeLight.colorScheme)],
+      ),
+      dark: themeDark.copyWith(
+        cupertinoOverrideTheme: darkCupertino,
+        splashFactory: isIOS ? NoSplash.splashFactory : null,
+        textTheme: isIOS ? Typography.whiteCupertino : null,
+        listTileTheme: isIOS ? _cupertinoListTileTheme(darkCupertino) : null,
+        menuTheme: isIOS ? Styles.cupertinoAnchorMenuTheme : null,
+        extensions: [lichessCustomColors.harmonized(themeDark.colorScheme)],
+      ),
+    );
+  }
+}
+
+/// Create a colored background theme based on the provided [BoardTheme] and [BoardBackgroundTheme].
+({ThemeData light, ThemeData dark}) makeColoredBackgroundTheme(
+  BoardTheme boardTheme,
+  BoardBackgroundTheme backgroundTheme, {
+  required bool isIOS,
+}) {
+  final flexScheme = backgroundTheme.getFlexScheme(boardTheme);
+  final lightTheme = FlexThemeData.light(
+    colors: flexScheme.light,
+    cupertinoOverrideTheme: const CupertinoThemeData(applyThemeToAll: true),
+    surfaceMode: FlexSurfaceMode.highScaffoldLevelSurface,
+    appBarStyle: isIOS ? null : FlexAppBarStyle.scaffoldBackground,
+    blendLevel: backgroundTheme.lightBlend,
+  );
+  final darkTheme = FlexThemeData.dark(
+    colors: flexScheme.dark,
+    surfaceMode: FlexSurfaceMode.highScaffoldLevelSurface,
+    blendLevel: backgroundTheme.darkBlend,
+    cupertinoOverrideTheme: const CupertinoThemeData(applyThemeToAll: true),
+    appBarStyle: isIOS ? null : FlexAppBarStyle.scaffoldBackground,
   );
 
-  static const darkColors = FlexSchemeColor(
-    primary: Color(0xFFF8ECD4),
-    primaryContainer: Color(0xFF705D49),
-    primaryLightRef: Color(0xFF5F4A45),
-    secondary: Color(0xFFEED6A6),
-    secondaryContainer: Color(0xFF8E774F),
-    secondaryLightRef: Color(0xFFE3B964),
-    tertiary: Color(0xFF8D7F7D),
-    tertiaryContainer: Color(0xFF452F2B),
-    tertiaryLightRef: Color(0xFFF5E9C9),
-    appBarColor: Color(0xFFFFDE9C),
-    error: Color(0xFFCF6679),
-    errorContainer: Color(0xFF93000A),
+  return (
+    light: _makeBackgroundTheme(theme: lightTheme, brightness: Brightness.light, isIOS: isIOS),
+    dark: _makeBackgroundTheme(theme: darkTheme, brightness: Brightness.dark, isIOS: isIOS),
+  );
+}
+
+/// Create a background theme based on the provided [ThemeData] base theme.
+({ThemeData light, ThemeData dark}) makeBackgroundImageTheme({
+  required ThemeData baseTheme,
+  required bool isIOS,
+}) {
+  final theme = _makeBackgroundTheme(
+    theme: baseTheme,
+    brightness: Brightness.dark,
+    isIOS: isIOS,
+    transparentScaffold: true,
+  );
+  return (light: theme, dark: theme);
+}
+
+CupertinoTextThemeData _cupertinoTextTheme(ColorScheme colors) =>
+    const CupertinoThemeData().textTheme.copyWith(
+      primaryColor: colors.primary,
+      textStyle: const CupertinoThemeData().textTheme.textStyle.copyWith(color: colors.onSurface),
+      navTitleTextStyle: const CupertinoThemeData().textTheme.navTitleTextStyle.copyWith(
+        color: colors.onSurface,
+      ),
+      navLargeTitleTextStyle: const CupertinoThemeData().textTheme.navLargeTitleTextStyle.copyWith(
+        color: colors.onSurface,
+      ),
+    );
+
+ListTileThemeData _cupertinoListTileTheme(CupertinoThemeData cupertinoTheme) => ListTileThemeData(
+  titleTextStyle: cupertinoTheme.textTheme.textStyle,
+  subtitleTextStyle: cupertinoTheme.textTheme.textStyle,
+  leadingAndTrailingTextStyle: cupertinoTheme.textTheme.textStyle,
+);
+
+ThemeData _makeBackgroundTheme({
+  required ThemeData theme,
+  required Brightness brightness,
+  required bool isIOS,
+  bool transparentScaffold = false,
+}) {
+  final cupertinoTheme = _makeCupertinoBackgroundTheme(
+    theme,
+    brightness: brightness,
+    transparentScaffold: transparentScaffold,
+  );
+
+  const baseSurfaceAlpha = 0.7;
+
+  return theme.copyWith(
+    colorScheme: theme.colorScheme.copyWith(
+      surface: theme.colorScheme.surface.withValues(
+        alpha: transparentScaffold ? baseSurfaceAlpha : 1,
+      ),
+      surfaceContainerLowest: theme.colorScheme.surfaceContainerLowest.withValues(
+        alpha: transparentScaffold ? baseSurfaceAlpha : 1,
+      ),
+      surfaceContainerLow: theme.colorScheme.surfaceContainerLow.withValues(
+        alpha: transparentScaffold ? baseSurfaceAlpha : 1,
+      ),
+      surfaceContainer: theme.colorScheme.surfaceContainer.withValues(
+        alpha: transparentScaffold ? baseSurfaceAlpha : 1,
+      ),
+      surfaceContainerHigh: theme.colorScheme.surfaceContainerHigh.withValues(
+        alpha: transparentScaffold ? baseSurfaceAlpha : 1,
+      ),
+      surfaceContainerHighest: theme.colorScheme.surfaceContainerHighest.withValues(
+        alpha: transparentScaffold ? baseSurfaceAlpha : 1,
+      ),
+      surfaceDim: theme.colorScheme.surfaceDim.withValues(
+        alpha: transparentScaffold ? baseSurfaceAlpha + 1 : 1,
+      ),
+      surfaceBright: theme.colorScheme.surfaceBright.withValues(
+        alpha: transparentScaffold ? baseSurfaceAlpha - 2 : 1,
+      ),
+    ),
+    cupertinoOverrideTheme: cupertinoTheme,
+    listTileTheme: isIOS ? _cupertinoListTileTheme(cupertinoTheme) : null,
+    menuTheme: isIOS ? Styles.cupertinoAnchorMenuTheme : null,
+    scaffoldBackgroundColor: theme.scaffoldBackgroundColor.withValues(
+      alpha: transparentScaffold ? 0 : 1,
+    ),
+    appBarTheme:
+        transparentScaffold
+            ? theme.appBarTheme.copyWith(
+              backgroundColor: theme.colorScheme.surfaceContainer.withValues(alpha: 0.0),
+            )
+            : null,
+    splashFactory: isIOS ? NoSplash.splashFactory : null,
+    textTheme:
+        isIOS
+            ? brightness == Brightness.light
+                ? Typography.blackCupertino
+                : Typography.whiteCupertino
+            : null,
+    extensions: [lichessCustomColors.harmonized(theme.colorScheme)],
+  );
+}
+
+CupertinoThemeData _makeCupertinoBackgroundTheme(
+  ThemeData theme, {
+  required Brightness brightness,
+  bool transparentScaffold = false,
+}) {
+  final primary = theme.colorScheme.primary;
+  final onPrimary = theme.colorScheme.onPrimary;
+  return CupertinoThemeData(
+    primaryColor: primary,
+    primaryContrastingColor: onPrimary,
+    brightness: brightness,
+    textTheme: _cupertinoTextTheme(theme.colorScheme),
+    scaffoldBackgroundColor: theme.scaffoldBackgroundColor.withValues(
+      alpha: transparentScaffold ? 0 : 1,
+    ),
+    barBackgroundColor: theme.colorScheme.surface.withValues(
+      alpha: transparentScaffold ? 0.5 : 0.8,
+    ),
+    applyThemeToAll: true,
   );
 }

--- a/lib/src/theme.dart
+++ b/lib/src/theme.dart
@@ -70,7 +70,7 @@ class ApplicationTheme extends _$ApplicationTheme {
       primaryColor: themeDark.colorScheme.primary,
       primaryContrastingColor: themeDark.colorScheme.onPrimary,
       brightness: Brightness.dark,
-      scaffoldBackgroundColor: themeDark.scaffoldBackgroundColor,
+      scaffoldBackgroundColor: lighten(themeDark.scaffoldBackgroundColor, 0.04),
       barBackgroundColor: themeDark.colorScheme.surface.withValues(alpha: 0.9),
       textTheme: cupertinoTextTheme(themeDark.colorScheme),
     );

--- a/lib/src/theme.dart
+++ b/lib/src/theme.dart
@@ -104,7 +104,7 @@ class ApplicationTheme extends _$ApplicationTheme {
   BoardBackgroundTheme backgroundTheme, {
   required bool isIOS,
 }) {
-  final flexScheme = backgroundTheme.getFlexScheme(boardTheme);
+  final flexScheme = backgroundTheme.scheme.data;
   final lightTheme = FlexThemeData.light(
     colors: flexScheme.light,
     cupertinoOverrideTheme: const CupertinoThemeData(applyThemeToAll: true),

--- a/lib/src/utils/color_palette.dart
+++ b/lib/src/utils/color_palette.dart
@@ -3,13 +3,10 @@ import 'dart:ui';
 import 'package:chessground/chessground.dart';
 import 'package:dartchess/dartchess.dart';
 import 'package:dynamic_color/dynamic_color.dart';
-import 'package:flex_color_scheme/flex_color_scheme.dart' show FlexSchemeColor, FlexSchemeData;
 import 'package:flutter/material.dart' show ColorScheme;
 import 'package:material_color_utilities/material_color_utilities.dart';
 
 CorePalette? _corePalette;
-
-FlexSchemeData? _systemScheme;
 
 ({ColorScheme light, ColorScheme dark})? _colorSchemes;
 
@@ -26,34 +23,6 @@ void setCorePalette(CorePalette? palette) {
     final darkScheme = palette.toColorScheme(brightness: Brightness.dark);
 
     _colorSchemes ??= _generateDynamicColourSchemes(lightScheme, darkScheme);
-
-    _systemScheme ??= FlexSchemeData(
-      name: 'System',
-      description: 'System core palette on Android 12+',
-      light: FlexSchemeColor(
-        primary: lightScheme.primary,
-        primaryContainer: lightScheme.primaryContainer,
-        secondary: lightScheme.secondary,
-        secondaryContainer: lightScheme.secondaryContainer,
-        tertiary: lightScheme.tertiary,
-        tertiaryContainer: lightScheme.tertiaryContainer,
-        error: lightScheme.error,
-        errorContainer: lightScheme.errorContainer,
-      ),
-      dark: FlexSchemeColor(
-        primary: darkScheme.primary,
-        primaryContainer: darkScheme.primaryContainer,
-        primaryLightRef: lightScheme.primary,
-        secondary: darkScheme.secondary,
-        secondaryContainer: darkScheme.secondaryContainer,
-        secondaryLightRef: lightScheme.secondary,
-        tertiary: darkScheme.tertiary,
-        tertiaryContainer: darkScheme.tertiaryContainer,
-        tertiaryLightRef: lightScheme.tertiary,
-        error: darkScheme.error,
-        errorContainer: darkScheme.errorContainer,
-      ),
-    );
 
     final darkSquare = Color(palette.secondary.get(60));
     final lightSquare = Color(palette.primary.get(95));
@@ -88,11 +57,6 @@ void setCorePalette(CorePalette? palette) {
 /// Get the core palette if available (android 12+ only).
 CorePalette? getCorePalette() {
   return _corePalette;
-}
-
-/// Get the system [FlexSchemeData] if available (android 12+ only).
-FlexSchemeData? getSystemScheme() {
-  return _systemScheme;
 }
 
 /// Get the system color schemes based on the core palette, if available (android 12+).

--- a/lib/src/utils/color_palette.dart
+++ b/lib/src/utils/color_palette.dart
@@ -11,7 +11,7 @@ CorePalette? _corePalette;
 
 FlexSchemeData? _systemScheme;
 
-(ColorScheme, ColorScheme)? _colorSchemes;
+({ColorScheme light, ColorScheme dark})? _colorSchemes;
 
 ChessboardColorScheme? _boardColorScheme;
 
@@ -96,7 +96,7 @@ FlexSchemeData? getSystemScheme() {
 }
 
 /// Get the system color schemes based on the core palette, if available (android 12+).
-(ColorScheme light, ColorScheme dark)? getDynamicColorSchemes() {
+({ColorScheme light, ColorScheme dark})? getDynamicColorSchemes() {
   return _colorSchemes;
 }
 
@@ -107,7 +107,7 @@ ChessboardColorScheme? getBoardColorScheme() {
 
 // --
 
-(ColorScheme light, ColorScheme dark) _generateDynamicColourSchemes(
+({ColorScheme light, ColorScheme dark}) _generateDynamicColourSchemes(
   ColorScheme lightDynamic,
   ColorScheme darkDynamic,
 ) {
@@ -123,7 +123,7 @@ ChessboardColorScheme? getBoardColorScheme() {
   final lightScheme = _insertAdditionalColours(lightBase, lightAdditionalColours);
   final darkScheme = _insertAdditionalColours(darkBase, darkAdditionalColours);
 
-  return (lightScheme.harmonized(), darkScheme.harmonized());
+  return (light: lightScheme.harmonized(), dark: darkScheme.harmonized());
 }
 
 List<Color> _extractAdditionalColours(ColorScheme scheme) => [

--- a/lib/src/utils/navigation.dart
+++ b/lib/src/utils/navigation.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/cupertino.dart';
 import 'package:flutter/material.dart';
+import 'package:lichess_mobile/src/widgets/background.dart';
 
 /// A page route that always builds the same screen widget.
 ///
@@ -11,7 +12,8 @@ abstract class ScreenRoute<T extends Object?> extends PageRoute<T> {
 
 /// A [MaterialPageRoute] that always builds the same screen widget.
 ///
-/// This is useful to test new screens being pushed to the Navigator.
+/// This route wraps the [screen] with a [FullScreenBackground] to ensure that the background
+/// is always filled with the configured app's background color or image.
 class MaterialScreenRoute<T extends Object?> extends MaterialPageRoute<T>
     implements ScreenRoute<T> {
   MaterialScreenRoute({
@@ -20,7 +22,7 @@ class MaterialScreenRoute<T extends Object?> extends MaterialPageRoute<T>
     super.maintainState,
     super.fullscreenDialog,
     super.allowSnapshotting,
-  }) : super(builder: (_) => screen);
+  }) : super(builder: (_) => FullScreenBackground(child: screen));
 
   @override
   final Widget screen;
@@ -28,7 +30,8 @@ class MaterialScreenRoute<T extends Object?> extends MaterialPageRoute<T>
 
 /// A [CupertinoPageRoute] that always builds the same screen widget.
 ///
-/// This is useful to test new screens being pushed to the Navigator.
+/// This route wraps the [screen] with a [FullScreenBackground] to ensure that the background
+/// is always filled with the configured app's background color or image.
 class CupertinoScreenRoute<T extends Object?> extends CupertinoPageRoute<T>
     implements ScreenRoute<T> {
   CupertinoScreenRoute({
@@ -37,81 +40,25 @@ class CupertinoScreenRoute<T extends Object?> extends CupertinoPageRoute<T>
     super.maintainState,
     super.fullscreenDialog,
     super.title,
-  }) : super(builder: (_) => screen);
+  }) : super(builder: (_) => FullScreenBackground(child: screen));
 
   @override
   final Widget screen;
 }
 
-/// Push a new route using Navigator.
+/// Builds a new route for the [screen] based on the platform.
 ///
-/// {@macro lichess.navigation.builder_or_screen}
-Future<void> pushPlatformRoute(
+/// This route wraps the [screen] with a [FullScreenBackground] to ensure that the background
+/// is always filled with the configured app's background color or image.
+///
+/// It will return a [MaterialScreenRoute] on Android and a [CupertinoScreenRoute] on iOS.
+Route<T> buildScreenRoute<T>(
   BuildContext context, {
-  Widget? screen,
-  WidgetBuilder? builder,
-  bool rootNavigator = false,
+  required Widget screen,
   bool fullscreenDialog = false,
   String? title,
 }) {
-  assert(screen != null || builder != null, 'Either screen or builder must be provided.');
-
-  return Navigator.of(context, rootNavigator: rootNavigator).push<void>(
-    createPlatformRoute(
-      context,
-      builder: builder,
-      screen: screen,
-      fullscreenDialog: fullscreenDialog,
-      title: title,
-    ),
-  );
-}
-
-/// Push a new route using Navigator and replace the current route.
-///
-/// {@macro lichess.navigation.builder_or_screen}
-Future<void> pushReplacementPlatformRoute(
-  BuildContext context, {
-  WidgetBuilder? builder,
-  Widget? screen,
-  bool rootNavigator = false,
-  bool fullscreenDialog = false,
-  String? title,
-}) {
-  return Navigator.of(context, rootNavigator: rootNavigator).pushReplacement<void, void>(
-    createPlatformRoute(
-      context,
-      builder: builder,
-      screen: screen,
-      fullscreenDialog: fullscreenDialog,
-      title: title,
-    ),
-  );
-}
-
-/// Create a route from either [builder] or [screen].
-///
-/// {@template lichess.navigation.builder_or_screen}
-/// If [builder] is provided, it will return a [MaterialPageRoute] on Android and
-/// a [CupertinoPageRoute] on iOS.
-///
-/// If [screen] is provided, it will return a [MaterialScreenRoute] on Android and
-/// a [CupertinoScreenRoute] on iOS.
-/// {@endtemplate}
-Route<dynamic> createPlatformRoute(
-  BuildContext context, {
-  Widget? screen,
-  WidgetBuilder? builder,
-  bool fullscreenDialog = false,
-  String? title,
-}) {
-  assert(screen != null || builder != null, 'Either screen or builder must be provided.');
-
   return Theme.of(context).platform == TargetPlatform.iOS
-      ? builder != null
-          ? CupertinoPageRoute(builder: builder, title: title, fullscreenDialog: fullscreenDialog)
-          : CupertinoScreenRoute(screen: screen!, title: title, fullscreenDialog: fullscreenDialog)
-      : builder != null
-      ? MaterialPageRoute(builder: builder, fullscreenDialog: fullscreenDialog)
-      : MaterialScreenRoute(screen: screen!, fullscreenDialog: fullscreenDialog);
+      ? CupertinoScreenRoute<T>(screen: screen, title: title, fullscreenDialog: fullscreenDialog)
+      : MaterialScreenRoute<T>(screen: screen, fullscreenDialog: fullscreenDialog);
 }

--- a/lib/src/view/account/edit_profile_screen.dart
+++ b/lib/src/view/account/edit_profile_screen.dart
@@ -50,7 +50,7 @@ class EditProfileScreen extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    return PlatformScaffold(
+    return PlatformThemedScaffold(
       appBar: PlatformAppBar(title: Text(context.l10n.editProfile)),
       body: PopScope(
         canPop: false,

--- a/lib/src/view/account/edit_profile_screen.dart
+++ b/lib/src/view/account/edit_profile_screen.dart
@@ -7,6 +7,7 @@ import 'package:lichess_mobile/src/model/user/user.dart';
 import 'package:lichess_mobile/src/network/http.dart';
 import 'package:lichess_mobile/src/styles/styles.dart';
 import 'package:lichess_mobile/src/utils/l10n_context.dart';
+import 'package:lichess_mobile/src/utils/navigation.dart';
 import 'package:lichess_mobile/src/view/user/countries.dart';
 import 'package:lichess_mobile/src/widgets/adaptive_autocomplete.dart';
 import 'package:lichess_mobile/src/widgets/adaptive_text_field.dart';
@@ -25,6 +26,14 @@ final _cupertinoTextFieldDecoration = BoxDecoration(
 
 class EditProfileScreen extends StatelessWidget {
   const EditProfileScreen({super.key});
+
+  static Route<dynamic> buildRoute(BuildContext context) {
+    return buildScreenRoute(
+      context,
+      screen: const EditProfileScreen(),
+      title: context.l10n.editProfile,
+    );
+  }
 
   Future<bool?> _showBackDialog(BuildContext context) async {
     return showAdaptiveDialog<bool>(

--- a/lib/src/view/account/edit_profile_screen.dart
+++ b/lib/src/view/account/edit_profile_screen.dart
@@ -59,7 +59,7 @@ class EditProfileScreen extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    return PlatformThemedScaffold(
+    return PlatformScaffold(
       appBar: PlatformAppBar(title: Text(context.l10n.editProfile)),
       body: PopScope(
         canPop: false,

--- a/lib/src/view/account/game_bookmarks_screen.dart
+++ b/lib/src/view/account/game_bookmarks_screen.dart
@@ -17,7 +17,7 @@ class GameBookmarksScreen extends ConsumerWidget {
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
-    return PlatformScaffold(
+    return PlatformThemedScaffold(
       backgroundColor: Styles.listingsScreenBackgroundColor(context),
       appBar: PlatformAppBar(title: Text(context.l10n.nbBookmarks(nbBookmarks))),
       body: const _Body(),

--- a/lib/src/view/account/game_bookmarks_screen.dart
+++ b/lib/src/view/account/game_bookmarks_screen.dart
@@ -5,6 +5,7 @@ import 'package:lichess_mobile/src/model/account/account_repository.dart';
 import 'package:lichess_mobile/src/model/game/game_bookmarks.dart';
 import 'package:lichess_mobile/src/styles/styles.dart';
 import 'package:lichess_mobile/src/utils/l10n_context.dart';
+import 'package:lichess_mobile/src/utils/navigation.dart';
 import 'package:lichess_mobile/src/view/game/game_list_tile.dart';
 import 'package:lichess_mobile/src/widgets/feedback.dart';
 import 'package:lichess_mobile/src/widgets/list.dart';
@@ -14,6 +15,14 @@ class GameBookmarksScreen extends ConsumerWidget {
   const GameBookmarksScreen({required this.nbBookmarks, super.key});
 
   final int nbBookmarks;
+
+  static Route<dynamic> buildRoute(BuildContext context, {required int nbBookmarks}) {
+    return buildScreenRoute(
+      context,
+      screen: GameBookmarksScreen(nbBookmarks: nbBookmarks),
+      title: context.l10n.nbBookmarks(nbBookmarks),
+    );
+  }
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {

--- a/lib/src/view/account/game_bookmarks_screen.dart
+++ b/lib/src/view/account/game_bookmarks_screen.dart
@@ -26,7 +26,7 @@ class GameBookmarksScreen extends ConsumerWidget {
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
-    return PlatformThemedScaffold(
+    return PlatformScaffold(
       backgroundColor: Styles.listingsScreenBackgroundColor(context),
       appBar: PlatformAppBar(title: Text(context.l10n.nbBookmarks(nbBookmarks))),
       body: const _Body(),

--- a/lib/src/view/account/profile_screen.dart
+++ b/lib/src/view/account/profile_screen.dart
@@ -21,6 +21,10 @@ import 'package:lichess_mobile/src/widgets/user_full_name.dart';
 class ProfileScreen extends ConsumerStatefulWidget {
   const ProfileScreen({super.key});
 
+  static Route<dynamic> buildRoute(BuildContext context) {
+    return buildScreenRoute(context, screen: const ProfileScreen(), title: context.l10n.profile);
+  }
+
   @override
   ConsumerState<ProfileScreen> createState() => _ProfileScreenState();
 }
@@ -44,7 +48,7 @@ class _ProfileScreenState extends ConsumerState<ProfileScreen> {
           AppBarIconButton(
             icon: const Icon(Icons.edit),
             semanticsLabel: context.l10n.editProfile,
-            onPressed: () => pushPlatformRoute(context, builder: (_) => const EditProfileScreen()),
+            onPressed: () => Navigator.of(context).push(EditProfileScreen.buildRoute(context)),
           ),
         ],
       ),
@@ -74,11 +78,11 @@ class _ProfileScreenState extends ConsumerState<ProfileScreen> {
                         title: Text(context.l10n.nbBookmarks(user.count!.bookmark)),
                         leading: const Icon(Icons.bookmarks_outlined),
                         onTap: () {
-                          pushPlatformRoute(
-                            context,
-                            title: context.l10n.nbBookmarks(user.count!.bookmark),
-                            builder:
-                                (context) => GameBookmarksScreen(nbBookmarks: user.count!.bookmark),
+                          Navigator.of(context).push(
+                            GameBookmarksScreen.buildRoute(
+                              context,
+                              nbBookmarks: user.count!.bookmark,
+                            ),
                           );
                         },
                       ),

--- a/lib/src/view/account/profile_screen.dart
+++ b/lib/src/view/account/profile_screen.dart
@@ -31,7 +31,7 @@ class _ProfileScreenState extends ConsumerState<ProfileScreen> {
   @override
   Widget build(BuildContext context) {
     final account = ref.watch(accountProvider);
-    return PlatformScaffold(
+    return PlatformThemedScaffold(
       appBar: PlatformAppBar(
         title: account.when(
           data:

--- a/lib/src/view/account/profile_screen.dart
+++ b/lib/src/view/account/profile_screen.dart
@@ -35,7 +35,7 @@ class _ProfileScreenState extends ConsumerState<ProfileScreen> {
   @override
   Widget build(BuildContext context) {
     final account = ref.watch(accountProvider);
-    return PlatformThemedScaffold(
+    return PlatformScaffold(
       appBar: PlatformAppBar(
         title: account.when(
           data:

--- a/lib/src/view/analysis/analysis_screen.dart
+++ b/lib/src/view/analysis/analysis_screen.dart
@@ -23,7 +23,7 @@ import 'package:lichess_mobile/src/view/engine/engine_gauge.dart';
 import 'package:lichess_mobile/src/view/engine/engine_lines.dart';
 import 'package:lichess_mobile/src/view/opening_explorer/opening_explorer_view.dart';
 import 'package:lichess_mobile/src/widgets/adaptive_action_sheet.dart';
-import 'package:lichess_mobile/src/widgets/background_theme.dart';
+import 'package:lichess_mobile/src/widgets/background.dart';
 import 'package:lichess_mobile/src/widgets/bottom_bar.dart';
 import 'package:lichess_mobile/src/widgets/bottom_bar_button.dart';
 import 'package:lichess_mobile/src/widgets/buttons.dart';
@@ -41,7 +41,7 @@ class AnalysisScreen extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    return FullScreenBackgroundTheme(
+    return FullScreenBackground(
       child: _AnalysisScreen(options: options, enableDrawingShapes: enableDrawingShapes),
     );
   }

--- a/lib/src/view/analysis/analysis_screen.dart
+++ b/lib/src/view/analysis/analysis_screen.dart
@@ -39,6 +39,10 @@ class AnalysisScreen extends StatelessWidget {
   final AnalysisOptions options;
   final bool enableDrawingShapes;
 
+  static Route<dynamic> buildRoute(BuildContext context, AnalysisOptions options) {
+    return buildScreenRoute(context, screen: AnalysisScreen(options: options));
+  }
+
   @override
   Widget build(BuildContext context) {
     return FullScreenBackground(
@@ -94,11 +98,7 @@ class _AnalysisScreenState extends ConsumerState<_AnalysisScreen>
       AppBarAnalysisTabIndicator(tabs: tabs, controller: _tabController),
       AppBarIconButton(
         onPressed: () {
-          pushPlatformRoute(
-            context,
-            title: context.l10n.settingsSettings,
-            builder: (_) => AnalysisSettings(widget.options),
-          );
+          Navigator.of(context).push(AnalysisSettings.buildRoute(context, options: widget.options));
         },
         semanticsLabel: context.l10n.settingsSettings,
         icon: const Icon(Icons.settings),
@@ -302,21 +302,15 @@ class _BottomBar extends ConsumerWidget {
             makeLabel: (context) => Text(context.l10n.boardEditor),
             onPressed: (context) {
               final boardFen = analysisState.position.fen;
-              pushPlatformRoute(
+              Navigator.of(
                 context,
-                title: context.l10n.boardEditor,
-                builder: (_) => BoardEditorScreen(initialFen: boardFen),
-              );
+              ).push(BoardEditorScreen.buildRoute(context, initialFen: boardFen));
             },
           ),
         BottomSheetAction(
           makeLabel: (context) => Text(context.l10n.mobileShareGamePGN),
           onPressed: (_) {
-            pushPlatformRoute(
-              context,
-              title: context.l10n.studyShareAndExport,
-              builder: (_) => AnalysisShareScreen(options: options),
-            );
+            Navigator.of(context).push(AnalysisShareScreen.buildRoute(context, options: options));
           },
         ),
         BottomSheetAction(

--- a/lib/src/view/analysis/analysis_screen.dart
+++ b/lib/src/view/analysis/analysis_screen.dart
@@ -107,7 +107,7 @@ class _AnalysisScreenState extends ConsumerState<_AnalysisScreen>
 
     switch (asyncState) {
       case AsyncData(:final value):
-        return PlatformScaffold(
+        return PlatformThemedScaffold(
           resizeToAvoidBottomInset: false,
           appBar: PlatformAppBar(title: _Title(variant: value.variant), actions: appBarActions),
           body: _Body(
@@ -124,7 +124,7 @@ class _AnalysisScreenState extends ConsumerState<_AnalysisScreen>
           },
         );
       case _:
-        return PlatformScaffold(
+        return PlatformThemedScaffold(
           resizeToAvoidBottomInset: false,
           appBar: PlatformAppBar(
             title: const _Title(variant: Variant.standard),

--- a/lib/src/view/analysis/analysis_screen.dart
+++ b/lib/src/view/analysis/analysis_screen.dart
@@ -23,7 +23,6 @@ import 'package:lichess_mobile/src/view/engine/engine_gauge.dart';
 import 'package:lichess_mobile/src/view/engine/engine_lines.dart';
 import 'package:lichess_mobile/src/view/opening_explorer/opening_explorer_view.dart';
 import 'package:lichess_mobile/src/widgets/adaptive_action_sheet.dart';
-import 'package:lichess_mobile/src/widgets/background.dart';
 import 'package:lichess_mobile/src/widgets/bottom_bar.dart';
 import 'package:lichess_mobile/src/widgets/bottom_bar_button.dart';
 import 'package:lichess_mobile/src/widgets/buttons.dart';
@@ -45,9 +44,7 @@ class AnalysisScreen extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    return FullScreenBackground(
-      child: _AnalysisScreen(options: options, enableDrawingShapes: enableDrawingShapes),
-    );
+    return _AnalysisScreen(options: options, enableDrawingShapes: enableDrawingShapes);
   }
 }
 
@@ -107,7 +104,7 @@ class _AnalysisScreenState extends ConsumerState<_AnalysisScreen>
 
     switch (asyncState) {
       case AsyncData(:final value):
-        return PlatformThemedScaffold(
+        return PlatformScaffold(
           resizeToAvoidBottomInset: false,
           appBar: PlatformAppBar(title: _Title(variant: value.variant), actions: appBarActions),
           body: _Body(
@@ -124,7 +121,7 @@ class _AnalysisScreenState extends ConsumerState<_AnalysisScreen>
           },
         );
       case _:
-        return PlatformThemedScaffold(
+        return PlatformScaffold(
           resizeToAvoidBottomInset: false,
           appBar: PlatformAppBar(
             title: const _Title(variant: Variant.standard),

--- a/lib/src/view/analysis/analysis_settings.dart
+++ b/lib/src/view/analysis/analysis_settings.dart
@@ -37,7 +37,7 @@ class AnalysisSettings extends ConsumerWidget {
 
     switch (asyncState) {
       case AsyncData(:final value):
-        return PlatformThemedScaffold(
+        return PlatformScaffold(
           appBar: PlatformAppBar(title: Text(context.l10n.settingsSettings)),
           body: ListView(
             children: [

--- a/lib/src/view/analysis/analysis_settings.dart
+++ b/lib/src/view/analysis/analysis_settings.dart
@@ -28,7 +28,7 @@ class AnalysisSettings extends ConsumerWidget {
 
     switch (asyncState) {
       case AsyncData(:final value):
-        return PlatformScaffold(
+        return PlatformThemedScaffold(
           appBar: PlatformAppBar(title: Text(context.l10n.settingsSettings)),
           body: ListView(
             children: [

--- a/lib/src/view/analysis/analysis_settings.dart
+++ b/lib/src/view/analysis/analysis_settings.dart
@@ -4,6 +4,7 @@ import 'package:lichess_mobile/src/model/analysis/analysis_controller.dart';
 import 'package:lichess_mobile/src/model/analysis/analysis_preferences.dart';
 import 'package:lichess_mobile/src/model/settings/general_preferences.dart';
 import 'package:lichess_mobile/src/utils/l10n_context.dart';
+import 'package:lichess_mobile/src/utils/navigation.dart';
 import 'package:lichess_mobile/src/view/analysis/stockfish_settings.dart';
 import 'package:lichess_mobile/src/view/opening_explorer/opening_explorer_settings.dart';
 import 'package:lichess_mobile/src/widgets/adaptive_bottom_sheet.dart';
@@ -16,6 +17,14 @@ class AnalysisSettings extends ConsumerWidget {
   const AnalysisSettings(this.options);
 
   final AnalysisOptions options;
+
+  static Route<dynamic> buildRoute(BuildContext context, {required AnalysisOptions options}) {
+    return buildScreenRoute(
+      context,
+      screen: AnalysisSettings(options),
+      title: context.l10n.settingsSettings,
+    );
+  }
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {

--- a/lib/src/view/analysis/analysis_share_screen.dart
+++ b/lib/src/view/analysis/analysis_share_screen.dart
@@ -8,6 +8,7 @@ import 'package:lichess_mobile/src/model/account/account_preferences.dart';
 import 'package:lichess_mobile/src/model/analysis/analysis_controller.dart';
 import 'package:lichess_mobile/src/styles/styles.dart';
 import 'package:lichess_mobile/src/utils/l10n_context.dart';
+import 'package:lichess_mobile/src/utils/navigation.dart';
 import 'package:lichess_mobile/src/utils/share.dart';
 import 'package:lichess_mobile/src/widgets/adaptive_choice_picker.dart';
 import 'package:lichess_mobile/src/widgets/adaptive_text_field.dart';
@@ -20,6 +21,14 @@ class AnalysisShareScreen extends StatelessWidget {
   const AnalysisShareScreen({required this.options});
 
   final AnalysisOptions options;
+
+  static Route<dynamic> buildRoute(BuildContext context, {required AnalysisOptions options}) {
+    return buildScreenRoute(
+      context,
+      screen: AnalysisShareScreen(options: options),
+      title: context.l10n.studyShareAndExport,
+    );
+  }
 
   @override
   Widget build(BuildContext context) {

--- a/lib/src/view/analysis/analysis_share_screen.dart
+++ b/lib/src/view/analysis/analysis_share_screen.dart
@@ -23,7 +23,7 @@ class AnalysisShareScreen extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    return PlatformScaffold(
+    return PlatformThemedScaffold(
       appBar: PlatformAppBar(title: Text(context.l10n.studyShareAndExport)),
       body: _EditPgnTagsForm(options),
     );

--- a/lib/src/view/analysis/analysis_share_screen.dart
+++ b/lib/src/view/analysis/analysis_share_screen.dart
@@ -32,7 +32,7 @@ class AnalysisShareScreen extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    return PlatformThemedScaffold(
+    return PlatformScaffold(
       appBar: PlatformAppBar(title: Text(context.l10n.studyShareAndExport)),
       body: _EditPgnTagsForm(options),
     );

--- a/lib/src/view/analysis/tree_view.dart
+++ b/lib/src/view/analysis/tree_view.dart
@@ -25,7 +25,7 @@ class AnalysisTreeView extends ConsumerWidget {
     final enableComputerAnalysis = !options.isLichessGameAnalysis || prefs.enableComputerAnalysis;
 
     return ColoredBox(
-      color: ColorScheme.of(context).surface,
+      color: ColorScheme.of(context).surfaceContainer,
       child: SingleChildScrollView(
         padding: EdgeInsets.zero,
         child: DebouncedPgnTreeView(

--- a/lib/src/view/board_editor/board_editor_screen.dart
+++ b/lib/src/view/board_editor/board_editor_screen.dart
@@ -35,7 +35,7 @@ class BoardEditorScreen extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    return PlatformThemedScaffold(
+    return PlatformScaffold(
       appBar: PlatformAppBar(title: Text(context.l10n.boardEditor)),
       body: _Body(initialFen),
     );

--- a/lib/src/view/board_editor/board_editor_screen.dart
+++ b/lib/src/view/board_editor/board_editor_screen.dart
@@ -25,6 +25,14 @@ class BoardEditorScreen extends StatelessWidget {
 
   final String? initialFen;
 
+  static Route<dynamic> buildRoute(BuildContext context, {String? initialFen}) {
+    return buildScreenRoute(
+      context,
+      title: context.l10n.boardEditor,
+      screen: BoardEditorScreen(initialFen: initialFen),
+    );
+  }
+
   @override
   Widget build(BuildContext context) {
     return PlatformThemedScaffold(
@@ -308,20 +316,18 @@ class _BottomBar extends ConsumerWidget {
                       pieceCount > 0 &&
                       pieceCount <= 32
                   ? () {
-                    pushPlatformRoute(
-                      context,
-                      rootNavigator: true,
-                      builder:
-                          (context) => AnalysisScreen(
-                            options: AnalysisOptions(
-                              orientation: editorState.orientation,
-                              standalone: (
-                                pgn: editorState.pgn!,
-                                isComputerAnalysisAllowed: true,
-                                variant: Variant.fromPosition,
-                              ),
-                            ),
+                    Navigator.of(context).push(
+                      AnalysisScreen.buildRoute(
+                        context,
+                        AnalysisOptions(
+                          orientation: editorState.orientation,
+                          standalone: (
+                            pgn: editorState.pgn!,
+                            isComputerAnalysisAllowed: true,
+                            variant: Variant.fromPosition,
                           ),
+                        ),
+                      ),
                     );
                   }
                   : null,

--- a/lib/src/view/board_editor/board_editor_screen.dart
+++ b/lib/src/view/board_editor/board_editor_screen.dart
@@ -27,7 +27,7 @@ class BoardEditorScreen extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    return PlatformBoardThemeScaffold(
+    return PlatformThemedScaffold(
       appBar: PlatformAppBar(title: Text(context.l10n.boardEditor)),
       body: _Body(initialFen),
     );

--- a/lib/src/view/broadcast/broadcast_boards_tab.dart
+++ b/lib/src/view/broadcast/broadcast_boards_tab.dart
@@ -8,7 +8,6 @@ import 'package:lichess_mobile/src/model/common/id.dart';
 import 'package:lichess_mobile/src/styles/styles.dart';
 import 'package:lichess_mobile/src/utils/duration.dart';
 import 'package:lichess_mobile/src/utils/l10n_context.dart';
-import 'package:lichess_mobile/src/utils/navigation.dart';
 import 'package:lichess_mobile/src/utils/screen.dart';
 import 'package:lichess_mobile/src/view/broadcast/broadcast_game_screen.dart';
 import 'package:lichess_mobile/src/view/broadcast/broadcast_player_widget.dart';
@@ -144,18 +143,16 @@ class BroadcastPreview extends StatelessWidget {
           return BoardThumbnail(
             animationDuration: const Duration(milliseconds: 150),
             onTap: () {
-              pushPlatformRoute(
-                context,
-                title: title,
-                builder:
-                    (context) => BroadcastGameScreen(
-                      tournamentId: tournamentId,
-                      roundId: roundId,
-                      gameId: game.id,
-                      tournamentSlug: tournamentSlug,
-                      roundSlug: roundSlug,
-                      title: title,
-                    ),
+              Navigator.of(context).push(
+                BroadcastGameScreen.buildRoute(
+                  context,
+                  tournamentId: tournamentId,
+                  roundId: roundId,
+                  gameId: game.id,
+                  tournamentSlug: tournamentSlug,
+                  roundSlug: roundSlug,
+                  title: title,
+                ),
               );
             },
             orientation: Side.white,

--- a/lib/src/view/broadcast/broadcast_game_screen.dart
+++ b/lib/src/view/broadcast/broadcast_game_screen.dart
@@ -106,7 +106,7 @@ class _BroadcastGameScreenState extends ConsumerState<BroadcastGameScreen>
               _ => const SizedBox.shrink(),
             };
 
-    return PlatformThemedScaffold(
+    return PlatformScaffold(
       appBar: PlatformAppBar(
         title: title,
         actions: [

--- a/lib/src/view/broadcast/broadcast_game_screen.dart
+++ b/lib/src/view/broadcast/broadcast_game_screen.dart
@@ -218,7 +218,7 @@ class _BroadcastGameTreeView extends ConsumerWidget {
     final analysisPrefs = ref.watch(analysisPreferencesProvider);
 
     return ColoredBox(
-      color: ColorScheme.of(context).surface,
+      color: ColorScheme.of(context).surfaceContainer,
       child: SingleChildScrollView(
         child: DebouncedPgnTreeView(
           root: state.root,

--- a/lib/src/view/broadcast/broadcast_game_screen.dart
+++ b/lib/src/view/broadcast/broadcast_game_screen.dart
@@ -46,6 +46,28 @@ class BroadcastGameScreen extends ConsumerStatefulWidget {
     this.title,
   });
 
+  static Route<dynamic> buildRoute(
+    BuildContext context, {
+    required BroadcastTournamentId tournamentId,
+    required BroadcastRoundId roundId,
+    required BroadcastGameId gameId,
+    String? tournamentSlug,
+    String? roundSlug,
+    String? title,
+  }) {
+    return buildScreenRoute(
+      context,
+      screen: BroadcastGameScreen(
+        tournamentId: tournamentId,
+        roundId: roundId,
+        gameId: gameId,
+        tournamentSlug: tournamentSlug,
+        roundSlug: roundSlug,
+        title: title,
+      ),
+    );
+  }
+
   @override
   ConsumerState<BroadcastGameScreen> createState() => _BroadcastGameScreenState();
 }
@@ -91,9 +113,12 @@ class _BroadcastGameScreenState extends ConsumerState<BroadcastGameScreen>
           AppBarAnalysisTabIndicator(tabs: tabs, controller: _tabController),
           AppBarIconButton(
             onPressed: () {
-              pushPlatformRoute(
-                context,
-                screen: BroadcastGameSettings(widget.roundId, widget.gameId),
+              Navigator.of(context).push(
+                BroadcastGameSettings.buildRoute(
+                  context,
+                  roundId: widget.roundId,
+                  gameId: widget.gameId,
+                ),
               );
             },
             semanticsLabel: context.l10n.settingsSettings,
@@ -391,15 +416,14 @@ class _PlayerWidget extends ConsumerWidget {
 
         return GestureDetector(
           onTap: () {
-            pushPlatformRoute(
-              context,
-              builder:
-                  (context) => BroadcastPlayerResultsScreen(
-                    tournamentId,
-                    (player.fideId != null) ? player.fideId!.toString() : player.name,
-                    player.title,
-                    player.name,
-                  ),
+            Navigator.of(context).push(
+              BroadcastPlayerResultsScreen.buildRoute(
+                context,
+                tournamentId,
+                (player.fideId != null) ? player.fideId!.toString() : player.name,
+                playerTitle: player.title,
+                playerName: player.name,
+              ),
             );
           },
           child: Container(

--- a/lib/src/view/broadcast/broadcast_game_screen.dart
+++ b/lib/src/view/broadcast/broadcast_game_screen.dart
@@ -84,7 +84,7 @@ class _BroadcastGameScreenState extends ConsumerState<BroadcastGameScreen>
               _ => const SizedBox.shrink(),
             };
 
-    return PlatformBoardThemeScaffold(
+    return PlatformThemedScaffold(
       appBar: PlatformAppBar(
         title: title,
         actions: [

--- a/lib/src/view/broadcast/broadcast_game_settings.dart
+++ b/lib/src/view/broadcast/broadcast_game_settings.dart
@@ -41,7 +41,7 @@ class BroadcastGameSettings extends ConsumerWidget {
       generalPreferencesProvider.select((pref) => pref.isSoundEnabled),
     );
 
-    return PlatformThemedScaffold(
+    return PlatformScaffold(
       appBar: PlatformAppBar(title: Text(context.l10n.settingsSettings)),
       body: ListView(
         children: [

--- a/lib/src/view/broadcast/broadcast_game_settings.dart
+++ b/lib/src/view/broadcast/broadcast_game_settings.dart
@@ -28,7 +28,7 @@ class BroadcastGameSettings extends ConsumerWidget {
       generalPreferencesProvider.select((pref) => pref.isSoundEnabled),
     );
 
-    return PlatformScaffold(
+    return PlatformThemedScaffold(
       appBar: PlatformAppBar(title: Text(context.l10n.settingsSettings)),
       body: ListView(
         children: [

--- a/lib/src/view/broadcast/broadcast_game_settings.dart
+++ b/lib/src/view/broadcast/broadcast_game_settings.dart
@@ -6,6 +6,7 @@ import 'package:lichess_mobile/src/model/broadcast/broadcast_analysis_controller
 import 'package:lichess_mobile/src/model/common/id.dart';
 import 'package:lichess_mobile/src/model/settings/general_preferences.dart';
 import 'package:lichess_mobile/src/utils/l10n_context.dart';
+import 'package:lichess_mobile/src/utils/navigation.dart';
 import 'package:lichess_mobile/src/view/analysis/stockfish_settings.dart';
 import 'package:lichess_mobile/src/view/opening_explorer/opening_explorer_settings.dart';
 import 'package:lichess_mobile/src/widgets/adaptive_bottom_sheet.dart';
@@ -18,6 +19,18 @@ class BroadcastGameSettings extends ConsumerWidget {
 
   final BroadcastRoundId roundId;
   final BroadcastGameId gameId;
+
+  static Route<dynamic> buildRoute(
+    BuildContext context, {
+    required BroadcastRoundId roundId,
+    required BroadcastGameId gameId,
+  }) {
+    return buildScreenRoute(
+      context,
+      screen: BroadcastGameSettings(roundId, gameId),
+      title: context.l10n.settingsSettings,
+    );
+  }
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {

--- a/lib/src/view/broadcast/broadcast_list_screen.dart
+++ b/lib/src/view/broadcast/broadcast_list_screen.dart
@@ -26,6 +26,7 @@ import 'package:lichess_mobile/src/utils/screen.dart';
 import 'package:lichess_mobile/src/utils/share.dart';
 import 'package:lichess_mobile/src/view/broadcast/broadcast_round_screen.dart';
 import 'package:lichess_mobile/src/widgets/adaptive_action_sheet.dart';
+import 'package:lichess_mobile/src/widgets/background_theme.dart';
 import 'package:lichess_mobile/src/widgets/buttons.dart';
 import 'package:lichess_mobile/src/widgets/platform.dart';
 import 'package:lichess_mobile/src/widgets/shimmer.dart';
@@ -46,18 +47,22 @@ class BroadcastListScreen extends StatelessWidget {
       overflow: TextOverflow.ellipsis,
       maxLines: 1,
     );
-    return PlatformWidget(
-      androidBuilder: (_) => Scaffold(body: const _Body(), appBar: AppBar(title: title)),
-      iosBuilder:
-          (_) => CupertinoPageScaffold(
-            navigationBar: CupertinoNavigationBar(
-              middle: title,
-              automaticBackgroundVisibility: false,
-              backgroundColor: CupertinoTheme.of(context).barBackgroundColor.withValues(alpha: 0.0),
-              border: null,
+    return FullScreenBackgroundTheme(
+      child: PlatformWidget(
+        androidBuilder: (_) => Scaffold(body: const _Body(), appBar: AppBar(title: title)),
+        iosBuilder:
+            (_) => CupertinoPageScaffold(
+              navigationBar: CupertinoNavigationBar(
+                middle: title,
+                automaticBackgroundVisibility: false,
+                backgroundColor: CupertinoTheme.of(
+                  context,
+                ).barBackgroundColor.withValues(alpha: 0.0),
+                border: null,
+              ),
+              child: const _Body(),
             ),
-            child: const _Body(),
-          ),
+      ),
     );
   }
 }

--- a/lib/src/view/broadcast/broadcast_list_screen.dart
+++ b/lib/src/view/broadcast/broadcast_list_screen.dart
@@ -39,6 +39,14 @@ const kDefaultCardOpacity = 0.9;
 class BroadcastListScreen extends StatelessWidget {
   const BroadcastListScreen({super.key});
 
+  static Route<dynamic> buildRoute(BuildContext context) {
+    return buildScreenRoute(
+      context,
+      title: context.l10n.broadcastBroadcasts,
+      screen: const BroadcastListScreen(),
+    );
+  }
+
   @override
   Widget build(BuildContext context) {
     final title = AutoSizeText(
@@ -534,15 +542,12 @@ class _BroadcastCardContent extends StatelessWidget {
                     semanticsLabel: context.l10n.broadcastOverview,
                     child: Text(context.l10n.broadcastOverview),
                     onPressed: () {
-                      pushPlatformRoute(
-                        context,
-                        title: broadcast.title,
-                        rootNavigator: true,
-                        builder:
-                            (context) => BroadcastRoundScreen(
-                              broadcast: broadcast,
-                              initialTab: BroadcastRoundTab.overview,
-                            ),
+                      Navigator.of(context, rootNavigator: true).push(
+                        BroadcastRoundScreen.buildRoute(
+                          context,
+                          broadcast,
+                          initialTab: BroadcastRoundTab.overview,
+                        ),
                       );
                     },
                   ),
@@ -551,15 +556,12 @@ class _BroadcastCardContent extends StatelessWidget {
                     semanticsLabel: context.l10n.broadcastBoards,
                     child: Text(context.l10n.broadcastBoards),
                     onPressed: () {
-                      pushPlatformRoute(
-                        context,
-                        title: broadcast.title,
-                        rootNavigator: true,
-                        builder:
-                            (context) => BroadcastRoundScreen(
-                              broadcast: broadcast,
-                              initialTab: BroadcastRoundTab.boards,
-                            ),
+                      Navigator.of(context, rootNavigator: true).push(
+                        BroadcastRoundScreen.buildRoute(
+                          context,
+                          broadcast,
+                          initialTab: BroadcastRoundTab.boards,
+                        ),
                       );
                     },
                   ),
@@ -568,15 +570,12 @@ class _BroadcastCardContent extends StatelessWidget {
                     semanticsLabel: context.l10n.players,
                     child: Text(context.l10n.players),
                     onPressed: () {
-                      pushPlatformRoute(
-                        context,
-                        title: broadcast.title,
-                        rootNavigator: true,
-                        builder:
-                            (context) => BroadcastRoundScreen(
-                              broadcast: broadcast,
-                              initialTab: BroadcastRoundTab.players,
-                            ),
+                      Navigator.of(context, rootNavigator: true).push(
+                        BroadcastRoundScreen.buildRoute(
+                          context,
+                          broadcast,
+                          initialTab: BroadcastRoundTab.players,
+                        ),
                       );
                     },
                   ),
@@ -743,12 +742,10 @@ class _BroadcastCardState extends State<BroadcastCard> {
 
     return GestureDetector(
       onTap: () {
-        pushPlatformRoute(
+        Navigator.of(
           context,
-          title: widget.broadcast.title,
           rootNavigator: true,
-          builder: (context) => BroadcastRoundScreen(broadcast: widget.broadcast),
-        );
+        ).push(BroadcastRoundScreen.buildRoute(context, widget.broadcast));
       },
       onTapDown: (_) => _onTapDown(),
       onTapCancel: _onTapCancel,
@@ -899,12 +896,10 @@ class _BroadcastCarouselItemState extends State<BroadcastCarouselItem> {
 
     return GestureDetector(
       onTap: () {
-        pushPlatformRoute(
+        Navigator.of(
           context,
-          title: widget.broadcast.title,
           rootNavigator: true,
-          builder: (context) => BroadcastRoundScreen(broadcast: widget.broadcast),
-        );
+        ).push(BroadcastRoundScreen.buildRoute(context, widget.broadcast));
       },
       onTapDown: (_) => _onTapDown(),
       onTapCancel: _onTapCancel,

--- a/lib/src/view/broadcast/broadcast_list_screen.dart
+++ b/lib/src/view/broadcast/broadcast_list_screen.dart
@@ -26,7 +26,7 @@ import 'package:lichess_mobile/src/utils/screen.dart';
 import 'package:lichess_mobile/src/utils/share.dart';
 import 'package:lichess_mobile/src/view/broadcast/broadcast_round_screen.dart';
 import 'package:lichess_mobile/src/widgets/adaptive_action_sheet.dart';
-import 'package:lichess_mobile/src/widgets/background_theme.dart';
+import 'package:lichess_mobile/src/widgets/background.dart';
 import 'package:lichess_mobile/src/widgets/buttons.dart';
 import 'package:lichess_mobile/src/widgets/platform.dart';
 import 'package:lichess_mobile/src/widgets/shimmer.dart';
@@ -47,7 +47,7 @@ class BroadcastListScreen extends StatelessWidget {
       overflow: TextOverflow.ellipsis,
       maxLines: 1,
     );
-    return FullScreenBackgroundTheme(
+    return FullScreenBackground(
       child: PlatformWidget(
         androidBuilder: (_) => Scaffold(body: const _Body(), appBar: AppBar(title: title)),
         iosBuilder:

--- a/lib/src/view/broadcast/broadcast_list_screen.dart
+++ b/lib/src/view/broadcast/broadcast_list_screen.dart
@@ -26,7 +26,6 @@ import 'package:lichess_mobile/src/utils/screen.dart';
 import 'package:lichess_mobile/src/utils/share.dart';
 import 'package:lichess_mobile/src/view/broadcast/broadcast_round_screen.dart';
 import 'package:lichess_mobile/src/widgets/adaptive_action_sheet.dart';
-import 'package:lichess_mobile/src/widgets/background.dart';
 import 'package:lichess_mobile/src/widgets/buttons.dart';
 import 'package:lichess_mobile/src/widgets/platform.dart';
 import 'package:lichess_mobile/src/widgets/shimmer.dart';
@@ -55,22 +54,18 @@ class BroadcastListScreen extends StatelessWidget {
       overflow: TextOverflow.ellipsis,
       maxLines: 1,
     );
-    return FullScreenBackground(
-      child: PlatformWidget(
-        androidBuilder: (_) => Scaffold(body: const _Body(), appBar: AppBar(title: title)),
-        iosBuilder:
-            (_) => CupertinoPageScaffold(
-              navigationBar: CupertinoNavigationBar(
-                middle: title,
-                automaticBackgroundVisibility: false,
-                backgroundColor: CupertinoTheme.of(
-                  context,
-                ).barBackgroundColor.withValues(alpha: 0.0),
-                border: null,
-              ),
-              child: const _Body(),
+    return PlatformWidget(
+      androidBuilder: (_) => Scaffold(body: const _Body(), appBar: AppBar(title: title)),
+      iosBuilder:
+          (_) => CupertinoPageScaffold(
+            navigationBar: CupertinoNavigationBar(
+              middle: title,
+              automaticBackgroundVisibility: false,
+              backgroundColor: CupertinoTheme.of(context).barBackgroundColor.withValues(alpha: 0.0),
+              border: null,
             ),
-      ),
+            child: const _Body(),
+          ),
     );
   }
 }

--- a/lib/src/view/broadcast/broadcast_player_results_screen.dart
+++ b/lib/src/view/broadcast/broadcast_player_results_screen.dart
@@ -50,7 +50,7 @@ class BroadcastPlayerResultsScreen extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    return PlatformThemedScaffold(
+    return PlatformScaffold(
       appBar: PlatformAppBar(title: BroadcastPlayerWidget(title: playerTitle, name: playerName)),
       body: _Body(tournamentId, playerId),
     );

--- a/lib/src/view/broadcast/broadcast_player_results_screen.dart
+++ b/lib/src/view/broadcast/broadcast_player_results_screen.dart
@@ -25,10 +25,28 @@ class BroadcastPlayerResultsScreen extends StatelessWidget {
 
   const BroadcastPlayerResultsScreen(
     this.tournamentId,
-    this.playerId,
+    this.playerId, {
+    required this.playerName,
     this.playerTitle,
-    this.playerName,
-  );
+  });
+
+  static Route<dynamic> buildRoute(
+    BuildContext context,
+    BroadcastTournamentId tournamentId,
+    String playerId, {
+    String? playerTitle,
+    required String playerName,
+  }) {
+    return buildScreenRoute(
+      context,
+      screen: BroadcastPlayerResultsScreen(
+        tournamentId,
+        playerId,
+        playerTitle: playerTitle,
+        playerName: playerName,
+      ),
+    );
+  }
 
   @override
   Widget build(BuildContext context) {
@@ -189,14 +207,13 @@ class _Body extends ConsumerWidget {
 
             return GestureDetector(
               onTap: () {
-                pushPlatformRoute(
-                  context,
-                  builder:
-                      (context) => BroadcastGameScreen(
-                        tournamentId: tournamentId,
-                        roundId: playerResult.roundId,
-                        gameId: playerResult.gameId,
-                      ),
+                Navigator.of(context).push(
+                  BroadcastGameScreen.buildRoute(
+                    context,
+                    tournamentId: tournamentId,
+                    roundId: playerResult.roundId,
+                    gameId: playerResult.gameId,
+                  ),
                 );
               },
               child: ColoredBox(

--- a/lib/src/view/broadcast/broadcast_player_results_screen.dart
+++ b/lib/src/view/broadcast/broadcast_player_results_screen.dart
@@ -32,7 +32,7 @@ class BroadcastPlayerResultsScreen extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    return PlatformScaffold(
+    return PlatformThemedScaffold(
       appBar: PlatformAppBar(title: BroadcastPlayerWidget(title: playerTitle, name: playerName)),
       body: _Body(tournamentId, playerId),
     );

--- a/lib/src/view/broadcast/broadcast_players_tab.dart
+++ b/lib/src/view/broadcast/broadcast_players_tab.dart
@@ -1,7 +1,6 @@
 import 'dart:math';
 
 import 'package:fast_immutable_collections/fast_immutable_collections.dart';
-import 'package:flutter/cupertino.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:lichess_mobile/src/model/broadcast/broadcast.dart';
@@ -196,11 +195,7 @@ class _PlayersListState extends ConsumerState<PlayersList> {
             },
             child: ColoredBox(
               color:
-                  Theme.of(context).platform == TargetPlatform.iOS
-                      ? index.isEven
-                          ? CupertinoColors.secondarySystemBackground.resolveFrom(context)
-                          : CupertinoColors.tertiarySystemBackground.resolveFrom(context)
-                      : index.isEven
+                  index.isEven
                       ? ColorScheme.of(context).surfaceContainerLow
                       : ColorScheme.of(context).surfaceContainerHigh,
               child: Row(

--- a/lib/src/view/broadcast/broadcast_players_tab.dart
+++ b/lib/src/view/broadcast/broadcast_players_tab.dart
@@ -8,7 +8,6 @@ import 'package:lichess_mobile/src/model/broadcast/broadcast_providers.dart';
 import 'package:lichess_mobile/src/model/common/id.dart';
 import 'package:lichess_mobile/src/styles/styles.dart';
 import 'package:lichess_mobile/src/utils/l10n_context.dart';
-import 'package:lichess_mobile/src/utils/navigation.dart';
 import 'package:lichess_mobile/src/view/broadcast/broadcast_player_results_screen.dart';
 import 'package:lichess_mobile/src/view/broadcast/broadcast_player_widget.dart';
 import 'package:lichess_mobile/src/widgets/progression_widget.dart';
@@ -182,15 +181,14 @@ class _PlayersListState extends ConsumerState<PlayersList> {
 
           return GestureDetector(
             onTap: () {
-              pushPlatformRoute(
-                context,
-                builder:
-                    (context) => BroadcastPlayerResultsScreen(
-                      widget.tournamentId,
-                      player.fideId != null ? player.fideId.toString() : player.name,
-                      player.title,
-                      player.name,
-                    ),
+              Navigator.of(context).push(
+                BroadcastPlayerResultsScreen.buildRoute(
+                  context,
+                  widget.tournamentId,
+                  player.fideId != null ? player.fideId.toString() : player.name,
+                  playerTitle: player.title,
+                  playerName: player.name,
+                ),
               );
             },
             child: ColoredBox(

--- a/lib/src/view/broadcast/broadcast_round_screen.dart
+++ b/lib/src/view/broadcast/broadcast_round_screen.dart
@@ -15,7 +15,6 @@ import 'package:lichess_mobile/src/view/broadcast/broadcast_boards_tab.dart';
 import 'package:lichess_mobile/src/view/broadcast/broadcast_overview_tab.dart';
 import 'package:lichess_mobile/src/view/broadcast/broadcast_players_tab.dart';
 import 'package:lichess_mobile/src/widgets/adaptive_bottom_sheet.dart';
-import 'package:lichess_mobile/src/widgets/background.dart';
 import 'package:lichess_mobile/src/widgets/bottom_bar.dart';
 import 'package:lichess_mobile/src/widgets/buttons.dart';
 import 'package:lichess_mobile/src/widgets/list.dart';
@@ -111,58 +110,56 @@ class _BroadcastRoundScreenState extends ConsumerState<BroadcastRoundScreen>
         }
       },
     );
-    return FullScreenBackground(
-      child: CupertinoPageScaffold(
-        navigationBar: CupertinoNavigationBar(
-          middle: AutoSizeText(
-            widget.broadcast.title,
-            minFontSize: 14.0,
-            overflow: TextOverflow.ellipsis,
-            maxLines: 1,
-          ),
+    return CupertinoPageScaffold(
+      navigationBar: CupertinoNavigationBar(
+        middle: AutoSizeText(
+          widget.broadcast.title,
+          minFontSize: 14.0,
+          overflow: TextOverflow.ellipsis,
+          maxLines: 1,
         ),
-        child: Column(
-          children: [
-            Expanded(
-              child: switch (asyncRound) {
-                AsyncData(value: final _) => switch (selectedTab) {
-                  BroadcastRoundTab.overview => _TabView(
-                    cupertinoTabSwitcher: tabSwitcher,
-                    sliver: BroadcastOverviewTab(
-                      broadcast: widget.broadcast,
+      ),
+      child: Column(
+        children: [
+          Expanded(
+            child: switch (asyncRound) {
+              AsyncData(value: final _) => switch (selectedTab) {
+                BroadcastRoundTab.overview => _TabView(
+                  cupertinoTabSwitcher: tabSwitcher,
+                  sliver: BroadcastOverviewTab(
+                    broadcast: widget.broadcast,
+                    tournamentId: _selectedTournamentId,
+                  ),
+                ),
+                BroadcastRoundTab.boards => _TabView(
+                  cupertinoTabSwitcher: tabSwitcher,
+                  sliver: switch (asyncTournament) {
+                    AsyncData(:final value) => BroadcastBoardsTab(
                       tournamentId: _selectedTournamentId,
+                      roundId: _selectedRoundId ?? value.defaultRoundId,
+                      tournamentSlug: widget.broadcast.tour.slug,
                     ),
-                  ),
-                  BroadcastRoundTab.boards => _TabView(
-                    cupertinoTabSwitcher: tabSwitcher,
-                    sliver: switch (asyncTournament) {
-                      AsyncData(:final value) => BroadcastBoardsTab(
-                        tournamentId: _selectedTournamentId,
-                        roundId: _selectedRoundId ?? value.defaultRoundId,
-                        tournamentSlug: widget.broadcast.tour.slug,
-                      ),
-                      _ => const SliverFillRemaining(child: SizedBox.shrink()),
-                    },
-                  ),
-                  BroadcastRoundTab.players => _TabView(
-                    cupertinoTabSwitcher: tabSwitcher,
-                    sliver: BroadcastPlayersTab(tournamentId: _selectedTournamentId),
-                  ),
-                },
-                _ => const Center(child: CircularProgressIndicator.adaptive()),
+                    _ => const SliverFillRemaining(child: SizedBox.shrink()),
+                  },
+                ),
+                BroadcastRoundTab.players => _TabView(
+                  cupertinoTabSwitcher: tabSwitcher,
+                  sliver: BroadcastPlayersTab(tournamentId: _selectedTournamentId),
+                ),
               },
-            ),
-            switch (asyncTournament) {
-              AsyncData(:final value) => _BottomBar(
-                tournament: value,
-                roundId: _selectedRoundId ?? value.defaultRoundId,
-                setTournamentId: setTournamentId,
-                setRoundId: setRoundId,
-              ),
-              _ => const PlatformBottomBar.empty(transparentBackground: false),
+              _ => const Center(child: CircularProgressIndicator.adaptive()),
             },
-          ],
-        ),
+          ),
+          switch (asyncTournament) {
+            AsyncData(:final value) => _BottomBar(
+              tournament: value,
+              roundId: _selectedRoundId ?? value.defaultRoundId,
+              setTournamentId: setTournamentId,
+              setRoundId: setRoundId,
+            ),
+            _ => const PlatformBottomBar.empty(transparentBackground: false),
+          },
+        ],
       ),
     );
   }
@@ -172,59 +169,57 @@ class _BroadcastRoundScreenState extends ConsumerState<BroadcastRoundScreen>
     AsyncValue<BroadcastTournament> asyncTournament,
     AsyncValue<BroadcastRoundWithGames> asyncRound,
   ) {
-    return FullScreenBackground(
-      child: Scaffold(
-        appBar: AppBar(
-          title: AutoSizeText(
-            widget.broadcast.title,
-            minFontSize: 14.0,
-            overflow: TextOverflow.ellipsis,
-            maxLines: 1,
-          ),
-          bottom: TabBar(
-            controller: _tabController,
-            tabs: <Widget>[
-              Tab(text: context.l10n.broadcastOverview),
-              Tab(text: context.l10n.broadcastBoards),
-              Tab(text: context.l10n.players),
-            ],
-          ),
+    return Scaffold(
+      appBar: AppBar(
+        title: AutoSizeText(
+          widget.broadcast.title,
+          minFontSize: 14.0,
+          overflow: TextOverflow.ellipsis,
+          maxLines: 1,
         ),
-        body: switch (asyncRound) {
-          AsyncData(value: final _) => TabBarView(
-            controller: _tabController,
-            children: <Widget>[
-              _TabView(
-                sliver: BroadcastOverviewTab(
-                  broadcast: widget.broadcast,
-                  tournamentId: _selectedTournamentId,
-                ),
-              ),
-              _TabView(
-                sliver: switch (asyncTournament) {
-                  AsyncData(:final value) => BroadcastBoardsTab(
-                    tournamentId: _selectedTournamentId,
-                    roundId: _selectedRoundId ?? value.defaultRoundId,
-                    tournamentSlug: widget.broadcast.tour.slug,
-                  ),
-                  _ => const SliverFillRemaining(child: SizedBox.shrink()),
-                },
-              ),
-              _TabView(sliver: BroadcastPlayersTab(tournamentId: _selectedTournamentId)),
-            ],
-          ),
-          _ => const Center(child: CircularProgressIndicator()),
-        },
-        bottomNavigationBar: switch (asyncTournament) {
-          AsyncData(:final value) => _BottomBar(
-            tournament: value,
-            roundId: _selectedRoundId ?? value.defaultRoundId,
-            setTournamentId: setTournamentId,
-            setRoundId: setRoundId,
-          ),
-          _ => const PlatformBottomBar.empty(transparentBackground: false),
-        },
+        bottom: TabBar(
+          controller: _tabController,
+          tabs: <Widget>[
+            Tab(text: context.l10n.broadcastOverview),
+            Tab(text: context.l10n.broadcastBoards),
+            Tab(text: context.l10n.players),
+          ],
+        ),
       ),
+      body: switch (asyncRound) {
+        AsyncData(value: final _) => TabBarView(
+          controller: _tabController,
+          children: <Widget>[
+            _TabView(
+              sliver: BroadcastOverviewTab(
+                broadcast: widget.broadcast,
+                tournamentId: _selectedTournamentId,
+              ),
+            ),
+            _TabView(
+              sliver: switch (asyncTournament) {
+                AsyncData(:final value) => BroadcastBoardsTab(
+                  tournamentId: _selectedTournamentId,
+                  roundId: _selectedRoundId ?? value.defaultRoundId,
+                  tournamentSlug: widget.broadcast.tour.slug,
+                ),
+                _ => const SliverFillRemaining(child: SizedBox.shrink()),
+              },
+            ),
+            _TabView(sliver: BroadcastPlayersTab(tournamentId: _selectedTournamentId)),
+          ],
+        ),
+        _ => const Center(child: CircularProgressIndicator()),
+      },
+      bottomNavigationBar: switch (asyncTournament) {
+        AsyncData(:final value) => _BottomBar(
+          tournament: value,
+          roundId: _selectedRoundId ?? value.defaultRoundId,
+          setTournamentId: setTournamentId,
+          setRoundId: setRoundId,
+        ),
+        _ => const PlatformBottomBar.empty(transparentBackground: false),
+      },
     );
   }
 

--- a/lib/src/view/broadcast/broadcast_round_screen.dart
+++ b/lib/src/view/broadcast/broadcast_round_screen.dart
@@ -14,7 +14,7 @@ import 'package:lichess_mobile/src/view/broadcast/broadcast_boards_tab.dart';
 import 'package:lichess_mobile/src/view/broadcast/broadcast_overview_tab.dart';
 import 'package:lichess_mobile/src/view/broadcast/broadcast_players_tab.dart';
 import 'package:lichess_mobile/src/widgets/adaptive_bottom_sheet.dart';
-import 'package:lichess_mobile/src/widgets/background_theme.dart';
+import 'package:lichess_mobile/src/widgets/background.dart';
 import 'package:lichess_mobile/src/widgets/bottom_bar.dart';
 import 'package:lichess_mobile/src/widgets/buttons.dart';
 import 'package:lichess_mobile/src/widgets/list.dart';
@@ -98,7 +98,7 @@ class _BroadcastRoundScreenState extends ConsumerState<BroadcastRoundScreen>
         }
       },
     );
-    return FullScreenBackgroundTheme(
+    return FullScreenBackground(
       child: CupertinoPageScaffold(
         navigationBar: CupertinoNavigationBar(
           middle: AutoSizeText(
@@ -159,7 +159,7 @@ class _BroadcastRoundScreenState extends ConsumerState<BroadcastRoundScreen>
     AsyncValue<BroadcastTournament> asyncTournament,
     AsyncValue<BroadcastRoundWithGames> asyncRound,
   ) {
-    return FullScreenBackgroundTheme(
+    return FullScreenBackground(
       child: Scaffold(
         appBar: AppBar(
           title: AutoSizeText(

--- a/lib/src/view/broadcast/broadcast_round_screen.dart
+++ b/lib/src/view/broadcast/broadcast_round_screen.dart
@@ -10,6 +10,7 @@ import 'package:lichess_mobile/src/model/broadcast/broadcast_round_controller.da
 import 'package:lichess_mobile/src/model/common/id.dart';
 import 'package:lichess_mobile/src/styles/styles.dart';
 import 'package:lichess_mobile/src/utils/l10n_context.dart';
+import 'package:lichess_mobile/src/utils/navigation.dart';
 import 'package:lichess_mobile/src/view/broadcast/broadcast_boards_tab.dart';
 import 'package:lichess_mobile/src/view/broadcast/broadcast_overview_tab.dart';
 import 'package:lichess_mobile/src/view/broadcast/broadcast_players_tab.dart';
@@ -27,6 +28,18 @@ class BroadcastRoundScreen extends ConsumerStatefulWidget {
   final BroadcastRoundTab? initialTab;
 
   const BroadcastRoundScreen({required this.broadcast, this.initialTab});
+
+  static Route<dynamic> buildRoute(
+    BuildContext context,
+    Broadcast broadcast, {
+    BroadcastRoundTab? initialTab,
+  }) {
+    return buildScreenRoute(
+      context,
+      screen: BroadcastRoundScreen(broadcast: broadcast, initialTab: initialTab),
+      title: broadcast.title,
+    );
+  }
 
   @override
   _BroadcastRoundScreenState createState() => _BroadcastRoundScreenState();

--- a/lib/src/view/broadcast/broadcast_round_screen.dart
+++ b/lib/src/view/broadcast/broadcast_round_screen.dart
@@ -14,6 +14,7 @@ import 'package:lichess_mobile/src/view/broadcast/broadcast_boards_tab.dart';
 import 'package:lichess_mobile/src/view/broadcast/broadcast_overview_tab.dart';
 import 'package:lichess_mobile/src/view/broadcast/broadcast_players_tab.dart';
 import 'package:lichess_mobile/src/widgets/adaptive_bottom_sheet.dart';
+import 'package:lichess_mobile/src/widgets/background_theme.dart';
 import 'package:lichess_mobile/src/widgets/bottom_bar.dart';
 import 'package:lichess_mobile/src/widgets/buttons.dart';
 import 'package:lichess_mobile/src/widgets/list.dart';
@@ -97,56 +98,58 @@ class _BroadcastRoundScreenState extends ConsumerState<BroadcastRoundScreen>
         }
       },
     );
-    return CupertinoPageScaffold(
-      navigationBar: CupertinoNavigationBar(
-        middle: AutoSizeText(
-          widget.broadcast.title,
-          minFontSize: 14.0,
-          overflow: TextOverflow.ellipsis,
-          maxLines: 1,
-        ),
-      ),
-      child: Column(
-        children: [
-          Expanded(
-            child: switch (asyncRound) {
-              AsyncData(value: final _) => switch (selectedTab) {
-                BroadcastRoundTab.overview => _TabView(
-                  cupertinoTabSwitcher: tabSwitcher,
-                  sliver: BroadcastOverviewTab(
-                    broadcast: widget.broadcast,
-                    tournamentId: _selectedTournamentId,
-                  ),
-                ),
-                BroadcastRoundTab.boards => _TabView(
-                  cupertinoTabSwitcher: tabSwitcher,
-                  sliver: switch (asyncTournament) {
-                    AsyncData(:final value) => BroadcastBoardsTab(
-                      tournamentId: _selectedTournamentId,
-                      roundId: _selectedRoundId ?? value.defaultRoundId,
-                      tournamentSlug: widget.broadcast.tour.slug,
-                    ),
-                    _ => const SliverFillRemaining(child: SizedBox.shrink()),
-                  },
-                ),
-                BroadcastRoundTab.players => _TabView(
-                  cupertinoTabSwitcher: tabSwitcher,
-                  sliver: BroadcastPlayersTab(tournamentId: _selectedTournamentId),
-                ),
-              },
-              _ => const Center(child: CircularProgressIndicator.adaptive()),
-            },
+    return FullScreenBackgroundTheme(
+      child: CupertinoPageScaffold(
+        navigationBar: CupertinoNavigationBar(
+          middle: AutoSizeText(
+            widget.broadcast.title,
+            minFontSize: 14.0,
+            overflow: TextOverflow.ellipsis,
+            maxLines: 1,
           ),
-          switch (asyncTournament) {
-            AsyncData(:final value) => _BottomBar(
-              tournament: value,
-              roundId: _selectedRoundId ?? value.defaultRoundId,
-              setTournamentId: setTournamentId,
-              setRoundId: setRoundId,
+        ),
+        child: Column(
+          children: [
+            Expanded(
+              child: switch (asyncRound) {
+                AsyncData(value: final _) => switch (selectedTab) {
+                  BroadcastRoundTab.overview => _TabView(
+                    cupertinoTabSwitcher: tabSwitcher,
+                    sliver: BroadcastOverviewTab(
+                      broadcast: widget.broadcast,
+                      tournamentId: _selectedTournamentId,
+                    ),
+                  ),
+                  BroadcastRoundTab.boards => _TabView(
+                    cupertinoTabSwitcher: tabSwitcher,
+                    sliver: switch (asyncTournament) {
+                      AsyncData(:final value) => BroadcastBoardsTab(
+                        tournamentId: _selectedTournamentId,
+                        roundId: _selectedRoundId ?? value.defaultRoundId,
+                        tournamentSlug: widget.broadcast.tour.slug,
+                      ),
+                      _ => const SliverFillRemaining(child: SizedBox.shrink()),
+                    },
+                  ),
+                  BroadcastRoundTab.players => _TabView(
+                    cupertinoTabSwitcher: tabSwitcher,
+                    sliver: BroadcastPlayersTab(tournamentId: _selectedTournamentId),
+                  ),
+                },
+                _ => const Center(child: CircularProgressIndicator.adaptive()),
+              },
             ),
-            _ => const PlatformBottomBar.empty(transparentBackground: false),
-          },
-        ],
+            switch (asyncTournament) {
+              AsyncData(:final value) => _BottomBar(
+                tournament: value,
+                roundId: _selectedRoundId ?? value.defaultRoundId,
+                setTournamentId: setTournamentId,
+                setRoundId: setRoundId,
+              ),
+              _ => const PlatformBottomBar.empty(transparentBackground: false),
+            },
+          ],
+        ),
       ),
     );
   }
@@ -156,57 +159,59 @@ class _BroadcastRoundScreenState extends ConsumerState<BroadcastRoundScreen>
     AsyncValue<BroadcastTournament> asyncTournament,
     AsyncValue<BroadcastRoundWithGames> asyncRound,
   ) {
-    return Scaffold(
-      appBar: AppBar(
-        title: AutoSizeText(
-          widget.broadcast.title,
-          minFontSize: 14.0,
-          overflow: TextOverflow.ellipsis,
-          maxLines: 1,
+    return FullScreenBackgroundTheme(
+      child: Scaffold(
+        appBar: AppBar(
+          title: AutoSizeText(
+            widget.broadcast.title,
+            minFontSize: 14.0,
+            overflow: TextOverflow.ellipsis,
+            maxLines: 1,
+          ),
+          bottom: TabBar(
+            controller: _tabController,
+            tabs: <Widget>[
+              Tab(text: context.l10n.broadcastOverview),
+              Tab(text: context.l10n.broadcastBoards),
+              Tab(text: context.l10n.players),
+            ],
+          ),
         ),
-        bottom: TabBar(
-          controller: _tabController,
-          tabs: <Widget>[
-            Tab(text: context.l10n.broadcastOverview),
-            Tab(text: context.l10n.broadcastBoards),
-            Tab(text: context.l10n.players),
-          ],
-        ),
-      ),
-      body: switch (asyncRound) {
-        AsyncData(value: final _) => TabBarView(
-          controller: _tabController,
-          children: <Widget>[
-            _TabView(
-              sliver: BroadcastOverviewTab(
-                broadcast: widget.broadcast,
-                tournamentId: _selectedTournamentId,
-              ),
-            ),
-            _TabView(
-              sliver: switch (asyncTournament) {
-                AsyncData(:final value) => BroadcastBoardsTab(
+        body: switch (asyncRound) {
+          AsyncData(value: final _) => TabBarView(
+            controller: _tabController,
+            children: <Widget>[
+              _TabView(
+                sliver: BroadcastOverviewTab(
+                  broadcast: widget.broadcast,
                   tournamentId: _selectedTournamentId,
-                  roundId: _selectedRoundId ?? value.defaultRoundId,
-                  tournamentSlug: widget.broadcast.tour.slug,
                 ),
-                _ => const SliverFillRemaining(child: SizedBox.shrink()),
-              },
-            ),
-            _TabView(sliver: BroadcastPlayersTab(tournamentId: _selectedTournamentId)),
-          ],
-        ),
-        _ => const Center(child: CircularProgressIndicator()),
-      },
-      bottomNavigationBar: switch (asyncTournament) {
-        AsyncData(:final value) => _BottomBar(
-          tournament: value,
-          roundId: _selectedRoundId ?? value.defaultRoundId,
-          setTournamentId: setTournamentId,
-          setRoundId: setRoundId,
-        ),
-        _ => const PlatformBottomBar.empty(transparentBackground: false),
-      },
+              ),
+              _TabView(
+                sliver: switch (asyncTournament) {
+                  AsyncData(:final value) => BroadcastBoardsTab(
+                    tournamentId: _selectedTournamentId,
+                    roundId: _selectedRoundId ?? value.defaultRoundId,
+                    tournamentSlug: widget.broadcast.tour.slug,
+                  ),
+                  _ => const SliverFillRemaining(child: SizedBox.shrink()),
+                },
+              ),
+              _TabView(sliver: BroadcastPlayersTab(tournamentId: _selectedTournamentId)),
+            ],
+          ),
+          _ => const Center(child: CircularProgressIndicator()),
+        },
+        bottomNavigationBar: switch (asyncTournament) {
+          AsyncData(:final value) => _BottomBar(
+            tournament: value,
+            roundId: _selectedRoundId ?? value.defaultRoundId,
+            setTournamentId: setTournamentId,
+            setRoundId: setRoundId,
+          ),
+          _ => const PlatformBottomBar.empty(transparentBackground: false),
+        },
+      ),
     );
   }
 

--- a/lib/src/view/clock/clock_settings.dart
+++ b/lib/src/view/clock/clock_settings.dart
@@ -8,6 +8,7 @@ import 'package:lichess_mobile/src/view/play/time_control_modal.dart';
 import 'package:lichess_mobile/src/widgets/adaptive_bottom_sheet.dart';
 
 const _iconSize = 38.0;
+const _kIconPadding = EdgeInsets.all(10.0);
 
 class ClockSettings extends ConsumerWidget {
   const ClockSettings({required this.orientation, super.key});
@@ -23,70 +24,83 @@ class ClockSettings extends ConsumerWidget {
       generalPreferencesProvider.select((prefs) => prefs.isSoundEnabled),
     );
 
-    return Padding(
-      padding:
-          orientation == Orientation.portrait
-              ? const EdgeInsets.symmetric(vertical: 10.0)
-              : const EdgeInsets.symmetric(horizontal: 10.0),
+    return ColoredBox(
+      color: Theme.of(context).colorScheme.surfaceContainer,
       child: (orientation == Orientation.portrait ? Row.new : Column.new)(
         mainAxisAlignment: MainAxisAlignment.spaceEvenly,
         children: [
-          const _PlayResumeButton(_iconSize),
-          IconButton(
-            tooltip: context.l10n.reset,
-            iconSize: _iconSize,
-            onPressed:
-                buttonsEnabled
-                    ? () {
-                      ref.read(clockToolControllerProvider.notifier).reset();
-                    }
-                    : null,
-            icon: const Icon(Icons.refresh),
+          const Expanded(child: _PlayResumeButton(_iconSize)),
+          Expanded(
+            child: IconButton(
+              padding: _kIconPadding,
+              tooltip: context.l10n.reset,
+              iconSize: _iconSize,
+              onPressed:
+                  buttonsEnabled
+                      ? () {
+                        ref.read(clockToolControllerProvider.notifier).reset();
+                      }
+                      : null,
+              icon: const Icon(Icons.refresh),
+            ),
           ),
-          IconButton(
-            tooltip: context.l10n.settingsSettings,
-            iconSize: _iconSize,
-            onPressed:
-                buttonsEnabled
-                    ? () {
-                      final double screenHeight = MediaQuery.sizeOf(context).height;
-                      showAdaptiveBottomSheet<void>(
-                        context: context,
-                        isScrollControlled: true,
-                        showDragHandle: true,
-                        constraints: BoxConstraints(maxHeight: screenHeight - (screenHeight / 10)),
-                        builder: (BuildContext context) {
-                          final options = ref.watch(
-                            clockToolControllerProvider.select((value) => value.options),
-                          );
-                          return TimeControlModal(
-                            excludeUltraBullet: true,
-                            value: TimeIncrement(
-                              options.whiteTime.inSeconds,
-                              options.whiteIncrement.inSeconds,
-                            ),
-                            onSelected: (choice) {
-                              ref.read(clockToolControllerProvider.notifier).updateOptions(choice);
-                            },
-                          );
-                        },
-                      );
-                    }
-                    : null,
-            icon: const Icon(Icons.settings),
+          Expanded(
+            child: IconButton(
+              padding: _kIconPadding,
+              tooltip: context.l10n.settingsSettings,
+              iconSize: _iconSize,
+              onPressed:
+                  buttonsEnabled
+                      ? () {
+                        final double screenHeight = MediaQuery.sizeOf(context).height;
+                        showAdaptiveBottomSheet<void>(
+                          context: context,
+                          isScrollControlled: true,
+                          showDragHandle: true,
+                          constraints: BoxConstraints(
+                            maxHeight: screenHeight - (screenHeight / 10),
+                          ),
+                          builder: (BuildContext context) {
+                            final options = ref.watch(
+                              clockToolControllerProvider.select((value) => value.options),
+                            );
+                            return TimeControlModal(
+                              excludeUltraBullet: true,
+                              value: TimeIncrement(
+                                options.whiteTime.inSeconds,
+                                options.whiteIncrement.inSeconds,
+                              ),
+                              onSelected: (choice) {
+                                ref
+                                    .read(clockToolControllerProvider.notifier)
+                                    .updateOptions(choice);
+                              },
+                            );
+                          },
+                        );
+                      }
+                      : null,
+              icon: const Icon(Icons.settings),
+            ),
           ),
-          IconButton(
-            iconSize: _iconSize,
-            // TODO: translate
-            tooltip: 'Toggle sound',
-            onPressed: () => ref.read(generalPreferencesProvider.notifier).toggleSoundEnabled(),
-            icon: Icon(isSoundEnabled ? Icons.volume_up : Icons.volume_off),
+          Expanded(
+            child: IconButton(
+              padding: _kIconPadding,
+              iconSize: _iconSize,
+              // TODO: translate
+              tooltip: 'Toggle sound',
+              onPressed: () => ref.read(generalPreferencesProvider.notifier).toggleSoundEnabled(),
+              icon: Icon(isSoundEnabled ? Icons.volume_up : Icons.volume_off),
+            ),
           ),
-          IconButton(
-            tooltip: context.l10n.close,
-            iconSize: _iconSize,
-            onPressed: buttonsEnabled ? () => Navigator.of(context).pop() : null,
-            icon: const Icon(Icons.home),
+          Expanded(
+            child: IconButton(
+              padding: _kIconPadding,
+              tooltip: context.l10n.close,
+              iconSize: _iconSize,
+              onPressed: buttonsEnabled ? () => Navigator.of(context).pop() : null,
+              icon: const Icon(Icons.home),
+            ),
           ),
         ],
       ),
@@ -104,29 +118,36 @@ class _PlayResumeButton extends ConsumerWidget {
     final controller = ref.read(clockToolControllerProvider.notifier);
     final state = ref.watch(clockToolControllerProvider);
 
-    if (!state.started) {
-      return IconButton(
-        tooltip: context.l10n.play,
-        iconSize: iconSize,
-        onPressed: () => controller.start(),
-        icon: const Icon(Icons.play_arrow),
-      );
-    }
-
-    if (state.paused) {
-      return IconButton(
-        tooltip: context.l10n.resume,
-        iconSize: iconSize,
-        onPressed: () => controller.resume(),
-        icon: const Icon(Icons.play_arrow),
-      );
-    }
-
-    return IconButton(
-      tooltip: context.l10n.pause,
-      iconSize: iconSize,
-      onPressed: () => controller.pause(),
-      icon: const Icon(Icons.pause),
+    return ColoredBox(
+      color:
+          !state.started
+              ? Theme.of(context).colorScheme.surfaceContainerHighest
+              : Colors.transparent,
+      child:
+          !state.started
+              ? IconButton(
+                padding: _kIconPadding,
+                color: Theme.of(context).colorScheme.primary,
+                tooltip: context.l10n.play,
+                iconSize: iconSize,
+                onPressed: () => controller.start(),
+                icon: const Icon(Icons.play_arrow),
+              )
+              : state.paused
+              ? IconButton(
+                padding: _kIconPadding,
+                tooltip: context.l10n.resume,
+                iconSize: iconSize,
+                onPressed: () => controller.resume(),
+                icon: const Icon(Icons.play_arrow),
+              )
+              : IconButton(
+                padding: _kIconPadding,
+                tooltip: context.l10n.pause,
+                iconSize: iconSize,
+                onPressed: () => controller.pause(),
+                icon: const Icon(Icons.pause),
+              ),
     );
   }
 }

--- a/lib/src/view/clock/clock_tool_screen.dart
+++ b/lib/src/view/clock/clock_tool_screen.dart
@@ -5,6 +5,7 @@ import 'package:lichess_mobile/src/model/clock/clock_tool_controller.dart';
 import 'package:lichess_mobile/src/model/common/time_increment.dart';
 import 'package:lichess_mobile/src/utils/immersive_mode.dart';
 import 'package:lichess_mobile/src/utils/l10n_context.dart';
+import 'package:lichess_mobile/src/utils/navigation.dart';
 import 'package:lichess_mobile/src/view/clock/clock_settings.dart';
 import 'package:lichess_mobile/src/view/clock/custom_clock_settings.dart';
 import 'package:lichess_mobile/src/widgets/adaptive_bottom_sheet.dart';
@@ -13,6 +14,10 @@ import 'package:lichess_mobile/src/widgets/clock.dart';
 
 class ClockToolScreen extends StatelessWidget {
   const ClockToolScreen({super.key});
+
+  static Route<dynamic> buildRoute(BuildContext context) {
+    return buildScreenRoute(context, screen: const ClockToolScreen());
+  }
 
   @override
   Widget build(BuildContext context) {

--- a/lib/src/view/coordinate_training/coordinate_training_screen.dart
+++ b/lib/src/view/coordinate_training/coordinate_training_screen.dart
@@ -12,6 +12,7 @@ import 'package:lichess_mobile/src/model/coordinate_training/coordinate_training
 import 'package:lichess_mobile/src/model/settings/board_preferences.dart';
 import 'package:lichess_mobile/src/styles/styles.dart';
 import 'package:lichess_mobile/src/utils/l10n_context.dart';
+import 'package:lichess_mobile/src/utils/navigation.dart';
 import 'package:lichess_mobile/src/utils/screen.dart';
 import 'package:lichess_mobile/src/view/coordinate_training/coordinate_display.dart';
 import 'package:lichess_mobile/src/widgets/adaptive_bottom_sheet.dart';
@@ -26,6 +27,10 @@ import 'package:lichess_mobile/src/widgets/settings.dart';
 
 class CoordinateTrainingScreen extends StatelessWidget {
   const CoordinateTrainingScreen({super.key});
+
+  static Route<dynamic> buildRoute(BuildContext context) {
+    return buildScreenRoute(context, screen: const CoordinateTrainingScreen());
+  }
 
   @override
   Widget build(BuildContext context) {

--- a/lib/src/view/coordinate_training/coordinate_training_screen.dart
+++ b/lib/src/view/coordinate_training/coordinate_training_screen.dart
@@ -34,7 +34,7 @@ class CoordinateTrainingScreen extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    return PlatformThemedScaffold(
+    return PlatformScaffold(
       appBar: PlatformAppBar(
         title: const Text('Coordinate Training'), // TODO l10n once script works
         actions: [

--- a/lib/src/view/coordinate_training/coordinate_training_screen.dart
+++ b/lib/src/view/coordinate_training/coordinate_training_screen.dart
@@ -29,7 +29,7 @@ class CoordinateTrainingScreen extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    return PlatformBoardThemeScaffold(
+    return PlatformThemedScaffold(
       appBar: PlatformAppBar(
         title: const Text('Coordinate Training'), // TODO l10n once script works
         actions: [

--- a/lib/src/view/correspondence/offline_correspondence_game_screen.dart
+++ b/lib/src/view/correspondence/offline_correspondence_game_screen.dart
@@ -63,7 +63,7 @@ class _OfflineCorrespondenceGameScreenState extends State<OfflineCorrespondenceG
   @override
   Widget build(BuildContext context) {
     final (lastModified, game) = currentGame;
-    return PlatformThemedScaffold(
+    return PlatformScaffold(
       appBar: PlatformAppBar(title: _Title(game)),
       body: _Body(game: game, lastModified: lastModified, onGameChanged: goToNextGame),
     );

--- a/lib/src/view/correspondence/offline_correspondence_game_screen.dart
+++ b/lib/src/view/correspondence/offline_correspondence_game_screen.dart
@@ -31,6 +31,16 @@ class OfflineCorrespondenceGameScreen extends StatefulWidget {
 
   final (DateTime, OfflineCorrespondenceGame) initialGame;
 
+  static Route<dynamic> buildRoute(
+    BuildContext context, {
+    required (DateTime, OfflineCorrespondenceGame) initialGame,
+  }) {
+    return buildScreenRoute(
+      context,
+      screen: OfflineCorrespondenceGameScreen(initialGame: initialGame),
+    );
+  }
+
   @override
   State<OfflineCorrespondenceGameScreen> createState() => _OfflineCorrespondenceGameScreenState();
 }
@@ -224,20 +234,19 @@ class _BodyState extends ConsumerState<_Body> {
             BottomBarButton(
               label: context.l10n.analysis,
               onTap: () {
-                pushPlatformRoute(
-                  context,
-                  builder:
-                      (_) => AnalysisScreen(
-                        options: AnalysisOptions(
-                          orientation: game.youAre!,
-                          standalone: (
-                            pgn: game.makePgn(),
-                            isComputerAnalysisAllowed: false,
-                            variant: game.variant,
-                          ),
-                          initialMoveCursor: stepCursor,
-                        ),
+                Navigator.of(context).push(
+                  AnalysisScreen.buildRoute(
+                    context,
+                    AnalysisOptions(
+                      orientation: game.youAre!,
+                      standalone: (
+                        pgn: game.makePgn(),
+                        isComputerAnalysisAllowed: false,
+                        variant: game.variant,
                       ),
+                      initialMoveCursor: stepCursor,
+                    ),
+                  ),
                 );
               },
               icon: Icons.biotech,

--- a/lib/src/view/correspondence/offline_correspondence_game_screen.dart
+++ b/lib/src/view/correspondence/offline_correspondence_game_screen.dart
@@ -53,7 +53,7 @@ class _OfflineCorrespondenceGameScreenState extends State<OfflineCorrespondenceG
   @override
   Widget build(BuildContext context) {
     final (lastModified, game) = currentGame;
-    return PlatformBoardThemeScaffold(
+    return PlatformThemedScaffold(
       appBar: PlatformAppBar(title: _Title(game)),
       body: _Body(game: game, lastModified: lastModified, onGameChanged: goToNextGame),
     );

--- a/lib/src/view/game/archived_game_screen.dart
+++ b/lib/src/view/game/archived_game_screen.dart
@@ -194,7 +194,7 @@ class _BodyState extends ConsumerState<_Body> {
   Widget build(BuildContext context) {
     final isLoggedIn = ref.watch(isLoggedInProvider);
 
-    return PlatformThemedScaffold(
+    return PlatformScaffold(
       appBar: PlatformAppBar(
         title:
             widget.gameData != null

--- a/lib/src/view/game/archived_game_screen.dart
+++ b/lib/src/view/game/archived_game_screen.dart
@@ -48,6 +48,26 @@ class ArchivedGameScreen extends ConsumerWidget {
   /// The context of the game list that opened this screen, if available.
   final (UserId?, GameFilterState)? gameListContext;
 
+  static Route<dynamic> buildRoute(
+    BuildContext context, {
+    GameId? gameId,
+    LightArchivedGame? gameData,
+    Side orientation = Side.white,
+    int? initialCursor,
+    (UserId?, GameFilterState)? gameListContext,
+  }) {
+    return buildScreenRoute(
+      context,
+      screen: ArchivedGameScreen(
+        gameId: gameId,
+        gameData: gameData,
+        orientation: orientation,
+        initialCursor: initialCursor,
+        gameListContext: gameListContext,
+      ),
+    );
+  }
+
   @override
   Widget build(BuildContext context, WidgetRef ref) {
     if (gameData != null) {
@@ -408,16 +428,15 @@ class _BottomBar extends ConsumerWidget {
               gameCursor.hasValue
                   ? () {
                     final cursor = gameCursor.requireValue.$2;
-                    pushPlatformRoute(
-                      context,
-                      builder:
-                          (context) => AnalysisScreen(
-                            options: AnalysisOptions(
-                              orientation: orientation,
-                              gameId: gameData.id,
-                              initialMoveCursor: cursor,
-                            ),
-                          ),
+                    Navigator.of(context).push(
+                      AnalysisScreen.buildRoute(
+                        context,
+                        AnalysisOptions(
+                          orientation: orientation,
+                          gameId: gameData.id,
+                          initialMoveCursor: cursor,
+                        ),
+                      ),
                     );
                   }
                   : null,

--- a/lib/src/view/game/archived_game_screen.dart
+++ b/lib/src/view/game/archived_game_screen.dart
@@ -174,7 +174,7 @@ class _BodyState extends ConsumerState<_Body> {
   Widget build(BuildContext context) {
     final isLoggedIn = ref.watch(isLoggedInProvider);
 
-    return PlatformBoardThemeScaffold(
+    return PlatformThemedScaffold(
       appBar: PlatformAppBar(
         title:
             widget.gameData != null

--- a/lib/src/view/game/game_body.dart
+++ b/lib/src/view/game/game_body.dart
@@ -17,7 +17,6 @@ import 'package:lichess_mobile/src/model/settings/board_preferences.dart';
 import 'package:lichess_mobile/src/utils/gestures_exclusion.dart';
 import 'package:lichess_mobile/src/utils/immersive_mode.dart';
 import 'package:lichess_mobile/src/utils/l10n_context.dart';
-import 'package:lichess_mobile/src/utils/navigation.dart';
 import 'package:lichess_mobile/src/view/analysis/analysis_screen.dart';
 import 'package:lichess_mobile/src/view/game/correspondence_clock_widget.dart';
 import 'package:lichess_mobile/src/view/game/game_common_widgets.dart';
@@ -516,10 +515,9 @@ class _GameBottomBar extends ConsumerWidget {
                 label: context.l10n.gameAnalysis,
                 icon: Icons.biotech,
                 onTap: () {
-                  pushPlatformRoute(
+                  Navigator.of(
                     context,
-                    builder: (_) => AnalysisScreen(options: gameState.analysisOptions),
-                  );
+                  ).push(AnalysisScreen.buildRoute(context, gameState.analysisOptions));
                 },
               )
             else if (gameState.game.meta.speed == Speed.bullet ||
@@ -569,15 +567,13 @@ class _GameBottomBar extends ConsumerWidget {
               onTap:
                   isChatEnabled
                       ? () {
-                        pushPlatformRoute(
-                          context,
-                          builder: (BuildContext context) {
-                            return MessageScreen(
-                              title: UserFullNameWidget(user: gameState.game.opponent?.user),
-                              me: gameState.game.me?.user,
-                              id: id,
-                            );
-                          },
+                        Navigator.of(context).push(
+                          MessageScreen.buildRoute(
+                            context,
+                            title: UserFullNameWidget(user: gameState.game.opponent?.user),
+                            me: gameState.game.me?.user,
+                            id: id,
+                          ),
                         );
                       }
                       : null,
@@ -639,10 +635,9 @@ class _GameBottomBar extends ConsumerWidget {
           BottomSheetAction(
             makeLabel: (context) => Text(context.l10n.analysis),
             onPressed: (context) {
-              pushPlatformRoute(
+              Navigator.of(
                 context,
-                builder: (_) => AnalysisScreen(options: gameState.analysisOptions),
-              );
+              ).push(AnalysisScreen.buildRoute(context, gameState.analysisOptions));
             },
           ),
         if (gameState.game.abortable)

--- a/lib/src/view/game/game_list_tile.dart
+++ b/lib/src/view/game/game_list_tile.dart
@@ -15,7 +15,6 @@ import 'package:lichess_mobile/src/styles/lichess_colors.dart';
 import 'package:lichess_mobile/src/styles/styles.dart';
 import 'package:lichess_mobile/src/utils/l10n.dart';
 import 'package:lichess_mobile/src/utils/l10n_context.dart';
-import 'package:lichess_mobile/src/utils/navigation.dart';
 import 'package:lichess_mobile/src/utils/share.dart';
 import 'package:lichess_mobile/src/view/analysis/analysis_screen.dart';
 import 'package:lichess_mobile/src/view/game/archived_game_screen.dart';
@@ -70,25 +69,23 @@ class GameListTile extends StatelessWidget {
       onTap:
           game.variant.isReadSupported
               ? () {
-                pushPlatformRoute(
-                  context,
-                  rootNavigator: true,
-                  builder:
-                      (context) =>
-                          game.fullId != null
-                              ? GameScreen(
-                                initialGameId: game.fullId,
-                                loadingFen: game.lastFen,
-                                loadingLastMove: game.lastMove,
-                                loadingOrientation: youAre,
-                                lastMoveAt: game.lastMoveAt,
-                                gameListContext: gameListContext,
-                              )
-                              : ArchivedGameScreen(
-                                gameData: game,
-                                orientation: youAre,
-                                gameListContext: gameListContext,
-                              ),
+                Navigator.of(context, rootNavigator: true).push(
+                  game.fullId != null
+                      ? GameScreen.buildRoute(
+                        context,
+                        initialGameId: game.fullId,
+                        loadingFen: game.lastFen,
+                        loadingLastMove: game.lastMove,
+                        loadingOrientation: youAre,
+                        lastMoveAt: game.lastMoveAt,
+                        gameListContext: gameListContext,
+                      )
+                      : ArchivedGameScreen.buildRoute(
+                        context,
+                        gameData: game,
+                        orientation: youAre,
+                        gameListContext: gameListContext,
+                      ),
                 );
               }
               : () {
@@ -308,12 +305,11 @@ class _ContextMenu extends ConsumerWidget {
           onPressed:
               game.variant.isReadSupported
                   ? () {
-                    pushPlatformRoute(
-                      context,
-                      builder:
-                          (context) => AnalysisScreen(
-                            options: AnalysisOptions(orientation: orientation, gameId: game.id),
-                          ),
+                    Navigator.of(context).push(
+                      AnalysisScreen.buildRoute(
+                        context,
+                        AnalysisOptions(orientation: orientation, gameId: game.id),
+                      ),
                     );
                   }
                   : () {

--- a/lib/src/view/game/game_player.dart
+++ b/lib/src/view/game/game_player.dart
@@ -16,7 +16,6 @@ import 'package:lichess_mobile/src/styles/lichess_icons.dart';
 import 'package:lichess_mobile/src/styles/styles.dart';
 import 'package:lichess_mobile/src/utils/l10n_context.dart';
 import 'package:lichess_mobile/src/utils/lichess_assets.dart';
-import 'package:lichess_mobile/src/utils/navigation.dart';
 import 'package:lichess_mobile/src/utils/screen.dart';
 import 'package:lichess_mobile/src/view/account/profile_screen.dart';
 import 'package:lichess_mobile/src/view/account/rating_pref_aware.dart';
@@ -188,13 +187,10 @@ class GamePlayer extends StatelessWidget {
                         onTap:
                             player.user != null
                                 ? () {
-                                  pushPlatformRoute(
-                                    context,
-                                    builder:
-                                        (context) =>
-                                            mePlaying
-                                                ? const ProfileScreen()
-                                                : UserScreen(user: player.user!),
+                                  Navigator.of(context).push(
+                                    mePlaying
+                                        ? ProfileScreen.buildRoute(context)
+                                        : UserScreen.buildRoute(context, player.user!),
                                   );
                                 }
                                 : null,

--- a/lib/src/view/game/game_result_dialog.dart
+++ b/lib/src/view/game/game_result_dialog.dart
@@ -14,7 +14,6 @@ import 'package:lichess_mobile/src/model/game/game_status.dart';
 import 'package:lichess_mobile/src/model/game/over_the_board_game.dart';
 import 'package:lichess_mobile/src/model/game/playable_game.dart';
 import 'package:lichess_mobile/src/utils/l10n_context.dart';
-import 'package:lichess_mobile/src/utils/navigation.dart';
 import 'package:lichess_mobile/src/view/analysis/analysis_screen.dart';
 import 'package:lichess_mobile/src/view/game/status_l10n.dart';
 import 'package:lichess_mobile/src/widgets/buttons.dart';
@@ -145,10 +144,9 @@ class _GameResultDialogState extends ConsumerState<GameResultDialog> {
           SecondaryButton(
             semanticsLabel: context.l10n.analysis,
             onPressed: () {
-              pushPlatformRoute(
+              Navigator.of(
                 context,
-                builder: (_) => AnalysisScreen(options: gameState.analysisOptions),
-              );
+              ).push(AnalysisScreen.buildRoute(context, gameState.analysisOptions));
             },
             child: Text(context.l10n.analysis, textAlign: TextAlign.center),
           ),
@@ -198,19 +196,18 @@ class OverTheBoardGameResultDialog extends StatelessWidget {
         SecondaryButton(
           semanticsLabel: context.l10n.analysis,
           onPressed: () {
-            pushPlatformRoute(
-              context,
-              builder:
-                  (_) => AnalysisScreen(
-                    options: AnalysisOptions(
-                      orientation: Side.white,
-                      standalone: (
-                        pgn: game.makePgn(),
-                        isComputerAnalysisAllowed: true,
-                        variant: game.meta.variant,
-                      ),
-                    ),
+            Navigator.of(context).push(
+              AnalysisScreen.buildRoute(
+                context,
+                AnalysisOptions(
+                  orientation: Side.white,
+                  standalone: (
+                    pgn: game.makePgn(),
+                    isComputerAnalysisAllowed: true,
+                    variant: game.meta.variant,
                   ),
+                ),
+              ),
             );
           },
           child: Text(context.l10n.analysis, textAlign: TextAlign.center),

--- a/lib/src/view/game/game_result_dialog.dart
+++ b/lib/src/view/game/game_result_dialog.dart
@@ -320,13 +320,17 @@ class GameResult extends StatelessWidget {
 }
 
 Widget _adaptiveDialog(BuildContext context, Widget content) {
+  final platform = Theme.of(context).platform;
   final screenWidth = MediaQuery.of(context).size.width;
-  final paddedContent = Padding(padding: const EdgeInsets.all(16.0), child: content);
+  final paddedContent = Padding(
+    padding: platform == TargetPlatform.iOS ? EdgeInsets.zero : const EdgeInsets.all(16.0),
+    child: content,
+  );
   final sizedContent = SizedBox(
     width: min(screenWidth, kMaterialPopupMenuMaxWidth),
     child: paddedContent,
   );
-  return Theme.of(context).platform == TargetPlatform.iOS
-      ? CupertinoAlertDialog(content: sizedContent)
+  return platform == TargetPlatform.iOS
+      ? CupertinoAlertDialog(content: paddedContent)
       : Dialog(child: sizedContent);
 }

--- a/lib/src/view/game/game_result_dialog.dart
+++ b/lib/src/view/game/game_result_dialog.dart
@@ -2,7 +2,6 @@ import 'dart:async';
 import 'dart:math';
 
 import 'package:dartchess/dartchess.dart';
-import 'package:flutter/cupertino.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:lichess_mobile/src/constants.dart';
@@ -156,7 +155,7 @@ class _GameResultDialogState extends ConsumerState<GameResultDialog> {
       ],
     );
 
-    return _adaptiveDialog(context, content);
+    return _ResultDialog(child: content);
   }
 }
 
@@ -173,7 +172,7 @@ class ArchivedGameResultDialog extends StatelessWidget {
       children: [GameResult(game: game), const SizedBox(height: 16.0), PlayerSummary(game: game)],
     );
 
-    return _adaptiveDialog(context, content);
+    return _ResultDialog(child: content);
   }
 }
 
@@ -219,7 +218,7 @@ class OverTheBoardGameResultDialog extends StatelessWidget {
       ],
     );
 
-    return _adaptiveDialog(context, content);
+    return _ResultDialog(child: content);
   }
 }
 
@@ -319,18 +318,19 @@ class GameResult extends StatelessWidget {
   }
 }
 
-Widget _adaptiveDialog(BuildContext context, Widget content) {
-  final platform = Theme.of(context).platform;
-  final screenWidth = MediaQuery.of(context).size.width;
-  final paddedContent = Padding(
-    padding: platform == TargetPlatform.iOS ? EdgeInsets.zero : const EdgeInsets.all(16.0),
-    child: content,
-  );
-  final sizedContent = SizedBox(
-    width: min(screenWidth, kMaterialPopupMenuMaxWidth),
-    child: paddedContent,
-  );
-  return platform == TargetPlatform.iOS
-      ? CupertinoAlertDialog(content: paddedContent)
-      : Dialog(child: sizedContent);
+class _ResultDialog extends StatelessWidget {
+  const _ResultDialog({required this.child});
+
+  final Widget child;
+
+  @override
+  Widget build(BuildContext context) {
+    final screenWidth = MediaQuery.of(context).size.width;
+    final paddedContent = Padding(padding: const EdgeInsets.all(16.0), child: child);
+    final sizedContent = SizedBox(
+      width: min(screenWidth, kMaterialPopupMenuMaxWidth),
+      child: paddedContent,
+    );
+    return Dialog(child: sizedContent);
+  }
 }

--- a/lib/src/view/game/game_screen.dart
+++ b/lib/src/view/game/game_screen.dart
@@ -183,7 +183,7 @@ class _GameScreenState extends ConsumerState<GameScreen> with RouteAware {
                               : ChallengeDeclineReason.generic.label(context.l10n),
                     )
                     : const LoadGameError('Could not create the game.');
-            return PlatformThemedScaffold(
+            return PlatformScaffold(
               resizeToAvoidBottomInset: false,
               appBar: _GameAppBar(
                 id: gameId,
@@ -207,7 +207,7 @@ class _GameScreenState extends ConsumerState<GameScreen> with RouteAware {
                     )
                     : const StandaloneGameLoadingBoard();
 
-            return PlatformThemedScaffold(
+            return PlatformScaffold(
               resizeToAvoidBottomInset: false,
               appBar: _GameAppBar(
                 seek: widget.seek,
@@ -233,7 +233,7 @@ class _GameScreenState extends ConsumerState<GameScreen> with RouteAware {
 
             final body = PopScope(child: message);
 
-            return PlatformThemedScaffold(
+            return PlatformScaffold(
               appBar: _GameAppBar(
                 seek: widget.seek,
                 lastMoveAt: widget.lastMoveAt,

--- a/lib/src/view/game/game_screen.dart
+++ b/lib/src/view/game/game_screen.dart
@@ -162,7 +162,7 @@ class _GameScreenState extends ConsumerState<GameScreen> with RouteAware {
                               : ChallengeDeclineReason.generic.label(context.l10n),
                     )
                     : const LoadGameError('Could not create the game.');
-            return PlatformBoardThemeScaffold(
+            return PlatformThemedScaffold(
               resizeToAvoidBottomInset: false,
               appBar: _GameAppBar(
                 id: gameId,
@@ -186,7 +186,7 @@ class _GameScreenState extends ConsumerState<GameScreen> with RouteAware {
                     )
                     : const StandaloneGameLoadingBoard();
 
-            return PlatformBoardThemeScaffold(
+            return PlatformThemedScaffold(
               resizeToAvoidBottomInset: false,
               appBar: _GameAppBar(
                 seek: widget.seek,
@@ -212,7 +212,7 @@ class _GameScreenState extends ConsumerState<GameScreen> with RouteAware {
 
             final body = PopScope(child: message);
 
-            return PlatformBoardThemeScaffold(
+            return PlatformThemedScaffold(
               appBar: _GameAppBar(
                 seek: widget.seek,
                 lastMoveAt: widget.lastMoveAt,

--- a/lib/src/view/game/game_screen.dart
+++ b/lib/src/view/game/game_screen.dart
@@ -51,11 +51,8 @@ class GameScreen extends ConsumerStatefulWidget {
          'Either a seek, a challenge or an initial game id must be provided.',
        );
 
-  // tweak
   final GameSeek? seek;
-
   final GameFullId? initialGameId;
-
   final ChallengeRequest? challenge;
 
   final String? loadingFen;
@@ -76,6 +73,32 @@ class GameScreen extends ConsumerStatefulWidget {
     } else {
       return _GameSource.lobby;
     }
+  }
+
+  static Route<dynamic> buildRoute(
+    BuildContext context, {
+    GameSeek? seek,
+    GameFullId? initialGameId,
+    ChallengeRequest? challenge,
+    String? loadingFen,
+    Move? loadingLastMove,
+    Side? loadingOrientation,
+    DateTime? lastMoveAt,
+    (UserId?, GameFilterState)? gameListContext,
+  }) {
+    return buildScreenRoute(
+      context,
+      screen: GameScreen(
+        seek: seek,
+        initialGameId: initialGameId,
+        challenge: challenge,
+        loadingFen: loadingFen,
+        loadingLastMove: loadingLastMove,
+        loadingOrientation: loadingOrientation,
+        lastMoveAt: lastMoveAt,
+        gameListContext: gameListContext,
+      ),
+    );
   }
 
   @override
@@ -142,13 +165,11 @@ class _GameScreenState extends ConsumerState<GameScreen> with RouteAware {
                           ref.read(provider.notifier).newOpponent();
                         } else {
                           final savedSetup = ref.read(gameSetupPreferencesProvider);
-                          pushReplacementPlatformRoute(
-                            context,
-                            rootNavigator: true,
-                            builder:
-                                (_) => GameScreen(
-                                  seek: GameSeek.newOpponentFromGame(game, savedSetup),
-                                ),
+                          Navigator.of(context, rootNavigator: true).pushReplacement(
+                            GameScreen.buildRoute(
+                              context,
+                              seek: GameSeek.newOpponentFromGame(game, savedSetup),
+                            ),
                           );
                         }
                       },

--- a/lib/src/view/game/game_settings.dart
+++ b/lib/src/view/game/game_settings.dart
@@ -5,7 +5,6 @@ import 'package:lichess_mobile/src/model/common/id.dart';
 import 'package:lichess_mobile/src/model/game/game_controller.dart';
 import 'package:lichess_mobile/src/model/game/game_preferences.dart';
 import 'package:lichess_mobile/src/utils/l10n_context.dart';
-import 'package:lichess_mobile/src/utils/navigation.dart';
 import 'package:lichess_mobile/src/view/game/game_screen_providers.dart';
 import 'package:lichess_mobile/src/view/settings/board_settings_screen.dart';
 import 'package:lichess_mobile/src/widgets/adaptive_bottom_sheet.dart';
@@ -59,7 +58,9 @@ class GameSettings extends ConsumerWidget {
           title: const Text('Board settings'),
           trailing: const Icon(CupertinoIcons.chevron_right),
           onTap: () {
-            pushPlatformRoute(context, fullscreenDialog: true, screen: const BoardSettingsScreen());
+            Navigator.of(
+              context,
+            ).push(BoardSettingsScreen.buildRoute(context, fullscreenDialog: true));
           },
         ),
         SwitchSettingTile(

--- a/lib/src/view/game/message_screen.dart
+++ b/lib/src/view/game/message_screen.dart
@@ -8,6 +8,7 @@ import 'package:lichess_mobile/src/model/user/user.dart';
 import 'package:lichess_mobile/src/navigation.dart';
 import 'package:lichess_mobile/src/styles/styles.dart';
 import 'package:lichess_mobile/src/utils/l10n_context.dart';
+import 'package:lichess_mobile/src/utils/navigation.dart';
 import 'package:lichess_mobile/src/widgets/adaptive_text_field.dart';
 import 'package:lichess_mobile/src/widgets/buttons.dart';
 import 'package:lichess_mobile/src/widgets/platform_scaffold.dart';
@@ -18,6 +19,15 @@ class MessageScreen extends ConsumerStatefulWidget {
   final LightUser? me;
 
   const MessageScreen({required this.id, required this.title, this.me});
+
+  static Route<dynamic> buildRoute(
+    BuildContext context, {
+    required GameFullId id,
+    required Widget title,
+    LightUser? me,
+  }) {
+    return buildScreenRoute(context, screen: MessageScreen(id: id, title: title, me: me));
+  }
 
   @override
   ConsumerState<ConsumerStatefulWidget> createState() => _MessageScreenState();

--- a/lib/src/view/game/message_screen.dart
+++ b/lib/src/view/game/message_screen.dart
@@ -47,7 +47,7 @@ class _MessageScreenState extends ConsumerState<MessageScreen> with RouteAware {
 
   @override
   Widget build(BuildContext context) {
-    return PlatformBoardThemeScaffold(
+    return PlatformThemedScaffold(
       appBar: PlatformAppBar(title: widget.title, centerTitle: true),
       body: _Body(me: widget.me, id: widget.id),
     );

--- a/lib/src/view/game/message_screen.dart
+++ b/lib/src/view/game/message_screen.dart
@@ -3,7 +3,6 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:lichess_mobile/src/model/auth/auth_session.dart';
 import 'package:lichess_mobile/src/model/common/id.dart';
 import 'package:lichess_mobile/src/model/game/chat_controller.dart';
-import 'package:lichess_mobile/src/model/settings/brightness.dart';
 import 'package:lichess_mobile/src/model/user/user.dart';
 import 'package:lichess_mobile/src/navigation.dart';
 import 'package:lichess_mobile/src/styles/styles.dart';
@@ -129,7 +128,7 @@ class _MessageBubble extends ConsumerWidget {
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
-    final brightness = ref.watch(currentBrightnessProvider);
+    final brightness = Theme.of(context).brightness;
 
     return FractionallySizedBox(
       alignment: you ? Alignment.centerRight : Alignment.centerLeft,

--- a/lib/src/view/game/message_screen.dart
+++ b/lib/src/view/game/message_screen.dart
@@ -57,7 +57,7 @@ class _MessageScreenState extends ConsumerState<MessageScreen> with RouteAware {
 
   @override
   Widget build(BuildContext context) {
-    return PlatformThemedScaffold(
+    return PlatformScaffold(
       appBar: PlatformAppBar(title: widget.title, centerTitle: true),
       body: _Body(me: widget.me, id: widget.id),
     );

--- a/lib/src/view/game/offline_correspondence_games_screen.dart
+++ b/lib/src/view/game/offline_correspondence_games_screen.dart
@@ -22,7 +22,7 @@ class OfflineCorrespondenceGamesScreen extends ConsumerWidget {
   @override
   Widget build(BuildContext context, WidgetRef ref) {
     final offlineGames = ref.watch(offlineOngoingCorrespondenceGamesProvider);
-    return PlatformThemedScaffold(
+    return PlatformScaffold(
       appBar: PlatformAppBar(
         title: offlineGames.maybeWhen(
           data: (data) => Text(context.l10n.nbGamesInPlay(data.length)),

--- a/lib/src/view/game/offline_correspondence_games_screen.dart
+++ b/lib/src/view/game/offline_correspondence_games_screen.dart
@@ -15,6 +15,10 @@ import 'package:lichess_mobile/src/widgets/user_full_name.dart';
 class OfflineCorrespondenceGamesScreen extends ConsumerWidget {
   const OfflineCorrespondenceGamesScreen({super.key});
 
+  static Route<dynamic> buildRoute(BuildContext context) {
+    return buildScreenRoute(context, screen: const OfflineCorrespondenceGamesScreen());
+  }
+
   @override
   Widget build(BuildContext context, WidgetRef ref) {
     final offlineGames = ref.watch(offlineOngoingCorrespondenceGamesProvider);
@@ -74,10 +78,8 @@ class OfflineCorrespondenceGamePreview extends ConsumerWidget {
         ],
       ),
       onTap: () {
-        pushPlatformRoute(
-          context,
-          rootNavigator: true,
-          builder: (_) => OfflineCorrespondenceGameScreen(initialGame: (lastModified, game)),
+        Navigator.of(context, rootNavigator: true).push(
+          OfflineCorrespondenceGameScreen.buildRoute(context, initialGame: (lastModified, game)),
         );
       },
     );

--- a/lib/src/view/game/offline_correspondence_games_screen.dart
+++ b/lib/src/view/game/offline_correspondence_games_screen.dart
@@ -18,7 +18,7 @@ class OfflineCorrespondenceGamesScreen extends ConsumerWidget {
   @override
   Widget build(BuildContext context, WidgetRef ref) {
     final offlineGames = ref.watch(offlineOngoingCorrespondenceGamesProvider);
-    return PlatformScaffold(
+    return PlatformThemedScaffold(
       appBar: PlatformAppBar(
         title: offlineGames.maybeWhen(
           data: (data) => Text(context.l10n.nbGamesInPlay(data.length)),

--- a/lib/src/view/home/home_tab_screen.dart
+++ b/lib/src/view/home/home_tab_screen.dart
@@ -24,7 +24,6 @@ import 'package:lichess_mobile/src/styles/lichess_icons.dart';
 import 'package:lichess_mobile/src/styles/styles.dart';
 import 'package:lichess_mobile/src/utils/l10n.dart';
 import 'package:lichess_mobile/src/utils/l10n_context.dart';
-import 'package:lichess_mobile/src/utils/navigation.dart';
 import 'package:lichess_mobile/src/utils/screen.dart';
 import 'package:lichess_mobile/src/view/account/profile_screen.dart';
 import 'package:lichess_mobile/src/view/correspondence/offline_correspondence_game_screen.dart';
@@ -159,11 +158,7 @@ class _HomeScreenState extends ConsumerState<HomeTabScreen> with RouteAware {
                     right: 8.0,
                     child: FloatingActionButton.extended(
                       onPressed: () {
-                        pushPlatformRoute(
-                          context,
-                          title: context.l10n.play,
-                          builder: (_) => const PlayScreen(),
-                        );
+                        Navigator.of(context).push(PlayScreen.buildRoute(context));
                       },
                       icon: const Icon(Icons.add),
                       label: Text(context.l10n.play),
@@ -203,7 +198,7 @@ class _HomeScreenState extends ConsumerState<HomeTabScreen> with RouteAware {
                     ? null
                     : FloatingActionButton.extended(
                       onPressed: () {
-                        pushPlatformRoute(context, builder: (_) => const PlayScreen());
+                        Navigator.of(context).push(PlayScreen.buildRoute(context));
                       },
                       icon: const Icon(Icons.add),
                       label: Text(context.l10n.play),
@@ -525,7 +520,7 @@ class _HelloWidget extends ConsumerWidget {
       child: GestureDetector(
         onTap: () {
           ref.invalidate(accountActivityProvider);
-          pushPlatformRoute(context, builder: (context) => const ProfileScreen());
+          Navigator.of(context).push(ProfileScreen.buildRoute(context));
         },
         child: Row(
           mainAxisSize: MainAxisSize.min,
@@ -585,20 +580,18 @@ class _OngoingGamesCarousel extends ConsumerWidget {
           list: data,
           onTap: (index) {
             final game = data[index];
-            pushPlatformRoute(
-              context,
-              rootNavigator: true,
-              builder:
-                  (_) => GameScreen(
-                    initialGameId: game.fullId,
-                    loadingFen: game.fen,
-                    loadingOrientation: game.orientation,
-                    loadingLastMove: game.lastMove,
-                  ),
+            Navigator.of(context, rootNavigator: true).push(
+              GameScreen.buildRoute(
+                context,
+                initialGameId: game.fullId,
+                loadingFen: game.fen,
+                loadingOrientation: game.orientation,
+                loadingLastMove: game.lastMove,
+              ),
             );
           },
           builder: (game) => _GamePreviewCarouselItem(game: game),
-          moreScreenBuilder: (_) => const OngoingGamesScreen(),
+          moreScreenRouteBuilder: OngoingGamesScreen.buildRoute,
           maxGamesToShow: maxGamesToShow,
         );
       },
@@ -625,10 +618,8 @@ class _OfflineCorrespondenceCarousel extends ConsumerWidget {
           list: data,
           onTap: (index) {
             final el = data[index];
-            pushPlatformRoute(
-              context,
-              rootNavigator: true,
-              builder: (_) => OfflineCorrespondenceGameScreen(initialGame: (el.$1, el.$2)),
+            Navigator.of(context, rootNavigator: true).push(
+              OfflineCorrespondenceGameScreen.buildRoute(context, initialGame: (el.$1, el.$2)),
             );
           },
           builder:
@@ -649,7 +640,7 @@ class _OfflineCorrespondenceCarousel extends ConsumerWidget {
                   secondsLeft: el.$2.myTimeLeft(el.$1)?.inSeconds,
                 ),
               ),
-          moreScreenBuilder: (_) => const OfflineCorrespondenceGamesScreen(),
+          moreScreenRouteBuilder: OfflineCorrespondenceGamesScreen.buildRoute,
           maxGamesToShow: maxGamesToShow,
         );
       },
@@ -663,13 +654,13 @@ class _GamesCarousel<T> extends StatefulWidget {
     required this.list,
     required this.builder,
     required this.onTap,
-    required this.moreScreenBuilder,
+    required this.moreScreenRouteBuilder,
     required this.maxGamesToShow,
   });
   final IList<T> list;
   final Widget Function(T data) builder;
   final void Function(int index)? onTap;
-  final Widget Function(BuildContext) moreScreenBuilder;
+  final Route<dynamic> Function(BuildContext) moreScreenRouteBuilder;
   final int maxGamesToShow;
 
   @override
@@ -725,11 +716,12 @@ class _GamesCarouselState<T> extends State<_GamesCarousel<T>> {
                   const SizedBox(width: 6.0),
                   NoPaddingTextButton(
                     onPressed: () {
-                      pushPlatformRoute(
-                        context,
-                        title: context.l10n.nbGamesInPlay(widget.list.length),
-                        builder: widget.moreScreenBuilder,
-                      );
+                      // pushPlatformRoute(
+                      //   context,
+                      //   title: context.l10n.nbGamesInPlay(widget.list.length),
+                      //   builder: widget.moreScreenRouteBuilder,
+                      // );
+                      Navigator.of(context).push(widget.moreScreenRouteBuilder(context));
                     },
                     child: Text(context.l10n.more),
                   ),
@@ -930,7 +922,7 @@ class _OngoingGamesPreview extends ConsumerWidget {
           list: data,
           maxGamesToShow: maxGamesToShow,
           builder: (el) => OngoingGamePreview(game: el),
-          moreScreenBuilder: (_) => const OngoingGamesScreen(),
+          moreScreenRouteBuilder: OngoingGamesScreen.buildRoute,
         );
       },
       orElse: () => const SizedBox.shrink(),
@@ -953,7 +945,7 @@ class _OfflineCorrespondencePreview extends ConsumerWidget {
           list: data,
           maxGamesToShow: maxGamesToShow,
           builder: (el) => OfflineCorrespondenceGamePreview(game: el.$2, lastModified: el.$1),
-          moreScreenBuilder: (_) => const OfflineCorrespondenceGamesScreen(),
+          moreScreenRouteBuilder: OfflineCorrespondenceGamesScreen.buildRoute,
         );
       },
       orElse: () => const SizedBox.shrink(),
@@ -965,12 +957,12 @@ class PreviewGameList<T> extends StatelessWidget {
   const PreviewGameList({
     required this.list,
     required this.builder,
-    required this.moreScreenBuilder,
+    required this.moreScreenRouteBuilder,
     required this.maxGamesToShow,
   });
   final IList<T> list;
   final Widget Function(T data) builder;
-  final Widget Function(BuildContext) moreScreenBuilder;
+  final Route<dynamic> Function(BuildContext) moreScreenRouteBuilder;
   final int maxGamesToShow;
 
   @override
@@ -999,11 +991,7 @@ class PreviewGameList<T> extends StatelessWidget {
                 const SizedBox(width: 6.0),
                 NoPaddingTextButton(
                   onPressed: () {
-                    pushPlatformRoute(
-                      context,
-                      title: context.l10n.nbGamesInPlay(list.length),
-                      builder: moreScreenBuilder,
-                    );
+                    Navigator.of(context).push(moreScreenRouteBuilder(context));
                   },
                   child: Text(context.l10n.more),
                 ),
@@ -1033,11 +1021,7 @@ class _PlayerScreenButton extends ConsumerWidget {
                 !connectivity.isOnline
                     ? null
                     : () {
-                      pushPlatformRoute(
-                        context,
-                        title: context.l10n.players,
-                        builder: (_) => const PlayerScreen(),
-                      );
+                      Navigator.of(context).push(PlayerScreen.buildRoute(context));
                     },
           ),
       orElse:
@@ -1075,11 +1059,7 @@ class _ChallengeScreenButton extends ConsumerWidget {
                     ? null
                     : () {
                       ref.invalidate(challengesProvider);
-                      pushPlatformRoute(
-                        context,
-                        title: context.l10n.preferencesNotifyChallenge,
-                        builder: (_) => const ChallengeRequestsScreen(),
-                      );
+                      Navigator.of(context).push(ChallengeRequestsScreen.buildRoute(context));
                     },
             count: count ?? 0,
           ),

--- a/lib/src/view/opening_explorer/opening_explorer_screen.dart
+++ b/lib/src/view/opening_explorer/opening_explorer_screen.dart
@@ -8,6 +8,7 @@ import 'package:lichess_mobile/src/model/common/chess.dart';
 import 'package:lichess_mobile/src/model/opening_explorer/opening_explorer.dart';
 import 'package:lichess_mobile/src/model/opening_explorer/opening_explorer_preferences.dart';
 import 'package:lichess_mobile/src/utils/l10n_context.dart';
+import 'package:lichess_mobile/src/utils/navigation.dart';
 import 'package:lichess_mobile/src/utils/screen.dart';
 import 'package:lichess_mobile/src/view/analysis/analysis_board.dart';
 import 'package:lichess_mobile/src/view/opening_explorer/opening_explorer_settings.dart';
@@ -27,6 +28,14 @@ class OpeningExplorerScreen extends ConsumerWidget {
   const OpeningExplorerScreen({required this.options});
 
   final AnalysisOptions options;
+
+  static Route<dynamic> buildRoute(BuildContext context, AnalysisOptions options) {
+    return buildScreenRoute(
+      context,
+      title: context.l10n.openingExplorer,
+      screen: OpeningExplorerScreen(options: options),
+    );
+  }
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {

--- a/lib/src/view/opening_explorer/opening_explorer_screen.dart
+++ b/lib/src/view/opening_explorer/opening_explorer_screen.dart
@@ -14,7 +14,6 @@ import 'package:lichess_mobile/src/view/analysis/analysis_board.dart';
 import 'package:lichess_mobile/src/view/opening_explorer/opening_explorer_settings.dart';
 import 'package:lichess_mobile/src/view/opening_explorer/opening_explorer_view.dart';
 import 'package:lichess_mobile/src/widgets/adaptive_bottom_sheet.dart';
-import 'package:lichess_mobile/src/widgets/background.dart';
 import 'package:lichess_mobile/src/widgets/bottom_bar.dart';
 import 'package:lichess_mobile/src/widgets/bottom_bar_button.dart';
 import 'package:lichess_mobile/src/widgets/buttons.dart';
@@ -49,26 +48,24 @@ class OpeningExplorerScreen extends ConsumerWidget {
       _ => const CenterLoadingIndicator(),
     };
 
-    return FullScreenBackground(
-      child: PlatformWidget(
-        androidBuilder:
-            (_) => Scaffold(
-              body: body,
-              appBar: AppBar(
-                title: Text(context.l10n.openingExplorer),
-                bottom: _MoveList(options: options),
-              ),
+    return PlatformWidget(
+      androidBuilder:
+          (_) => Scaffold(
+            body: body,
+            appBar: AppBar(
+              title: Text(context.l10n.openingExplorer),
+              bottom: _MoveList(options: options),
             ),
-        iosBuilder:
-            (_) => CupertinoPageScaffold(
-              navigationBar: CupertinoNavigationBar(
-                middle: Text(context.l10n.openingExplorer),
-                automaticBackgroundVisibility: false,
-                border: null,
-              ),
-              child: body,
+          ),
+      iosBuilder:
+          (_) => CupertinoPageScaffold(
+            navigationBar: CupertinoNavigationBar(
+              middle: Text(context.l10n.openingExplorer),
+              automaticBackgroundVisibility: false,
+              border: null,
             ),
-      ),
+            child: body,
+          ),
     );
   }
 }

--- a/lib/src/view/opening_explorer/opening_explorer_screen.dart
+++ b/lib/src/view/opening_explorer/opening_explorer_screen.dart
@@ -13,7 +13,7 @@ import 'package:lichess_mobile/src/view/analysis/analysis_board.dart';
 import 'package:lichess_mobile/src/view/opening_explorer/opening_explorer_settings.dart';
 import 'package:lichess_mobile/src/view/opening_explorer/opening_explorer_view.dart';
 import 'package:lichess_mobile/src/widgets/adaptive_bottom_sheet.dart';
-import 'package:lichess_mobile/src/widgets/background_theme.dart';
+import 'package:lichess_mobile/src/widgets/background.dart';
 import 'package:lichess_mobile/src/widgets/bottom_bar.dart';
 import 'package:lichess_mobile/src/widgets/bottom_bar_button.dart';
 import 'package:lichess_mobile/src/widgets/buttons.dart';
@@ -40,7 +40,7 @@ class OpeningExplorerScreen extends ConsumerWidget {
       _ => const CenterLoadingIndicator(),
     };
 
-    return FullScreenBackgroundTheme(
+    return FullScreenBackground(
       child: PlatformWidget(
         androidBuilder:
             (_) => Scaffold(

--- a/lib/src/view/opening_explorer/opening_explorer_settings.dart
+++ b/lib/src/view/opening_explorer/opening_explorer_settings.dart
@@ -7,7 +7,6 @@ import 'package:lichess_mobile/src/model/common/perf.dart';
 import 'package:lichess_mobile/src/model/opening_explorer/opening_explorer.dart';
 import 'package:lichess_mobile/src/model/opening_explorer/opening_explorer_preferences.dart';
 import 'package:lichess_mobile/src/utils/l10n_context.dart';
-import 'package:lichess_mobile/src/utils/navigation.dart';
 import 'package:lichess_mobile/src/view/user/search_screen.dart';
 import 'package:lichess_mobile/src/widgets/adaptive_bottom_sheet.dart';
 import 'package:lichess_mobile/src/widgets/list.dart';
@@ -117,19 +116,16 @@ class OpeningExplorerSettings extends ConsumerWidget {
                 recognizer:
                     TapGestureRecognizer()
                       ..onTap =
-                          () => pushPlatformRoute(
-                            context,
-                            fullscreenDialog: true,
-                            builder:
-                                (_) => SearchScreen(
-                                  onUserTap:
-                                      (user) => {
-                                        ref
-                                            .read(openingExplorerPreferencesProvider.notifier)
-                                            .setPlayerDbUsernameOrId(user.name),
-                                        Navigator.of(context).pop(),
-                                      },
-                                ),
+                          () => Navigator.of(context).push(
+                            SearchScreen.buildRoute(
+                              context,
+                              onUserTap: (user) {
+                                ref
+                                    .read(openingExplorerPreferencesProvider.notifier)
+                                    .setPlayerDbUsernameOrId(user.name);
+                                Navigator.of(context).pop();
+                              },
+                            ),
                           ),
                 style: const TextStyle(
                   fontWeight: FontWeight.bold,

--- a/lib/src/view/opening_explorer/opening_explorer_widgets.dart
+++ b/lib/src/view/opening_explorer/opening_explorer_widgets.dart
@@ -6,7 +6,6 @@ import 'package:intl/intl.dart';
 import 'package:lichess_mobile/src/model/common/chess.dart';
 import 'package:lichess_mobile/src/model/opening_explorer/opening_explorer.dart';
 import 'package:lichess_mobile/src/utils/l10n_context.dart';
-import 'package:lichess_mobile/src/utils/navigation.dart';
 import 'package:lichess_mobile/src/view/game/archived_game_screen.dart';
 import 'package:lichess_mobile/src/widgets/buttons.dart';
 import 'package:url_launcher/url_launcher.dart';
@@ -355,14 +354,13 @@ class _OpeningExplorerGameTileState extends ConsumerState<OpeningExplorerGameTil
       color: widget.color,
       child: AdaptiveInkWell(
         onTap: () {
-          pushPlatformRoute(
-            context,
-            builder:
-                (_) => ArchivedGameScreen(
-                  gameId: widget.game.id,
-                  orientation: Side.white,
-                  initialCursor: widget.ply,
-                ),
+          Navigator.of(context).push(
+            ArchivedGameScreen.buildRoute(
+              context,
+              gameId: widget.game.id,
+              orientation: Side.white,
+              initialCursor: widget.ply,
+            ),
           );
         },
         child: Row(

--- a/lib/src/view/over_the_board/over_the_board_screen.dart
+++ b/lib/src/view/over_the_board/over_the_board_screen.dart
@@ -13,6 +13,7 @@ import 'package:lichess_mobile/src/model/settings/board_preferences.dart';
 import 'package:lichess_mobile/src/model/settings/over_the_board_preferences.dart';
 import 'package:lichess_mobile/src/utils/immersive_mode.dart';
 import 'package:lichess_mobile/src/utils/l10n_context.dart';
+import 'package:lichess_mobile/src/utils/navigation.dart';
 import 'package:lichess_mobile/src/view/game/game_player.dart';
 import 'package:lichess_mobile/src/view/game/game_result_dialog.dart';
 import 'package:lichess_mobile/src/view/over_the_board/configure_over_the_board_game.dart';
@@ -25,6 +26,10 @@ import 'package:lichess_mobile/src/widgets/platform_scaffold.dart';
 
 class OverTheBoardScreen extends StatelessWidget {
   const OverTheBoardScreen({super.key});
+
+  static Route<void> buildRoute(BuildContext context) {
+    return buildScreenRoute(context, title: 'Over the board', screen: const OverTheBoardScreen());
+  }
 
   @override
   Widget build(BuildContext context) {

--- a/lib/src/view/over_the_board/over_the_board_screen.dart
+++ b/lib/src/view/over_the_board/over_the_board_screen.dart
@@ -28,7 +28,7 @@ class OverTheBoardScreen extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    return PlatformScaffold(
+    return PlatformThemedScaffold(
       appBar: PlatformAppBar(
         title: const Text('Over the board'), // TODO: l10n
         actions: [

--- a/lib/src/view/over_the_board/over_the_board_screen.dart
+++ b/lib/src/view/over_the_board/over_the_board_screen.dart
@@ -33,7 +33,7 @@ class OverTheBoardScreen extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    return PlatformThemedScaffold(
+    return PlatformScaffold(
       appBar: PlatformAppBar(
         title: const Text('Over the board'), // TODO: l10n
         actions: [

--- a/lib/src/view/play/challenge_odd_bots_screen.dart
+++ b/lib/src/view/play/challenge_odd_bots_screen.dart
@@ -23,6 +23,14 @@ class ChallengeOddBotsScreen extends StatelessWidget {
 
   final LightUser bot;
 
+  static Route<dynamic> buildRoute(BuildContext context, LightUser bot) {
+    return buildScreenRoute(
+      context,
+      title: context.l10n.challengeChallengesX(bot.name),
+      screen: ChallengeOddBotsScreen(bot),
+    );
+  }
+
   @override
   Widget build(BuildContext context) {
     return PlatformThemedScaffold(
@@ -270,25 +278,22 @@ class _ChallengeBodyState extends ConsumerState<_ChallengeBody> {
               onPressed:
                   fen != null
                       ? () {
-                        pushPlatformRoute(
-                          context,
-                          rootNavigator: true,
-                          builder: (BuildContext context) {
-                            return GameScreen(
-                              challenge: ChallengeRequest(
-                                destUser: widget.bot,
-                                variant: Variant.fromPosition,
-                                timeControl: ChallengeTimeControlType.clock,
-                                clock: (
-                                  time: Duration(seconds: seconds),
-                                  increment: Duration(seconds: incrementSeconds),
-                                ),
-                                rated: false,
-                                sideChoice: sideChoice,
-                                initialFen: fen,
+                        Navigator.of(context, rootNavigator: true).push(
+                          GameScreen.buildRoute(
+                            context,
+                            challenge: ChallengeRequest(
+                              destUser: widget.bot,
+                              variant: Variant.fromPosition,
+                              timeControl: ChallengeTimeControlType.clock,
+                              clock: (
+                                time: Duration(seconds: seconds),
+                                increment: Duration(seconds: incrementSeconds),
                               ),
-                            );
-                          },
+                              rated: false,
+                              sideChoice: sideChoice,
+                              initialFen: fen,
+                            ),
+                          ),
                         );
                       }
                       : null,

--- a/lib/src/view/play/challenge_odd_bots_screen.dart
+++ b/lib/src/view/play/challenge_odd_bots_screen.dart
@@ -33,7 +33,7 @@ class ChallengeOddBotsScreen extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    return PlatformThemedScaffold(
+    return PlatformScaffold(
       appBar: PlatformAppBar(title: Text(context.l10n.challengeChallengesX(bot.name))),
       body: _ChallengeBody(bot),
     );

--- a/lib/src/view/play/challenge_odd_bots_screen.dart
+++ b/lib/src/view/play/challenge_odd_bots_screen.dart
@@ -25,7 +25,7 @@ class ChallengeOddBotsScreen extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    return PlatformScaffold(
+    return PlatformThemedScaffold(
       appBar: PlatformAppBar(title: Text(context.l10n.challengeChallengesX(bot.name))),
       body: _ChallengeBody(bot),
     );

--- a/lib/src/view/play/create_challenge_screen.dart
+++ b/lib/src/view/play/create_challenge_screen.dart
@@ -35,6 +35,14 @@ class CreateChallengeScreen extends StatelessWidget {
 
   final LightUser user;
 
+  static Route<dynamic> buildRoute(BuildContext context, LightUser user) {
+    return buildScreenRoute(
+      context,
+      screen: CreateChallengeScreen(user),
+      title: context.l10n.challengeChallengesX(user.name),
+    );
+  }
+
   @override
   Widget build(BuildContext context) {
     return PlatformThemedScaffold(
@@ -350,19 +358,16 @@ class _ChallengeBodyState extends ConsumerState<_ChallengeBody> {
                           timeControl == ChallengeTimeControlType.clock
                               ? isValidTimeControl && isValidPosition
                                   ? () {
-                                    pushPlatformRoute(
-                                      context,
-                                      rootNavigator: true,
-                                      builder: (BuildContext context) {
-                                        return GameScreen(
-                                          challenge: preferences.makeRequest(
-                                            widget.user,
-                                            preferences.variant != Variant.fromPosition
-                                                ? null
-                                                : fromPositionFenInput,
-                                          ),
-                                        );
-                                      },
+                                    Navigator.of(context, rootNavigator: true).push(
+                                      GameScreen.buildRoute(
+                                        context,
+                                        challenge: preferences.makeRequest(
+                                          widget.user,
+                                          preferences.variant != Variant.fromPosition
+                                              ? null
+                                              : fromPositionFenInput,
+                                        ),
+                                      ),
                                     );
                                   }
                                   : null
@@ -392,7 +397,9 @@ class _ChallengeBodyState extends ConsumerState<_ChallengeBody> {
                                 // Navigate to the challenges screen where
                                 // the new correspondence challenge will be
                                 // displayed
-                                pushPlatformRoute(context, screen: const ChallengeRequestsScreen());
+                                Navigator.of(
+                                  context,
+                                ).push(ChallengeRequestsScreen.buildRoute(context));
                               }
                               : null,
                       child: Text(context.l10n.challengeChallengeToPlay, style: Styles.bold),

--- a/lib/src/view/play/create_challenge_screen.dart
+++ b/lib/src/view/play/create_challenge_screen.dart
@@ -37,7 +37,7 @@ class CreateChallengeScreen extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    return PlatformScaffold(
+    return PlatformThemedScaffold(
       appBar: PlatformAppBar(title: Text(context.l10n.challengeChallengesX(user.name))),
       body: _ChallengeBody(user),
     );

--- a/lib/src/view/play/create_challenge_screen.dart
+++ b/lib/src/view/play/create_challenge_screen.dart
@@ -45,7 +45,7 @@ class CreateChallengeScreen extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    return PlatformThemedScaffold(
+    return PlatformScaffold(
       appBar: PlatformAppBar(title: Text(context.l10n.challengeChallengesX(user.name))),
       body: _ChallengeBody(user),
     );

--- a/lib/src/view/play/create_custom_game_screen.dart
+++ b/lib/src/view/play/create_custom_game_screen.dart
@@ -40,6 +40,14 @@ enum _ViewMode { create, challenges }
 class CreateCustomGameScreen extends StatelessWidget {
   const CreateCustomGameScreen();
 
+  static Route<dynamic> buildRoute(BuildContext context) {
+    return buildScreenRoute(
+      context,
+      screen: const CreateCustomGameScreen(),
+      title: context.l10n.custom,
+    );
+  }
+
   @override
   Widget build(BuildContext context) {
     return FullScreenBackground(
@@ -279,13 +287,10 @@ class _ChallengesBodyState extends ConsumerState<_ChallengesBody> {
           final data = event.data as Map<String, dynamic>;
           final gameFullId = pick(data['id']).asGameFullIdOrThrow();
           if (mounted) {
-            pushPlatformRoute(
+            Navigator.of(
               context,
               rootNavigator: true,
-              builder: (BuildContext context) {
-                return GameScreen(initialGameId: gameFullId);
-              },
-            );
+            ).push(GameScreen.buildRoute(context, initialGameId: gameFullId));
           }
           widget.setViewMode(_ViewMode.create);
 
@@ -634,14 +639,11 @@ class _CreateGameBodyState extends ConsumerState<_CreateGameBody> {
                           timeControl == TimeControl.realTime
                               ? isValidTimeControl
                                   ? () {
-                                    pushPlatformRoute(
-                                      context,
-                                      rootNavigator: true,
-                                      builder: (BuildContext context) {
-                                        return GameScreen(
-                                          seek: GameSeek.custom(preferences, account),
-                                        );
-                                      },
+                                    Navigator.of(context, rootNavigator: true).push(
+                                      GameScreen.buildRoute(
+                                        context,
+                                        seek: GameSeek.custom(preferences, account),
+                                      ),
                                     );
                                   }
                                   : null

--- a/lib/src/view/play/create_custom_game_screen.dart
+++ b/lib/src/view/play/create_custom_game_screen.dart
@@ -27,7 +27,7 @@ import 'package:lichess_mobile/src/view/play/challenge_list_item.dart';
 import 'package:lichess_mobile/src/view/play/common_play_widgets.dart';
 import 'package:lichess_mobile/src/widgets/adaptive_action_sheet.dart';
 import 'package:lichess_mobile/src/widgets/adaptive_choice_picker.dart';
-import 'package:lichess_mobile/src/widgets/background_theme.dart';
+import 'package:lichess_mobile/src/widgets/background.dart';
 import 'package:lichess_mobile/src/widgets/buttons.dart';
 import 'package:lichess_mobile/src/widgets/expanded_section.dart';
 import 'package:lichess_mobile/src/widgets/feedback.dart';
@@ -42,7 +42,7 @@ class CreateCustomGameScreen extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    return FullScreenBackgroundTheme(
+    return FullScreenBackground(
       child: PlatformWidget(androidBuilder: _buildAndroid, iosBuilder: _buildIos),
     );
   }

--- a/lib/src/view/play/create_custom_game_screen.dart
+++ b/lib/src/view/play/create_custom_game_screen.dart
@@ -27,7 +27,6 @@ import 'package:lichess_mobile/src/view/play/challenge_list_item.dart';
 import 'package:lichess_mobile/src/view/play/common_play_widgets.dart';
 import 'package:lichess_mobile/src/widgets/adaptive_action_sheet.dart';
 import 'package:lichess_mobile/src/widgets/adaptive_choice_picker.dart';
-import 'package:lichess_mobile/src/widgets/background.dart';
 import 'package:lichess_mobile/src/widgets/buttons.dart';
 import 'package:lichess_mobile/src/widgets/expanded_section.dart';
 import 'package:lichess_mobile/src/widgets/feedback.dart';
@@ -50,9 +49,7 @@ class CreateCustomGameScreen extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    return FullScreenBackground(
-      child: PlatformWidget(androidBuilder: _buildAndroid, iosBuilder: _buildIos),
-    );
+    return PlatformWidget(androidBuilder: _buildAndroid, iosBuilder: _buildIos);
   }
 
   Widget _buildIos(BuildContext context) {

--- a/lib/src/view/play/create_custom_game_screen.dart
+++ b/lib/src/view/play/create_custom_game_screen.dart
@@ -27,6 +27,7 @@ import 'package:lichess_mobile/src/view/play/challenge_list_item.dart';
 import 'package:lichess_mobile/src/view/play/common_play_widgets.dart';
 import 'package:lichess_mobile/src/widgets/adaptive_action_sheet.dart';
 import 'package:lichess_mobile/src/widgets/adaptive_choice_picker.dart';
+import 'package:lichess_mobile/src/widgets/background_theme.dart';
 import 'package:lichess_mobile/src/widgets/buttons.dart';
 import 'package:lichess_mobile/src/widgets/expanded_section.dart';
 import 'package:lichess_mobile/src/widgets/feedback.dart';
@@ -41,7 +42,9 @@ class CreateCustomGameScreen extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    return PlatformWidget(androidBuilder: _buildAndroid, iosBuilder: _buildIos);
+    return FullScreenBackgroundTheme(
+      child: PlatformWidget(androidBuilder: _buildAndroid, iosBuilder: _buildIos),
+    );
   }
 
   Widget _buildIos(BuildContext context) {

--- a/lib/src/view/play/create_game_options.dart
+++ b/lib/src/view/play/create_game_options.dart
@@ -110,7 +110,7 @@ class _CreateGamePlatformButton extends StatelessWidget {
           title: Text(label, style: Styles.mainListTileTitle),
           onTap: onTap,
         )
-        : OutlinedButton.icon(
+        : FilledButton.tonalIcon(
           onPressed: onTap,
           icon: Icon(icon),
           label: Text(label, style: const TextStyle(fontSize: 18, fontWeight: FontWeight.w500)),

--- a/lib/src/view/play/create_game_options.dart
+++ b/lib/src/view/play/create_game_options.dart
@@ -6,7 +6,6 @@ import 'package:lichess_mobile/src/network/connectivity.dart';
 import 'package:lichess_mobile/src/styles/lichess_icons.dart';
 import 'package:lichess_mobile/src/styles/styles.dart';
 import 'package:lichess_mobile/src/utils/l10n_context.dart';
-import 'package:lichess_mobile/src/utils/navigation.dart';
 import 'package:lichess_mobile/src/view/over_the_board/over_the_board_screen.dart';
 import 'package:lichess_mobile/src/view/play/create_custom_game_screen.dart';
 import 'package:lichess_mobile/src/view/play/online_bots_screen.dart';
@@ -29,11 +28,7 @@ class CreateGameOptions extends ConsumerWidget {
                   isOnline
                       ? () {
                         ref.invalidate(accountProvider);
-                        pushPlatformRoute(
-                          context,
-                          title: context.l10n.custom,
-                          builder: (_) => const CreateCustomGameScreen(),
-                        );
+                        Navigator.of(context).push(CreateCustomGameScreen.buildRoute(context));
                       }
                       : null,
               icon: Icons.tune,
@@ -43,11 +38,12 @@ class CreateGameOptions extends ConsumerWidget {
               onTap:
                   isOnline
                       ? () {
-                        pushPlatformRoute(
-                          context,
-                          title: context.l10n.onlineBots,
-                          builder: (_) => const OnlineBotsScreen(),
-                        );
+                        // pushPlatformRoute(
+                        //   context,
+                        //   title: context.l10n.onlineBots,
+                        //   builder: (_) => const OnlineBotsScreen(),
+                        // );
+                        Navigator.of(context).push(OnlineBotsScreen.buildRoute(context));
                       }
                       : null,
               icon: Icons.computer,
@@ -59,12 +55,10 @@ class CreateGameOptions extends ConsumerWidget {
           children: [
             _CreateGamePlatformButton(
               onTap: () {
-                pushPlatformRoute(
+                Navigator.of(
                   context,
-                  title: 'Over the Board',
                   rootNavigator: true,
-                  builder: (_) => const OverTheBoardScreen(),
-                );
+                ).push(OverTheBoardScreen.buildRoute(context));
               },
               icon: LichessIcons.chess_board,
               label: 'Over the board',

--- a/lib/src/view/play/ongoing_games_screen.dart
+++ b/lib/src/view/play/ongoing_games_screen.dart
@@ -9,7 +9,7 @@ import 'package:lichess_mobile/src/utils/l10n_context.dart';
 import 'package:lichess_mobile/src/utils/navigation.dart';
 import 'package:lichess_mobile/src/view/game/game_screen.dart';
 import 'package:lichess_mobile/src/widgets/board_preview.dart';
-import 'package:lichess_mobile/src/widgets/platform.dart';
+import 'package:lichess_mobile/src/widgets/platform_scaffold.dart';
 import 'package:lichess_mobile/src/widgets/user_full_name.dart';
 
 class OngoingGamesScreen extends ConsumerWidget {
@@ -17,19 +17,11 @@ class OngoingGamesScreen extends ConsumerWidget {
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
-    return ConsumerPlatformWidget(ref: ref, androidBuilder: _buildAndroid, iosBuilder: _buildIos);
-  }
-
-  Widget _buildIos(BuildContext context, WidgetRef ref) {
-    return CupertinoPageScaffold(navigationBar: const CupertinoNavigationBar(), child: _Body());
-  }
-
-  Widget _buildAndroid(BuildContext context, WidgetRef ref) {
     final ongoingGames = ref.watch(ongoingGamesProvider);
-    return Scaffold(
+    return PlatformThemedScaffold(
       appBar: ongoingGames.maybeWhen(
-        data: (data) => AppBar(title: Text(context.l10n.nbGamesInPlay(data.length))),
-        orElse: () => AppBar(title: const SizedBox.shrink()),
+        data: (data) => PlatformAppBar(title: Text(context.l10n.nbGamesInPlay(data.length))),
+        orElse: () => const PlatformAppBar(title: SizedBox.shrink()),
       ),
       body: _Body(),
     );

--- a/lib/src/view/play/ongoing_games_screen.dart
+++ b/lib/src/view/play/ongoing_games_screen.dart
@@ -15,6 +15,10 @@ import 'package:lichess_mobile/src/widgets/user_full_name.dart';
 class OngoingGamesScreen extends ConsumerWidget {
   const OngoingGamesScreen({super.key});
 
+  static Route<dynamic> buildRoute(BuildContext context) {
+    return buildScreenRoute(context, screen: const OngoingGamesScreen());
+  }
+
   @override
   Widget build(BuildContext context, WidgetRef ref) {
     final ongoingGames = ref.watch(ongoingGamesProvider);
@@ -80,21 +84,21 @@ class OngoingGamePreview extends ConsumerWidget {
         ],
       ),
       onTap: () {
-        pushPlatformRoute(
-          context,
-          rootNavigator: true,
-          builder:
-              (context) => GameScreen(
+        Navigator.of(context, rootNavigator: true)
+            .push(
+              GameScreen.buildRoute(
+                context,
                 initialGameId: game.fullId,
                 loadingFen: game.fen,
                 loadingOrientation: game.orientation,
                 loadingLastMove: game.lastMove,
               ),
-        ).then((_) {
-          if (context.mounted) {
-            ref.invalidate(ongoingGamesProvider);
-          }
-        });
+            )
+            .then((_) {
+              if (context.mounted) {
+                ref.invalidate(ongoingGamesProvider);
+              }
+            });
       },
     );
   }

--- a/lib/src/view/play/ongoing_games_screen.dart
+++ b/lib/src/view/play/ongoing_games_screen.dart
@@ -22,7 +22,7 @@ class OngoingGamesScreen extends ConsumerWidget {
   @override
   Widget build(BuildContext context, WidgetRef ref) {
     final ongoingGames = ref.watch(ongoingGamesProvider);
-    return PlatformThemedScaffold(
+    return PlatformScaffold(
       appBar: ongoingGames.maybeWhen(
         data: (data) => PlatformAppBar(title: Text(context.l10n.nbGamesInPlay(data.length))),
         orElse: () => const PlatformAppBar(title: SizedBox.shrink()),

--- a/lib/src/view/play/online_bots_screen.dart
+++ b/lib/src/view/play/online_bots_screen.dart
@@ -39,7 +39,7 @@ class OnlineBotsScreen extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    return PlatformThemedScaffold(
+    return PlatformScaffold(
       backgroundColor: Styles.listingsScreenBackgroundColor(context),
       appBar: PlatformAppBar(title: Text(context.l10n.onlineBots)),
       body: _Body(),

--- a/lib/src/view/play/online_bots_screen.dart
+++ b/lib/src/view/play/online_bots_screen.dart
@@ -35,7 +35,7 @@ class OnlineBotsScreen extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    return PlatformScaffold(
+    return PlatformThemedScaffold(
       backgroundColor: Styles.listingsScreenBackgroundColor(context),
       appBar: PlatformAppBar(title: Text(context.l10n.onlineBots)),
       body: _Body(),

--- a/lib/src/view/play/online_bots_screen.dart
+++ b/lib/src/view/play/online_bots_screen.dart
@@ -33,6 +33,10 @@ final _onlineBotsProvider = FutureProvider.autoDispose<IList<User>>((ref) async 
 class OnlineBotsScreen extends StatelessWidget {
   const OnlineBotsScreen();
 
+  static Route<dynamic> buildRoute(BuildContext context) {
+    return buildScreenRoute(context, screen: const OnlineBotsScreen());
+  }
+
   @override
   Widget build(BuildContext context) {
     return PlatformThemedScaffold(
@@ -125,14 +129,10 @@ class _Body extends ConsumerWidget {
                     return;
                   }
                   final isOddBot = oddBots.contains(bot.lightUser.name.toLowerCase());
-                  pushPlatformRoute(
-                    context,
-                    title: context.l10n.challengeChallengesX(bot.lightUser.name),
-                    builder:
-                        (context) =>
-                            isOddBot
-                                ? ChallengeOddBotsScreen(bot.lightUser)
-                                : CreateChallengeScreen(bot.lightUser),
+                  Navigator.of(context).push(
+                    isOddBot
+                        ? ChallengeOddBotsScreen.buildRoute(context, bot.lightUser)
+                        : CreateChallengeScreen.buildRoute(context, bot.lightUser),
                   );
                 },
                 onLongPress: () {
@@ -178,12 +178,11 @@ class _ContextMenu extends ConsumerWidget {
                   onOpen: (link) async {
                     if (link.originText.startsWith('@')) {
                       final username = link.originText.substring(1);
-                      pushPlatformRoute(
-                        context,
-                        builder:
-                            (ctx) => UserScreen(
-                              user: LightUser(id: UserId.fromUserName(username), name: username),
-                            ),
+                      Navigator.of(context).push(
+                        UserScreen.buildRoute(
+                          context,
+                          LightUser(id: UserId.fromUserName(username), name: username),
+                        ),
                       );
                     } else {
                       launchUrl(Uri.parse(link.url));
@@ -204,7 +203,7 @@ class _ContextMenu extends ConsumerWidget {
         const PlatformDivider(),
         BottomSheetContextMenuAction(
           onPressed: () {
-            pushPlatformRoute(context, builder: (context) => UserScreen(user: bot.lightUser));
+            Navigator.of(context).push(UserScreen.buildRoute(context, bot.lightUser));
           },
           icon: Icons.person,
           child: Text(context.l10n.profile),

--- a/lib/src/view/play/play_screen.dart
+++ b/lib/src/view/play/play_screen.dart
@@ -2,12 +2,17 @@ import 'package:flutter/cupertino.dart';
 import 'package:flutter/material.dart';
 import 'package:lichess_mobile/src/styles/styles.dart';
 import 'package:lichess_mobile/src/utils/l10n_context.dart';
+import 'package:lichess_mobile/src/utils/navigation.dart';
 import 'package:lichess_mobile/src/view/play/create_game_options.dart';
 import 'package:lichess_mobile/src/view/play/quick_game_button.dart';
 import 'package:lichess_mobile/src/widgets/platform_scaffold.dart';
 
 class PlayScreen extends StatelessWidget {
   const PlayScreen();
+
+  static Route<dynamic> buildRoute(BuildContext context) {
+    return buildScreenRoute(context, screen: const PlayScreen(), title: context.l10n.play);
+  }
 
   @override
   Widget build(BuildContext context) {

--- a/lib/src/view/play/play_screen.dart
+++ b/lib/src/view/play/play_screen.dart
@@ -11,7 +11,7 @@ class PlayScreen extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    return PlatformScaffold(
+    return PlatformThemedScaffold(
       appBar: PlatformAppBar(title: Text(context.l10n.play)),
       body: const SafeArea(
         child: Column(

--- a/lib/src/view/play/play_screen.dart
+++ b/lib/src/view/play/play_screen.dart
@@ -16,7 +16,7 @@ class PlayScreen extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    return PlatformThemedScaffold(
+    return PlatformScaffold(
       appBar: PlatformAppBar(title: Text(context.l10n.play)),
       body: const SafeArea(
         child: Column(

--- a/lib/src/view/play/quick_game_button.dart
+++ b/lib/src/view/play/quick_game_button.dart
@@ -7,7 +7,6 @@ import 'package:lichess_mobile/src/model/lobby/game_seek.dart';
 import 'package:lichess_mobile/src/model/lobby/game_setup_preferences.dart';
 import 'package:lichess_mobile/src/network/connectivity.dart';
 import 'package:lichess_mobile/src/utils/l10n_context.dart';
-import 'package:lichess_mobile/src/utils/navigation.dart';
 import 'package:lichess_mobile/src/view/game/game_screen.dart';
 import 'package:lichess_mobile/src/view/play/time_control_modal.dart';
 import 'package:lichess_mobile/src/widgets/adaptive_bottom_sheet.dart';
@@ -75,16 +74,14 @@ class QuickGameButton extends ConsumerWidget {
                     onPressed:
                         isOnline
                             ? () {
-                              pushPlatformRoute(
-                                context,
-                                rootNavigator: true,
-                                builder:
-                                    (_) => GameScreen(
-                                      seek: GameSeek.fastPairing(
-                                        playPrefs.quickPairingTimeIncrement,
-                                        session,
-                                      ),
-                                    ),
+                              Navigator.of(context, rootNavigator: true).push(
+                                GameScreen.buildRoute(
+                                  context,
+                                  seek: GameSeek.fastPairing(
+                                    playPrefs.quickPairingTimeIncrement,
+                                    session,
+                                  ),
+                                ),
                               );
                             }
                             : null,
@@ -94,16 +91,14 @@ class QuickGameButton extends ConsumerWidget {
                     onPressed:
                         isOnline
                             ? () {
-                              pushPlatformRoute(
-                                context,
-                                rootNavigator: true,
-                                builder:
-                                    (_) => GameScreen(
-                                      seek: GameSeek.fastPairing(
-                                        playPrefs.quickPairingTimeIncrement,
-                                        session,
-                                      ),
-                                    ),
+                              Navigator.of(context, rootNavigator: true).push(
+                                GameScreen.buildRoute(
+                                  context,
+                                  seek: GameSeek.fastPairing(
+                                    playPrefs.quickPairingTimeIncrement,
+                                    session,
+                                  ),
+                                ),
                               );
                             }
                             : null,

--- a/lib/src/view/play/quick_game_matrix.dart
+++ b/lib/src/view/play/quick_game_matrix.dart
@@ -142,17 +142,13 @@ class _ChoiceChip extends StatefulWidget {
 class _ChoiceChipState extends State<_ChoiceChip> {
   @override
   Widget build(BuildContext context) {
-    final theme = Theme.of(context);
-    final bgColor =
-        theme.brightness == Brightness.light
-            ? theme.colorScheme.surfaceContainerLowest
-            : theme.colorScheme.surfaceContainerHighest;
+    final bgColor = Styles.cardColor(context);
 
     return Opacity(
       opacity: widget.onTap != null ? 1.0 : 0.5,
       child: Container(
         decoration: BoxDecoration(
-          color: bgColor.withValues(alpha: 0.7),
+          color: bgColor.withValues(alpha: 0.8),
           borderRadius: const BorderRadius.all(Radius.circular(6.0)),
         ),
         child: AdaptiveInkWell(

--- a/lib/src/view/play/quick_game_matrix.dart
+++ b/lib/src/view/play/quick_game_matrix.dart
@@ -8,7 +8,6 @@ import 'package:lichess_mobile/src/model/lobby/game_seek.dart';
 import 'package:lichess_mobile/src/network/connectivity.dart';
 import 'package:lichess_mobile/src/styles/styles.dart';
 import 'package:lichess_mobile/src/utils/l10n_context.dart';
-import 'package:lichess_mobile/src/utils/navigation.dart';
 import 'package:lichess_mobile/src/view/game/game_screen.dart';
 import 'package:lichess_mobile/src/view/play/create_custom_game_screen.dart';
 import 'package:lichess_mobile/src/widgets/buttons.dart';
@@ -84,11 +83,11 @@ class _SectionChoices extends ConsumerWidget {
                     onTap:
                         isOnline
                             ? () {
-                              pushPlatformRoute(
-                                context,
-                                rootNavigator: true,
-                                builder:
-                                    (_) => GameScreen(seek: GameSeek.fastPairing(choice, session)),
+                              Navigator.of(context, rootNavigator: true).push(
+                                GameScreen.buildRoute(
+                                  context,
+                                  seek: GameSeek.fastPairing(choice, session),
+                                ),
                               );
                             }
                             : null,
@@ -113,10 +112,7 @@ class _SectionChoices extends ConsumerWidget {
                 onTap:
                     isOnline
                         ? () {
-                          pushPlatformRoute(
-                            context,
-                            builder: (_) => const CreateCustomGameScreen(),
-                          );
+                          Navigator.of(context).push(CreateCustomGameScreen.buildRoute(context));
                         }
                         : null,
               ),

--- a/lib/src/view/puzzle/dashboard_screen.dart
+++ b/lib/src/view/puzzle/dashboard_screen.dart
@@ -33,7 +33,7 @@ class PuzzleDashboardScreen extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    return const PlatformThemedScaffold(
+    return const PlatformScaffold(
       body: _Body(),
       appBar: PlatformAppBar(title: SizedBox.shrink(), actions: [DaysSelector()]),
     );

--- a/lib/src/view/puzzle/dashboard_screen.dart
+++ b/lib/src/view/puzzle/dashboard_screen.dart
@@ -24,7 +24,7 @@ class PuzzleDashboardScreen extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    return const PlatformScaffold(
+    return const PlatformThemedScaffold(
       body: _Body(),
       appBar: PlatformAppBar(title: SizedBox.shrink(), actions: [DaysSelector()]),
     );

--- a/lib/src/view/puzzle/dashboard_screen.dart
+++ b/lib/src/view/puzzle/dashboard_screen.dart
@@ -8,6 +8,7 @@ import 'package:lichess_mobile/src/model/puzzle/puzzle.dart';
 import 'package:lichess_mobile/src/model/puzzle/puzzle_providers.dart';
 import 'package:lichess_mobile/src/styles/styles.dart';
 import 'package:lichess_mobile/src/utils/l10n_context.dart';
+import 'package:lichess_mobile/src/utils/navigation.dart';
 import 'package:lichess_mobile/src/utils/screen.dart';
 import 'package:lichess_mobile/src/utils/string.dart';
 import 'package:lichess_mobile/src/widgets/adaptive_choice_picker.dart';
@@ -21,6 +22,14 @@ final daysProvider = StateProvider<Days>((ref) => Days.month);
 
 class PuzzleDashboardScreen extends StatelessWidget {
   const PuzzleDashboardScreen({super.key});
+
+  static Route<dynamic> buildRoute(BuildContext context) {
+    return buildScreenRoute(
+      context,
+      title: context.l10n.puzzlePuzzleDashboard,
+      screen: const PuzzleDashboardScreen(),
+    );
+  }
 
   @override
   Widget build(BuildContext context) {

--- a/lib/src/view/puzzle/opening_screen.dart
+++ b/lib/src/view/puzzle/opening_screen.dart
@@ -29,6 +29,14 @@ final _openingsProvider =
 class OpeningThemeScreen extends StatelessWidget {
   const OpeningThemeScreen({super.key});
 
+  static Route<dynamic> buildRoute(BuildContext context) {
+    return buildScreenRoute(
+      context,
+      screen: const OpeningThemeScreen(),
+      title: context.l10n.puzzlePuzzlesByOpenings,
+    );
+  }
+
   @override
   Widget build(BuildContext context) {
     return PlatformThemedScaffold(
@@ -131,11 +139,10 @@ class _OpeningFamily extends ConsumerWidget {
                   style: TextStyle(color: textShade(context, 0.5)),
                 ),
                 onTap: () {
-                  pushPlatformRoute(
+                  Navigator.of(
                     context,
                     rootNavigator: true,
-                    builder: (context) => PuzzleScreen(angle: PuzzleOpening(openingFamily.key)),
-                  );
+                  ).push(PuzzleScreen.buildRoute(context, angle: PuzzleOpening(openingFamily.key)));
                 },
               ),
     );
@@ -162,11 +169,10 @@ class _OpeningTile extends StatelessWidget {
       title: Text(name, overflow: TextOverflow.ellipsis, style: titleStyle),
       trailing: Text('$count', style: TextStyle(color: textShade(context, Styles.subtitleOpacity))),
       onTap: () {
-        pushPlatformRoute(
+        Navigator.of(
           context,
           rootNavigator: true,
-          builder: (context) => PuzzleScreen(angle: PuzzleOpening(openingKey)),
-        );
+        ).push(PuzzleScreen.buildRoute(context, angle: PuzzleOpening(openingKey)));
       },
     );
   }

--- a/lib/src/view/puzzle/opening_screen.dart
+++ b/lib/src/view/puzzle/opening_screen.dart
@@ -31,7 +31,7 @@ class OpeningThemeScreen extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    return PlatformScaffold(
+    return PlatformThemedScaffold(
       appBar: PlatformAppBar(title: Text(context.l10n.puzzlePuzzlesByOpenings)),
       body: const _Body(),
     );

--- a/lib/src/view/puzzle/opening_screen.dart
+++ b/lib/src/view/puzzle/opening_screen.dart
@@ -39,7 +39,7 @@ class OpeningThemeScreen extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    return PlatformThemedScaffold(
+    return PlatformScaffold(
       appBar: PlatformAppBar(title: Text(context.l10n.puzzlePuzzlesByOpenings)),
       body: const _Body(),
     );

--- a/lib/src/view/puzzle/puzzle_feedback_widget.dart
+++ b/lib/src/view/puzzle/puzzle_feedback_widget.dart
@@ -4,7 +4,6 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:lichess_mobile/src/model/puzzle/puzzle.dart';
 import 'package:lichess_mobile/src/model/puzzle/puzzle_controller.dart';
 import 'package:lichess_mobile/src/model/settings/board_preferences.dart';
-import 'package:lichess_mobile/src/model/settings/brightness.dart';
 import 'package:lichess_mobile/src/styles/styles.dart';
 import 'package:lichess_mobile/src/utils/l10n_context.dart';
 import 'package:lichess_mobile/src/utils/string.dart';
@@ -21,7 +20,7 @@ class PuzzleFeedbackWidget extends ConsumerWidget {
   Widget build(BuildContext context, WidgetRef ref) {
     final pieceSet = ref.watch(boardPreferencesProvider.select((value) => value.pieceSet));
     final boardTheme = ref.watch(boardPreferencesProvider.select((state) => state.boardTheme));
-    final brightness = ref.watch(currentBrightnessProvider);
+    final brightness = Theme.of(context).brightness;
 
     final piece = state.pov == Side.white ? PieceKind.whiteKing : PieceKind.blackKing;
     final asset = pieceSet.assets[piece]!;

--- a/lib/src/view/puzzle/puzzle_history_screen.dart
+++ b/lib/src/view/puzzle/puzzle_history_screen.dart
@@ -75,7 +75,7 @@ class PuzzleHistoryScreen extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    return PlatformThemedScaffold(
+    return PlatformScaffold(
       appBar: PlatformAppBar(title: Text(context.l10n.puzzleHistory)),
       body: _Body(),
     );

--- a/lib/src/view/puzzle/puzzle_history_screen.dart
+++ b/lib/src/view/puzzle/puzzle_history_screen.dart
@@ -67,7 +67,7 @@ class PuzzleHistoryScreen extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    return PlatformScaffold(
+    return PlatformThemedScaffold(
       appBar: PlatformAppBar(title: Text(context.l10n.puzzleHistory)),
       body: _Body(),
     );

--- a/lib/src/view/puzzle/puzzle_history_screen.dart
+++ b/lib/src/view/puzzle/puzzle_history_screen.dart
@@ -39,12 +39,12 @@ class PuzzleHistoryPreview extends ConsumerWidget {
           return BoardThumbnail(
             size: boardWidth,
             onTap: () {
-              pushPlatformRoute(
-                context,
-                rootNavigator: true,
-                builder:
-                    (_) =>
-                        PuzzleScreen(angle: const PuzzleTheme(PuzzleThemeKey.mix), puzzleId: e.id),
+              Navigator.of(context, rootNavigator: true).push(
+                PuzzleScreen.buildRoute(
+                  context,
+                  angle: const PuzzleTheme(PuzzleThemeKey.mix),
+                  puzzleId: e.id,
+                ),
               );
             },
             orientation: side,
@@ -64,6 +64,14 @@ class PuzzleHistoryPreview extends ConsumerWidget {
 /// A screen that displays the full puzzle history.
 class PuzzleHistoryScreen extends StatelessWidget {
   const PuzzleHistoryScreen();
+
+  static Route<dynamic> buildRoute(BuildContext context) {
+    return buildScreenRoute(
+      context,
+      screen: const PuzzleHistoryScreen(),
+      title: context.l10n.puzzleHistory,
+    );
+  }
 
   @override
   Widget build(BuildContext context) {
@@ -196,12 +204,12 @@ class PuzzleHistoryBoard extends ConsumerWidget {
       child: BoardThumbnail(
         size: boardWidth,
         onTap: () {
-          pushPlatformRoute(
-            context,
-            rootNavigator: true,
-            builder:
-                (ctx) =>
-                    PuzzleScreen(angle: const PuzzleTheme(PuzzleThemeKey.mix), puzzleId: puzzle.id),
+          Navigator.of(context, rootNavigator: true).push(
+            PuzzleScreen.buildRoute(
+              context,
+              angle: const PuzzleTheme(PuzzleThemeKey.mix),
+              puzzleId: puzzle.id,
+            ),
           );
         },
         orientation: turn,

--- a/lib/src/view/puzzle/puzzle_screen.dart
+++ b/lib/src/view/puzzle/puzzle_screen.dart
@@ -84,7 +84,7 @@ class _PuzzleScreenState extends ConsumerState<PuzzleScreen> with RouteAware {
   @override
   Widget build(BuildContext context) {
     return WakelockWidget(
-      child: PlatformBoardThemeScaffold(
+      child: PlatformThemedScaffold(
         appBar: PlatformAppBar(
           actions: const [ToggleSoundButton(), _PuzzleSettingsButton()],
           title: _Title(angle: widget.angle),

--- a/lib/src/view/puzzle/puzzle_screen.dart
+++ b/lib/src/view/puzzle/puzzle_screen.dart
@@ -53,6 +53,14 @@ class PuzzleScreen extends ConsumerStatefulWidget {
   final PuzzleAngle angle;
   final PuzzleId? puzzleId;
 
+  static Route<dynamic> buildRoute(
+    BuildContext context, {
+    required PuzzleAngle angle,
+    PuzzleId? puzzleId,
+  }) {
+    return buildScreenRoute(context, screen: PuzzleScreen(angle: angle, puzzleId: puzzleId));
+  }
+
   @override
   ConsumerState<PuzzleScreen> createState() => _PuzzleScreenState();
 }
@@ -437,20 +445,19 @@ class _BottomBar extends ConsumerWidget {
         BottomSheetAction(
           makeLabel: (context) => Text(context.l10n.analysis),
           onPressed: (context) {
-            pushPlatformRoute(
-              context,
-              builder:
-                  (context) => AnalysisScreen(
-                    options: AnalysisOptions(
-                      orientation: puzzleState.pov,
-                      standalone: (
-                        pgn: ref.read(ctrlProvider.notifier).makePgn(),
-                        isComputerAnalysisAllowed: true,
-                        variant: Variant.standard,
-                      ),
-                      initialMoveCursor: 0,
-                    ),
+            Navigator.of(context).push(
+              AnalysisScreen.buildRoute(
+                context,
+                AnalysisOptions(
+                  orientation: puzzleState.pov,
+                  standalone: (
+                    pgn: ref.read(ctrlProvider.notifier).makePgn(),
+                    isComputerAnalysisAllowed: true,
+                    variant: Variant.standard,
                   ),
+                  initialMoveCursor: 0,
+                ),
+              ),
             );
           },
         ),
@@ -462,14 +469,13 @@ class _BottomBar extends ConsumerWidget {
               archivedGameProvider(id: puzzleState.puzzle.game.id).future,
             );
             if (context.mounted) {
-              pushPlatformRoute(
-                context,
-                builder:
-                    (context) => ArchivedGameScreen(
-                      gameData: game.data,
-                      orientation: puzzleState.pov,
-                      initialCursor: puzzleState.puzzle.puzzle.initialPly + 1,
-                    ),
+              Navigator.of(context).push(
+                ArchivedGameScreen.buildRoute(
+                  context,
+                  gameData: game.data,
+                  orientation: puzzleState.pov,
+                  initialCursor: puzzleState.puzzle.puzzle.initialPly + 1,
+                ),
               );
             }
           },

--- a/lib/src/view/puzzle/puzzle_screen.dart
+++ b/lib/src/view/puzzle/puzzle_screen.dart
@@ -92,7 +92,7 @@ class _PuzzleScreenState extends ConsumerState<PuzzleScreen> with RouteAware {
   @override
   Widget build(BuildContext context) {
     return WakelockWidget(
-      child: PlatformThemedScaffold(
+      child: PlatformScaffold(
         appBar: PlatformAppBar(
           actions: const [ToggleSoundButton(), _PuzzleSettingsButton()],
           title: _Title(angle: widget.angle),

--- a/lib/src/view/puzzle/puzzle_session_widget.dart
+++ b/lib/src/view/puzzle/puzzle_session_widget.dart
@@ -8,7 +8,6 @@ import 'package:lichess_mobile/src/model/puzzle/puzzle_controller.dart';
 import 'package:lichess_mobile/src/model/puzzle/puzzle_providers.dart';
 import 'package:lichess_mobile/src/model/puzzle/puzzle_service.dart';
 import 'package:lichess_mobile/src/model/puzzle/puzzle_session.dart';
-import 'package:lichess_mobile/src/model/settings/brightness.dart';
 import 'package:lichess_mobile/src/styles/lichess_colors.dart';
 import 'package:lichess_mobile/src/utils/screen.dart';
 import 'package:lichess_mobile/src/view/account/rating_pref_aware.dart';
@@ -57,7 +56,7 @@ class PuzzleSessionWidgetState extends ConsumerState<PuzzleSessionWidget> {
       puzzleSessionProvider(widget.initialPuzzleContext.userId, widget.initialPuzzleContext.angle),
     );
     final puzzleState = ref.watch(widget.ctrlProvider);
-    final brightness = ref.watch(currentBrightnessProvider);
+    final brightness = Theme.of(context).brightness;
     final currentAttempt = session.attempts.firstWhereOrNull(
       (a) => a.id == puzzleState.puzzle.puzzle.id,
     );

--- a/lib/src/view/puzzle/puzzle_settings_screen.dart
+++ b/lib/src/view/puzzle/puzzle_settings_screen.dart
@@ -2,7 +2,6 @@ import 'package:flutter/cupertino.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:lichess_mobile/src/model/puzzle/puzzle_preferences.dart';
 import 'package:lichess_mobile/src/utils/l10n_context.dart';
-import 'package:lichess_mobile/src/utils/navigation.dart';
 import 'package:lichess_mobile/src/view/settings/board_settings_screen.dart';
 import 'package:lichess_mobile/src/widgets/adaptive_bottom_sheet.dart';
 import 'package:lichess_mobile/src/widgets/list.dart';
@@ -27,7 +26,9 @@ class PuzzleSettingsScreen extends ConsumerWidget {
           title: const Text('Board settings'),
           trailing: const Icon(CupertinoIcons.chevron_right),
           onTap: () {
-            pushPlatformRoute(context, fullscreenDialog: true, screen: const BoardSettingsScreen());
+            Navigator.of(
+              context,
+            ).push(BoardSettingsScreen.buildRoute(context, fullscreenDialog: true));
           },
         ),
       ],

--- a/lib/src/view/puzzle/puzzle_tab_screen.dart
+++ b/lib/src/view/puzzle/puzzle_tab_screen.dart
@@ -205,7 +205,6 @@ class _CupertinoTabBodyState extends ConsumerState<_CupertinoTabBody> {
           ),
           Expanded(
             child: CupertinoPageScaffold(
-              backgroundColor: CupertinoColors.systemBackground.resolveFrom(context),
               navigationBar: CupertinoNavigationBar(
                 transitionBetweenRoutes: false,
                 middle: Text(context.l10n.puzzleHistory),
@@ -484,7 +483,6 @@ class PuzzleHistoryWidget extends ConsumerWidget {
             isTablet ? _kNumberOfHistoryItemsOnTablet : _kNumberOfHistoryItemsOnHandset;
 
         return ListSection(
-          cupertinoBackgroundColor: CupertinoPageScaffoldBackgroundColor.maybeOf(context),
           cupertinoClipBehavior: Clip.none,
           header: showHeader ? Text(context.l10n.puzzleHistory) : null,
           headerTrailing:

--- a/lib/src/view/puzzle/puzzle_tab_screen.dart
+++ b/lib/src/view/puzzle/puzzle_tab_screen.dart
@@ -19,7 +19,6 @@ import 'package:lichess_mobile/src/styles/lichess_icons.dart';
 import 'package:lichess_mobile/src/styles/puzzle_icons.dart';
 import 'package:lichess_mobile/src/styles/styles.dart';
 import 'package:lichess_mobile/src/utils/l10n_context.dart';
-import 'package:lichess_mobile/src/utils/navigation.dart';
 import 'package:lichess_mobile/src/utils/screen.dart';
 import 'package:lichess_mobile/src/utils/string.dart';
 import 'package:lichess_mobile/src/view/puzzle/dashboard_screen.dart';
@@ -80,11 +79,10 @@ Widget _buildMainListItem(
       return PuzzleAnglePreview(
         angle: const PuzzleTheme(PuzzleThemeKey.mix),
         onTap: () {
-          pushPlatformRoute(
+          Navigator.of(
             context,
             rootNavigator: true,
-            builder: (context) => const PuzzleScreen(angle: PuzzleTheme(PuzzleThemeKey.mix)),
-          );
+          ).push(PuzzleScreen.buildRoute(context, angle: const PuzzleTheme(PuzzleThemeKey.mix)));
         },
       );
     default:
@@ -92,11 +90,10 @@ Widget _buildMainListItem(
       return PuzzleAnglePreview(
         angle: angle,
         onTap: () {
-          pushPlatformRoute(
+          Navigator.of(
             context,
             rootNavigator: true,
-            builder: (context) => PuzzleScreen(angle: angle),
-          );
+          ).push(PuzzleScreen.buildRoute(context, angle: angle));
         },
       );
   }
@@ -399,11 +396,7 @@ class _PuzzleMenu extends ConsumerWidget {
           title: context.l10n.puzzlePuzzleThemes,
           subtitle: context.l10n.mobilePuzzleThemesSubtitle,
           onTap: () {
-            pushPlatformRoute(
-              context,
-              title: context.l10n.puzzlePuzzleThemes,
-              builder: (context) => const PuzzleThemesScreen(),
-            );
+            Navigator.of(context).push(PuzzleThemesScreen.buildRoute(context));
           },
         ),
         Opacity(
@@ -419,11 +412,10 @@ class _PuzzleMenu extends ConsumerWidget {
             onTap:
                 isOnline
                     ? () {
-                      pushPlatformRoute(
+                      Navigator.of(
                         context,
                         rootNavigator: true,
-                        builder: (context) => const StreakScreen(),
-                      );
+                      ).push(StreakScreen.buildRoute(context));
                     }
                     : null,
           ),
@@ -437,11 +429,10 @@ class _PuzzleMenu extends ConsumerWidget {
             onTap:
                 isOnline
                     ? () {
-                      pushPlatformRoute(
+                      Navigator.of(
                         context,
                         rootNavigator: true,
-                        builder: (context) => const StormScreen(),
-                      );
+                      ).push(StormScreen.buildRoute(context));
                     }
                     : null,
           ),
@@ -489,10 +480,7 @@ class PuzzleHistoryWidget extends ConsumerWidget {
               showHeader
                   ? NoPaddingTextButton(
                     onPressed:
-                        () => pushPlatformRoute(
-                          context,
-                          builder: (context) => const PuzzleHistoryScreen(),
-                        ),
+                        () => Navigator.of(context).push(PuzzleHistoryScreen.buildRoute(context)),
                     child: Text(context.l10n.more),
                   )
                   : null,
@@ -539,11 +527,7 @@ class _DashboardButton extends ConsumerWidget {
         .whenIs(
           online:
               () => () {
-                pushPlatformRoute(
-                  context,
-                  title: context.l10n.puzzlePuzzleDashboard,
-                  builder: (_) => const PuzzleDashboardScreen(),
-                );
+                Navigator.of(context).push(PuzzleDashboardScreen.buildRoute(context));
               },
           offline: () => null,
         );
@@ -570,11 +554,7 @@ class _HistoryButton extends ConsumerWidget {
         .whenIs(
           online:
               () => () {
-                pushPlatformRoute(
-                  context,
-                  title: context.l10n.puzzleHistory,
-                  builder: (_) => const PuzzleHistoryScreen(),
-                );
+                Navigator.of(context).push(PuzzleHistoryScreen.buildRoute(context));
               },
           offline: () => null,
         );
@@ -637,14 +617,12 @@ class DailyPuzzle extends ConsumerWidget {
           ),
           onTap: () {
             if (!context.mounted) return;
-            pushPlatformRoute(
-              context,
-              rootNavigator: true,
-              builder:
-                  (context) => PuzzleScreen(
-                    angle: const PuzzleTheme(PuzzleThemeKey.mix),
-                    puzzleId: data.puzzle.id,
-                  ),
+            Navigator.of(context, rootNavigator: true).push(
+              PuzzleScreen.buildRoute(
+                context,
+                angle: const PuzzleTheme(PuzzleThemeKey.mix),
+                puzzleId: data.puzzle.id,
+              ),
             );
           },
         );

--- a/lib/src/view/puzzle/puzzle_themes_screen.dart
+++ b/lib/src/view/puzzle/puzzle_themes_screen.dart
@@ -36,7 +36,7 @@ class PuzzleThemesScreen extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    return PlatformScaffold(
+    return PlatformThemedScaffold(
       appBar: PlatformAppBar(title: Text(context.l10n.puzzlePuzzleThemes)),
       body: const _Body(),
     );

--- a/lib/src/view/puzzle/puzzle_themes_screen.dart
+++ b/lib/src/view/puzzle/puzzle_themes_screen.dart
@@ -34,6 +34,14 @@ final _themesProvider = FutureProvider.autoDispose<
 class PuzzleThemesScreen extends StatelessWidget {
   const PuzzleThemesScreen({super.key});
 
+  static Route<dynamic> buildRoute(BuildContext context) {
+    return buildScreenRoute(
+      context,
+      screen: const PuzzleThemesScreen(),
+      title: context.l10n.puzzlePuzzleThemes,
+    );
+  }
+
   @override
   Widget build(BuildContext context) {
     return PlatformThemedScaffold(
@@ -75,10 +83,7 @@ class _Body extends ConsumerWidget {
                   onExpansionChanged:
                       openingsAvailable
                           ? (expanded) {
-                            pushPlatformRoute(
-                              context,
-                              builder: (ctx) => const OpeningThemeScreen(),
-                            );
+                            Navigator.of(context).push(OpeningThemeScreen.buildRoute(context));
                           }
                           : null,
                 ),
@@ -180,11 +185,10 @@ class _Category extends ConsumerWidget {
                       onTap:
                           isThemeAvailable
                               ? () {
-                                pushPlatformRoute(
+                                Navigator.of(
                                   context,
                                   rootNavigator: true,
-                                  builder: (context) => PuzzleScreen(angle: PuzzleTheme(theme)),
-                                );
+                                ).push(PuzzleScreen.buildRoute(context, angle: PuzzleTheme(theme)));
                               }
                               : null,
                     ),

--- a/lib/src/view/puzzle/puzzle_themes_screen.dart
+++ b/lib/src/view/puzzle/puzzle_themes_screen.dart
@@ -44,7 +44,7 @@ class PuzzleThemesScreen extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    return PlatformThemedScaffold(
+    return PlatformScaffold(
       appBar: PlatformAppBar(title: Text(context.l10n.puzzlePuzzleThemes)),
       body: const _Body(),
     );

--- a/lib/src/view/puzzle/storm_dashboard.dart
+++ b/lib/src/view/puzzle/storm_dashboard.dart
@@ -19,7 +19,7 @@ class StormDashboardModal extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    return PlatformScaffold(
+    return PlatformThemedScaffold(
       body: _Body(user: user),
       appBar: PlatformAppBar(
         title: Row(

--- a/lib/src/view/puzzle/storm_dashboard.dart
+++ b/lib/src/view/puzzle/storm_dashboard.dart
@@ -24,7 +24,7 @@ class StormDashboardModal extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    return PlatformThemedScaffold(
+    return PlatformScaffold(
       body: _Body(user: user),
       appBar: PlatformAppBar(
         title: Row(

--- a/lib/src/view/puzzle/storm_dashboard.dart
+++ b/lib/src/view/puzzle/storm_dashboard.dart
@@ -7,6 +7,7 @@ import 'package:lichess_mobile/src/styles/lichess_colors.dart';
 import 'package:lichess_mobile/src/styles/lichess_icons.dart';
 import 'package:lichess_mobile/src/styles/styles.dart';
 import 'package:lichess_mobile/src/utils/l10n_context.dart';
+import 'package:lichess_mobile/src/utils/navigation.dart';
 import 'package:lichess_mobile/src/widgets/list.dart';
 import 'package:lichess_mobile/src/widgets/platform_scaffold.dart';
 import 'package:lichess_mobile/src/widgets/shimmer.dart';
@@ -16,6 +17,10 @@ class StormDashboardModal extends StatelessWidget {
   const StormDashboardModal({super.key, required this.user});
 
   final LightUser user;
+
+  static Route<dynamic> buildRoute(BuildContext context, LightUser user) {
+    return buildScreenRoute(context, screen: StormDashboardModal(user: user));
+  }
 
   @override
   Widget build(BuildContext context) {

--- a/lib/src/view/puzzle/storm_screen.dart
+++ b/lib/src/view/puzzle/storm_screen.dart
@@ -36,6 +36,10 @@ import 'package:lichess_mobile/src/widgets/yes_no_dialog.dart';
 class StormScreen extends ConsumerStatefulWidget {
   const StormScreen({super.key});
 
+  static Route<dynamic> buildRoute(BuildContext context) {
+    return buildScreenRoute(context, screen: const StormScreen(), title: 'Puzzle Storm');
+  }
+
   @override
   ConsumerState<StormScreen> createState() => _StormScreenState();
 }
@@ -247,12 +251,7 @@ Future<void> _stormInfoDialogBuilder(BuildContext context) {
 }
 
 void _showStats(BuildContext context, StormRunStats stats) {
-  pushPlatformRoute(
-    context,
-    rootNavigator: true,
-    fullscreenDialog: true,
-    builder: (_) => _RunStats(stats),
-  );
+  Navigator.of(context, rootNavigator: true).push(_RunStats.buildRoute(context, stats));
 }
 
 class _TopTable extends ConsumerWidget {
@@ -567,6 +566,15 @@ class _RunStats extends StatelessWidget {
   const _RunStats(this.stats);
   final StormRunStats stats;
 
+  static Route<dynamic> buildRoute(BuildContext context, StormRunStats stats) {
+    return buildScreenRoute(
+      context,
+      screen: _RunStats(stats),
+      title: 'Storm Stats',
+      fullscreenDialog: true,
+    );
+  }
+
   @override
   Widget build(BuildContext context) {
     return PlatformThemedScaffold(
@@ -765,10 +773,8 @@ class _StormDashboardButton extends ConsumerWidget {
     return const SizedBox.shrink();
   }
 
-  void _showDashboard(BuildContext context, AuthSessionState session) => pushPlatformRoute(
+  void _showDashboard(BuildContext context, AuthSessionState session) => Navigator.of(
     context,
     rootNavigator: true,
-    fullscreenDialog: true,
-    builder: (_) => StormDashboardModal(user: session.user),
-  );
+  ).push(StormDashboardModal.buildRoute(context, session.user));
 }

--- a/lib/src/view/puzzle/storm_screen.dart
+++ b/lib/src/view/puzzle/storm_screen.dart
@@ -46,7 +46,7 @@ class _StormScreenState extends ConsumerState<StormScreen> {
   @override
   Widget build(BuildContext context) {
     return WakelockWidget(
-      child: PlatformBoardThemeScaffold(
+      child: PlatformThemedScaffold(
         appBar: PlatformAppBar(
           actions: [_StormDashboardButton(), const ToggleSoundButton()],
           title: const Text('Puzzle Storm'),
@@ -569,7 +569,7 @@ class _RunStats extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    return PlatformBoardThemeScaffold(
+    return PlatformThemedScaffold(
       body: _RunStatsPopup(stats),
       appBar: PlatformAppBar(
         leading: IconButton(

--- a/lib/src/view/puzzle/storm_screen.dart
+++ b/lib/src/view/puzzle/storm_screen.dart
@@ -50,7 +50,7 @@ class _StormScreenState extends ConsumerState<StormScreen> {
   @override
   Widget build(BuildContext context) {
     return WakelockWidget(
-      child: PlatformThemedScaffold(
+      child: PlatformScaffold(
         appBar: PlatformAppBar(
           actions: [_StormDashboardButton(), const ToggleSoundButton()],
           title: const Text('Puzzle Storm'),
@@ -577,7 +577,7 @@ class _RunStats extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    return PlatformThemedScaffold(
+    return PlatformScaffold(
       body: _RunStatsPopup(stats),
       appBar: PlatformAppBar(
         leading: IconButton(

--- a/lib/src/view/puzzle/streak_screen.dart
+++ b/lib/src/view/puzzle/streak_screen.dart
@@ -15,7 +15,6 @@ import 'package:lichess_mobile/src/model/puzzle/puzzle_streak.dart';
 import 'package:lichess_mobile/src/model/puzzle/puzzle_theme.dart';
 import 'package:lichess_mobile/src/network/http.dart';
 import 'package:lichess_mobile/src/styles/lichess_icons.dart';
-import 'package:lichess_mobile/src/styles/styles.dart';
 import 'package:lichess_mobile/src/utils/immersive_mode.dart';
 import 'package:lichess_mobile/src/utils/l10n_context.dart';
 import 'package:lichess_mobile/src/utils/navigation.dart';
@@ -38,7 +37,7 @@ class StreakScreen extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     return const WakelockWidget(
-      child: PlatformBoardThemeScaffold(
+      child: PlatformThemedScaffold(
         appBar: PlatformAppBar(actions: [ToggleSoundButton()], title: Text('Puzzle Streak')),
         body: _Load(),
       ),

--- a/lib/src/view/puzzle/streak_screen.dart
+++ b/lib/src/view/puzzle/streak_screen.dart
@@ -26,6 +26,7 @@ import 'package:lichess_mobile/src/view/settings/toggle_sound_button.dart';
 import 'package:lichess_mobile/src/widgets/board_table.dart';
 import 'package:lichess_mobile/src/widgets/bottom_bar.dart';
 import 'package:lichess_mobile/src/widgets/bottom_bar_button.dart';
+import 'package:lichess_mobile/src/widgets/platform.dart';
 import 'package:lichess_mobile/src/widgets/platform_alert_dialog.dart';
 import 'package:lichess_mobile/src/widgets/platform_scaffold.dart';
 import 'package:lichess_mobile/src/widgets/yes_no_dialog.dart';
@@ -152,19 +153,28 @@ class _Body extends ConsumerWidget {
                   child: Row(
                     mainAxisAlignment: MainAxisAlignment.spaceAround,
                     children: [
-                      Row(
-                        children: [
-                          Icon(LichessIcons.streak, size: 40.0, color: context.lichessColors.brag),
-                          const SizedBox(width: 8.0),
-                          Text(
-                            puzzleState.streak!.index.toString(),
-                            style: TextStyle(
-                              fontSize: 30.0,
-                              fontWeight: FontWeight.bold,
-                              color: context.lichessColors.brag,
-                            ),
+                      PlatformCard(
+                        child: Padding(
+                          padding: const EdgeInsets.all(8.0),
+                          child: Row(
+                            children: [
+                              Icon(
+                                LichessIcons.streak,
+                                size: 50.0,
+                                color: ColorScheme.of(context).primary,
+                              ),
+                              const SizedBox(width: 8.0),
+                              Text(
+                                puzzleState.streak!.index.toString(),
+                                style: TextStyle(
+                                  fontSize: 30.0,
+                                  fontWeight: FontWeight.bold,
+                                  color: ColorScheme.of(context).primary,
+                                ),
+                              ),
+                            ],
                           ),
-                        ],
+                        ),
                       ),
                       Text(context.l10n.puzzleRatingX(puzzleState.puzzle.puzzle.rating.toString())),
                     ],

--- a/lib/src/view/puzzle/streak_screen.dart
+++ b/lib/src/view/puzzle/streak_screen.dart
@@ -41,7 +41,7 @@ class StreakScreen extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     return const WakelockWidget(
-      child: PlatformThemedScaffold(
+      child: PlatformScaffold(
         appBar: PlatformAppBar(actions: [ToggleSoundButton()], title: Text('Puzzle Streak')),
         body: _Load(),
       ),

--- a/lib/src/view/puzzle/streak_screen.dart
+++ b/lib/src/view/puzzle/streak_screen.dart
@@ -34,6 +34,10 @@ import 'package:result_extensions/result_extensions.dart';
 class StreakScreen extends StatelessWidget {
   const StreakScreen({super.key});
 
+  static Route<dynamic> buildRoute(BuildContext context) {
+    return buildScreenRoute(context, title: 'Puzzle Streak', screen: const StreakScreen());
+  }
+
   @override
   Widget build(BuildContext context) {
     return const WakelockWidget(
@@ -260,20 +264,19 @@ class _BottomBar extends ConsumerWidget {
         if (puzzleState.streak!.finished)
           BottomBarButton(
             onTap: () {
-              pushPlatformRoute(
-                context,
-                builder:
-                    (context) => AnalysisScreen(
-                      options: AnalysisOptions(
-                        orientation: puzzleState.pov,
-                        standalone: (
-                          pgn: ref.read(ctrlProvider.notifier).makePgn(),
-                          isComputerAnalysisAllowed: true,
-                          variant: Variant.standard,
-                        ),
-                        initialMoveCursor: 0,
-                      ),
+              Navigator.of(context, rootNavigator: true).push(
+                AnalysisScreen.buildRoute(
+                  context,
+                  AnalysisOptions(
+                    orientation: puzzleState.pov,
+                    standalone: (
+                      pgn: ref.read(ctrlProvider.notifier).makePgn(),
+                      isComputerAnalysisAllowed: true,
+                      variant: Variant.standard,
                     ),
+                    initialMoveCursor: 0,
+                  ),
+                ),
               );
             },
             label: context.l10n.analysis,

--- a/lib/src/view/relation/following_screen.dart
+++ b/lib/src/view/relation/following_screen.dart
@@ -27,6 +27,11 @@ final _getFollowingAndOnlinesProvider = FutureProvider.autoDispose<(IList<User>,
 
 class FollowingScreen extends StatelessWidget {
   const FollowingScreen({super.key});
+
+  static Route<dynamic> buildRoute(BuildContext context) {
+    return buildScreenRoute(context, title: context.l10n.friends, screen: const FollowingScreen());
+  }
+
   @override
   Widget build(BuildContext context) {
     return PlatformThemedScaffold(
@@ -97,10 +102,9 @@ class _Body extends ConsumerWidget {
                       _isOnline(user, data.$2),
                       onTap:
                           () => {
-                            pushPlatformRoute(
+                            Navigator.of(
                               context,
-                              builder: (context) => UserScreen(user: user.lightUser),
-                            ),
+                            ).push(UserScreen.buildRoute(context, user.lightUser)),
                           },
                     ),
                   );

--- a/lib/src/view/relation/following_screen.dart
+++ b/lib/src/view/relation/following_screen.dart
@@ -29,7 +29,7 @@ class FollowingScreen extends StatelessWidget {
   const FollowingScreen({super.key});
   @override
   Widget build(BuildContext context) {
-    return PlatformScaffold(
+    return PlatformThemedScaffold(
       backgroundColor: Styles.listingsScreenBackgroundColor(context),
       appBar: PlatformAppBar(title: Text(context.l10n.friends)),
       body: const _Body(),

--- a/lib/src/view/relation/following_screen.dart
+++ b/lib/src/view/relation/following_screen.dart
@@ -34,7 +34,7 @@ class FollowingScreen extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    return PlatformThemedScaffold(
+    return PlatformScaffold(
       backgroundColor: Styles.listingsScreenBackgroundColor(context),
       appBar: PlatformAppBar(title: Text(context.l10n.friends)),
       body: const _Body(),

--- a/lib/src/view/settings/account_preferences_screen.dart
+++ b/lib/src/view/settings/account_preferences_screen.dart
@@ -5,7 +5,7 @@ import 'package:lichess_mobile/src/model/account/account_preferences.dart';
 import 'package:lichess_mobile/src/utils/l10n_context.dart';
 import 'package:lichess_mobile/src/utils/navigation.dart';
 import 'package:lichess_mobile/src/widgets/adaptive_choice_picker.dart';
-import 'package:lichess_mobile/src/widgets/background_theme.dart';
+import 'package:lichess_mobile/src/widgets/background.dart';
 import 'package:lichess_mobile/src/widgets/feedback.dart';
 import 'package:lichess_mobile/src/widgets/list.dart';
 import 'package:lichess_mobile/src/widgets/platform_scaffold.dart';
@@ -437,8 +437,8 @@ class _ZenSettingsScreenState extends ConsumerState<ZenSettingsScreen> {
           return Center(child: Text(context.l10n.mobileMustBeLoggedIn));
         }
 
-        return FullScreenBackgroundTheme(
-          child: FullScreenBackgroundTheme(
+        return FullScreenBackground(
+          child: FullScreenBackground(
             child: CupertinoPageScaffold(
               navigationBar: CupertinoNavigationBar(
                 trailing: isLoading ? const CircularProgressIndicator.adaptive() : null,
@@ -501,7 +501,7 @@ class _PieceNotationSettingsScreenState extends ConsumerState<PieceNotationSetti
         return FutureBuilder(
           future: _pendingSetPieceNotation,
           builder: (context, snapshot) {
-            return FullScreenBackgroundTheme(
+            return FullScreenBackground(
               child: CupertinoPageScaffold(
                 navigationBar: CupertinoNavigationBar(
                   trailing:
@@ -562,7 +562,7 @@ class _ShowRatingsSettingsScreenState extends ConsumerState<ShowRatingsSettingsS
         return FutureBuilder(
           future: _pendingSetShowRatings,
           builder: (context, snapshot) {
-            return FullScreenBackgroundTheme(
+            return FullScreenBackground(
               child: CupertinoPageScaffold(
                 navigationBar: CupertinoNavigationBar(
                   trailing:
@@ -620,7 +620,7 @@ class _TakebackSettingsScreenState extends ConsumerState<TakebackSettingsScreen>
           return Center(child: Text(context.l10n.mobileMustBeLoggedIn));
         }
 
-        return FullScreenBackgroundTheme(
+        return FullScreenBackground(
           child: CupertinoPageScaffold(
             navigationBar: CupertinoNavigationBar(
               trailing: isLoading ? const CircularProgressIndicator.adaptive() : null,
@@ -682,7 +682,7 @@ class _AutoQueenSettingsScreenState extends ConsumerState<AutoQueenSettingsScree
         return FutureBuilder(
           future: _pendingSetAutoQueen,
           builder: (context, snapshot) {
-            return FullScreenBackgroundTheme(
+            return FullScreenBackground(
               child: CupertinoPageScaffold(
                 navigationBar: CupertinoNavigationBar(
                   trailing:
@@ -743,7 +743,7 @@ class _AutoThreefoldSettingsScreenState extends ConsumerState<AutoThreefoldSetti
         return FutureBuilder(
           future: _pendingSetAutoThreefold,
           builder: (context, snapshot) {
-            return FullScreenBackgroundTheme(
+            return FullScreenBackground(
               child: CupertinoPageScaffold(
                 navigationBar: CupertinoNavigationBar(
                   trailing:
@@ -804,7 +804,7 @@ class _MoretimeSettingsScreenState extends ConsumerState<MoretimeSettingsScreen>
         return FutureBuilder(
           future: _pendingSetMoretime,
           builder: (context, snapshot) {
-            return FullScreenBackgroundTheme(
+            return FullScreenBackground(
               child: CupertinoPageScaffold(
                 navigationBar: CupertinoNavigationBar(
                   trailing:
@@ -864,7 +864,7 @@ class _ChallengeSettingsScreenState extends ConsumerState<_ChallengeSettingsScre
         return FutureBuilder(
           future: _pendingSetChallenge,
           builder: (context, snapshot) {
-            return FullScreenBackgroundTheme(
+            return FullScreenBackground(
               child: CupertinoPageScaffold(
                 navigationBar: CupertinoNavigationBar(
                   trailing:

--- a/lib/src/view/settings/account_preferences_screen.dart
+++ b/lib/src/view/settings/account_preferences_screen.dart
@@ -5,7 +5,6 @@ import 'package:lichess_mobile/src/model/account/account_preferences.dart';
 import 'package:lichess_mobile/src/utils/l10n_context.dart';
 import 'package:lichess_mobile/src/utils/navigation.dart';
 import 'package:lichess_mobile/src/widgets/adaptive_choice_picker.dart';
-import 'package:lichess_mobile/src/widgets/background.dart';
 import 'package:lichess_mobile/src/widgets/feedback.dart';
 import 'package:lichess_mobile/src/widgets/list.dart';
 import 'package:lichess_mobile/src/widgets/platform_scaffold.dart';
@@ -384,7 +383,7 @@ class _AccountPreferencesScreenState extends ConsumerState<AccountPreferencesScr
       },
     );
 
-    return PlatformThemedScaffold(
+    return PlatformScaffold(
       appBar: PlatformAppBar(
         title: Text(context.l10n.preferencesPreferences),
         actions: [if (isLoading) const PlatformAppBarLoadingIndicator()],
@@ -421,39 +420,35 @@ class _ZenSettingsScreenState extends ConsumerState<ZenSettingsScreen> {
           return Center(child: Text(context.l10n.mobileMustBeLoggedIn));
         }
 
-        return FullScreenBackground(
-          child: FullScreenBackground(
-            child: CupertinoPageScaffold(
-              navigationBar: CupertinoNavigationBar(
-                trailing: isLoading ? const CircularProgressIndicator.adaptive() : null,
+        return CupertinoPageScaffold(
+          navigationBar: CupertinoNavigationBar(
+            trailing: isLoading ? const CircularProgressIndicator.adaptive() : null,
+          ),
+          child: ListView(
+            children: [
+              ChoicePicker(
+                choices: Zen.values,
+                selectedItem: data.zenMode,
+                titleBuilder: (t) => Text(t.label(context)),
+                onSelectedItemChanged:
+                    isLoading
+                        ? null
+                        : (Zen? v) async {
+                          setState(() {
+                            isLoading = true;
+                          });
+                          try {
+                            await ref
+                                .read(accountPreferencesProvider.notifier)
+                                .setZen(v ?? data.zenMode);
+                          } finally {
+                            setState(() {
+                              isLoading = false;
+                            });
+                          }
+                        },
               ),
-              child: ListView(
-                children: [
-                  ChoicePicker(
-                    choices: Zen.values,
-                    selectedItem: data.zenMode,
-                    titleBuilder: (t) => Text(t.label(context)),
-                    onSelectedItemChanged:
-                        isLoading
-                            ? null
-                            : (Zen? v) async {
-                              setState(() {
-                                isLoading = true;
-                              });
-                              try {
-                                await ref
-                                    .read(accountPreferencesProvider.notifier)
-                                    .setZen(v ?? data.zenMode);
-                              } finally {
-                                setState(() {
-                                  isLoading = false;
-                                });
-                              }
-                            },
-                  ),
-                ],
-              ),
-            ),
+            ],
           ),
         );
       },
@@ -493,34 +488,32 @@ class _PieceNotationSettingsScreenState extends ConsumerState<PieceNotationSetti
         return FutureBuilder(
           future: _pendingSetPieceNotation,
           builder: (context, snapshot) {
-            return FullScreenBackground(
-              child: CupertinoPageScaffold(
-                navigationBar: CupertinoNavigationBar(
-                  trailing:
-                      snapshot.connectionState == ConnectionState.waiting
-                          ? const CircularProgressIndicator.adaptive()
-                          : null,
-                ),
-                child: ListView(
-                  children: [
-                    ChoicePicker(
-                      choices: PieceNotation.values,
-                      selectedItem: data.pieceNotation,
-                      titleBuilder: (t) => Text(t.label(context)),
-                      onSelectedItemChanged:
-                          snapshot.connectionState == ConnectionState.waiting
-                              ? null
-                              : (PieceNotation? v) {
-                                final future = ref
-                                    .read(accountPreferencesProvider.notifier)
-                                    .setPieceNotation(v ?? data.pieceNotation);
-                                setState(() {
-                                  _pendingSetPieceNotation = future;
-                                });
-                              },
-                    ),
-                  ],
-                ),
+            return CupertinoPageScaffold(
+              navigationBar: CupertinoNavigationBar(
+                trailing:
+                    snapshot.connectionState == ConnectionState.waiting
+                        ? const CircularProgressIndicator.adaptive()
+                        : null,
+              ),
+              child: ListView(
+                children: [
+                  ChoicePicker(
+                    choices: PieceNotation.values,
+                    selectedItem: data.pieceNotation,
+                    titleBuilder: (t) => Text(t.label(context)),
+                    onSelectedItemChanged:
+                        snapshot.connectionState == ConnectionState.waiting
+                            ? null
+                            : (PieceNotation? v) {
+                              final future = ref
+                                  .read(accountPreferencesProvider.notifier)
+                                  .setPieceNotation(v ?? data.pieceNotation);
+                              setState(() {
+                                _pendingSetPieceNotation = future;
+                              });
+                            },
+                  ),
+                ],
               ),
             );
           },
@@ -562,34 +555,32 @@ class _ShowRatingsSettingsScreenState extends ConsumerState<ShowRatingsSettingsS
         return FutureBuilder(
           future: _pendingSetShowRatings,
           builder: (context, snapshot) {
-            return FullScreenBackground(
-              child: CupertinoPageScaffold(
-                navigationBar: CupertinoNavigationBar(
-                  trailing:
-                      snapshot.connectionState == ConnectionState.waiting
-                          ? const CircularProgressIndicator.adaptive()
-                          : null,
-                ),
-                child: ListView(
-                  children: [
-                    ChoicePicker(
-                      choices: ShowRatings.values,
-                      selectedItem: data.showRatings,
-                      titleBuilder: (t) => Text(t.label(context)),
-                      onSelectedItemChanged:
-                          snapshot.connectionState == ConnectionState.waiting
-                              ? null
-                              : (ShowRatings? v) {
-                                final future = ref
-                                    .read(accountPreferencesProvider.notifier)
-                                    .setShowRatings(v ?? data.showRatings);
-                                setState(() {
-                                  _pendingSetShowRatings = future;
-                                });
-                              },
-                    ),
-                  ],
-                ),
+            return CupertinoPageScaffold(
+              navigationBar: CupertinoNavigationBar(
+                trailing:
+                    snapshot.connectionState == ConnectionState.waiting
+                        ? const CircularProgressIndicator.adaptive()
+                        : null,
+              ),
+              child: ListView(
+                children: [
+                  ChoicePicker(
+                    choices: ShowRatings.values,
+                    selectedItem: data.showRatings,
+                    titleBuilder: (t) => Text(t.label(context)),
+                    onSelectedItemChanged:
+                        snapshot.connectionState == ConnectionState.waiting
+                            ? null
+                            : (ShowRatings? v) {
+                              final future = ref
+                                  .read(accountPreferencesProvider.notifier)
+                                  .setShowRatings(v ?? data.showRatings);
+                              setState(() {
+                                _pendingSetShowRatings = future;
+                              });
+                            },
+                  ),
+                ],
               ),
             );
           },
@@ -628,37 +619,35 @@ class _TakebackSettingsScreenState extends ConsumerState<TakebackSettingsScreen>
           return Center(child: Text(context.l10n.mobileMustBeLoggedIn));
         }
 
-        return FullScreenBackground(
-          child: CupertinoPageScaffold(
-            navigationBar: CupertinoNavigationBar(
-              trailing: isLoading ? const CircularProgressIndicator.adaptive() : null,
-            ),
-            child: ListView(
-              children: [
-                ChoicePicker(
-                  choices: Takeback.values,
-                  selectedItem: data.takeback,
-                  titleBuilder: (t) => Text(t.label(context)),
-                  onSelectedItemChanged:
-                      isLoading
-                          ? null
-                          : (Takeback? v) async {
+        return CupertinoPageScaffold(
+          navigationBar: CupertinoNavigationBar(
+            trailing: isLoading ? const CircularProgressIndicator.adaptive() : null,
+          ),
+          child: ListView(
+            children: [
+              ChoicePicker(
+                choices: Takeback.values,
+                selectedItem: data.takeback,
+                titleBuilder: (t) => Text(t.label(context)),
+                onSelectedItemChanged:
+                    isLoading
+                        ? null
+                        : (Takeback? v) async {
+                          setState(() {
+                            isLoading = true;
+                          });
+                          try {
+                            await ref
+                                .read(accountPreferencesProvider.notifier)
+                                .setTakeback(v ?? data.takeback);
+                          } finally {
                             setState(() {
-                              isLoading = true;
+                              isLoading = false;
                             });
-                            try {
-                              await ref
-                                  .read(accountPreferencesProvider.notifier)
-                                  .setTakeback(v ?? data.takeback);
-                            } finally {
-                              setState(() {
-                                isLoading = false;
-                              });
-                            }
-                          },
-                ),
-              ],
-            ),
+                          }
+                        },
+              ),
+            ],
           ),
         );
       },
@@ -698,34 +687,32 @@ class _AutoQueenSettingsScreenState extends ConsumerState<AutoQueenSettingsScree
         return FutureBuilder(
           future: _pendingSetAutoQueen,
           builder: (context, snapshot) {
-            return FullScreenBackground(
-              child: CupertinoPageScaffold(
-                navigationBar: CupertinoNavigationBar(
-                  trailing:
-                      snapshot.connectionState == ConnectionState.waiting
-                          ? const CircularProgressIndicator.adaptive()
-                          : null,
-                ),
-                child: ListView(
-                  children: [
-                    ChoicePicker(
-                      choices: AutoQueen.values,
-                      selectedItem: data.autoQueen,
-                      titleBuilder: (t) => Text(t.label(context)),
-                      onSelectedItemChanged:
-                          snapshot.connectionState == ConnectionState.waiting
-                              ? null
-                              : (AutoQueen? v) {
-                                final future = ref
-                                    .read(accountPreferencesProvider.notifier)
-                                    .setAutoQueen(v ?? data.autoQueen);
-                                setState(() {
-                                  _pendingSetAutoQueen = future;
-                                });
-                              },
-                    ),
-                  ],
-                ),
+            return CupertinoPageScaffold(
+              navigationBar: CupertinoNavigationBar(
+                trailing:
+                    snapshot.connectionState == ConnectionState.waiting
+                        ? const CircularProgressIndicator.adaptive()
+                        : null,
+              ),
+              child: ListView(
+                children: [
+                  ChoicePicker(
+                    choices: AutoQueen.values,
+                    selectedItem: data.autoQueen,
+                    titleBuilder: (t) => Text(t.label(context)),
+                    onSelectedItemChanged:
+                        snapshot.connectionState == ConnectionState.waiting
+                            ? null
+                            : (AutoQueen? v) {
+                              final future = ref
+                                  .read(accountPreferencesProvider.notifier)
+                                  .setAutoQueen(v ?? data.autoQueen);
+                              setState(() {
+                                _pendingSetAutoQueen = future;
+                              });
+                            },
+                  ),
+                ],
               ),
             );
           },
@@ -767,34 +754,32 @@ class _AutoThreefoldSettingsScreenState extends ConsumerState<AutoThreefoldSetti
         return FutureBuilder(
           future: _pendingSetAutoThreefold,
           builder: (context, snapshot) {
-            return FullScreenBackground(
-              child: CupertinoPageScaffold(
-                navigationBar: CupertinoNavigationBar(
-                  trailing:
-                      snapshot.connectionState == ConnectionState.waiting
-                          ? const CircularProgressIndicator.adaptive()
-                          : null,
-                ),
-                child: ListView(
-                  children: [
-                    ChoicePicker(
-                      choices: AutoThreefold.values,
-                      selectedItem: data.autoThreefold,
-                      titleBuilder: (t) => Text(t.label(context)),
-                      onSelectedItemChanged:
-                          snapshot.connectionState == ConnectionState.waiting
-                              ? null
-                              : (AutoThreefold? v) {
-                                final future = ref
-                                    .read(accountPreferencesProvider.notifier)
-                                    .setAutoThreefold(v ?? data.autoThreefold);
-                                setState(() {
-                                  _pendingSetAutoThreefold = future;
-                                });
-                              },
-                    ),
-                  ],
-                ),
+            return CupertinoPageScaffold(
+              navigationBar: CupertinoNavigationBar(
+                trailing:
+                    snapshot.connectionState == ConnectionState.waiting
+                        ? const CircularProgressIndicator.adaptive()
+                        : null,
+              ),
+              child: ListView(
+                children: [
+                  ChoicePicker(
+                    choices: AutoThreefold.values,
+                    selectedItem: data.autoThreefold,
+                    titleBuilder: (t) => Text(t.label(context)),
+                    onSelectedItemChanged:
+                        snapshot.connectionState == ConnectionState.waiting
+                            ? null
+                            : (AutoThreefold? v) {
+                              final future = ref
+                                  .read(accountPreferencesProvider.notifier)
+                                  .setAutoThreefold(v ?? data.autoThreefold);
+                              setState(() {
+                                _pendingSetAutoThreefold = future;
+                              });
+                            },
+                  ),
+                ],
               ),
             );
           },
@@ -836,33 +821,31 @@ class _MoretimeSettingsScreenState extends ConsumerState<MoretimeSettingsScreen>
         return FutureBuilder(
           future: _pendingSetMoretime,
           builder: (context, snapshot) {
-            return FullScreenBackground(
-              child: CupertinoPageScaffold(
-                navigationBar: CupertinoNavigationBar(
-                  trailing:
-                      snapshot.connectionState == ConnectionState.waiting
-                          ? const CircularProgressIndicator.adaptive()
-                          : null,
-                ),
-                child: ListView(
-                  children: [
-                    ChoicePicker(
-                      choices: Moretime.values,
-                      selectedItem: data.moretime,
-                      titleBuilder: (t) => Text(t.label(context)),
-                      onSelectedItemChanged:
-                          snapshot.connectionState == ConnectionState.waiting
-                              ? null
-                              : (Moretime? v) {
-                                setState(() {
-                                  _pendingSetMoretime = ref
-                                      .read(accountPreferencesProvider.notifier)
-                                      .setMoretime(v ?? data.moretime);
-                                });
-                              },
-                    ),
-                  ],
-                ),
+            return CupertinoPageScaffold(
+              navigationBar: CupertinoNavigationBar(
+                trailing:
+                    snapshot.connectionState == ConnectionState.waiting
+                        ? const CircularProgressIndicator.adaptive()
+                        : null,
+              ),
+              child: ListView(
+                children: [
+                  ChoicePicker(
+                    choices: Moretime.values,
+                    selectedItem: data.moretime,
+                    titleBuilder: (t) => Text(t.label(context)),
+                    onSelectedItemChanged:
+                        snapshot.connectionState == ConnectionState.waiting
+                            ? null
+                            : (Moretime? v) {
+                              setState(() {
+                                _pendingSetMoretime = ref
+                                    .read(accountPreferencesProvider.notifier)
+                                    .setMoretime(v ?? data.moretime);
+                              });
+                            },
+                  ),
+                ],
               ),
             );
           },
@@ -904,34 +887,32 @@ class _ChallengeSettingsScreenState extends ConsumerState<_ChallengeSettingsScre
         return FutureBuilder(
           future: _pendingSetChallenge,
           builder: (context, snapshot) {
-            return FullScreenBackground(
-              child: CupertinoPageScaffold(
-                navigationBar: CupertinoNavigationBar(
-                  trailing:
-                      snapshot.connectionState == ConnectionState.waiting
-                          ? const CircularProgressIndicator.adaptive()
-                          : null,
-                ),
-                child: ListView(
-                  children: [
-                    ChoicePicker(
-                      choices: Challenge.values,
-                      selectedItem: data.challenge,
-                      titleBuilder: (t) => Text(t.label(context)),
-                      onSelectedItemChanged:
-                          snapshot.connectionState == ConnectionState.waiting
-                              ? null
-                              : (Challenge? v) {
-                                final future = ref
-                                    .read(accountPreferencesProvider.notifier)
-                                    .setChallenge(v ?? data.challenge);
-                                setState(() {
-                                  _pendingSetChallenge = future;
-                                });
-                              },
-                    ),
-                  ],
-                ),
+            return CupertinoPageScaffold(
+              navigationBar: CupertinoNavigationBar(
+                trailing:
+                    snapshot.connectionState == ConnectionState.waiting
+                        ? const CircularProgressIndicator.adaptive()
+                        : null,
+              ),
+              child: ListView(
+                children: [
+                  ChoicePicker(
+                    choices: Challenge.values,
+                    selectedItem: data.challenge,
+                    titleBuilder: (t) => Text(t.label(context)),
+                    onSelectedItemChanged:
+                        snapshot.connectionState == ConnectionState.waiting
+                            ? null
+                            : (Challenge? v) {
+                              final future = ref
+                                  .read(accountPreferencesProvider.notifier)
+                                  .setChallenge(v ?? data.challenge);
+                              setState(() {
+                                _pendingSetChallenge = future;
+                              });
+                            },
+                  ),
+                ],
               ),
             );
           },

--- a/lib/src/view/settings/account_preferences_screen.dart
+++ b/lib/src/view/settings/account_preferences_screen.dart
@@ -14,6 +14,14 @@ import 'package:lichess_mobile/src/widgets/settings.dart';
 class AccountPreferencesScreen extends ConsumerStatefulWidget {
   const AccountPreferencesScreen({super.key});
 
+  static Route<dynamic> buildRoute(BuildContext context) {
+    return buildScreenRoute(
+      context,
+      screen: const AccountPreferencesScreen(),
+      title: context.l10n.preferencesPreferences,
+    );
+  }
+
   @override
   ConsumerState<AccountPreferencesScreen> createState() => _AccountPreferencesScreenState();
 }
@@ -73,11 +81,7 @@ class _AccountPreferencesScreenState extends ConsumerState<AccountPreferencesScr
                                 },
                       );
                     } else {
-                      pushPlatformRoute(
-                        context,
-                        title: context.l10n.preferencesZenMode,
-                        builder: (context) => const ZenSettingsScreen(),
-                      );
+                      Navigator.of(context).push(ZenSettingsScreen.buildRoute(context));
                     }
                   },
                 ),
@@ -104,11 +108,7 @@ class _AccountPreferencesScreenState extends ConsumerState<AccountPreferencesScr
                                 },
                       );
                     } else {
-                      pushPlatformRoute(
-                        context,
-                        title: context.l10n.preferencesPgnPieceNotation,
-                        builder: (context) => const PieceNotationSettingsScreen(),
-                      );
+                      Navigator.of(context).push(PieceNotationSettingsScreen.buildRoute(context));
                     }
                   },
                 ),
@@ -135,11 +135,7 @@ class _AccountPreferencesScreenState extends ConsumerState<AccountPreferencesScr
                                 },
                       );
                     } else {
-                      pushPlatformRoute(
-                        context,
-                        title: context.l10n.preferencesShowPlayerRatings,
-                        builder: (context) => const ShowRatingsSettingsScreen(),
-                      );
+                      Navigator.of(context).push(ShowRatingsSettingsScreen.buildRoute(context));
                     }
                   },
                   explanation: context.l10n.preferencesExplainShowPlayerRatings,
@@ -201,11 +197,7 @@ class _AccountPreferencesScreenState extends ConsumerState<AccountPreferencesScr
                                 },
                       );
                     } else {
-                      pushPlatformRoute(
-                        context,
-                        title: context.l10n.preferencesTakebacksWithOpponentApproval,
-                        builder: (context) => const TakebackSettingsScreen(),
-                      );
+                      Navigator.of(context).push(TakebackSettingsScreen.buildRoute(context));
                     }
                   },
                 ),
@@ -232,11 +224,7 @@ class _AccountPreferencesScreenState extends ConsumerState<AccountPreferencesScr
                                 },
                       );
                     } else {
-                      pushPlatformRoute(
-                        context,
-                        title: context.l10n.preferencesPromoteToQueenAutomatically,
-                        builder: (context) => const AutoQueenSettingsScreen(),
-                      );
+                      Navigator.of(context).push(AutoQueenSettingsScreen.buildRoute(context));
                     }
                   },
                 ),
@@ -265,11 +253,7 @@ class _AccountPreferencesScreenState extends ConsumerState<AccountPreferencesScr
                                 },
                       );
                     } else {
-                      pushPlatformRoute(
-                        context,
-                        title: context.l10n.preferencesClaimDrawOnThreefoldRepetitionAutomatically,
-                        builder: (context) => const AutoThreefoldSettingsScreen(),
-                      );
+                      Navigator.of(context).push(AutoThreefoldSettingsScreen.buildRoute(context));
                     }
                   },
                 ),
@@ -324,11 +308,7 @@ class _AccountPreferencesScreenState extends ConsumerState<AccountPreferencesScr
                                 },
                       );
                     } else {
-                      pushPlatformRoute(
-                        context,
-                        title: context.l10n.preferencesGiveMoreTime,
-                        builder: (context) => const MoretimeSettingsScreen(),
-                      );
+                      Navigator.of(context).push(MoretimeSettingsScreen.buildRoute(context));
                     }
                   },
                 ),
@@ -389,11 +369,7 @@ class _AccountPreferencesScreenState extends ConsumerState<AccountPreferencesScr
                                 },
                       );
                     } else {
-                      pushPlatformRoute(
-                        context,
-                        title: context.l10n.letOtherPlayersChallengeYou,
-                        builder: (context) => const _ChallengeSettingsScreen(),
-                      );
+                      Navigator.of(context).push(_ChallengeSettingsScreen.buildRoute(context));
                     }
                   },
                 ),
@@ -420,6 +396,14 @@ class _AccountPreferencesScreenState extends ConsumerState<AccountPreferencesScr
 
 class ZenSettingsScreen extends ConsumerStatefulWidget {
   const ZenSettingsScreen({super.key});
+
+  static Route<dynamic> buildRoute(BuildContext context) {
+    return buildScreenRoute(
+      context,
+      screen: const ZenSettingsScreen(),
+      title: context.l10n.preferencesZenMode,
+    );
+  }
 
   @override
   ConsumerState<ZenSettingsScreen> createState() => _ZenSettingsScreenState();
@@ -482,6 +466,14 @@ class _ZenSettingsScreenState extends ConsumerState<ZenSettingsScreen> {
 class PieceNotationSettingsScreen extends ConsumerStatefulWidget {
   const PieceNotationSettingsScreen({super.key});
 
+  static Route<dynamic> buildRoute(BuildContext context) {
+    return buildScreenRoute(
+      context,
+      screen: const PieceNotationSettingsScreen(),
+      title: context.l10n.preferencesPgnPieceNotation,
+    );
+  }
+
   @override
   ConsumerState<PieceNotationSettingsScreen> createState() => _PieceNotationSettingsScreenState();
 }
@@ -542,6 +534,14 @@ class _PieceNotationSettingsScreenState extends ConsumerState<PieceNotationSetti
 
 class ShowRatingsSettingsScreen extends ConsumerStatefulWidget {
   const ShowRatingsSettingsScreen({super.key});
+
+  static Route<dynamic> buildRoute(BuildContext context) {
+    return buildScreenRoute(
+      context,
+      screen: const ShowRatingsSettingsScreen(),
+      title: context.l10n.preferencesShowPlayerRatings,
+    );
+  }
 
   @override
   ConsumerState<ShowRatingsSettingsScreen> createState() => _ShowRatingsSettingsScreenState();
@@ -604,6 +604,14 @@ class _ShowRatingsSettingsScreenState extends ConsumerState<ShowRatingsSettingsS
 class TakebackSettingsScreen extends ConsumerStatefulWidget {
   const TakebackSettingsScreen({super.key});
 
+  static Route<dynamic> buildRoute(BuildContext context) {
+    return buildScreenRoute(
+      context,
+      screen: const TakebackSettingsScreen(),
+      title: context.l10n.preferencesTakebacksWithOpponentApproval,
+    );
+  }
+
   @override
   ConsumerState<TakebackSettingsScreen> createState() => _TakebackSettingsScreenState();
 }
@@ -662,6 +670,14 @@ class _TakebackSettingsScreenState extends ConsumerState<TakebackSettingsScreen>
 
 class AutoQueenSettingsScreen extends ConsumerStatefulWidget {
   const AutoQueenSettingsScreen({super.key});
+
+  static Route<dynamic> buildRoute(BuildContext context) {
+    return buildScreenRoute(
+      context,
+      screen: const AutoQueenSettingsScreen(),
+      title: context.l10n.preferencesPromoteToQueenAutomatically,
+    );
+  }
 
   @override
   ConsumerState<AutoQueenSettingsScreen> createState() => _AutoQueenSettingsScreenState();
@@ -724,6 +740,14 @@ class _AutoQueenSettingsScreenState extends ConsumerState<AutoQueenSettingsScree
 class AutoThreefoldSettingsScreen extends ConsumerStatefulWidget {
   const AutoThreefoldSettingsScreen({super.key});
 
+  static Route<dynamic> buildRoute(BuildContext context) {
+    return buildScreenRoute(
+      context,
+      screen: const AutoThreefoldSettingsScreen(),
+      title: context.l10n.preferencesClaimDrawOnThreefoldRepetitionAutomatically,
+    );
+  }
+
   @override
   ConsumerState<AutoThreefoldSettingsScreen> createState() => _AutoThreefoldSettingsScreenState();
 }
@@ -785,6 +809,14 @@ class _AutoThreefoldSettingsScreenState extends ConsumerState<AutoThreefoldSetti
 class MoretimeSettingsScreen extends ConsumerStatefulWidget {
   const MoretimeSettingsScreen({super.key});
 
+  static Route<dynamic> buildRoute(BuildContext context) {
+    return buildScreenRoute(
+      context,
+      screen: const MoretimeSettingsScreen(),
+      title: context.l10n.preferencesGiveMoreTime,
+    );
+  }
+
   @override
   ConsumerState<MoretimeSettingsScreen> createState() => _MoretimeSettingsScreenState();
 }
@@ -844,6 +876,14 @@ class _MoretimeSettingsScreenState extends ConsumerState<MoretimeSettingsScreen>
 
 class _ChallengeSettingsScreen extends ConsumerStatefulWidget {
   const _ChallengeSettingsScreen();
+
+  static Route<dynamic> buildRoute(BuildContext context) {
+    return buildScreenRoute(
+      context,
+      screen: const _ChallengeSettingsScreen(),
+      title: context.l10n.letOtherPlayersChallengeYou,
+    );
+  }
 
   @override
   ConsumerState<_ChallengeSettingsScreen> createState() => _ChallengeSettingsScreenState();

--- a/lib/src/view/settings/account_preferences_screen.dart
+++ b/lib/src/view/settings/account_preferences_screen.dart
@@ -5,6 +5,7 @@ import 'package:lichess_mobile/src/model/account/account_preferences.dart';
 import 'package:lichess_mobile/src/utils/l10n_context.dart';
 import 'package:lichess_mobile/src/utils/navigation.dart';
 import 'package:lichess_mobile/src/widgets/adaptive_choice_picker.dart';
+import 'package:lichess_mobile/src/widgets/background_theme.dart';
 import 'package:lichess_mobile/src/widgets/feedback.dart';
 import 'package:lichess_mobile/src/widgets/list.dart';
 import 'package:lichess_mobile/src/widgets/platform_scaffold.dart';
@@ -436,35 +437,39 @@ class _ZenSettingsScreenState extends ConsumerState<ZenSettingsScreen> {
           return Center(child: Text(context.l10n.mobileMustBeLoggedIn));
         }
 
-        return CupertinoPageScaffold(
-          navigationBar: CupertinoNavigationBar(
-            trailing: isLoading ? const CircularProgressIndicator.adaptive() : null,
-          ),
-          child: ListView(
-            children: [
-              ChoicePicker(
-                choices: Zen.values,
-                selectedItem: data.zenMode,
-                titleBuilder: (t) => Text(t.label(context)),
-                onSelectedItemChanged:
-                    isLoading
-                        ? null
-                        : (Zen? v) async {
-                          setState(() {
-                            isLoading = true;
-                          });
-                          try {
-                            await ref
-                                .read(accountPreferencesProvider.notifier)
-                                .setZen(v ?? data.zenMode);
-                          } finally {
-                            setState(() {
-                              isLoading = false;
-                            });
-                          }
-                        },
+        return FullScreenBackgroundTheme(
+          child: FullScreenBackgroundTheme(
+            child: CupertinoPageScaffold(
+              navigationBar: CupertinoNavigationBar(
+                trailing: isLoading ? const CircularProgressIndicator.adaptive() : null,
               ),
-            ],
+              child: ListView(
+                children: [
+                  ChoicePicker(
+                    choices: Zen.values,
+                    selectedItem: data.zenMode,
+                    titleBuilder: (t) => Text(t.label(context)),
+                    onSelectedItemChanged:
+                        isLoading
+                            ? null
+                            : (Zen? v) async {
+                              setState(() {
+                                isLoading = true;
+                              });
+                              try {
+                                await ref
+                                    .read(accountPreferencesProvider.notifier)
+                                    .setZen(v ?? data.zenMode);
+                              } finally {
+                                setState(() {
+                                  isLoading = false;
+                                });
+                              }
+                            },
+                  ),
+                ],
+              ),
+            ),
           ),
         );
       },
@@ -496,32 +501,34 @@ class _PieceNotationSettingsScreenState extends ConsumerState<PieceNotationSetti
         return FutureBuilder(
           future: _pendingSetPieceNotation,
           builder: (context, snapshot) {
-            return CupertinoPageScaffold(
-              navigationBar: CupertinoNavigationBar(
-                trailing:
-                    snapshot.connectionState == ConnectionState.waiting
-                        ? const CircularProgressIndicator.adaptive()
-                        : null,
-              ),
-              child: ListView(
-                children: [
-                  ChoicePicker(
-                    choices: PieceNotation.values,
-                    selectedItem: data.pieceNotation,
-                    titleBuilder: (t) => Text(t.label(context)),
-                    onSelectedItemChanged:
-                        snapshot.connectionState == ConnectionState.waiting
-                            ? null
-                            : (PieceNotation? v) {
-                              final future = ref
-                                  .read(accountPreferencesProvider.notifier)
-                                  .setPieceNotation(v ?? data.pieceNotation);
-                              setState(() {
-                                _pendingSetPieceNotation = future;
-                              });
-                            },
-                  ),
-                ],
+            return FullScreenBackgroundTheme(
+              child: CupertinoPageScaffold(
+                navigationBar: CupertinoNavigationBar(
+                  trailing:
+                      snapshot.connectionState == ConnectionState.waiting
+                          ? const CircularProgressIndicator.adaptive()
+                          : null,
+                ),
+                child: ListView(
+                  children: [
+                    ChoicePicker(
+                      choices: PieceNotation.values,
+                      selectedItem: data.pieceNotation,
+                      titleBuilder: (t) => Text(t.label(context)),
+                      onSelectedItemChanged:
+                          snapshot.connectionState == ConnectionState.waiting
+                              ? null
+                              : (PieceNotation? v) {
+                                final future = ref
+                                    .read(accountPreferencesProvider.notifier)
+                                    .setPieceNotation(v ?? data.pieceNotation);
+                                setState(() {
+                                  _pendingSetPieceNotation = future;
+                                });
+                              },
+                    ),
+                  ],
+                ),
               ),
             );
           },
@@ -555,32 +562,34 @@ class _ShowRatingsSettingsScreenState extends ConsumerState<ShowRatingsSettingsS
         return FutureBuilder(
           future: _pendingSetShowRatings,
           builder: (context, snapshot) {
-            return CupertinoPageScaffold(
-              navigationBar: CupertinoNavigationBar(
-                trailing:
-                    snapshot.connectionState == ConnectionState.waiting
-                        ? const CircularProgressIndicator.adaptive()
-                        : null,
-              ),
-              child: ListView(
-                children: [
-                  ChoicePicker(
-                    choices: ShowRatings.values,
-                    selectedItem: data.showRatings,
-                    titleBuilder: (t) => Text(t.label(context)),
-                    onSelectedItemChanged:
-                        snapshot.connectionState == ConnectionState.waiting
-                            ? null
-                            : (ShowRatings? v) {
-                              final future = ref
-                                  .read(accountPreferencesProvider.notifier)
-                                  .setShowRatings(v ?? data.showRatings);
-                              setState(() {
-                                _pendingSetShowRatings = future;
-                              });
-                            },
-                  ),
-                ],
+            return FullScreenBackgroundTheme(
+              child: CupertinoPageScaffold(
+                navigationBar: CupertinoNavigationBar(
+                  trailing:
+                      snapshot.connectionState == ConnectionState.waiting
+                          ? const CircularProgressIndicator.adaptive()
+                          : null,
+                ),
+                child: ListView(
+                  children: [
+                    ChoicePicker(
+                      choices: ShowRatings.values,
+                      selectedItem: data.showRatings,
+                      titleBuilder: (t) => Text(t.label(context)),
+                      onSelectedItemChanged:
+                          snapshot.connectionState == ConnectionState.waiting
+                              ? null
+                              : (ShowRatings? v) {
+                                final future = ref
+                                    .read(accountPreferencesProvider.notifier)
+                                    .setShowRatings(v ?? data.showRatings);
+                                setState(() {
+                                  _pendingSetShowRatings = future;
+                                });
+                              },
+                    ),
+                  ],
+                ),
               ),
             );
           },
@@ -611,35 +620,37 @@ class _TakebackSettingsScreenState extends ConsumerState<TakebackSettingsScreen>
           return Center(child: Text(context.l10n.mobileMustBeLoggedIn));
         }
 
-        return CupertinoPageScaffold(
-          navigationBar: CupertinoNavigationBar(
-            trailing: isLoading ? const CircularProgressIndicator.adaptive() : null,
-          ),
-          child: ListView(
-            children: [
-              ChoicePicker(
-                choices: Takeback.values,
-                selectedItem: data.takeback,
-                titleBuilder: (t) => Text(t.label(context)),
-                onSelectedItemChanged:
-                    isLoading
-                        ? null
-                        : (Takeback? v) async {
-                          setState(() {
-                            isLoading = true;
-                          });
-                          try {
-                            await ref
-                                .read(accountPreferencesProvider.notifier)
-                                .setTakeback(v ?? data.takeback);
-                          } finally {
+        return FullScreenBackgroundTheme(
+          child: CupertinoPageScaffold(
+            navigationBar: CupertinoNavigationBar(
+              trailing: isLoading ? const CircularProgressIndicator.adaptive() : null,
+            ),
+            child: ListView(
+              children: [
+                ChoicePicker(
+                  choices: Takeback.values,
+                  selectedItem: data.takeback,
+                  titleBuilder: (t) => Text(t.label(context)),
+                  onSelectedItemChanged:
+                      isLoading
+                          ? null
+                          : (Takeback? v) async {
                             setState(() {
-                              isLoading = false;
+                              isLoading = true;
                             });
-                          }
-                        },
-              ),
-            ],
+                            try {
+                              await ref
+                                  .read(accountPreferencesProvider.notifier)
+                                  .setTakeback(v ?? data.takeback);
+                            } finally {
+                              setState(() {
+                                isLoading = false;
+                              });
+                            }
+                          },
+                ),
+              ],
+            ),
           ),
         );
       },
@@ -671,32 +682,34 @@ class _AutoQueenSettingsScreenState extends ConsumerState<AutoQueenSettingsScree
         return FutureBuilder(
           future: _pendingSetAutoQueen,
           builder: (context, snapshot) {
-            return CupertinoPageScaffold(
-              navigationBar: CupertinoNavigationBar(
-                trailing:
-                    snapshot.connectionState == ConnectionState.waiting
-                        ? const CircularProgressIndicator.adaptive()
-                        : null,
-              ),
-              child: ListView(
-                children: [
-                  ChoicePicker(
-                    choices: AutoQueen.values,
-                    selectedItem: data.autoQueen,
-                    titleBuilder: (t) => Text(t.label(context)),
-                    onSelectedItemChanged:
-                        snapshot.connectionState == ConnectionState.waiting
-                            ? null
-                            : (AutoQueen? v) {
-                              final future = ref
-                                  .read(accountPreferencesProvider.notifier)
-                                  .setAutoQueen(v ?? data.autoQueen);
-                              setState(() {
-                                _pendingSetAutoQueen = future;
-                              });
-                            },
-                  ),
-                ],
+            return FullScreenBackgroundTheme(
+              child: CupertinoPageScaffold(
+                navigationBar: CupertinoNavigationBar(
+                  trailing:
+                      snapshot.connectionState == ConnectionState.waiting
+                          ? const CircularProgressIndicator.adaptive()
+                          : null,
+                ),
+                child: ListView(
+                  children: [
+                    ChoicePicker(
+                      choices: AutoQueen.values,
+                      selectedItem: data.autoQueen,
+                      titleBuilder: (t) => Text(t.label(context)),
+                      onSelectedItemChanged:
+                          snapshot.connectionState == ConnectionState.waiting
+                              ? null
+                              : (AutoQueen? v) {
+                                final future = ref
+                                    .read(accountPreferencesProvider.notifier)
+                                    .setAutoQueen(v ?? data.autoQueen);
+                                setState(() {
+                                  _pendingSetAutoQueen = future;
+                                });
+                              },
+                    ),
+                  ],
+                ),
               ),
             );
           },
@@ -730,32 +743,34 @@ class _AutoThreefoldSettingsScreenState extends ConsumerState<AutoThreefoldSetti
         return FutureBuilder(
           future: _pendingSetAutoThreefold,
           builder: (context, snapshot) {
-            return CupertinoPageScaffold(
-              navigationBar: CupertinoNavigationBar(
-                trailing:
-                    snapshot.connectionState == ConnectionState.waiting
-                        ? const CircularProgressIndicator.adaptive()
-                        : null,
-              ),
-              child: ListView(
-                children: [
-                  ChoicePicker(
-                    choices: AutoThreefold.values,
-                    selectedItem: data.autoThreefold,
-                    titleBuilder: (t) => Text(t.label(context)),
-                    onSelectedItemChanged:
-                        snapshot.connectionState == ConnectionState.waiting
-                            ? null
-                            : (AutoThreefold? v) {
-                              final future = ref
-                                  .read(accountPreferencesProvider.notifier)
-                                  .setAutoThreefold(v ?? data.autoThreefold);
-                              setState(() {
-                                _pendingSetAutoThreefold = future;
-                              });
-                            },
-                  ),
-                ],
+            return FullScreenBackgroundTheme(
+              child: CupertinoPageScaffold(
+                navigationBar: CupertinoNavigationBar(
+                  trailing:
+                      snapshot.connectionState == ConnectionState.waiting
+                          ? const CircularProgressIndicator.adaptive()
+                          : null,
+                ),
+                child: ListView(
+                  children: [
+                    ChoicePicker(
+                      choices: AutoThreefold.values,
+                      selectedItem: data.autoThreefold,
+                      titleBuilder: (t) => Text(t.label(context)),
+                      onSelectedItemChanged:
+                          snapshot.connectionState == ConnectionState.waiting
+                              ? null
+                              : (AutoThreefold? v) {
+                                final future = ref
+                                    .read(accountPreferencesProvider.notifier)
+                                    .setAutoThreefold(v ?? data.autoThreefold);
+                                setState(() {
+                                  _pendingSetAutoThreefold = future;
+                                });
+                              },
+                    ),
+                  ],
+                ),
               ),
             );
           },
@@ -789,31 +804,33 @@ class _MoretimeSettingsScreenState extends ConsumerState<MoretimeSettingsScreen>
         return FutureBuilder(
           future: _pendingSetMoretime,
           builder: (context, snapshot) {
-            return CupertinoPageScaffold(
-              navigationBar: CupertinoNavigationBar(
-                trailing:
-                    snapshot.connectionState == ConnectionState.waiting
-                        ? const CircularProgressIndicator.adaptive()
-                        : null,
-              ),
-              child: ListView(
-                children: [
-                  ChoicePicker(
-                    choices: Moretime.values,
-                    selectedItem: data.moretime,
-                    titleBuilder: (t) => Text(t.label(context)),
-                    onSelectedItemChanged:
-                        snapshot.connectionState == ConnectionState.waiting
-                            ? null
-                            : (Moretime? v) {
-                              setState(() {
-                                _pendingSetMoretime = ref
-                                    .read(accountPreferencesProvider.notifier)
-                                    .setMoretime(v ?? data.moretime);
-                              });
-                            },
-                  ),
-                ],
+            return FullScreenBackgroundTheme(
+              child: CupertinoPageScaffold(
+                navigationBar: CupertinoNavigationBar(
+                  trailing:
+                      snapshot.connectionState == ConnectionState.waiting
+                          ? const CircularProgressIndicator.adaptive()
+                          : null,
+                ),
+                child: ListView(
+                  children: [
+                    ChoicePicker(
+                      choices: Moretime.values,
+                      selectedItem: data.moretime,
+                      titleBuilder: (t) => Text(t.label(context)),
+                      onSelectedItemChanged:
+                          snapshot.connectionState == ConnectionState.waiting
+                              ? null
+                              : (Moretime? v) {
+                                setState(() {
+                                  _pendingSetMoretime = ref
+                                      .read(accountPreferencesProvider.notifier)
+                                      .setMoretime(v ?? data.moretime);
+                                });
+                              },
+                    ),
+                  ],
+                ),
               ),
             );
           },
@@ -847,32 +864,34 @@ class _ChallengeSettingsScreenState extends ConsumerState<_ChallengeSettingsScre
         return FutureBuilder(
           future: _pendingSetChallenge,
           builder: (context, snapshot) {
-            return CupertinoPageScaffold(
-              navigationBar: CupertinoNavigationBar(
-                trailing:
-                    snapshot.connectionState == ConnectionState.waiting
-                        ? const CircularProgressIndicator.adaptive()
-                        : null,
-              ),
-              child: ListView(
-                children: [
-                  ChoicePicker(
-                    choices: Challenge.values,
-                    selectedItem: data.challenge,
-                    titleBuilder: (t) => Text(t.label(context)),
-                    onSelectedItemChanged:
-                        snapshot.connectionState == ConnectionState.waiting
-                            ? null
-                            : (Challenge? v) {
-                              final future = ref
-                                  .read(accountPreferencesProvider.notifier)
-                                  .setChallenge(v ?? data.challenge);
-                              setState(() {
-                                _pendingSetChallenge = future;
-                              });
-                            },
-                  ),
-                ],
+            return FullScreenBackgroundTheme(
+              child: CupertinoPageScaffold(
+                navigationBar: CupertinoNavigationBar(
+                  trailing:
+                      snapshot.connectionState == ConnectionState.waiting
+                          ? const CircularProgressIndicator.adaptive()
+                          : null,
+                ),
+                child: ListView(
+                  children: [
+                    ChoicePicker(
+                      choices: Challenge.values,
+                      selectedItem: data.challenge,
+                      titleBuilder: (t) => Text(t.label(context)),
+                      onSelectedItemChanged:
+                          snapshot.connectionState == ConnectionState.waiting
+                              ? null
+                              : (Challenge? v) {
+                                final future = ref
+                                    .read(accountPreferencesProvider.notifier)
+                                    .setChallenge(v ?? data.challenge);
+                                setState(() {
+                                  _pendingSetChallenge = future;
+                                });
+                              },
+                    ),
+                  ],
+                ),
               ),
             );
           },

--- a/lib/src/view/settings/account_preferences_screen.dart
+++ b/lib/src/view/settings/account_preferences_screen.dart
@@ -407,7 +407,7 @@ class _AccountPreferencesScreenState extends ConsumerState<AccountPreferencesScr
       },
     );
 
-    return PlatformScaffold(
+    return PlatformThemedScaffold(
       appBar: PlatformAppBar(
         title: Text(context.l10n.preferencesPreferences),
         actions: [if (isLoading) const PlatformAppBarLoadingIndicator()],

--- a/lib/src/view/settings/app_background_mode_screen.dart
+++ b/lib/src/view/settings/app_background_mode_screen.dart
@@ -3,11 +3,20 @@ import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:lichess_mobile/src/model/settings/general_preferences.dart';
 import 'package:lichess_mobile/src/utils/l10n_context.dart';
+import 'package:lichess_mobile/src/utils/navigation.dart';
 import 'package:lichess_mobile/src/widgets/platform_scaffold.dart';
 import 'package:lichess_mobile/src/widgets/settings.dart';
 
 class AppBackgroundModeScreen extends StatelessWidget {
   const AppBackgroundModeScreen({super.key});
+
+  static Route<dynamic> buildRoute(BuildContext context) {
+    return buildScreenRoute(
+      context,
+      screen: const AppBackgroundModeScreen(),
+      title: context.l10n.background,
+    );
+  }
 
   @override
   Widget build(BuildContext context) {

--- a/lib/src/view/settings/app_background_mode_screen.dart
+++ b/lib/src/view/settings/app_background_mode_screen.dart
@@ -20,7 +20,7 @@ class AppBackgroundModeScreen extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    return PlatformThemedScaffold(
+    return PlatformScaffold(
       appBar: PlatformAppBar(title: Text(context.l10n.background)),
       body: _Body(),
     );

--- a/lib/src/view/settings/app_background_mode_screen.dart
+++ b/lib/src/view/settings/app_background_mode_screen.dart
@@ -11,7 +11,7 @@ class AppBackgroundModeScreen extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    return PlatformScaffold(
+    return PlatformThemedScaffold(
       appBar: PlatformAppBar(title: Text(context.l10n.background)),
       body: _Body(),
     );

--- a/lib/src/view/settings/background_theme_choice_screen.dart
+++ b/lib/src/view/settings/background_theme_choice_screen.dart
@@ -11,10 +11,11 @@ import 'package:image_picker/image_picker.dart';
 import 'package:lichess_mobile/src/model/common/preloaded_data.dart';
 import 'package:lichess_mobile/src/model/settings/board_preferences.dart';
 import 'package:lichess_mobile/src/model/settings/general_preferences.dart';
+import 'package:lichess_mobile/src/styles/styles.dart';
 import 'package:lichess_mobile/src/theme.dart';
 import 'package:lichess_mobile/src/utils/image.dart';
 import 'package:lichess_mobile/src/utils/l10n_context.dart';
-import 'package:lichess_mobile/src/widgets/background_theme.dart';
+import 'package:lichess_mobile/src/widgets/background.dart';
 import 'package:lichess_mobile/src/widgets/buttons.dart';
 import 'package:lichess_mobile/src/widgets/list.dart';
 import 'package:lichess_mobile/src/widgets/platform.dart';
@@ -27,7 +28,7 @@ class BackgroundThemeChoiceScreen extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    return FullScreenBackgroundTheme(
+    return FullScreenBackground(
       child: PlatformWidget(androidBuilder: _androidBuilder, iosBuilder: _iosBuilder),
     );
   }
@@ -56,7 +57,7 @@ class _Body extends ConsumerWidget {
 
     return ListView(
       children: [
-        if (appDocumentsDirectory != null)
+        if (appDocumentsDirectory != null) ...[
           ListSection(
             children: [
               PlatformListTile(
@@ -131,6 +132,11 @@ class _Body extends ConsumerWidget {
               ),
             ],
           ),
+          const Padding(
+            padding: Styles.horizontalBodyPadding,
+            child: Text('Custom background works only in dark mode. A dark image is recommended.'),
+          ),
+        ],
         ListSection(
           header: const SettingsSectionTitle('Presets'),
           backgroundColor: ColorScheme.of(context).surfaceContainerLowest,
@@ -285,7 +291,7 @@ class ConfirmImageBackgroundScreen extends StatefulWidget {
           ? BoxFit.fitWidth
           : BoxFit.fitHeight;
 
-  Size get imageFitSize => FullScreenBackgroundImageTheme.imageFitSize(boxFit, imageSize, viewport);
+  Size get imageFitSize => FullScreenBackgroundImage.imageFitSize(boxFit, imageSize, viewport);
 
   Matrix4 get centerWidthMatrix =>
       Matrix4.translationValues((viewport.width - imageFitSize.width) / 2, 0, 0);

--- a/lib/src/view/settings/background_theme_choice_screen.dart
+++ b/lib/src/view/settings/background_theme_choice_screen.dart
@@ -37,9 +37,7 @@ class BackgroundChoiceScreen extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    return FullScreenBackground(
-      child: PlatformWidget(androidBuilder: _androidBuilder, iosBuilder: _iosBuilder),
-    );
+    return PlatformWidget(androidBuilder: _androidBuilder, iosBuilder: _iosBuilder);
   }
 
   Widget _androidBuilder(BuildContext context) {

--- a/lib/src/view/settings/background_theme_choice_screen.dart
+++ b/lib/src/view/settings/background_theme_choice_screen.dart
@@ -23,8 +23,8 @@ import 'package:lichess_mobile/src/widgets/settings.dart';
 import 'package:material_color_utilities/score/score.dart';
 import 'package:path/path.dart';
 
-class BackgroundThemeChoiceScreen extends StatelessWidget {
-  const BackgroundThemeChoiceScreen({super.key});
+class BackgroundChoiceScreen extends StatelessWidget {
+  const BackgroundChoiceScreen({super.key});
 
   @override
   Widget build(BuildContext context) {
@@ -198,12 +198,8 @@ class ConfirmColorBackgroundScreen extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    return Theme(
-      data:
-          makeBackgroundImageTheme(
-            baseTheme: BackgroundImage.getTheme(color),
-            isIOS: Theme.of(context).platform == TargetPlatform.iOS,
-          ).dark,
+    return _BackgroundTheme(
+      baseTheme: BackgroundImage.getTheme(color),
       child: Scaffold(
         body: LayoutBuilder(
           builder: (context, constraints) {
@@ -341,12 +337,8 @@ class _ConfirmImageBackgroundScreenState extends State<ConfirmImageBackgroundScr
 
     final landscapeBoardPadding = MediaQuery.paddingOf(context).top + 60.0;
 
-    return Theme(
-      data:
-          makeBackgroundImageTheme(
-            baseTheme: baseTheme,
-            isIOS: Theme.of(context).platform == TargetPlatform.iOS,
-          ).dark,
+    return _BackgroundTheme(
+      baseTheme: baseTheme,
       child: Scaffold(
         body: Stack(
           children: [
@@ -495,6 +487,40 @@ class _ConfirmImageBackgroundScreenState extends State<ConfirmImageBackgroundScr
               ),
             ),
           ],
+        ),
+      ),
+    );
+  }
+}
+
+/// Applies the background theme, based on [baseTheme], to the child widget.
+///
+/// This is used to try new background themes without changing the whole app theme.
+class _BackgroundTheme extends StatelessWidget {
+  const _BackgroundTheme({required this.baseTheme, required this.child});
+
+  final ThemeData baseTheme;
+  final Widget child;
+
+  @override
+  Widget build(BuildContext context) {
+    final cupertinoTheme = CupertinoThemeData(
+      applyThemeToAll: true,
+      primaryColor: baseTheme.colorScheme.primary,
+      primaryContrastingColor: baseTheme.colorScheme.onPrimary,
+      brightness: Brightness.dark,
+      scaffoldBackgroundColor: baseTheme.scaffoldBackgroundColor,
+      barBackgroundColor: baseTheme.colorScheme.surface.withValues(alpha: 0.9),
+      textTheme: cupertinoTextTheme(baseTheme.colorScheme),
+    );
+
+    return Theme(
+      data: baseTheme,
+      child: CupertinoTheme(
+        data: cupertinoTheme,
+        child: IconTheme(
+          data: IconThemeData(color: cupertinoTheme.textTheme.textStyle.color),
+          child: DefaultTextStyle.merge(style: cupertinoTheme.textTheme.textStyle, child: child),
         ),
       ),
     );

--- a/lib/src/view/settings/background_theme_choice_screen.dart
+++ b/lib/src/view/settings/background_theme_choice_screen.dart
@@ -15,6 +15,7 @@ import 'package:lichess_mobile/src/styles/styles.dart';
 import 'package:lichess_mobile/src/theme.dart';
 import 'package:lichess_mobile/src/utils/image.dart';
 import 'package:lichess_mobile/src/utils/l10n_context.dart';
+import 'package:lichess_mobile/src/utils/navigation.dart';
 import 'package:lichess_mobile/src/widgets/background.dart';
 import 'package:lichess_mobile/src/widgets/buttons.dart';
 import 'package:lichess_mobile/src/widgets/list.dart';
@@ -25,6 +26,14 @@ import 'package:path/path.dart';
 
 class BackgroundChoiceScreen extends StatelessWidget {
   const BackgroundChoiceScreen({super.key});
+
+  static Route<dynamic> buildRoute(BuildContext context) {
+    return buildScreenRoute(
+      context,
+      screen: const BackgroundChoiceScreen(),
+      title: context.l10n.background,
+    );
+  }
 
   @override
   Widget build(BuildContext context) {

--- a/lib/src/view/settings/background_theme_choice_screen.dart
+++ b/lib/src/view/settings/background_theme_choice_screen.dart
@@ -10,6 +10,7 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:image_picker/image_picker.dart';
 import 'package:lichess_mobile/src/model/common/preloaded_data.dart';
 import 'package:lichess_mobile/src/model/settings/board_preferences.dart';
+import 'package:lichess_mobile/src/model/settings/general_preferences.dart';
 import 'package:lichess_mobile/src/theme.dart';
 import 'package:lichess_mobile/src/utils/image.dart';
 import 'package:lichess_mobile/src/utils/l10n_context.dart';
@@ -21,8 +22,8 @@ import 'package:lichess_mobile/src/widgets/settings.dart';
 import 'package:material_color_utilities/score/score.dart';
 import 'package:path/path.dart';
 
-class BoardBackgroundThemeChoiceScreen extends StatelessWidget {
-  const BoardBackgroundThemeChoiceScreen({super.key});
+class BackgroundThemeChoiceScreen extends StatelessWidget {
+  const BackgroundThemeChoiceScreen({super.key});
 
   @override
   Widget build(BuildContext context) {
@@ -40,7 +41,7 @@ class BoardBackgroundThemeChoiceScreen extends StatelessWidget {
   }
 }
 
-const colorChoices = BoardBackgroundTheme.values;
+const colorChoices = BackgroundTheme.values;
 const itemsByRow = 3;
 
 class _Body extends ConsumerWidget {
@@ -99,7 +100,7 @@ class _Body extends ConsumerWidget {
                     if (context.mounted) {
                       Navigator.of(context, rootNavigator: true)
                           .push(
-                            MaterialPageRoute<BoardBackgroundImage?>(
+                            MaterialPageRoute<BackgroundImage?>(
                               builder:
                                   (_) => ConfirmImageBackgroundScreen(
                                     boardPrefs: boardPrefs,
@@ -119,7 +120,7 @@ class _Body extends ConsumerWidget {
                           .then((value) {
                             if (context.mounted && value != null) {
                               ref
-                                  .read(boardPreferencesProvider.notifier)
+                                  .read(generalPreferencesProvider.notifier)
                                   .setBackground(backgroundImage: value);
                               Navigator.pop(context);
                             }
@@ -165,7 +166,7 @@ class _Body extends ConsumerWidget {
                             if (context.mounted) {
                               if (value == true) {
                                 ref
-                                    .read(boardPreferencesProvider.notifier)
+                                    .read(generalPreferencesProvider.notifier)
                                     .setBackground(backgroundTheme: t);
                                 Navigator.pop(context);
                               }
@@ -194,7 +195,7 @@ class ConfirmColorBackgroundScreen extends StatelessWidget {
     return Theme(
       data:
           makeBackgroundImageTheme(
-            baseTheme: BoardBackgroundImage.getTheme(color),
+            baseTheme: BackgroundImage.getTheme(color),
             isIOS: Theme.of(context).platform == TargetPlatform.iOS,
           ).dark,
       child: Scaffold(
@@ -326,8 +327,8 @@ class _ConfirmImageBackgroundScreenState extends State<ConfirmImageBackgroundScr
 
   @override
   Widget build(BuildContext context) {
-    final baseTheme = BoardBackgroundImage.getTheme(widget.baseColor);
-    final filterColor = BoardBackgroundImage.getFilterColor(
+    final baseTheme = BackgroundImage.getTheme(widget.baseColor);
+    final filterColor = BackgroundImage.getFilterColor(
       baseTheme.colorScheme.surface,
       widget.meanLuminance,
     );
@@ -465,9 +466,9 @@ class _ConfirmImageBackgroundScreenState extends State<ConfirmImageBackgroundScr
                           await FileImage(File(targetPath)).evict();
                           await File(widget.image.path).copy(targetPath);
                           if (context.mounted) {
-                            return Navigator.pop<BoardBackgroundImage>(
+                            return Navigator.pop<BackgroundImage>(
                               context,
-                              BoardBackgroundImage(
+                              BackgroundImage(
                                 path: relativePath,
                                 transform: _transformationMatrix,
                                 isBlurred: blur,

--- a/lib/src/view/settings/board_background_theme_choice_screen.dart
+++ b/lib/src/view/settings/board_background_theme_choice_screen.dart
@@ -26,7 +26,9 @@ class BoardBackgroundThemeChoiceScreen extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    return PlatformWidget(androidBuilder: _androidBuilder, iosBuilder: _iosBuilder);
+    return FullScreenBackgroundTheme(
+      child: PlatformWidget(androidBuilder: _androidBuilder, iosBuilder: _iosBuilder),
+    );
   }
 
   Widget _androidBuilder(BuildContext context) {

--- a/lib/src/view/settings/board_background_theme_choice_screen.dart
+++ b/lib/src/view/settings/board_background_theme_choice_screen.dart
@@ -136,7 +136,7 @@ class _Body extends ConsumerWidget {
           ),
         ListSection(
           header: const SettingsSectionTitle('Color presets'),
-          cupertinoBackgroundColor: ColorScheme.of(context).surfaceContainerLow,
+          backgroundColor: ColorScheme.of(context).surfaceContainerLowest,
           children: [
             GridView.builder(
               primary: false,
@@ -168,15 +168,12 @@ class _Body extends ConsumerWidget {
 
                 final autoColor =
                     brightness == Brightness.light
-                        ? darken(theme.scaffoldBackgroundColor, 0.2)
-                        : lighten(theme.scaffoldBackgroundColor, 0.2);
+                        ? darken(theme.scaffoldBackgroundColor, 0.3)
+                        : lighten(theme.scaffoldBackgroundColor, 0.3);
 
                 return Tooltip(
                   message: 'Background based on chessboard colors.',
-                  triggerMode:
-                      t == BoardBackgroundTheme.board || t == BoardBackgroundTheme.dimBoard
-                          ? null
-                          : TooltipTriggerMode.manual,
+                  triggerMode: t == BoardBackgroundTheme.board ? null : TooltipTriggerMode.manual,
                   child: GestureDetector(
                     onTap:
                         () => Navigator.of(context, rootNavigator: true)
@@ -204,17 +201,21 @@ class _Body extends ConsumerWidget {
                       child: ColoredBox(
                         color: theme.scaffoldBackgroundColor,
                         child:
-                            t == BoardBackgroundTheme.board || t == BoardBackgroundTheme.dimBoard
+                            t == BoardBackgroundTheme.board
                                 ? Column(
                                   mainAxisAlignment: MainAxisAlignment.center,
                                   children: [
                                     Icon(LichessIcons.chess_board, color: autoColor),
                                     const SizedBox(height: 8),
                                     Center(
-                                      child: Text(
-                                        'auto',
-                                        style: theme.textTheme.labelSmall?.copyWith(
-                                          color: autoColor,
+                                      child: Padding(
+                                        padding: const EdgeInsets.all(8.0),
+                                        child: Text(
+                                          'Chessboard colors',
+                                          style: theme.textTheme.labelSmall?.copyWith(
+                                            color: autoColor,
+                                          ),
+                                          textAlign: TextAlign.center,
                                         ),
                                       ),
                                     ),

--- a/lib/src/view/settings/board_background_theme_choice_screen.dart
+++ b/lib/src/view/settings/board_background_theme_choice_screen.dart
@@ -11,8 +11,6 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:image_picker/image_picker.dart';
 import 'package:lichess_mobile/src/model/common/preloaded_data.dart';
 import 'package:lichess_mobile/src/model/settings/board_preferences.dart';
-import 'package:lichess_mobile/src/styles/lichess_icons.dart';
-import 'package:lichess_mobile/src/styles/styles.dart';
 import 'package:lichess_mobile/src/theme.dart';
 import 'package:lichess_mobile/src/utils/image.dart';
 import 'package:lichess_mobile/src/utils/l10n_context.dart';
@@ -149,7 +147,7 @@ class _Body extends ConsumerWidget {
               ),
               itemBuilder: (context, index) {
                 final t = colorChoices[index];
-                final fsd = t.getFlexScheme(boardPrefs.boardTheme);
+                final fsd = t.scheme.data;
 
                 final theme =
                     brightness == Brightness.light
@@ -164,65 +162,30 @@ class _Body extends ConsumerWidget {
                           blendLevel: t.darkBlend,
                         );
 
-                final autoColor =
-                    brightness == Brightness.light
-                        ? darken(theme.scaffoldBackgroundColor, 0.3)
-                        : lighten(theme.scaffoldBackgroundColor, 0.3);
-
-                return Tooltip(
-                  message: 'Background based on chessboard colors.',
-                  triggerMode: t == BoardBackgroundTheme.board ? null : TooltipTriggerMode.manual,
-                  child: GestureDetector(
-                    onTap:
-                        () => Navigator.of(context, rootNavigator: true)
-                            .push(
-                              MaterialPageRoute<double?>(
-                                builder:
-                                    (_) => ConfirmColorBackgroundScreen(
-                                      boardPrefs: boardPrefs,
-                                      initialIndex: index,
-                                    ),
-                                fullscreenDialog: true,
-                              ),
-                            )
-                            .then((value) {
-                              if (context.mounted) {
-                                if (value != null) {
-                                  ref
-                                      .read(boardPreferencesProvider.notifier)
-                                      .setBackground(backgroundTheme: colorChoices[value.toInt()]);
-                                  Navigator.pop(context);
-                                }
+                return GestureDetector(
+                  onTap:
+                      () => Navigator.of(context, rootNavigator: true)
+                          .push(
+                            MaterialPageRoute<double?>(
+                              builder:
+                                  (_) => ConfirmColorBackgroundScreen(
+                                    boardPrefs: boardPrefs,
+                                    initialIndex: index,
+                                  ),
+                              fullscreenDialog: true,
+                            ),
+                          )
+                          .then((value) {
+                            if (context.mounted) {
+                              if (value != null) {
+                                ref
+                                    .read(boardPreferencesProvider.notifier)
+                                    .setBackground(backgroundTheme: colorChoices[value.toInt()]);
+                                Navigator.pop(context);
                               }
-                            }),
-                    child: SizedBox.expand(
-                      child: ColoredBox(
-                        color: theme.scaffoldBackgroundColor,
-                        child:
-                            t == BoardBackgroundTheme.board
-                                ? Column(
-                                  mainAxisAlignment: MainAxisAlignment.center,
-                                  children: [
-                                    Icon(LichessIcons.chess_board, color: autoColor),
-                                    const SizedBox(height: 8),
-                                    Center(
-                                      child: Padding(
-                                        padding: const EdgeInsets.all(8.0),
-                                        child: Text(
-                                          'Chessboard colors',
-                                          style: theme.textTheme.labelSmall?.copyWith(
-                                            color: autoColor,
-                                          ),
-                                          textAlign: TextAlign.center,
-                                        ),
-                                      ),
-                                    ),
-                                  ],
-                                )
-                                : null,
-                      ),
-                    ),
-                  ),
+                            }
+                          }),
+                  child: SizedBox.expand(child: ColoredBox(color: theme.scaffoldBackgroundColor)),
                 );
               },
               itemCount: colorChoices.length,

--- a/lib/src/view/settings/board_choice_screen.dart
+++ b/lib/src/view/settings/board_choice_screen.dart
@@ -5,26 +5,23 @@ import 'package:lichess_mobile/src/model/settings/board_preferences.dart';
 import 'package:lichess_mobile/src/utils/color_palette.dart';
 import 'package:lichess_mobile/src/utils/l10n_context.dart';
 import 'package:lichess_mobile/src/widgets/list.dart';
-import 'package:lichess_mobile/src/widgets/platform.dart';
+import 'package:lichess_mobile/src/widgets/platform_scaffold.dart';
 
 class BoardChoiceScreen extends StatelessWidget {
   const BoardChoiceScreen({super.key});
 
   @override
   Widget build(BuildContext context) {
-    return PlatformWidget(androidBuilder: _androidBuilder, iosBuilder: _iosBuilder);
-  }
-
-  Widget _androidBuilder(BuildContext context) {
-    return Scaffold(appBar: AppBar(title: Text(context.l10n.board)), body: _Body());
-  }
-
-  Widget _iosBuilder(BuildContext context) {
-    return CupertinoPageScaffold(navigationBar: const CupertinoNavigationBar(), child: _Body());
+    return PlatformThemedScaffold(
+      appBar: PlatformAppBar(title: Text(context.l10n.board)),
+      body: const _Body(),
+    );
   }
 }
 
 class _Body extends ConsumerWidget {
+  const _Body();
+
   @override
   Widget build(BuildContext context, WidgetRef ref) {
     final boardTheme = ref.watch(boardPreferencesProvider.select((p) => p.boardTheme));

--- a/lib/src/view/settings/board_choice_screen.dart
+++ b/lib/src/view/settings/board_choice_screen.dart
@@ -4,11 +4,16 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:lichess_mobile/src/model/settings/board_preferences.dart';
 import 'package:lichess_mobile/src/utils/color_palette.dart';
 import 'package:lichess_mobile/src/utils/l10n_context.dart';
+import 'package:lichess_mobile/src/utils/navigation.dart';
 import 'package:lichess_mobile/src/widgets/list.dart';
 import 'package:lichess_mobile/src/widgets/platform_scaffold.dart';
 
 class BoardChoiceScreen extends StatelessWidget {
   const BoardChoiceScreen({super.key});
+
+  static Route<dynamic> buildRoute(BuildContext context) {
+    return buildScreenRoute(context, screen: const BoardChoiceScreen(), title: context.l10n.board);
+  }
 
   @override
   Widget build(BuildContext context) {

--- a/lib/src/view/settings/board_choice_screen.dart
+++ b/lib/src/view/settings/board_choice_screen.dart
@@ -17,7 +17,7 @@ class BoardChoiceScreen extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    return PlatformThemedScaffold(
+    return PlatformScaffold(
       appBar: PlatformAppBar(title: Text(context.l10n.board)),
       body: const _Body(),
     );

--- a/lib/src/view/settings/board_settings_screen.dart
+++ b/lib/src/view/settings/board_settings_screen.dart
@@ -11,7 +11,7 @@ import 'package:lichess_mobile/src/utils/screen.dart';
 import 'package:lichess_mobile/src/utils/system.dart';
 import 'package:lichess_mobile/src/widgets/adaptive_choice_picker.dart';
 import 'package:lichess_mobile/src/widgets/list.dart';
-import 'package:lichess_mobile/src/widgets/platform.dart';
+import 'package:lichess_mobile/src/widgets/platform_scaffold.dart';
 import 'package:lichess_mobile/src/widgets/settings.dart';
 
 class BoardSettingsScreen extends StatelessWidget {
@@ -19,18 +19,10 @@ class BoardSettingsScreen extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    return PlatformWidget(androidBuilder: _androidBuilder, iosBuilder: _iosBuilder);
-  }
-
-  Widget _androidBuilder(BuildContext context) {
-    return Scaffold(
-      appBar: AppBar(title: Text(context.l10n.preferencesGameBehavior)),
+    return PlatformThemedScaffold(
+      appBar: PlatformAppBar(title: Text(context.l10n.preferencesGameBehavior)),
       body: const _Body(),
     );
-  }
-
-  Widget _iosBuilder(BuildContext context) {
-    return const CupertinoPageScaffold(navigationBar: CupertinoNavigationBar(), child: _Body());
   }
 }
 

--- a/lib/src/view/settings/board_settings_screen.dart
+++ b/lib/src/view/settings/board_settings_screen.dart
@@ -17,6 +17,15 @@ import 'package:lichess_mobile/src/widgets/settings.dart';
 class BoardSettingsScreen extends StatelessWidget {
   const BoardSettingsScreen({super.key});
 
+  static Route<dynamic> buildRoute(BuildContext context, {bool fullscreenDialog = false}) {
+    return buildScreenRoute(
+      context,
+      fullscreenDialog: fullscreenDialog,
+      screen: const BoardSettingsScreen(),
+      title: context.l10n.preferencesGameBehavior,
+    );
+  }
+
   @override
   Widget build(BuildContext context) {
     return PlatformThemedScaffold(
@@ -59,11 +68,7 @@ class _Body extends ConsumerWidget {
                     },
                   );
                 } else {
-                  pushPlatformRoute(
-                    context,
-                    title: context.l10n.preferencesHowDoYouMovePieces,
-                    builder: (context) => const PieceShiftMethodSettingsScreen(),
-                  );
+                  Navigator.of(context).push(PieceShiftMethodSettingsScreen.buildRoute(context));
                 }
               },
             ),
@@ -95,11 +100,7 @@ class _Body extends ConsumerWidget {
                     },
                   );
                 } else {
-                  pushPlatformRoute(
-                    context,
-                    title: 'Dragged piece target',
-                    builder: (context) => const DragTargetKindSettingsScreen(),
-                  );
+                  Navigator.of(context).push(DragTargetKindSettingsScreen.buildRoute(context));
                 }
               },
             ),
@@ -161,11 +162,7 @@ class _Body extends ConsumerWidget {
                             .setClockPosition(value ?? ClockPosition.right),
                   );
                 } else {
-                  pushPlatformRoute(
-                    context,
-                    title: 'Clock position',
-                    builder: (context) => const BoardClockPositionScreen(),
-                  );
+                  Navigator.of(context).push(BoardClockPositionScreen.buildRoute(context));
                 }
               },
             ),
@@ -201,11 +198,7 @@ class _Body extends ConsumerWidget {
                             ),
                   );
                 } else {
-                  pushPlatformRoute(
-                    context,
-                    title: 'Material',
-                    builder: (context) => const MaterialDifferenceFormatScreen(),
-                  );
+                  Navigator.of(context).push(MaterialDifferenceFormatScreen.buildRoute(context));
                 }
               },
             ),
@@ -231,6 +224,14 @@ class _Body extends ConsumerWidget {
 
 class PieceShiftMethodSettingsScreen extends ConsumerWidget {
   const PieceShiftMethodSettingsScreen({super.key});
+
+  static Route<dynamic> buildRoute(BuildContext context) {
+    return buildScreenRoute(
+      context,
+      screen: const PieceShiftMethodSettingsScreen(),
+      title: context.l10n.preferencesHowDoYouMovePieces,
+    );
+  }
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
@@ -266,6 +267,14 @@ class PieceShiftMethodSettingsScreen extends ConsumerWidget {
 class BoardClockPositionScreen extends ConsumerWidget {
   const BoardClockPositionScreen({super.key});
 
+  static Route<dynamic> buildRoute(BuildContext context) {
+    return buildScreenRoute(
+      context,
+      screen: const BoardClockPositionScreen(),
+      title: 'Clock position',
+    );
+  }
+
   @override
   Widget build(BuildContext context, WidgetRef ref) {
     final clockPosition = ref.watch(
@@ -294,6 +303,14 @@ class BoardClockPositionScreen extends ConsumerWidget {
 class MaterialDifferenceFormatScreen extends ConsumerWidget {
   const MaterialDifferenceFormatScreen({super.key});
 
+  static Route<dynamic> buildRoute(BuildContext context) {
+    return buildScreenRoute(
+      context,
+      screen: const MaterialDifferenceFormatScreen(),
+      title: 'Material',
+    );
+  }
+
   @override
   Widget build(BuildContext context, WidgetRef ref) {
     final materialDifferenceFormat = ref.watch(
@@ -320,6 +337,14 @@ class MaterialDifferenceFormatScreen extends ConsumerWidget {
 
 class DragTargetKindSettingsScreen extends ConsumerWidget {
   const DragTargetKindSettingsScreen({super.key});
+
+  static Route<dynamic> buildRoute(BuildContext context) {
+    return buildScreenRoute(
+      context,
+      screen: const DragTargetKindSettingsScreen(),
+      title: 'Dragged piece target',
+    );
+  }
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {

--- a/lib/src/view/settings/board_settings_screen.dart
+++ b/lib/src/view/settings/board_settings_screen.dart
@@ -28,7 +28,7 @@ class BoardSettingsScreen extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    return PlatformThemedScaffold(
+    return PlatformScaffold(
       appBar: PlatformAppBar(title: Text(context.l10n.preferencesGameBehavior)),
       body: const _Body(),
     );

--- a/lib/src/view/settings/piece_set_screen.dart
+++ b/lib/src/view/settings/piece_set_screen.dart
@@ -55,7 +55,7 @@ class _PieceSetScreenState extends ConsumerState<PieceSetScreen> {
   Widget build(BuildContext context) {
     final boardPrefs = ref.watch(boardPreferencesProvider);
 
-    return PlatformThemedScaffold(
+    return PlatformScaffold(
       appBar: PlatformAppBar(
         title: Text(context.l10n.pieceSet),
         actions: [if (isLoading) const PlatformAppBarLoadingIndicator()],

--- a/lib/src/view/settings/piece_set_screen.dart
+++ b/lib/src/view/settings/piece_set_screen.dart
@@ -50,7 +50,7 @@ class _PieceSetScreenState extends ConsumerState<PieceSetScreen> {
   Widget build(BuildContext context) {
     final boardPrefs = ref.watch(boardPreferencesProvider);
 
-    return PlatformScaffold(
+    return PlatformThemedScaffold(
       appBar: PlatformAppBar(
         title: Text(context.l10n.pieceSet),
         actions: [if (isLoading) const PlatformAppBarLoadingIndicator()],

--- a/lib/src/view/settings/piece_set_screen.dart
+++ b/lib/src/view/settings/piece_set_screen.dart
@@ -6,11 +6,16 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:lichess_mobile/src/model/settings/board_preferences.dart';
 import 'package:lichess_mobile/src/utils/chessboard.dart';
 import 'package:lichess_mobile/src/utils/l10n_context.dart';
+import 'package:lichess_mobile/src/utils/navigation.dart';
 import 'package:lichess_mobile/src/widgets/list.dart';
 import 'package:lichess_mobile/src/widgets/platform_scaffold.dart';
 
 class PieceSetScreen extends ConsumerStatefulWidget {
   const PieceSetScreen({super.key});
+
+  static Route<dynamic> buildRoute(BuildContext context) {
+    return buildScreenRoute(context, screen: const PieceSetScreen(), title: context.l10n.pieceSet);
+  }
 
   @override
   ConsumerState<PieceSetScreen> createState() => _PieceSetScreenState();

--- a/lib/src/view/settings/settings_tab_screen.dart
+++ b/lib/src/view/settings/settings_tab_screen.dart
@@ -15,7 +15,6 @@ import 'package:lichess_mobile/src/styles/styles.dart';
 import 'package:lichess_mobile/src/utils/color_palette.dart' show getCorePalette;
 import 'package:lichess_mobile/src/utils/l10n.dart';
 import 'package:lichess_mobile/src/utils/l10n_context.dart';
-import 'package:lichess_mobile/src/utils/navigation.dart';
 import 'package:lichess_mobile/src/view/account/profile_screen.dart';
 import 'package:lichess_mobile/src/view/settings/account_preferences_screen.dart';
 import 'package:lichess_mobile/src/view/settings/app_background_mode_screen.dart';
@@ -126,11 +125,7 @@ class _Body extends ConsumerWidget {
                       : null,
               onTap: () {
                 ref.invalidate(accountActivityProvider);
-                pushPlatformRoute(
-                  context,
-                  title: context.l10n.profile,
-                  builder: (context) => const ProfileScreen(),
-                );
+                Navigator.of(context).push(ProfileScreen.buildRoute(context));
               },
             ),
             PlatformListTile(
@@ -141,11 +136,7 @@ class _Body extends ConsumerWidget {
                       ? const CupertinoListTileChevron()
                       : null,
               onTap: () {
-                pushPlatformRoute(
-                  context,
-                  title: context.l10n.preferencesPreferences,
-                  builder: (context) => const AccountPreferencesScreen(),
-                );
+                Navigator.of(context).push(AccountPreferencesScreen.buildRoute(context));
               },
             ),
             if (authController.isLoading)
@@ -189,11 +180,7 @@ class _Body extends ConsumerWidget {
             settingsValue:
                 '${soundThemeL10n(context, generalPrefs.soundTheme)} (${volumeLabel(generalPrefs.masterVolume)})',
             onTap: () {
-              pushPlatformRoute(
-                context,
-                title: context.l10n.sound,
-                builder: (context) => const SoundSettingsScreen(),
-              );
+              Navigator.of(context).push(SoundSettingsScreen.buildRoute(context));
             },
           ),
           Opacity(
@@ -222,11 +209,7 @@ class _Body extends ConsumerWidget {
                                     .setBackgroundThemeMode(value ?? BackgroundThemeMode.system),
                           );
                         } else {
-                          pushPlatformRoute(
-                            context,
-                            title: context.l10n.background,
-                            builder: (context) => const AppBackgroundModeScreen(),
-                          );
+                          Navigator.of(context).push(AppBackgroundModeScreen.buildRoute(context));
                         }
                       },
             ),
@@ -239,11 +222,7 @@ class _Body extends ConsumerWidget {
                     ? const CupertinoListTileChevron()
                     : null,
             onTap: () {
-              pushPlatformRoute(
-                context,
-                title: context.l10n.mobileTheme,
-                builder: (context) => const ThemeSettingsScreen(),
-              );
+              Navigator.of(context).push(ThemeSettingsScreen.buildRoute(context));
             },
           ),
           PlatformListTile(
@@ -254,11 +233,7 @@ class _Body extends ConsumerWidget {
                     ? const CupertinoListTileChevron()
                     : null,
             onTap: () {
-              pushPlatformRoute(
-                context,
-                title: context.l10n.preferencesGameBehavior,
-                builder: (context) => const BoardSettingsScreen(),
-              );
+              Navigator.of(context).push(BoardSettingsScreen.buildRoute(context));
             },
           ),
           SettingsListTile(

--- a/lib/src/view/settings/settings_tab_screen.dart
+++ b/lib/src/view/settings/settings_tab_screen.dart
@@ -20,8 +20,8 @@ import 'package:lichess_mobile/src/view/account/profile_screen.dart';
 import 'package:lichess_mobile/src/view/settings/account_preferences_screen.dart';
 import 'package:lichess_mobile/src/view/settings/app_background_mode_screen.dart';
 import 'package:lichess_mobile/src/view/settings/board_settings_screen.dart';
-import 'package:lichess_mobile/src/view/settings/board_theme_screen.dart';
 import 'package:lichess_mobile/src/view/settings/sound_settings_screen.dart';
+import 'package:lichess_mobile/src/view/settings/theme_settings_screen.dart';
 import 'package:lichess_mobile/src/widgets/adaptive_action_sheet.dart';
 import 'package:lichess_mobile/src/widgets/adaptive_choice_picker.dart';
 import 'package:lichess_mobile/src/widgets/feedback.dart';
@@ -229,7 +229,7 @@ class _Body extends ConsumerWidget {
               pushPlatformRoute(
                 context,
                 title: context.l10n.mobileTheme,
-                builder: (context) => const BoardThemeScreen(),
+                builder: (context) => const ThemeSettingsScreen(),
               );
             },
           ),

--- a/lib/src/view/settings/settings_tab_screen.dart
+++ b/lib/src/view/settings/settings_tab_screen.dart
@@ -86,6 +86,9 @@ class _Body extends ConsumerWidget {
     final packageInfo = ref.read(preloadedDataProvider).requireValue.packageInfo;
     final dbSize = ref.watch(getDbSizeInBytesProvider);
 
+    final isForcedDarkMode =
+        generalPrefs.backgroundTheme != null || generalPrefs.backgroundImage != null;
+
     final Widget? donateButton =
         userSession == null || userSession.user.isPatron != true
             ? PlatformListTile(
@@ -193,30 +196,40 @@ class _Body extends ConsumerWidget {
               );
             },
           ),
-          SettingsListTile(
-            icon: const Icon(Icons.brightness_medium_outlined),
-            settingsLabel: Text(context.l10n.background),
-            settingsValue: AppBackgroundModeScreen.themeTitle(context, generalPrefs.themeMode),
-            onTap: () {
-              if (Theme.of(context).platform == TargetPlatform.android) {
-                showChoicePicker(
-                  context,
-                  choices: BackgroundThemeMode.values,
-                  selectedItem: generalPrefs.themeMode,
-                  labelBuilder: (t) => Text(AppBackgroundModeScreen.themeTitle(context, t)),
-                  onSelectedItemChanged:
-                      (BackgroundThemeMode? value) => ref
-                          .read(generalPreferencesProvider.notifier)
-                          .setBackgroundThemeMode(value ?? BackgroundThemeMode.system),
-                );
-              } else {
-                pushPlatformRoute(
-                  context,
-                  title: context.l10n.background,
-                  builder: (context) => const AppBackgroundModeScreen(),
-                );
-              }
-            },
+          Opacity(
+            opacity: isForcedDarkMode ? 0.5 : 1.0,
+            child: SettingsListTile(
+              icon: const Icon(Icons.brightness_medium_outlined),
+              settingsLabel: Text(context.l10n.background),
+              settingsValue: AppBackgroundModeScreen.themeTitle(
+                context,
+                isForcedDarkMode ? BackgroundThemeMode.dark : generalPrefs.themeMode,
+              ),
+              onTap:
+                  isForcedDarkMode
+                      ? null
+                      : () {
+                        if (Theme.of(context).platform == TargetPlatform.android) {
+                          showChoicePicker(
+                            context,
+                            choices: BackgroundThemeMode.values,
+                            selectedItem: generalPrefs.themeMode,
+                            labelBuilder:
+                                (t) => Text(AppBackgroundModeScreen.themeTitle(context, t)),
+                            onSelectedItemChanged:
+                                (BackgroundThemeMode? value) => ref
+                                    .read(generalPreferencesProvider.notifier)
+                                    .setBackgroundThemeMode(value ?? BackgroundThemeMode.system),
+                          );
+                        } else {
+                          pushPlatformRoute(
+                            context,
+                            title: context.l10n.background,
+                            builder: (context) => const AppBackgroundModeScreen(),
+                          );
+                        }
+                      },
+            ),
           ),
           PlatformListTile(
             leading: const Icon(Icons.palette_outlined),

--- a/lib/src/view/settings/settings_tab_screen.dart
+++ b/lib/src/view/settings/settings_tab_screen.dart
@@ -85,9 +85,6 @@ class _Body extends ConsumerWidget {
     final packageInfo = ref.read(preloadedDataProvider).requireValue.packageInfo;
     final dbSize = ref.watch(getDbSizeInBytesProvider);
 
-    final isForcedDarkMode =
-        generalPrefs.backgroundTheme != null || generalPrefs.backgroundImage != null;
-
     final Widget? donateButton =
         userSession == null || userSession.user.isPatron != true
             ? PlatformListTile(
@@ -184,16 +181,16 @@ class _Body extends ConsumerWidget {
             },
           ),
           Opacity(
-            opacity: isForcedDarkMode ? 0.5 : 1.0,
+            opacity: generalPrefs.isForcedDarkMode ? 0.5 : 1.0,
             child: SettingsListTile(
               icon: const Icon(Icons.brightness_medium_outlined),
               settingsLabel: Text(context.l10n.background),
               settingsValue: AppBackgroundModeScreen.themeTitle(
                 context,
-                isForcedDarkMode ? BackgroundThemeMode.dark : generalPrefs.themeMode,
+                generalPrefs.isForcedDarkMode ? BackgroundThemeMode.dark : generalPrefs.themeMode,
               ),
               onTap:
-                  isForcedDarkMode
+                  generalPrefs.isForcedDarkMode
                       ? null
                       : () {
                         if (Theme.of(context).platform == TargetPlatform.android) {

--- a/lib/src/view/settings/sound_settings_screen.dart
+++ b/lib/src/view/settings/sound_settings_screen.dart
@@ -23,10 +23,7 @@ class SoundSettingsScreen extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    return PlatformThemedScaffold(
-      appBar: PlatformAppBar(title: Text(context.l10n.sound)),
-      body: _Body(),
-    );
+    return PlatformScaffold(appBar: PlatformAppBar(title: Text(context.l10n.sound)), body: _Body());
   }
 }
 

--- a/lib/src/view/settings/sound_settings_screen.dart
+++ b/lib/src/view/settings/sound_settings_screen.dart
@@ -1,11 +1,10 @@
-import 'package:flutter/cupertino.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:lichess_mobile/src/model/common/service/sound_service.dart';
 import 'package:lichess_mobile/src/model/settings/general_preferences.dart';
 import 'package:lichess_mobile/src/utils/l10n_context.dart';
 import 'package:lichess_mobile/src/widgets/list.dart';
-import 'package:lichess_mobile/src/widgets/platform.dart';
+import 'package:lichess_mobile/src/widgets/platform_scaffold.dart';
 import 'package:lichess_mobile/src/widgets/settings.dart';
 
 const kMasterVolumeValues = [0.0, 0.1, 0.2, 0.3, 0.4, 0.5, 0.6, 0.7, 0.8, 0.9, 1.0];
@@ -15,15 +14,10 @@ class SoundSettingsScreen extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    return PlatformWidget(androidBuilder: _androidBuilder, iosBuilder: _iosBuilder);
-  }
-
-  Widget _androidBuilder(BuildContext context) {
-    return Scaffold(appBar: AppBar(title: Text(context.l10n.sound)), body: _Body());
-  }
-
-  Widget _iosBuilder(BuildContext context) {
-    return CupertinoPageScaffold(navigationBar: const CupertinoNavigationBar(), child: _Body());
+    return PlatformThemedScaffold(
+      appBar: PlatformAppBar(title: Text(context.l10n.sound)),
+      body: _Body(),
+    );
   }
 }
 

--- a/lib/src/view/settings/sound_settings_screen.dart
+++ b/lib/src/view/settings/sound_settings_screen.dart
@@ -3,6 +3,7 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:lichess_mobile/src/model/common/service/sound_service.dart';
 import 'package:lichess_mobile/src/model/settings/general_preferences.dart';
 import 'package:lichess_mobile/src/utils/l10n_context.dart';
+import 'package:lichess_mobile/src/utils/navigation.dart';
 import 'package:lichess_mobile/src/widgets/list.dart';
 import 'package:lichess_mobile/src/widgets/platform_scaffold.dart';
 import 'package:lichess_mobile/src/widgets/settings.dart';
@@ -11,6 +12,14 @@ const kMasterVolumeValues = [0.0, 0.1, 0.2, 0.3, 0.4, 0.5, 0.6, 0.7, 0.8, 0.9, 1
 
 class SoundSettingsScreen extends StatelessWidget {
   const SoundSettingsScreen({super.key});
+
+  static Route<dynamic> buildRoute(BuildContext context) {
+    return buildScreenRoute(
+      context,
+      screen: const SoundSettingsScreen(),
+      title: context.l10n.sound,
+    );
+  }
 
   @override
   Widget build(BuildContext context) {

--- a/lib/src/view/settings/theme_settings_screen.dart
+++ b/lib/src/view/settings/theme_settings_screen.dart
@@ -7,12 +7,13 @@ import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:lichess_mobile/src/constants.dart';
 import 'package:lichess_mobile/src/model/settings/board_preferences.dart';
+import 'package:lichess_mobile/src/model/settings/general_preferences.dart';
 import 'package:lichess_mobile/src/styles/lichess_icons.dart';
 import 'package:lichess_mobile/src/styles/styles.dart';
 import 'package:lichess_mobile/src/utils/l10n_context.dart';
 import 'package:lichess_mobile/src/utils/navigation.dart';
 import 'package:lichess_mobile/src/utils/screen.dart';
-import 'package:lichess_mobile/src/view/settings/board_background_theme_choice_screen.dart';
+import 'package:lichess_mobile/src/view/settings/background_theme_choice_screen.dart';
 import 'package:lichess_mobile/src/view/settings/board_choice_screen.dart';
 import 'package:lichess_mobile/src/view/settings/piece_set_screen.dart';
 import 'package:lichess_mobile/src/widgets/adaptive_choice_picker.dart';
@@ -21,8 +22,8 @@ import 'package:lichess_mobile/src/widgets/list.dart';
 import 'package:lichess_mobile/src/widgets/platform.dart';
 import 'package:lichess_mobile/src/widgets/settings.dart';
 
-class BoardThemeScreen extends ConsumerWidget {
-  const BoardThemeScreen({super.key});
+class ThemeSettingsScreen extends ConsumerWidget {
+  const ThemeSettingsScreen({super.key});
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
@@ -104,6 +105,7 @@ class _BodyState extends ConsumerState<_Body> {
 
   @override
   Widget build(BuildContext context) {
+    final generalPrefs = ref.watch(generalPreferencesProvider);
     final boardPrefs = ref.watch(boardPreferencesProvider);
 
     final bool hasAjustedColors =
@@ -186,23 +188,23 @@ class _BodyState extends ConsumerState<_Body> {
                     icon: const Icon(Icons.wallpaper),
                     settingsLabel: Text(context.l10n.background),
                     settingsValue:
-                        boardPrefs.backgroundTheme?.label(context.l10n) ??
-                        (boardPrefs.backgroundImage != null ? 'Image' : 'Default'),
+                        generalPrefs.backgroundTheme?.label(context.l10n) ??
+                        (generalPrefs.backgroundImage != null ? 'Image' : 'Default'),
                     onTap: () {
                       pushPlatformRoute(
                         context,
                         title: context.l10n.background,
-                        builder: (context) => const BoardBackgroundThemeChoiceScreen(),
+                        builder: (context) => const BackgroundThemeChoiceScreen(),
                       );
                     },
                   ),
-                  if (boardPrefs.backgroundTheme != null || boardPrefs.backgroundImage != null)
+                  if (generalPrefs.backgroundTheme != null || generalPrefs.backgroundImage != null)
                     PlatformListTile(
                       leading: const Icon(Icons.cancel),
                       title: const Text('Reset background'),
                       onTap: () {
                         ref
-                            .read(boardPreferencesProvider.notifier)
+                            .read(generalPreferencesProvider.notifier)
                             .setBackground(backgroundTheme: null, backgroundImage: null);
                       },
                     ),

--- a/lib/src/view/settings/theme_settings_screen.dart
+++ b/lib/src/view/settings/theme_settings_screen.dart
@@ -25,6 +25,14 @@ import 'package:lichess_mobile/src/widgets/settings.dart';
 class ThemeSettingsScreen extends ConsumerWidget {
   const ThemeSettingsScreen({super.key});
 
+  static Route<dynamic> buildRoute(BuildContext context) {
+    return buildScreenRoute(
+      context,
+      screen: const ThemeSettingsScreen(),
+      title: context.l10n.mobileTheme,
+    );
+  }
+
   @override
   Widget build(BuildContext context, WidgetRef ref) {
     return FullScreenBackground(
@@ -177,11 +185,7 @@ class _BodyState extends ConsumerState<_Body> {
                     settingsLabel: Text(context.l10n.board),
                     settingsValue: boardPrefs.boardTheme.label,
                     onTap: () {
-                      pushPlatformRoute(
-                        context,
-                        title: context.l10n.board,
-                        builder: (context) => const BoardChoiceScreen(),
-                      );
+                      Navigator.of(context).push(BoardChoiceScreen.buildRoute(context));
                     },
                   ),
                   SettingsListTile(
@@ -191,11 +195,7 @@ class _BodyState extends ConsumerState<_Body> {
                         generalPrefs.backgroundTheme?.label(context.l10n) ??
                         (generalPrefs.backgroundImage != null ? 'Image' : 'Default'),
                     onTap: () {
-                      pushPlatformRoute(
-                        context,
-                        title: context.l10n.background,
-                        builder: (context) => const BackgroundChoiceScreen(),
-                      );
+                      Navigator.of(context).push(BackgroundChoiceScreen.buildRoute(context));
                     },
                   ),
                   if (generalPrefs.backgroundTheme != null || generalPrefs.backgroundImage != null)
@@ -213,11 +213,7 @@ class _BodyState extends ConsumerState<_Body> {
                     settingsLabel: Text(context.l10n.pieceSet),
                     settingsValue: boardPrefs.pieceSet.label,
                     onTap: () {
-                      pushPlatformRoute(
-                        context,
-                        title: context.l10n.pieceSet,
-                        builder: (context) => const PieceSetScreen(),
-                      );
+                      Navigator.of(context).push(PieceSetScreen.buildRoute(context));
                     },
                   ),
                   SettingsListTile(

--- a/lib/src/view/settings/theme_settings_screen.dart
+++ b/lib/src/view/settings/theme_settings_screen.dart
@@ -17,7 +17,7 @@ import 'package:lichess_mobile/src/view/settings/background_theme_choice_screen.
 import 'package:lichess_mobile/src/view/settings/board_choice_screen.dart';
 import 'package:lichess_mobile/src/view/settings/piece_set_screen.dart';
 import 'package:lichess_mobile/src/widgets/adaptive_choice_picker.dart';
-import 'package:lichess_mobile/src/widgets/background_theme.dart';
+import 'package:lichess_mobile/src/widgets/background.dart';
 import 'package:lichess_mobile/src/widgets/list.dart';
 import 'package:lichess_mobile/src/widgets/platform.dart';
 import 'package:lichess_mobile/src/widgets/settings.dart';
@@ -27,7 +27,7 @@ class ThemeSettingsScreen extends ConsumerWidget {
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
-    return FullScreenBackgroundTheme(
+    return FullScreenBackground(
       child: PlatformWidget(
         androidBuilder: (context) => const Scaffold(body: _Body()),
         iosBuilder:

--- a/lib/src/view/settings/theme_settings_screen.dart
+++ b/lib/src/view/settings/theme_settings_screen.dart
@@ -17,7 +17,6 @@ import 'package:lichess_mobile/src/view/settings/background_theme_choice_screen.
 import 'package:lichess_mobile/src/view/settings/board_choice_screen.dart';
 import 'package:lichess_mobile/src/view/settings/piece_set_screen.dart';
 import 'package:lichess_mobile/src/widgets/adaptive_choice_picker.dart';
-import 'package:lichess_mobile/src/widgets/background.dart';
 import 'package:lichess_mobile/src/widgets/list.dart';
 import 'package:lichess_mobile/src/widgets/platform.dart';
 import 'package:lichess_mobile/src/widgets/settings.dart';
@@ -35,21 +34,17 @@ class ThemeSettingsScreen extends ConsumerWidget {
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
-    return FullScreenBackground(
-      child: PlatformWidget(
-        androidBuilder: (context) => const Scaffold(body: _Body()),
-        iosBuilder:
-            (context) => CupertinoPageScaffold(
-              navigationBar: CupertinoNavigationBar(
-                automaticBackgroundVisibility: false,
-                backgroundColor: CupertinoTheme.of(
-                  context,
-                ).barBackgroundColor.withValues(alpha: 0.0),
-                border: null,
-              ),
-              child: const _Body(),
+    return PlatformWidget(
+      androidBuilder: (context) => const Scaffold(body: _Body()),
+      iosBuilder:
+          (context) => CupertinoPageScaffold(
+            navigationBar: CupertinoNavigationBar(
+              automaticBackgroundVisibility: false,
+              backgroundColor: CupertinoTheme.of(context).barBackgroundColor.withValues(alpha: 0.0),
+              border: null,
             ),
-      ),
+            child: const _Body(),
+          ),
     );
   }
 }

--- a/lib/src/view/settings/theme_settings_screen.dart
+++ b/lib/src/view/settings/theme_settings_screen.dart
@@ -194,7 +194,7 @@ class _BodyState extends ConsumerState<_Body> {
                       pushPlatformRoute(
                         context,
                         title: context.l10n.background,
-                        builder: (context) => const BackgroundThemeChoiceScreen(),
+                        builder: (context) => const BackgroundChoiceScreen(),
                       );
                     },
                   ),

--- a/lib/src/view/study/study_bottom_bar.dart
+++ b/lib/src/view/study/study_bottom_bar.dart
@@ -5,7 +5,6 @@ import 'package:lichess_mobile/src/model/analysis/analysis_controller.dart';
 import 'package:lichess_mobile/src/model/common/id.dart';
 import 'package:lichess_mobile/src/model/study/study_controller.dart';
 import 'package:lichess_mobile/src/utils/l10n_context.dart';
-import 'package:lichess_mobile/src/utils/navigation.dart';
 import 'package:lichess_mobile/src/view/analysis/analysis_screen.dart';
 import 'package:lichess_mobile/src/widgets/adaptive_bottom_sheet.dart';
 import 'package:lichess_mobile/src/widgets/bottom_bar.dart';
@@ -145,20 +144,18 @@ class _GamebookBottomBar extends ConsumerWidget {
             if (!state.isIntroductoryChapter)
               BottomBarButton(
                 onTap:
-                    () => pushPlatformRoute(
-                      context,
-                      rootNavigator: true,
-                      builder:
-                          (context) => AnalysisScreen(
-                            options: AnalysisOptions(
-                              orientation: state.pov,
-                              standalone: (
-                                pgn: state.pgn,
-                                isComputerAnalysisAllowed: true,
-                                variant: state.variant,
-                              ),
-                            ),
+                    () => Navigator.of(context, rootNavigator: true).push(
+                      AnalysisScreen.buildRoute(
+                        context,
+                        AnalysisOptions(
+                          orientation: state.pov,
+                          standalone: (
+                            pgn: state.pgn,
+                            isComputerAnalysisAllowed: true,
+                            variant: state.variant,
                           ),
+                        ),
+                      ),
                     ),
                 icon: Icons.biotech,
                 label: context.l10n.analysis,

--- a/lib/src/view/study/study_gamebook.dart
+++ b/lib/src/view/study/study_gamebook.dart
@@ -15,7 +15,7 @@ class StudyGamebook extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     return Container(
-      color: ColorScheme.of(context).surface,
+      color: ColorScheme.of(context).surfaceContainer,
       padding: const EdgeInsets.all(16.0),
       child: Column(
         crossAxisAlignment: CrossAxisAlignment.stretch,

--- a/lib/src/view/study/study_list_screen.dart
+++ b/lib/src/view/study/study_list_screen.dart
@@ -38,7 +38,7 @@ class StudyListScreen extends ConsumerWidget {
     final filter = ref.watch(studyFilterProvider);
     final title = Text(isLoggedIn ? filter.category.l10n(context.l10n) : context.l10n.studyMenu);
 
-    return PlatformThemedScaffold(
+    return PlatformScaffold(
       backgroundColor: Styles.listingsScreenBackgroundColor(context),
       appBar: PlatformAppBar(
         title: title,

--- a/lib/src/view/study/study_list_screen.dart
+++ b/lib/src/view/study/study_list_screen.dart
@@ -34,7 +34,7 @@ class StudyListScreen extends ConsumerWidget {
     final filter = ref.watch(studyFilterProvider);
     final title = Text(isLoggedIn ? filter.category.l10n(context.l10n) : context.l10n.studyMenu);
 
-    return PlatformScaffold(
+    return PlatformThemedScaffold(
       backgroundColor: Styles.listingsScreenBackgroundColor(context),
       appBar: PlatformAppBar(
         title: title,

--- a/lib/src/view/study/study_list_screen.dart
+++ b/lib/src/view/study/study_list_screen.dart
@@ -27,6 +27,10 @@ final _logger = Logger('StudyListScreen');
 class StudyListScreen extends ConsumerWidget {
   const StudyListScreen({super.key});
 
+  static Route<dynamic> buildRoute(BuildContext context) {
+    return buildScreenRoute(context, screen: const StudyListScreen());
+  }
+
   @override
   Widget build(BuildContext context, WidgetRef ref) {
     final isLoggedIn = ref.watch(authSessionProvider)?.user.id != null;
@@ -234,11 +238,10 @@ class _StudyListItem extends StatelessWidget {
       ),
       subtitle: _StudySubtitle(study: study),
       onTap:
-          () => pushPlatformRoute(
+          () => Navigator.of(
             context,
             rootNavigator: true,
-            builder: (context) => StudyScreen(id: study.id),
-          ),
+          ).push(StudyScreen.buildRoute(context, study.id)),
       onLongPress: () {
         showAdaptiveBottomSheet<void>(
           context: context,

--- a/lib/src/view/study/study_screen.dart
+++ b/lib/src/view/study/study_screen.dart
@@ -30,7 +30,6 @@ import 'package:lichess_mobile/src/view/study/study_gamebook.dart';
 import 'package:lichess_mobile/src/view/study/study_settings.dart';
 import 'package:lichess_mobile/src/view/study/study_tree_view.dart';
 import 'package:lichess_mobile/src/widgets/adaptive_action_sheet.dart';
-import 'package:lichess_mobile/src/widgets/background.dart';
 import 'package:lichess_mobile/src/widgets/buttons.dart';
 import 'package:lichess_mobile/src/widgets/feedback.dart';
 import 'package:lichess_mobile/src/widgets/pgn.dart';
@@ -51,7 +50,7 @@ class StudyScreen extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    return FullScreenBackground(child: _StudyScreenLoader(id: id));
+    return _StudyScreenLoader(id: id);
   }
 }
 
@@ -68,7 +67,7 @@ class _StudyScreenLoader extends ConsumerWidget {
         return _StudyScreen(id: id, studyState: value);
       case AsyncError(:final error, :final stackTrace):
         _logger.severe('Cannot load study: $error', stackTrace);
-        return PlatformThemedScaffold(
+        return PlatformScaffold(
           appBar: const PlatformAppBar(title: Text('')),
           body: DefaultTabController(
             length: 1,
@@ -88,7 +87,7 @@ class _StudyScreenLoader extends ConsumerWidget {
           ),
         );
       case _:
-        return PlatformThemedScaffold(
+        return PlatformScaffold(
           appBar: PlatformAppBar(
             title: Shimmer(
               child: ShimmerLoading(
@@ -179,7 +178,7 @@ class _StudyScreenState extends ConsumerState<_StudyScreen> with TickerProviderS
 
   @override
   Widget build(BuildContext context) {
-    return PlatformThemedScaffold(
+    return PlatformScaffold(
       appBar: PlatformAppBar(
         title: AutoSizeText(
           widget.studyState.currentChapterTitle,

--- a/lib/src/view/study/study_screen.dart
+++ b/lib/src/view/study/study_screen.dart
@@ -64,7 +64,7 @@ class _StudyScreenLoader extends ConsumerWidget {
         return _StudyScreen(id: id, studyState: value);
       case AsyncError(:final error, :final stackTrace):
         _logger.severe('Cannot load study: $error', stackTrace);
-        return PlatformScaffold(
+        return PlatformThemedScaffold(
           appBar: const PlatformAppBar(title: Text('')),
           body: DefaultTabController(
             length: 1,
@@ -84,7 +84,7 @@ class _StudyScreenLoader extends ConsumerWidget {
           ),
         );
       case _:
-        return PlatformScaffold(
+        return PlatformThemedScaffold(
           appBar: PlatformAppBar(
             title: Shimmer(
               child: ShimmerLoading(
@@ -175,7 +175,7 @@ class _StudyScreenState extends ConsumerState<_StudyScreen> with TickerProviderS
 
   @override
   Widget build(BuildContext context) {
-    return PlatformScaffold(
+    return PlatformThemedScaffold(
       appBar: PlatformAppBar(
         title: AutoSizeText(
           widget.studyState.currentChapterTitle,

--- a/lib/src/view/study/study_screen.dart
+++ b/lib/src/view/study/study_screen.dart
@@ -30,7 +30,7 @@ import 'package:lichess_mobile/src/view/study/study_gamebook.dart';
 import 'package:lichess_mobile/src/view/study/study_settings.dart';
 import 'package:lichess_mobile/src/view/study/study_tree_view.dart';
 import 'package:lichess_mobile/src/widgets/adaptive_action_sheet.dart';
-import 'package:lichess_mobile/src/widgets/background_theme.dart';
+import 'package:lichess_mobile/src/widgets/background.dart';
 import 'package:lichess_mobile/src/widgets/buttons.dart';
 import 'package:lichess_mobile/src/widgets/feedback.dart';
 import 'package:lichess_mobile/src/widgets/pgn.dart';
@@ -47,7 +47,7 @@ class StudyScreen extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    return FullScreenBackgroundTheme(child: _StudyScreenLoader(id: id));
+    return FullScreenBackground(child: _StudyScreenLoader(id: id));
   }
 }
 

--- a/lib/src/view/study/study_screen.dart
+++ b/lib/src/view/study/study_screen.dart
@@ -45,6 +45,10 @@ class StudyScreen extends StatelessWidget {
 
   final StudyId id;
 
+  static Route<dynamic> buildRoute(BuildContext context, StudyId id) {
+    return buildScreenRoute(context, screen: StudyScreen(id: id));
+  }
+
   @override
   Widget build(BuildContext context) {
     return FullScreenBackground(child: _StudyScreenLoader(id: id));
@@ -221,7 +225,7 @@ class _StudyMenu extends ConsumerWidget {
           semanticsLabel: context.l10n.settingsSettings,
           child: Text(context.l10n.settingsSettings),
           onPressed: () {
-            pushPlatformRoute(context, screen: StudySettings(id));
+            Navigator.of(context).push(StudySettings.buildRoute(context, id));
           },
         ),
         MenuItemButton(

--- a/lib/src/view/study/study_settings.dart
+++ b/lib/src/view/study/study_settings.dart
@@ -38,7 +38,7 @@ class StudySettings extends ConsumerWidget {
       generalPreferencesProvider.select((pref) => pref.isSoundEnabled),
     );
 
-    return PlatformThemedScaffold(
+    return PlatformScaffold(
       appBar: PlatformAppBar(title: Text(context.l10n.settingsSettings)),
       body: ListView(
         children: [

--- a/lib/src/view/study/study_settings.dart
+++ b/lib/src/view/study/study_settings.dart
@@ -33,7 +33,7 @@ class StudySettings extends ConsumerWidget {
       generalPreferencesProvider.select((pref) => pref.isSoundEnabled),
     );
 
-    return PlatformScaffold(
+    return PlatformThemedScaffold(
       appBar: PlatformAppBar(title: Text(context.l10n.settingsSettings)),
       body: ListView(
         children: [

--- a/lib/src/view/study/study_settings.dart
+++ b/lib/src/view/study/study_settings.dart
@@ -7,6 +7,7 @@ import 'package:lichess_mobile/src/model/settings/general_preferences.dart';
 import 'package:lichess_mobile/src/model/study/study_controller.dart';
 import 'package:lichess_mobile/src/model/study/study_preferences.dart';
 import 'package:lichess_mobile/src/utils/l10n_context.dart';
+import 'package:lichess_mobile/src/utils/navigation.dart';
 import 'package:lichess_mobile/src/view/analysis/stockfish_settings.dart';
 import 'package:lichess_mobile/src/view/opening_explorer/opening_explorer_settings.dart';
 import 'package:lichess_mobile/src/widgets/adaptive_bottom_sheet.dart';
@@ -18,6 +19,10 @@ class StudySettings extends ConsumerWidget {
   const StudySettings(this.id);
 
   final StudyId id;
+
+  static Route<dynamic> buildRoute(BuildContext context, StudyId id) {
+    return buildScreenRoute(context, screen: StudySettings(id));
+  }
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {

--- a/lib/src/view/study/study_tree_view.dart
+++ b/lib/src/view/study/study_tree_view.dart
@@ -34,7 +34,7 @@ class StudyTreeView extends ConsumerWidget {
     final analysisPrefs = ref.watch(analysisPreferencesProvider);
 
     return ColoredBox(
-      color: ColorScheme.of(context).surface,
+      color: ColorScheme.of(context).surfaceContainer,
       child: CustomScrollView(
         slivers: [
           SliverFillRemaining(

--- a/lib/src/view/tools/load_position_screen.dart
+++ b/lib/src/view/tools/load_position_screen.dart
@@ -18,7 +18,7 @@ class LoadPositionScreen extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    return PlatformScaffold(
+    return PlatformThemedScaffold(
       appBar: PlatformAppBar(title: Text(context.l10n.loadPosition)),
       body: const _Body(),
     );

--- a/lib/src/view/tools/load_position_screen.dart
+++ b/lib/src/view/tools/load_position_screen.dart
@@ -16,6 +16,10 @@ import 'package:lichess_mobile/src/widgets/platform_scaffold.dart';
 class LoadPositionScreen extends StatelessWidget {
   const LoadPositionScreen({super.key});
 
+  static Route<dynamic> buildRoute(BuildContext context) {
+    return buildScreenRoute(context, screen: const LoadPositionScreen());
+  }
+
   @override
   Widget build(BuildContext context) {
     return PlatformThemedScaffold(
@@ -81,11 +85,10 @@ class _BodyState extends State<_Body> {
                   semanticsLabel: context.l10n.analysis,
                   onPressed:
                       parsedInput != null
-                          ? () => pushPlatformRoute(
+                          ? () => Navigator.of(
                             context,
                             rootNavigator: true,
-                            builder: (context) => AnalysisScreen(options: parsedInput!.options),
-                          )
+                          ).push(AnalysisScreen.buildRoute(context, parsedInput!.options))
                           : null,
                   child: Text(context.l10n.analysis),
                 ),
@@ -94,10 +97,8 @@ class _BodyState extends State<_Body> {
                   semanticsLabel: context.l10n.boardEditor,
                   onPressed:
                       parsedInput != null
-                          ? () => pushPlatformRoute(
-                            context,
-                            rootNavigator: true,
-                            builder: (context) => BoardEditorScreen(initialFen: parsedInput!.fen),
+                          ? () => Navigator.of(context, rootNavigator: true).push(
+                            BoardEditorScreen.buildRoute(context, initialFen: parsedInput!.fen),
                           )
                           : null,
                   child: Text(context.l10n.boardEditor),

--- a/lib/src/view/tools/load_position_screen.dart
+++ b/lib/src/view/tools/load_position_screen.dart
@@ -22,7 +22,7 @@ class LoadPositionScreen extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    return PlatformThemedScaffold(
+    return PlatformScaffold(
       appBar: PlatformAppBar(title: Text(context.l10n.loadPosition)),
       body: const _Body(),
     );

--- a/lib/src/view/tools/tools_tab_screen.dart
+++ b/lib/src/view/tools/tools_tab_screen.dart
@@ -9,7 +9,6 @@ import 'package:lichess_mobile/src/network/connectivity.dart';
 import 'package:lichess_mobile/src/styles/lichess_icons.dart';
 import 'package:lichess_mobile/src/styles/styles.dart';
 import 'package:lichess_mobile/src/utils/l10n_context.dart';
-import 'package:lichess_mobile/src/utils/navigation.dart';
 import 'package:lichess_mobile/src/view/analysis/analysis_screen.dart';
 import 'package:lichess_mobile/src/view/board_editor/board_editor_screen.dart';
 import 'package:lichess_mobile/src/view/clock/clock_tool_screen.dart';
@@ -112,27 +111,24 @@ class _Body extends ConsumerWidget {
           _ToolsButton(
             icon: Icons.upload_file,
             title: context.l10n.loadPosition,
-            onTap:
-                () => pushPlatformRoute(context, builder: (context) => const LoadPositionScreen()),
+            onTap: () => Navigator.of(context).push(LoadPositionScreen.buildRoute(context)),
           ),
           _ToolsButton(
             icon: Icons.biotech,
             title: context.l10n.analysis,
             onTap:
-                () => pushPlatformRoute(
-                  context,
-                  rootNavigator: true,
-                  builder:
-                      (context) => const AnalysisScreen(
-                        options: AnalysisOptions(
-                          orientation: Side.white,
-                          standalone: (
-                            pgn: '',
-                            isComputerAnalysisAllowed: true,
-                            variant: Variant.standard,
-                          ),
-                        ),
+                () => Navigator.of(context, rootNavigator: true).push(
+                  AnalysisScreen.buildRoute(
+                    context,
+                    const AnalysisOptions(
+                      orientation: Side.white,
+                      standalone: (
+                        pgn: '',
+                        isComputerAnalysisAllowed: true,
+                        variant: Variant.standard,
                       ),
+                    ),
+                  ),
                 ),
           ),
           _ToolsButton(
@@ -140,20 +136,18 @@ class _Body extends ConsumerWidget {
             title: context.l10n.openingExplorer,
             onTap:
                 isOnline
-                    ? () => pushPlatformRoute(
-                      context,
-                      rootNavigator: true,
-                      builder:
-                          (context) => const OpeningExplorerScreen(
-                            options: AnalysisOptions(
-                              orientation: Side.white,
-                              standalone: (
-                                pgn: '',
-                                isComputerAnalysisAllowed: false,
-                                variant: Variant.standard,
-                              ),
-                            ),
+                    ? () => Navigator.of(context, rootNavigator: true).push(
+                      OpeningExplorerScreen.buildRoute(
+                        context,
+                        const AnalysisOptions(
+                          orientation: Side.white,
+                          standalone: (
+                            pgn: '',
+                            isComputerAnalysisAllowed: false,
+                            variant: Variant.standard,
                           ),
+                        ),
+                      ),
                     )
                     : null,
           ),
@@ -162,39 +156,35 @@ class _Body extends ConsumerWidget {
             title: context.l10n.studyMenu,
             onTap:
                 isOnline
-                    ? () =>
-                        pushPlatformRoute(context, builder: (context) => const StudyListScreen())
+                    ? () => Navigator.of(context).push(StudyListScreen.buildRoute(context))
                     : null,
           ),
           _ToolsButton(
             icon: Icons.edit_outlined,
             title: context.l10n.boardEditor,
             onTap:
-                () => pushPlatformRoute(
+                () => Navigator.of(
                   context,
-                  builder: (context) => const BoardEditorScreen(),
                   rootNavigator: true,
-                ),
+                ).push(BoardEditorScreen.buildRoute(context)),
           ),
           _ToolsButton(
             icon: Icons.where_to_vote_outlined,
             title: 'Coordinate Training', // TODO l10n
             onTap:
-                () => pushPlatformRoute(
+                () => Navigator.of(
                   context,
                   rootNavigator: true,
-                  builder: (context) => const CoordinateTrainingScreen(),
-                ),
+                ).push(CoordinateTrainingScreen.buildRoute(context)),
           ),
           _ToolsButton(
             icon: Icons.alarm,
             title: context.l10n.clock,
             onTap:
-                () => pushPlatformRoute(
+                () => Navigator.of(
                   context,
-                  builder: (context) => const ClockToolScreen(),
                   rootNavigator: true,
-                ),
+                ).push(ClockToolScreen.buildRoute(context)),
           ),
         ],
       ),

--- a/lib/src/view/user/challenge_requests_screen.dart
+++ b/lib/src/view/user/challenge_requests_screen.dart
@@ -28,7 +28,7 @@ class ChallengeRequestsScreen extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    return PlatformThemedScaffold(
+    return PlatformScaffold(
       backgroundColor: Styles.listingsScreenBackgroundColor(context),
       appBar: PlatformAppBar(title: Text(context.l10n.preferencesNotifyChallenge)),
       body: _Body(),

--- a/lib/src/view/user/challenge_requests_screen.dart
+++ b/lib/src/view/user/challenge_requests_screen.dart
@@ -18,6 +18,14 @@ import 'package:lichess_mobile/src/widgets/platform_scaffold.dart';
 class ChallengeRequestsScreen extends StatelessWidget {
   const ChallengeRequestsScreen({super.key});
 
+  static Route<dynamic> buildRoute(BuildContext context) {
+    return buildScreenRoute(
+      context,
+      screen: const ChallengeRequestsScreen(),
+      title: context.l10n.preferencesNotifyChallenge,
+    );
+  }
+
   @override
   Widget build(BuildContext context) {
     return PlatformThemedScaffold(
@@ -59,13 +67,10 @@ class _Body extends ConsumerWidget {
                   .show(challenge.id)
                   .then((challenge) => challenge.gameFullId);
               if (!context.mounted) return;
-              pushPlatformRoute(
+              Navigator.of(
                 context,
                 rootNavigator: true,
-                builder: (BuildContext context) {
-                  return GameScreen(initialGameId: fullId);
-                },
-              );
+              ).push(GameScreen.buildRoute(context, initialGameId: fullId));
             }
 
             Future<void> declineChallenge(ChallengeDeclineReason? reason) async {

--- a/lib/src/view/user/challenge_requests_screen.dart
+++ b/lib/src/view/user/challenge_requests_screen.dart
@@ -20,7 +20,7 @@ class ChallengeRequestsScreen extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    return PlatformScaffold(
+    return PlatformThemedScaffold(
       backgroundColor: Styles.listingsScreenBackgroundColor(context),
       appBar: PlatformAppBar(title: Text(context.l10n.preferencesNotifyChallenge)),
       body: _Body(),

--- a/lib/src/view/user/game_history_screen.dart
+++ b/lib/src/view/user/game_history_screen.dart
@@ -11,6 +11,7 @@ import 'package:lichess_mobile/src/model/user/user.dart';
 import 'package:lichess_mobile/src/model/user/user_repository_providers.dart';
 import 'package:lichess_mobile/src/styles/styles.dart';
 import 'package:lichess_mobile/src/utils/l10n_context.dart';
+import 'package:lichess_mobile/src/utils/navigation.dart';
 import 'package:lichess_mobile/src/view/game/game_list_tile.dart';
 import 'package:lichess_mobile/src/widgets/adaptive_bottom_sheet.dart';
 import 'package:lichess_mobile/src/widgets/buttons.dart';
@@ -29,6 +30,18 @@ class GameHistoryScreen extends ConsumerWidget {
   final LightUser? user;
   final bool isOnline;
   final GameFilterState gameFilter;
+
+  static Route<dynamic> buildRoute(
+    BuildContext context, {
+    LightUser? user,
+    bool isOnline = false,
+    GameFilterState gameFilter = const GameFilterState(),
+  }) {
+    return buildScreenRoute(
+      context,
+      screen: GameHistoryScreen(user: user, isOnline: isOnline, gameFilter: gameFilter),
+    );
+  }
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {

--- a/lib/src/view/user/game_history_screen.dart
+++ b/lib/src/view/user/game_history_screen.dart
@@ -83,7 +83,7 @@ class GameHistoryScreen extends ConsumerWidget {
           }),
     );
 
-    return PlatformThemedScaffold(
+    return PlatformScaffold(
       backgroundColor: Styles.listingsScreenBackgroundColor(context),
       appBar: PlatformAppBar(title: title, actions: [filterBtn]),
       body: _Body(user: user, isOnline: isOnline, gameFilter: gameFilter),

--- a/lib/src/view/user/game_history_screen.dart
+++ b/lib/src/view/user/game_history_screen.dart
@@ -70,7 +70,7 @@ class GameHistoryScreen extends ConsumerWidget {
           }),
     );
 
-    return PlatformScaffold(
+    return PlatformThemedScaffold(
       backgroundColor: Styles.listingsScreenBackgroundColor(context),
       appBar: PlatformAppBar(title: title, actions: [filterBtn]),
       body: _Body(user: user, isOnline: isOnline, gameFilter: gameFilter),

--- a/lib/src/view/user/leaderboard_screen.dart
+++ b/lib/src/view/user/leaderboard_screen.dart
@@ -20,7 +20,7 @@ class LeaderboardScreen extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    return PlatformScaffold(
+    return PlatformThemedScaffold(
       appBar: PlatformAppBar(title: Text(context.l10n.leaderboard)),
       body: const _Body(),
     );

--- a/lib/src/view/user/leaderboard_screen.dart
+++ b/lib/src/view/user/leaderboard_screen.dart
@@ -18,6 +18,14 @@ import 'package:lichess_mobile/src/widgets/user_full_name.dart';
 class LeaderboardScreen extends StatelessWidget {
   const LeaderboardScreen({super.key});
 
+  static Route<dynamic> buildRoute(BuildContext context) {
+    return buildScreenRoute(
+      context,
+      title: context.l10n.leaderboard,
+      screen: const LeaderboardScreen(),
+    );
+  }
+
   @override
   Widget build(BuildContext context) {
     return PlatformThemedScaffold(
@@ -101,7 +109,7 @@ class LeaderboardListTile extends StatelessWidget {
   }
 
   void _handleTap(BuildContext context) {
-    pushPlatformRoute(context, builder: (context) => UserScreen(user: user.lightUser));
+    Navigator.of(context).push(UserScreen.buildRoute(context, user.lightUser));
   }
 }
 

--- a/lib/src/view/user/leaderboard_screen.dart
+++ b/lib/src/view/user/leaderboard_screen.dart
@@ -28,7 +28,7 @@ class LeaderboardScreen extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    return PlatformThemedScaffold(
+    return PlatformScaffold(
       appBar: PlatformAppBar(title: Text(context.l10n.leaderboard)),
       body: const _Body(),
     );

--- a/lib/src/view/user/leaderboard_widget.dart
+++ b/lib/src/view/user/leaderboard_widget.dart
@@ -3,7 +3,6 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:lichess_mobile/src/model/user/user_repository_providers.dart';
 import 'package:lichess_mobile/src/styles/styles.dart';
 import 'package:lichess_mobile/src/utils/l10n_context.dart';
-import 'package:lichess_mobile/src/utils/navigation.dart';
 import 'package:lichess_mobile/src/view/user/leaderboard_screen.dart';
 import 'package:lichess_mobile/src/widgets/buttons.dart';
 import 'package:lichess_mobile/src/widgets/list.dart';
@@ -24,11 +23,7 @@ class LeaderboardWidget extends ConsumerWidget {
           header: Text(context.l10n.leaderboard),
           headerTrailing: NoPaddingTextButton(
             onPressed: () {
-              pushPlatformRoute(
-                context,
-                title: context.l10n.leaderboard,
-                builder: (context) => const LeaderboardScreen(),
-              );
+              Navigator.of(context).push(LeaderboardScreen.buildRoute(context));
             },
             child: Text(context.l10n.more),
           ),

--- a/lib/src/view/user/perf_cards.dart
+++ b/lib/src/view/user/perf_cards.dart
@@ -5,7 +5,6 @@ import 'package:lichess_mobile/src/model/common/perf.dart';
 import 'package:lichess_mobile/src/model/user/user.dart';
 import 'package:lichess_mobile/src/styles/lichess_icons.dart';
 import 'package:lichess_mobile/src/styles/styles.dart';
-import 'package:lichess_mobile/src/utils/navigation.dart';
 import 'package:lichess_mobile/src/view/account/rating_pref_aware.dart';
 import 'package:lichess_mobile/src/view/puzzle/dashboard_screen.dart';
 import 'package:lichess_mobile/src/view/puzzle/storm_dashboard.dart';
@@ -141,18 +140,10 @@ class PerfCards extends StatelessWidget {
   }
 
   void _handlePerfCardTap(BuildContext context, Perf perf) {
-    pushPlatformRoute(
-      context,
-      builder: (context) {
-        switch (perf) {
-          case Perf.puzzle:
-            return const PuzzleDashboardScreen();
-          case Perf.storm:
-            return StormDashboardModal(user: user.lightUser);
-          default:
-            return PerfStatsScreen(user: user, perf: perf);
-        }
-      },
-    );
+    Navigator.of(context).push(switch (perf) {
+      Perf.puzzle => PuzzleDashboardScreen.buildRoute(context),
+      Perf.storm => StormDashboardModal.buildRoute(context, user.lightUser),
+      _ => PerfStatsScreen.buildRoute(context, user: user, perf: perf),
+    });
   }
 }

--- a/lib/src/view/user/perf_stats_screen.dart
+++ b/lib/src/view/user/perf_stats_screen.dart
@@ -47,6 +47,14 @@ class PerfStatsScreen extends StatelessWidget {
   final User user;
   final Perf perf;
 
+  static Route<dynamic> buildRoute(BuildContext context, {required User user, required Perf perf}) {
+    return buildScreenRoute(
+      context,
+      title: context.l10n.perfStatPerfStats(perf.title),
+      screen: PerfStatsScreen(user: user, perf: perf),
+    );
+  }
+
   @override
   Widget build(BuildContext context) {
     return PlatformThemedScaffold(
@@ -104,12 +112,9 @@ class _Title extends StatelessWidget {
                         ],
                       ),
                   onPressed: (ctx) {
-                    pushReplacementPlatformRoute(
+                    Navigator.of(
                       context,
-                      builder: (ctx) {
-                        return PerfStatsScreen(user: user, perf: p);
-                      },
-                    );
+                    ).pushReplacement(PerfStatsScreen.buildRoute(context, user: user, perf: p));
                   },
                 );
               })
@@ -254,14 +259,13 @@ class _Body extends ConsumerWidget {
                 message: context.l10n.perfStatViewTheGames,
                 child: AdaptiveInkWell(
                   onTap: () {
-                    pushPlatformRoute(
-                      context,
-                      builder:
-                          (context) => GameHistoryScreen(
-                            user: user.lightUser,
-                            isOnline: true,
-                            gameFilter: GameFilterState(perfs: ISet({perf})),
-                          ),
+                    Navigator.of(context).push(
+                      GameHistoryScreen.buildRoute(
+                        context,
+                        user: user.lightUser,
+                        isOnline: true,
+                        gameFilter: GameFilterState(perfs: ISet({perf})),
+                      ),
                     );
                   },
                   child: Padding(
@@ -621,14 +625,12 @@ class _GameListWidget extends ConsumerWidget {
               );
               final gameData = list.firstWhereOrNull((g) => g.id == game.gameId);
               if (context.mounted && gameData != null && gameData.variant.isReadSupported) {
-                pushPlatformRoute(
-                  context,
-                  rootNavigator: true,
-                  builder:
-                      (context) => ArchivedGameScreen(
-                        gameData: gameData,
-                        orientation: user.id == gameData.white.user?.id ? Side.white : Side.black,
-                      ),
+                Navigator.of(context, rootNavigator: true).push(
+                  ArchivedGameScreen.buildRoute(
+                    context,
+                    gameData: gameData,
+                    orientation: user.id == gameData.white.user?.id ? Side.white : Side.black,
+                  ),
                 );
               } else if (context.mounted && gameData != null) {
                 showPlatformSnackbar(context, 'This variant is not supported yet');

--- a/lib/src/view/user/perf_stats_screen.dart
+++ b/lib/src/view/user/perf_stats_screen.dart
@@ -57,7 +57,7 @@ class PerfStatsScreen extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    return PlatformThemedScaffold(
+    return PlatformScaffold(
       appBar: PlatformAppBar(androidTitleSpacing: 0, title: _Title(user: user, perf: perf)),
       body: _Body(user: user, perf: perf),
     );

--- a/lib/src/view/user/perf_stats_screen.dart
+++ b/lib/src/view/user/perf_stats_screen.dart
@@ -49,7 +49,7 @@ class PerfStatsScreen extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    return PlatformScaffold(
+    return PlatformThemedScaffold(
       appBar: PlatformAppBar(androidTitleSpacing: 0, title: _Title(user: user, perf: perf)),
       body: _Body(user: user, perf: perf),
     );

--- a/lib/src/view/user/player_screen.dart
+++ b/lib/src/view/user/player_screen.dart
@@ -34,7 +34,7 @@ class PlayerScreen extends ConsumerWidget {
           ref.read(onlineFriendsProvider.notifier).stopWatchingFriends();
         }
       },
-      child: PlatformScaffold(
+      child: PlatformThemedScaffold(
         appBar: PlatformAppBar(title: Text(context.l10n.players)),
         body: _Body(),
       ),

--- a/lib/src/view/user/player_screen.dart
+++ b/lib/src/view/user/player_screen.dart
@@ -38,7 +38,7 @@ class PlayerScreen extends ConsumerWidget {
           ref.read(onlineFriendsProvider.notifier).stopWatchingFriends();
         }
       },
-      child: PlatformThemedScaffold(
+      child: PlatformScaffold(
         appBar: PlatformAppBar(title: Text(context.l10n.players)),
         body: _Body(),
       ),

--- a/lib/src/view/user/player_screen.dart
+++ b/lib/src/view/user/player_screen.dart
@@ -23,6 +23,10 @@ import 'package:lichess_mobile/src/widgets/user_full_name.dart';
 class PlayerScreen extends ConsumerWidget {
   const PlayerScreen({super.key});
 
+  static Route<dynamic> buildRoute(BuildContext context) {
+    return buildScreenRoute(context, screen: const PlayerScreen(), title: context.l10n.players);
+  }
+
   @override
   Widget build(BuildContext context, WidgetRef ref) {
     return FocusDetector(
@@ -68,17 +72,13 @@ class _SearchButton extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     void onUserTap(LightUser user) =>
-        pushPlatformRoute(context, builder: (ctx) => UserScreen(user: user));
+        Navigator.of(context).push(UserScreen.buildRoute(context, user));
 
     return PlatformSearchBar(
       hintText: context.l10n.searchSearch,
       focusNode: AlwaysDisabledFocusNode(),
       onTap:
-          () => pushPlatformRoute(
-            context,
-            fullscreenDialog: true,
-            builder: (_) => SearchScreen(onUserTap: onUserTap),
-          ),
+          () => Navigator.of(context).push(SearchScreen.buildRoute(context, onUserTap: onUserTap)),
     );
   }
 }
@@ -112,12 +112,7 @@ class _OnlineFriendsWidget extends ConsumerWidget {
                   padding: const EdgeInsets.only(right: 5.0),
                   child: UserFullNameWidget(user: user),
                 ),
-                onTap:
-                    () => pushPlatformRoute(
-                      context,
-                      title: user.name,
-                      builder: (_) => UserScreen(user: user),
-                    ),
+                onTap: () => Navigator.of(context).push(UserScreen.buildRoute(context, user)),
               ),
           ],
         );
@@ -139,10 +134,6 @@ class _OnlineFriendsWidget extends ConsumerWidget {
   }
 
   void _handleTap(BuildContext context, IList<LightUser> followingOnlines) {
-    pushPlatformRoute(
-      context,
-      title: context.l10n.friends,
-      builder: (_) => const FollowingScreen(),
-    );
+    Navigator.of(context).push(FollowingScreen.buildRoute(context));
   }
 }

--- a/lib/src/view/user/recent_games.dart
+++ b/lib/src/view/user/recent_games.dart
@@ -6,7 +6,6 @@ import 'package:lichess_mobile/src/model/user/user.dart';
 import 'package:lichess_mobile/src/network/connectivity.dart';
 import 'package:lichess_mobile/src/styles/styles.dart';
 import 'package:lichess_mobile/src/utils/l10n_context.dart';
-import 'package:lichess_mobile/src/utils/navigation.dart';
 import 'package:lichess_mobile/src/view/game/game_list_tile.dart';
 import 'package:lichess_mobile/src/view/user/game_history_screen.dart';
 import 'package:lichess_mobile/src/widgets/buttons.dart';
@@ -48,13 +47,12 @@ class RecentGamesWidget extends ConsumerWidget {
               nbOfGames > list.length
                   ? NoPaddingTextButton(
                     onPressed: () {
-                      pushPlatformRoute(
-                        context,
-                        builder:
-                            (context) => GameHistoryScreen(
-                              user: user,
-                              isOnline: connectivity.valueOrNull?.isOnline == true,
-                            ),
+                      Navigator.of(context).push(
+                        GameHistoryScreen.buildRoute(
+                          context,
+                          user: user,
+                          isOnline: connectivity.valueOrNull?.isOnline == true,
+                        ),
                       );
                     },
                     child: Text(context.l10n.more),

--- a/lib/src/view/user/search_screen.dart
+++ b/lib/src/view/user/search_screen.dart
@@ -7,6 +7,7 @@ import 'package:lichess_mobile/src/model/user/user.dart';
 import 'package:lichess_mobile/src/model/user/user_repository_providers.dart';
 import 'package:lichess_mobile/src/utils/l10n_context.dart';
 import 'package:lichess_mobile/src/utils/rate_limit.dart';
+import 'package:lichess_mobile/src/widgets/background_theme.dart';
 import 'package:lichess_mobile/src/widgets/buttons.dart';
 import 'package:lichess_mobile/src/widgets/feedback.dart';
 import 'package:lichess_mobile/src/widgets/list.dart';
@@ -77,27 +78,29 @@ class _SearchScreenState extends ConsumerState<SearchScreen> {
 
     final body = _Body(_term, setSearchText, widget.onUserTap);
 
-    return PlatformWidget(
-      androidBuilder:
-          (context) => Scaffold(
-            appBar: AppBar(
-              toolbarHeight: 80, // Custom height to fit the search bar
-              title: searchBar,
-            ),
-            body: body,
-          ),
-      iosBuilder:
-          (context) => CupertinoPageScaffold(
-            navigationBar: CupertinoNavigationBar(
-              automaticallyImplyLeading: false,
-              middle: SizedBox(height: 36.0, child: searchBar),
-              trailing: NoPaddingTextButton(
-                child: Text(context.l10n.close),
-                onPressed: () => Navigator.pop(context),
+    return FullScreenBackgroundTheme(
+      child: PlatformWidget(
+        androidBuilder:
+            (context) => Scaffold(
+              appBar: AppBar(
+                toolbarHeight: 80, // Custom height to fit the search bar
+                title: searchBar,
               ),
+              body: body,
             ),
-            child: body,
-          ),
+        iosBuilder:
+            (context) => CupertinoPageScaffold(
+              navigationBar: CupertinoNavigationBar(
+                automaticallyImplyLeading: false,
+                middle: SizedBox(height: 36.0, child: searchBar),
+                trailing: NoPaddingTextButton(
+                  child: Text(context.l10n.close),
+                  onPressed: () => Navigator.pop(context),
+                ),
+              ),
+              child: body,
+            ),
+      ),
     );
   }
 }

--- a/lib/src/view/user/search_screen.dart
+++ b/lib/src/view/user/search_screen.dart
@@ -8,7 +8,6 @@ import 'package:lichess_mobile/src/model/user/user_repository_providers.dart';
 import 'package:lichess_mobile/src/utils/l10n_context.dart';
 import 'package:lichess_mobile/src/utils/navigation.dart';
 import 'package:lichess_mobile/src/utils/rate_limit.dart';
-import 'package:lichess_mobile/src/widgets/background.dart';
 import 'package:lichess_mobile/src/widgets/buttons.dart';
 import 'package:lichess_mobile/src/widgets/feedback.dart';
 import 'package:lichess_mobile/src/widgets/list.dart';
@@ -87,29 +86,27 @@ class _SearchScreenState extends ConsumerState<SearchScreen> {
 
     final body = _Body(_term, setSearchText, widget.onUserTap);
 
-    return FullScreenBackground(
-      child: PlatformWidget(
-        androidBuilder:
-            (context) => Scaffold(
-              appBar: AppBar(
-                toolbarHeight: 80, // Custom height to fit the search bar
-                title: searchBar,
-              ),
-              body: body,
+    return PlatformWidget(
+      androidBuilder:
+          (context) => Scaffold(
+            appBar: AppBar(
+              toolbarHeight: 80, // Custom height to fit the search bar
+              title: searchBar,
             ),
-        iosBuilder:
-            (context) => CupertinoPageScaffold(
-              navigationBar: CupertinoNavigationBar(
-                automaticallyImplyLeading: false,
-                middle: SizedBox(height: 36.0, child: searchBar),
-                trailing: NoPaddingTextButton(
-                  child: Text(context.l10n.close),
-                  onPressed: () => Navigator.pop(context),
-                ),
+            body: body,
+          ),
+      iosBuilder:
+          (context) => CupertinoPageScaffold(
+            navigationBar: CupertinoNavigationBar(
+              automaticallyImplyLeading: false,
+              middle: SizedBox(height: 36.0, child: searchBar),
+              trailing: NoPaddingTextButton(
+                child: Text(context.l10n.close),
+                onPressed: () => Navigator.pop(context),
               ),
-              child: body,
             ),
-      ),
+            child: body,
+          ),
     );
   }
 }

--- a/lib/src/view/user/search_screen.dart
+++ b/lib/src/view/user/search_screen.dart
@@ -6,6 +6,7 @@ import 'package:lichess_mobile/src/model/user/search_history.dart';
 import 'package:lichess_mobile/src/model/user/user.dart';
 import 'package:lichess_mobile/src/model/user/user_repository_providers.dart';
 import 'package:lichess_mobile/src/utils/l10n_context.dart';
+import 'package:lichess_mobile/src/utils/navigation.dart';
 import 'package:lichess_mobile/src/utils/rate_limit.dart';
 import 'package:lichess_mobile/src/widgets/background.dart';
 import 'package:lichess_mobile/src/widgets/buttons.dart';
@@ -21,6 +22,14 @@ class SearchScreen extends ConsumerStatefulWidget {
   const SearchScreen({this.onUserTap});
 
   final void Function(LightUser)? onUserTap;
+
+  static Route<dynamic> buildRoute(BuildContext context, {void Function(LightUser)? onUserTap}) {
+    return buildScreenRoute(
+      context,
+      screen: SearchScreen(onUserTap: onUserTap),
+      fullscreenDialog: true,
+    );
+  }
 
   @override
   ConsumerState<SearchScreen> createState() => _SearchScreenState();

--- a/lib/src/view/user/search_screen.dart
+++ b/lib/src/view/user/search_screen.dart
@@ -7,7 +7,7 @@ import 'package:lichess_mobile/src/model/user/user.dart';
 import 'package:lichess_mobile/src/model/user/user_repository_providers.dart';
 import 'package:lichess_mobile/src/utils/l10n_context.dart';
 import 'package:lichess_mobile/src/utils/rate_limit.dart';
-import 'package:lichess_mobile/src/widgets/background_theme.dart';
+import 'package:lichess_mobile/src/widgets/background.dart';
 import 'package:lichess_mobile/src/widgets/buttons.dart';
 import 'package:lichess_mobile/src/widgets/feedback.dart';
 import 'package:lichess_mobile/src/widgets/list.dart';
@@ -78,7 +78,7 @@ class _SearchScreenState extends ConsumerState<SearchScreen> {
 
     final body = _Body(_term, setSearchText, widget.onUserTap);
 
-    return FullScreenBackgroundTheme(
+    return FullScreenBackground(
       child: PlatformWidget(
         androidBuilder:
             (context) => Scaffold(

--- a/lib/src/view/user/user_profile.dart
+++ b/lib/src/view/user/user_profile.dart
@@ -13,7 +13,6 @@ import 'package:lichess_mobile/src/utils/duration.dart';
 import 'package:lichess_mobile/src/utils/l10n.dart';
 import 'package:lichess_mobile/src/utils/l10n_context.dart';
 import 'package:lichess_mobile/src/utils/lichess_assets.dart';
-import 'package:lichess_mobile/src/utils/navigation.dart';
 import 'package:lichess_mobile/src/view/user/countries.dart';
 import 'package:lichess_mobile/src/view/user/user_screen.dart';
 import 'package:lichess_mobile/src/widgets/buttons.dart';
@@ -71,12 +70,11 @@ class UserProfileWidget extends ConsumerWidget {
                 onOpen: (link) async {
                   if (link.originText.startsWith('@')) {
                     final username = link.originText.substring(1);
-                    pushPlatformRoute(
-                      context,
-                      builder:
-                          (ctx) => UserScreen(
-                            user: LightUser(id: UserId.fromUserName(username), name: username),
-                          ),
+                    Navigator.of(context).push(
+                      UserScreen.buildRoute(
+                        context,
+                        LightUser(id: UserId.fromUserName(username), name: username),
+                      ),
                     );
                   } else {
                     launchUrl(Uri.parse(link.url));

--- a/lib/src/view/user/user_screen.dart
+++ b/lib/src/view/user/user_screen.dart
@@ -28,6 +28,10 @@ class UserScreen extends ConsumerStatefulWidget {
 
   final LightUser user;
 
+  static Route<dynamic> buildRoute(BuildContext context, LightUser user) {
+    return buildScreenRoute(context, title: user.name, screen: UserScreen(user: user));
+  }
+
   @override
   ConsumerState<UserScreen> createState() => _UserScreenState();
 }
@@ -120,14 +124,10 @@ class _UserProfileListView extends ConsumerWidget {
                   leading: const Icon(LichessIcons.crossed_swords),
                   onTap: () {
                     final isOddBot = oddBots.contains(user.lightUser.name.toLowerCase());
-                    pushPlatformRoute(
-                      context,
-                      title: context.l10n.challengeChallengesX(user.lightUser.name),
-                      builder:
-                          (context) =>
-                              isOddBot
-                                  ? ChallengeOddBotsScreen(user.lightUser)
-                                  : CreateChallengeScreen(user.lightUser),
+                    Navigator.of(context).push(
+                      isOddBot
+                          ? ChallengeOddBotsScreen.buildRoute(context, user.lightUser)
+                          : CreateChallengeScreen.buildRoute(context, user.lightUser),
                     );
                   },
                 ),

--- a/lib/src/view/user/user_screen.dart
+++ b/lib/src/view/user/user_screen.dart
@@ -48,7 +48,7 @@ class _UserScreenState extends ConsumerState<UserScreen> {
       data: (data) => data.$1.lightUser.copyWith(isOnline: data.$2.online),
       orElse: () => null,
     );
-    return PlatformScaffold(
+    return PlatformThemedScaffold(
       appBar: PlatformAppBar(
         title: UserFullNameWidget(
           user: updatedLightUser ?? widget.user,

--- a/lib/src/view/user/user_screen.dart
+++ b/lib/src/view/user/user_screen.dart
@@ -52,7 +52,7 @@ class _UserScreenState extends ConsumerState<UserScreen> {
       data: (data) => data.$1.lightUser.copyWith(isOnline: data.$2.online),
       orElse: () => null,
     );
-    return PlatformThemedScaffold(
+    return PlatformScaffold(
       appBar: PlatformAppBar(
         title: UserFullNameWidget(
           user: updatedLightUser ?? widget.user,

--- a/lib/src/view/watch/live_tv_channels_screen.dart
+++ b/lib/src/view/watch/live_tv_channels_screen.dart
@@ -29,7 +29,7 @@ class LiveTvChannelsScreen extends ConsumerWidget {
           ref.read(liveTvChannelsProvider.notifier).stopWatching();
         }
       },
-      child: const PlatformThemedScaffold(
+      child: const PlatformScaffold(
         appBar: PlatformAppBar(title: Text('Lichess TV')),
         body: _Body(),
       ),

--- a/lib/src/view/watch/live_tv_channels_screen.dart
+++ b/lib/src/view/watch/live_tv_channels_screen.dart
@@ -25,7 +25,7 @@ class LiveTvChannelsScreen extends ConsumerWidget {
           ref.read(liveTvChannelsProvider.notifier).stopWatching();
         }
       },
-      child: const PlatformScaffold(
+      child: const PlatformThemedScaffold(
         appBar: PlatformAppBar(title: Text('Lichess TV')),
         body: _Body(),
       ),

--- a/lib/src/view/watch/live_tv_channels_screen.dart
+++ b/lib/src/view/watch/live_tv_channels_screen.dart
@@ -14,6 +14,10 @@ import 'package:lichess_mobile/src/widgets/user_full_name.dart';
 class LiveTvChannelsScreen extends ConsumerWidget {
   const LiveTvChannelsScreen({super.key});
 
+  static Route<dynamic> buildRoute(BuildContext context) {
+    return buildScreenRoute(context, title: 'Lichess TV', screen: const LiveTvChannelsScreen());
+  }
+
   @override
   Widget build(BuildContext context, WidgetRef ref) {
     return FocusDetector(
@@ -51,12 +55,13 @@ class _Body extends ConsumerWidget {
             final game = list[index];
             return SmallBoardPreview(
               onTap: () {
-                pushPlatformRoute(
-                  context,
-                  rootNavigator: true,
-                  builder:
-                      (_) =>
-                          TvScreen(channel: game.channel, initialGame: (game.id, game.orientation)),
+                Navigator.of(context, rootNavigator: true).push(
+                  TvScreen.buildRoute(
+                    context,
+                    game.channel,
+                    gameId: game.id,
+                    orientation: game.orientation,
+                  ),
                 );
               },
               orientation: game.orientation,

--- a/lib/src/view/watch/streamer_screen.dart
+++ b/lib/src/view/watch/streamer_screen.dart
@@ -6,7 +6,6 @@ import 'package:lichess_mobile/src/styles/social_icons.dart';
 import 'package:lichess_mobile/src/styles/styles.dart';
 import 'package:lichess_mobile/src/utils/l10n_context.dart';
 import 'package:lichess_mobile/src/utils/navigation.dart';
-import 'package:lichess_mobile/src/widgets/background.dart';
 import 'package:lichess_mobile/src/widgets/buttons.dart';
 import 'package:lichess_mobile/src/widgets/list.dart';
 import 'package:lichess_mobile/src/widgets/platform.dart';
@@ -27,9 +26,7 @@ class StreamerScreen extends StatelessWidget {
 
   @override
   Widget build(BuildContext build) {
-    return FullScreenBackground(
-      child: PlatformWidget(androidBuilder: _buildAndroid, iosBuilder: _buildIos),
-    );
+    return PlatformWidget(androidBuilder: _buildAndroid, iosBuilder: _buildIos);
   }
 
   Widget _buildAndroid(BuildContext context) {

--- a/lib/src/view/watch/streamer_screen.dart
+++ b/lib/src/view/watch/streamer_screen.dart
@@ -5,6 +5,7 @@ import 'package:lichess_mobile/src/model/user/streamer.dart';
 import 'package:lichess_mobile/src/styles/social_icons.dart';
 import 'package:lichess_mobile/src/styles/styles.dart';
 import 'package:lichess_mobile/src/utils/l10n_context.dart';
+import 'package:lichess_mobile/src/widgets/background_theme.dart';
 import 'package:lichess_mobile/src/widgets/buttons.dart';
 import 'package:lichess_mobile/src/widgets/list.dart';
 import 'package:lichess_mobile/src/widgets/platform.dart';
@@ -17,7 +18,9 @@ class StreamerScreen extends StatelessWidget {
 
   @override
   Widget build(BuildContext build) {
-    return PlatformWidget(androidBuilder: _buildAndroid, iosBuilder: _buildIos);
+    return FullScreenBackgroundTheme(
+      child: PlatformWidget(androidBuilder: _buildAndroid, iosBuilder: _buildIos),
+    );
   }
 
   Widget _buildAndroid(BuildContext context) {

--- a/lib/src/view/watch/streamer_screen.dart
+++ b/lib/src/view/watch/streamer_screen.dart
@@ -5,7 +5,7 @@ import 'package:lichess_mobile/src/model/user/streamer.dart';
 import 'package:lichess_mobile/src/styles/social_icons.dart';
 import 'package:lichess_mobile/src/styles/styles.dart';
 import 'package:lichess_mobile/src/utils/l10n_context.dart';
-import 'package:lichess_mobile/src/widgets/background_theme.dart';
+import 'package:lichess_mobile/src/widgets/background.dart';
 import 'package:lichess_mobile/src/widgets/buttons.dart';
 import 'package:lichess_mobile/src/widgets/list.dart';
 import 'package:lichess_mobile/src/widgets/platform.dart';
@@ -18,7 +18,7 @@ class StreamerScreen extends StatelessWidget {
 
   @override
   Widget build(BuildContext build) {
-    return FullScreenBackgroundTheme(
+    return FullScreenBackground(
       child: PlatformWidget(androidBuilder: _buildAndroid, iosBuilder: _buildIos),
     );
   }

--- a/lib/src/view/watch/streamer_screen.dart
+++ b/lib/src/view/watch/streamer_screen.dart
@@ -5,6 +5,7 @@ import 'package:lichess_mobile/src/model/user/streamer.dart';
 import 'package:lichess_mobile/src/styles/social_icons.dart';
 import 'package:lichess_mobile/src/styles/styles.dart';
 import 'package:lichess_mobile/src/utils/l10n_context.dart';
+import 'package:lichess_mobile/src/utils/navigation.dart';
 import 'package:lichess_mobile/src/widgets/background.dart';
 import 'package:lichess_mobile/src/widgets/buttons.dart';
 import 'package:lichess_mobile/src/widgets/list.dart';
@@ -15,6 +16,14 @@ class StreamerScreen extends StatelessWidget {
   const StreamerScreen({required this.streamers});
 
   final IList<Streamer> streamers;
+
+  static Route<dynamic> buildRoute(BuildContext context, IList<Streamer> streamers) {
+    return buildScreenRoute(
+      context,
+      title: context.l10n.mobileLiveStreamers,
+      screen: StreamerScreen(streamers: streamers),
+    );
+  }
 
   @override
   Widget build(BuildContext build) {

--- a/lib/src/view/watch/tv_screen.dart
+++ b/lib/src/view/watch/tv_screen.dart
@@ -61,7 +61,7 @@ class _TvScreenState extends ConsumerState<TvScreen> {
           ref.read(_tvGameCtrl.notifier).stopWatching();
         }
       },
-      child: PlatformThemedScaffold(
+      child: PlatformScaffold(
         appBar: PlatformAppBar(
           title: Text('${widget.channel.label} TV'),
           actions: const [ToggleSoundButton()],

--- a/lib/src/view/watch/tv_screen.dart
+++ b/lib/src/view/watch/tv_screen.dart
@@ -7,6 +7,7 @@ import 'package:lichess_mobile/src/model/tv/tv_channel.dart';
 import 'package:lichess_mobile/src/model/tv/tv_controller.dart';
 import 'package:lichess_mobile/src/utils/focus_detector.dart';
 import 'package:lichess_mobile/src/utils/l10n_context.dart';
+import 'package:lichess_mobile/src/utils/navigation.dart';
 import 'package:lichess_mobile/src/view/game/game_loading_board.dart';
 import 'package:lichess_mobile/src/view/game/game_player.dart';
 import 'package:lichess_mobile/src/view/settings/toggle_sound_button.dart';
@@ -23,6 +24,21 @@ class TvScreen extends ConsumerStatefulWidget {
 
   final TvChannel channel;
   final (GameId id, Side orientation)? initialGame;
+
+  static Route<dynamic> buildRoute(
+    BuildContext context,
+    TvChannel channel, {
+    GameId? gameId,
+    Side? orientation,
+  }) {
+    return buildScreenRoute(
+      context,
+      screen: TvScreen(
+        channel: channel,
+        initialGame: gameId != null ? (gameId, orientation ?? Side.white) : null,
+      ),
+    );
+  }
 
   @override
   ConsumerState<TvScreen> createState() => _TvScreenState();

--- a/lib/src/view/watch/tv_screen.dart
+++ b/lib/src/view/watch/tv_screen.dart
@@ -45,7 +45,7 @@ class _TvScreenState extends ConsumerState<TvScreen> {
           ref.read(_tvGameCtrl.notifier).stopWatching();
         }
       },
-      child: PlatformBoardThemeScaffold(
+      child: PlatformThemedScaffold(
         appBar: PlatformAppBar(
           title: Text('${widget.channel.label} TV'),
           actions: const [ToggleSoundButton()],

--- a/lib/src/view/watch/watch_tab_screen.dart
+++ b/lib/src/view/watch/watch_tab_screen.dart
@@ -16,7 +16,6 @@ import 'package:lichess_mobile/src/network/http.dart';
 import 'package:lichess_mobile/src/styles/styles.dart';
 import 'package:lichess_mobile/src/utils/image.dart';
 import 'package:lichess_mobile/src/utils/l10n_context.dart';
-import 'package:lichess_mobile/src/utils/navigation.dart';
 import 'package:lichess_mobile/src/view/broadcast/broadcast_list_screen.dart';
 import 'package:lichess_mobile/src/view/watch/live_tv_channels_screen.dart';
 import 'package:lichess_mobile/src/view/watch/streamer_screen.dart';
@@ -222,11 +221,7 @@ class _BroadcastWidget extends ConsumerWidget {
                 const SizedBox(width: 6.0),
                 NoPaddingTextButton(
                   onPressed: () {
-                    pushPlatformRoute(
-                      context,
-                      title: context.l10n.broadcastBroadcasts,
-                      builder: (context) => const BroadcastListScreen(),
-                    );
+                    Navigator.of(context).push(BroadcastListScreen.buildRoute(context));
                   },
                   child: Text(context.l10n.more),
                 ),
@@ -269,10 +264,9 @@ class _WatchTvWidget extends ConsumerWidget {
           hasLeading: true,
           headerTrailing: NoPaddingTextButton(
             onPressed:
-                () => pushPlatformRoute(
+                () => Navigator.of(
                   context,
-                  builder: (context) => const LiveTvChannelsScreen(),
-                ).then((_) => _refreshData(ref)),
+                ).push(LiveTvChannelsScreen.buildRoute(context)).then((_) => _refreshData(ref)),
             child: Text(context.l10n.more),
           ),
           children: data
@@ -286,11 +280,16 @@ class _WatchTvWidget extends ConsumerWidget {
                     rating: snapshot.player.rating,
                   ),
                   onTap:
-                      () => pushPlatformRoute(
-                        context,
-                        rootNavigator: true,
-                        builder: (context) => TvScreen(channel: snapshot.channel),
-                      ).then((_) => _refreshData(ref)),
+                      () => Navigator.of(context, rootNavigator: true)
+                          .push(
+                            TvScreen.buildRoute(
+                              context,
+                              snapshot.channel,
+                              gameId: snapshot.id,
+                              orientation: snapshot.player.side,
+                            ),
+                          )
+                          .then((_) => _refreshData(ref)),
                 );
               })
               .toList(growable: false),
@@ -332,11 +331,7 @@ class _StreamerWidget extends ConsumerWidget {
           header: Text(context.l10n.streamersMenu),
           hasLeading: true,
           headerTrailing: NoPaddingTextButton(
-            onPressed:
-                () => pushPlatformRoute(
-                  context,
-                  builder: (context) => StreamerScreen(streamers: data),
-                ),
+            onPressed: () => Navigator.of(context).push(StreamerScreen.buildRoute(context, data)),
             child: Text(context.l10n.more),
           ),
           children: [

--- a/lib/src/widgets/background.dart
+++ b/lib/src/widgets/background.dart
@@ -6,7 +6,6 @@ import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:lichess_mobile/src/model/common/preloaded_data.dart';
 import 'package:lichess_mobile/src/model/settings/general_preferences.dart';
-import 'package:lichess_mobile/src/theme.dart';
 
 const kBackgroundImageBlurFactor = 8.0;
 
@@ -17,8 +16,8 @@ const kBackgroundImageBlurFactor = 8.0;
 ///
 /// Since the background image is always full screen, this widget should be used to wrap only [Scaffold]
 /// or [CupertinoPageScaffold] widgets.
-class FullScreenBackgroundTheme extends ConsumerWidget {
-  const FullScreenBackgroundTheme({required this.child, super.key});
+class FullScreenBackground extends ConsumerWidget {
+  const FullScreenBackground({required this.child, super.key});
 
   /// The child widget to apply the theme to.
   final Widget child;
@@ -30,7 +29,7 @@ class FullScreenBackgroundTheme extends ConsumerWidget {
         ref.read(preloadedDataProvider).requireValue.appDocumentsDirectory;
 
     if (generalPrefs.backgroundImage != null && appDocumentsDirectory != null) {
-      return FullScreenBackgroundImageTheme(
+      return FullScreenBackgroundImage(
         backgroundImage: generalPrefs.backgroundImage!,
         viewport: MediaQuery.sizeOf(context),
         appDocumentsDirectory: appDocumentsDirectory,
@@ -51,8 +50,8 @@ class FullScreenBackgroundTheme extends ConsumerWidget {
 ///
 /// The image is always sized to cover the full screen, and the image is blurred if requested.
 /// This is intended to be used with [Scaffold] or [CupertinoPageScaffold] as the child.
-class FullScreenBackgroundImageTheme extends StatefulWidget {
-  const FullScreenBackgroundImageTheme({
+class FullScreenBackgroundImage extends StatefulWidget {
+  const FullScreenBackgroundImage({
     required this.backgroundImage,
     required this.viewport,
     required this.appDocumentsDirectory,
@@ -77,10 +76,10 @@ class FullScreenBackgroundImageTheme extends StatefulWidget {
   };
 
   @override
-  State<FullScreenBackgroundImageTheme> createState() => _FullScreenBackgroundImageState();
+  State<FullScreenBackgroundImage> createState() => _FullScreenBackgroundImageState();
 }
 
-class _FullScreenBackgroundImageState extends State<FullScreenBackgroundImageTheme> {
+class _FullScreenBackgroundImageState extends State<FullScreenBackgroundImage> {
   final TransformationController _controller = TransformationController();
 
   Size get pickedImageViewport =>
@@ -93,7 +92,7 @@ class _FullScreenBackgroundImageState extends State<FullScreenBackgroundImageThe
   }
 
   @override
-  void didUpdateWidget(FullScreenBackgroundImageTheme oldWidget) {
+  void didUpdateWidget(FullScreenBackgroundImage oldWidget) {
     super.didUpdateWidget(oldWidget);
     if (widget.backgroundImage.transform != oldWidget.backgroundImage.transform ||
         widget.viewport != oldWidget.viewport) {
@@ -130,7 +129,7 @@ class _FullScreenBackgroundImageState extends State<FullScreenBackgroundImageThe
             ? BoxFit.fitWidth
             : BoxFit.fitHeight;
 
-    final imageFitSize = FullScreenBackgroundImageTheme.imageFitSize(
+    final imageFitSize = FullScreenBackgroundImage.imageFitSize(
       boxFit,
       Size(widget.backgroundImage.width, widget.backgroundImage.height),
       widget.viewport,
@@ -142,55 +141,48 @@ class _FullScreenBackgroundImageState extends State<FullScreenBackgroundImageThe
       widget.backgroundImage.meanLuminance,
     );
 
-    return Theme(
-      data:
-          makeBackgroundImageTheme(
-            baseTheme: baseTheme,
-            isIOS: Theme.of(context).platform == TargetPlatform.iOS,
-          ).dark,
-      child: Stack(
-        children: [
-          InteractiveViewer(
-            transformationController: _controller,
-            constrained: false,
-            minScale: 1,
-            maxScale: 2,
-            panEnabled: false,
-            scaleEnabled: false,
-            child: Container(
-              width: switch (boxFit) {
-                BoxFit.fitHeight => imageFitSize.width,
-                _ => widget.viewport.width,
-              },
-              height: switch (boxFit) {
-                BoxFit.fitWidth => imageFitSize.height,
-                _ => widget.viewport.height,
-              },
-              decoration: BoxDecoration(
-                color: Theme.of(context).colorScheme.surface,
-                image: DecorationImage(
-                  image: FileImage(
-                    File('${widget.appDocumentsDirectory.path}/${widget.backgroundImage.path}'),
-                  ),
-                  fit: boxFit,
-                  colorFilter: ColorFilter.mode(filterColor, BlendMode.srcOver),
+    return Stack(
+      children: [
+        InteractiveViewer(
+          transformationController: _controller,
+          constrained: false,
+          minScale: 1,
+          maxScale: 2,
+          panEnabled: false,
+          scaleEnabled: false,
+          child: Container(
+            width: switch (boxFit) {
+              BoxFit.fitHeight => imageFitSize.width,
+              _ => widget.viewport.width,
+            },
+            height: switch (boxFit) {
+              BoxFit.fitWidth => imageFitSize.height,
+              _ => widget.viewport.height,
+            },
+            decoration: BoxDecoration(
+              color: Theme.of(context).colorScheme.surface,
+              image: DecorationImage(
+                image: FileImage(
+                  File('${widget.appDocumentsDirectory.path}/${widget.backgroundImage.path}'),
                 ),
+                fit: boxFit,
+                colorFilter: ColorFilter.mode(filterColor, BlendMode.srcOver),
               ),
-              child: ClipRect(
-                child: BackdropFilter(
-                  enabled: widget.backgroundImage.isBlurred,
-                  filter: ImageFilter.blur(
-                    sigmaX: kBackgroundImageBlurFactor,
-                    sigmaY: kBackgroundImageBlurFactor,
-                  ),
-                  child: const SizedBox.expand(),
+            ),
+            child: ClipRect(
+              child: BackdropFilter(
+                enabled: widget.backgroundImage.isBlurred,
+                filter: ImageFilter.blur(
+                  sigmaX: kBackgroundImageBlurFactor,
+                  sigmaY: kBackgroundImageBlurFactor,
                 ),
+                child: const SizedBox.expand(),
               ),
             ),
           ),
-          Positioned.fill(child: widget.child),
-        ],
-      ),
+        ),
+        Positioned.fill(child: widget.child),
+      ],
     );
   }
 }
@@ -203,18 +195,11 @@ class _FullScreenBackgroundColorTheme extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    return Theme(
-      data:
-          makeBackgroundImageTheme(
-            baseTheme: backgroundTheme.baseTheme,
-            isIOS: Theme.of(context).platform == TargetPlatform.iOS,
-          ).dark,
-      child: Stack(
-        children: [
-          ColoredBox(color: backgroundTheme.color, child: const SizedBox.expand()),
-          Positioned.fill(child: child),
-        ],
-      ),
+    return Stack(
+      children: [
+        ColoredBox(color: backgroundTheme.color, child: const SizedBox.expand()),
+        Positioned.fill(child: child),
+      ],
     );
   }
 }

--- a/lib/src/widgets/background_theme.dart
+++ b/lib/src/widgets/background_theme.dart
@@ -144,7 +144,7 @@ class BackgroundThemeWrapper extends StatelessWidget {
                 child: IconTheme(
                   data: IconThemeData(color: cupertinoTheme.textTheme.textStyle.color),
                   child: DefaultTextStyle.merge(
-                    style: cupertinoTheme.textTheme.textStyle,
+                    style: Theme.of(context).textTheme.bodyMedium,
                     child: child,
                   ),
                 ),

--- a/lib/src/widgets/background_theme.dart
+++ b/lib/src/widgets/background_theme.dart
@@ -5,7 +5,7 @@ import 'package:flutter/cupertino.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:lichess_mobile/src/model/common/preloaded_data.dart';
-import 'package:lichess_mobile/src/model/settings/board_preferences.dart';
+import 'package:lichess_mobile/src/model/settings/general_preferences.dart';
 import 'package:lichess_mobile/src/theme.dart';
 
 const kBackgroundImageBlurFactor = 8.0;
@@ -25,20 +25,20 @@ class FullScreenBackgroundTheme extends ConsumerWidget {
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
-    final boardPrefs = ref.watch(boardPreferencesProvider);
+    final generalPrefs = ref.watch(generalPreferencesProvider);
     final appDocumentsDirectory =
         ref.read(preloadedDataProvider).requireValue.appDocumentsDirectory;
 
-    if (boardPrefs.backgroundImage != null && appDocumentsDirectory != null) {
+    if (generalPrefs.backgroundImage != null && appDocumentsDirectory != null) {
       return FullScreenBackgroundImageTheme(
-        backgroundImage: boardPrefs.backgroundImage!,
+        backgroundImage: generalPrefs.backgroundImage!,
         viewport: MediaQuery.sizeOf(context),
         appDocumentsDirectory: appDocumentsDirectory,
         child: child,
       );
-    } else if (boardPrefs.backgroundTheme != null) {
+    } else if (generalPrefs.backgroundTheme != null) {
       return _FullScreenBackgroundColorTheme(
-        backgroundTheme: boardPrefs.backgroundTheme!,
+        backgroundTheme: generalPrefs.backgroundTheme!,
         child: child,
       );
     } else {
@@ -59,7 +59,7 @@ class FullScreenBackgroundImageTheme extends StatefulWidget {
     required this.child,
   });
 
-  final BoardBackgroundImage backgroundImage;
+  final BackgroundImage backgroundImage;
   final Size viewport;
   final Directory appDocumentsDirectory;
   final Widget child;
@@ -136,8 +136,8 @@ class _FullScreenBackgroundImageState extends State<FullScreenBackgroundImageThe
       widget.viewport,
     );
 
-    final baseTheme = BoardBackgroundImage.getTheme(widget.backgroundImage.seedColor);
-    final filterColor = BoardBackgroundImage.getFilterColor(
+    final baseTheme = BackgroundImage.getTheme(widget.backgroundImage.seedColor);
+    final filterColor = BackgroundImage.getFilterColor(
       baseTheme.colorScheme.surface,
       widget.backgroundImage.meanLuminance,
     );
@@ -198,7 +198,7 @@ class _FullScreenBackgroundImageState extends State<FullScreenBackgroundImageThe
 class _FullScreenBackgroundColorTheme extends StatelessWidget {
   const _FullScreenBackgroundColorTheme({required this.backgroundTheme, required this.child});
 
-  final BoardBackgroundTheme backgroundTheme;
+  final BackgroundTheme backgroundTheme;
   final Widget child;
 
   @override

--- a/lib/src/widgets/buttons.dart
+++ b/lib/src/widgets/buttons.dart
@@ -267,7 +267,13 @@ class CupertinoIconButton extends StatelessWidget {
       child: CupertinoButton(
         padding: padding,
         onPressed: onPressed,
-        child: IconTheme.merge(data: const IconThemeData(size: 24.0), child: icon),
+        child: IconTheme.merge(
+          data: IconThemeData(
+            size: 24.0,
+            color: CupertinoTheme.of(context).textTheme.textStyle.color,
+          ),
+          child: icon,
+        ),
       ),
     );
   }

--- a/lib/src/widgets/buttons.dart
+++ b/lib/src/widgets/buttons.dart
@@ -267,13 +267,7 @@ class CupertinoIconButton extends StatelessWidget {
       child: CupertinoButton(
         padding: padding,
         onPressed: onPressed,
-        child: IconTheme.merge(
-          data: IconThemeData(
-            size: 24.0,
-            color: CupertinoTheme.of(context).textTheme.textStyle.color,
-          ),
-          child: icon,
-        ),
+        child: IconTheme.merge(data: const IconThemeData(size: 24.0), child: icon),
       ),
     );
   }

--- a/lib/src/widgets/list.dart
+++ b/lib/src/widgets/list.dart
@@ -18,7 +18,7 @@ class ListSection extends StatelessWidget {
     this.showDividerBetweenTiles = false,
     this.dense = false,
     this.cupertinoAdditionalDividerMargin,
-    this.cupertinoBackgroundColor,
+    this.backgroundColor,
     this.cupertinoBorderRadius,
     this.cupertinoClipBehavior = Clip.hardEdge,
   }) : _isLoading = false;
@@ -35,7 +35,7 @@ class ListSection extends StatelessWidget {
        showDividerBetweenTiles = false,
        dense = false,
        cupertinoAdditionalDividerMargin = null,
-       cupertinoBackgroundColor = null,
+       backgroundColor = null,
        cupertinoBorderRadius = null,
        cupertinoClipBehavior = Clip.hardEdge,
        _isLoading = true;
@@ -66,7 +66,7 @@ class ListSection extends StatelessWidget {
   /// See [CupertinoListSection.additionalDividerMargin].
   final double? cupertinoAdditionalDividerMargin;
 
-  final Color? cupertinoBackgroundColor;
+  final Color? backgroundColor;
 
   final BorderRadiusGeometry? cupertinoBorderRadius;
 
@@ -83,6 +83,7 @@ class ListSection extends StatelessWidget {
             ? PlatformCard(
               clipBehavior: Clip.hardEdge,
               margin: margin ?? Styles.bodySectionPadding,
+              color: backgroundColor,
               child: Column(
                 children: [
                   if (header != null)
@@ -115,6 +116,7 @@ class ListSection extends StatelessWidget {
             : PlatformCard(
               clipBehavior: Clip.hardEdge,
               margin: margin ?? Styles.bodySectionPadding,
+              color: backgroundColor,
               child: Column(
                 crossAxisAlignment: CrossAxisAlignment.start,
                 children: [
@@ -205,7 +207,7 @@ class ListSection extends StatelessWidget {
                     clipBehavior: cupertinoClipBehavior,
                     backgroundColor: CupertinoTheme.of(context).scaffoldBackgroundColor,
                     decoration: BoxDecoration(
-                      color: cupertinoBackgroundColor ?? Styles.cardColor(context),
+                      color: backgroundColor ?? Styles.cardColor(context),
                       borderRadius:
                           cupertinoBorderRadius ?? const BorderRadius.all(Radius.circular(10.0)),
                     ),
@@ -287,7 +289,7 @@ class PlatformListTile extends StatelessWidget {
     this.selected = false,
     this.isThreeLine = false,
     this.padding,
-    this.cupertinoBackgroundColor,
+    this.backgroundColor,
     this.visualDensity,
     this.harmonizeCupertinoTitleStyle = false,
     super.key,
@@ -300,7 +302,7 @@ class PlatformListTile extends StatelessWidget {
 
   final EdgeInsetsGeometry? padding;
 
-  final Color? cupertinoBackgroundColor;
+  final Color? backgroundColor;
 
   /// only on iOS
   final Widget? additionalInfo;
@@ -350,13 +352,13 @@ class PlatformListTile extends StatelessWidget {
           contentPadding: padding,
         );
       case TargetPlatform.iOS:
-        final activatedColor = colorScheme.surfaceContainerHighest;
+        final activatedColor = Styles.backgroundActivated(context);
         return IconTheme(
           data: CupertinoIconThemeData(color: colorScheme.onSurface.withValues(alpha: 0.7)),
           child: GestureDetector(
             onLongPress: onLongPress,
             child: CupertinoListTile.notched(
-              backgroundColor: selected == true ? activatedColor : cupertinoBackgroundColor,
+              backgroundColor: selected == true ? activatedColor : backgroundColor,
               backgroundColorActivated: activatedColor,
               leading: leading,
               title:

--- a/lib/src/widgets/platform_scaffold.dart
+++ b/lib/src/widgets/platform_scaffold.dart
@@ -1,13 +1,13 @@
 import 'package:flutter/cupertino.dart';
 import 'package:flutter/material.dart';
-import 'package:lichess_mobile/src/widgets/background_theme.dart';
+import 'package:lichess_mobile/src/widgets/background.dart';
 import 'package:lichess_mobile/src/widgets/platform.dart';
 
 const kCupertinoAppBarWithActionPadding = EdgeInsetsDirectional.only(start: 16.0, end: 8.0);
 
 /// A screen with a navigation bar and a body that adapts to the platform.
 ///
-/// It is also aware of the configured [FullScreenBackgroundTheme].
+/// It is also aware of the configured [FullScreenBackground].
 ///
 /// On Android, this is a [Scaffold] with an [AppBar],
 /// on iOS a [CupertinoPageScaffold] with a [CupertinoNavigationBar].
@@ -58,7 +58,7 @@ class PlatformThemedScaffold extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    return FullScreenBackgroundTheme(
+    return FullScreenBackground(
       child: PlatformWidget(androidBuilder: _androidBuilder, iosBuilder: _iosBuilder),
     );
   }

--- a/lib/src/widgets/platform_scaffold.dart
+++ b/lib/src/widgets/platform_scaffold.dart
@@ -7,7 +7,7 @@ const kCupertinoAppBarWithActionPadding = EdgeInsetsDirectional.only(start: 16.0
 
 /// Displays an [AppBar] for Android and a [CupertinoNavigationBar] for iOS.
 ///
-/// Intended to be passed to [PlatformScaffold].
+/// Intended to be passed to [PlatformThemedScaffold].
 class PlatformAppBar extends StatelessWidget {
   const PlatformAppBar({
     super.key,
@@ -106,12 +106,14 @@ class _CupertinoNavBarWrapper extends StatelessWidget implements ObstructingPref
 
 /// A screen with a navigation bar and a body that adapts to the platform.
 ///
+/// It is also aware of the configured [FullScreenBackgroundTheme].
+///
 /// On Android, this is a [Scaffold] with an [AppBar],
 /// on iOS a [CupertinoPageScaffold] with a [CupertinoNavigationBar].
 ///
 /// See [PlatformAppBar] for an app bar that adapts to the platform and needs to be passed to this widget.
-class PlatformScaffold extends StatelessWidget {
-  const PlatformScaffold({
+class PlatformThemedScaffold extends StatelessWidget {
+  const PlatformThemedScaffold({
     super.key,
     this.appBar,
     required this.body,
@@ -155,37 +157,8 @@ class PlatformScaffold extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    return PlatformWidget(androidBuilder: _androidBuilder, iosBuilder: _iosBuilder);
-  }
-}
-
-class PlatformBoardThemeScaffold extends StatelessWidget {
-  const PlatformBoardThemeScaffold({
-    super.key,
-    this.appBar,
-    required this.body,
-    this.resizeToAvoidBottomInset = true,
-  });
-
-  /// Acts as the [AppBar] for Android and as the [CupertinoNavigationBar] for iOS.
-  ///
-  /// Usually an instance of [PlatformAppBar].
-  final Widget? appBar;
-
-  /// The main content of the screen, displayed below the navigation bar.
-  final Widget body;
-
-  /// See [Scaffold.resizeToAvoidBottomInset] and [CupertinoPageScaffold.resizeToAvoidBottomInset]
-  final bool resizeToAvoidBottomInset;
-
-  @override
-  Widget build(BuildContext context) {
     return FullScreenBackgroundTheme(
-      child: PlatformScaffold(
-        resizeToAvoidBottomInset: resizeToAvoidBottomInset,
-        appBar: appBar,
-        body: body,
-      ),
+      child: PlatformWidget(androidBuilder: _androidBuilder, iosBuilder: _iosBuilder),
     );
   }
 }

--- a/lib/src/widgets/platform_scaffold.dart
+++ b/lib/src/widgets/platform_scaffold.dart
@@ -5,6 +5,65 @@ import 'package:lichess_mobile/src/widgets/platform.dart';
 
 const kCupertinoAppBarWithActionPadding = EdgeInsetsDirectional.only(start: 16.0, end: 8.0);
 
+/// A screen with a navigation bar and a body that adapts to the platform.
+///
+/// It is also aware of the configured [FullScreenBackgroundTheme].
+///
+/// On Android, this is a [Scaffold] with an [AppBar],
+/// on iOS a [CupertinoPageScaffold] with a [CupertinoNavigationBar].
+///
+/// See [PlatformAppBar] for an app bar that adapts to the platform and needs to be passed to this widget.
+class PlatformThemedScaffold extends StatelessWidget {
+  const PlatformThemedScaffold({
+    super.key,
+    this.appBar,
+    required this.body,
+    this.resizeToAvoidBottomInset = true,
+    this.backgroundColor,
+  });
+
+  /// Acts as the [AppBar] for Android and as the [CupertinoNavigationBar] for iOS.
+  ///
+  /// Usually an instance of [PlatformAppBar].
+  final Widget? appBar;
+
+  /// The main content of the screen, displayed below the navigation bar.
+  final Widget body;
+
+  /// See [Scaffold.resizeToAvoidBottomInset] and [CupertinoPageScaffold.resizeToAvoidBottomInset]
+  final bool resizeToAvoidBottomInset;
+
+  final Color? backgroundColor;
+
+  Widget _androidBuilder(BuildContext context) {
+    return Scaffold(
+      resizeToAvoidBottomInset: resizeToAvoidBottomInset,
+      backgroundColor: backgroundColor,
+      appBar:
+          appBar != null
+              ? PreferredSize(preferredSize: const Size.fromHeight(kToolbarHeight), child: appBar!)
+              : null,
+      body: body,
+    );
+  }
+
+  Widget _iosBuilder(BuildContext context) {
+    return CupertinoPageScaffold(
+      resizeToAvoidBottomInset: resizeToAvoidBottomInset,
+      navigationBar: appBar != null ? _CupertinoNavBarWrapper(child: appBar!) : null,
+      backgroundColor: backgroundColor,
+      child: body,
+    );
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return FullScreenBackgroundTheme(
+      child: PlatformWidget(androidBuilder: _androidBuilder, iosBuilder: _iosBuilder),
+    );
+  }
+}
+
 /// Displays an [AppBar] for Android and a [CupertinoNavigationBar] for iOS.
 ///
 /// Intended to be passed to [PlatformThemedScaffold].
@@ -101,64 +160,5 @@ class _CupertinoNavBarWrapper extends StatelessWidget implements ObstructingPref
   bool shouldFullyObstruct(BuildContext context) {
     final Color backgroundColor = CupertinoTheme.of(context).barBackgroundColor;
     return backgroundColor.a == 0xFF;
-  }
-}
-
-/// A screen with a navigation bar and a body that adapts to the platform.
-///
-/// It is also aware of the configured [FullScreenBackgroundTheme].
-///
-/// On Android, this is a [Scaffold] with an [AppBar],
-/// on iOS a [CupertinoPageScaffold] with a [CupertinoNavigationBar].
-///
-/// See [PlatformAppBar] for an app bar that adapts to the platform and needs to be passed to this widget.
-class PlatformThemedScaffold extends StatelessWidget {
-  const PlatformThemedScaffold({
-    super.key,
-    this.appBar,
-    required this.body,
-    this.resizeToAvoidBottomInset = true,
-    this.backgroundColor,
-  });
-
-  /// Acts as the [AppBar] for Android and as the [CupertinoNavigationBar] for iOS.
-  ///
-  /// Usually an instance of [PlatformAppBar].
-  final Widget? appBar;
-
-  /// The main content of the screen, displayed below the navigation bar.
-  final Widget body;
-
-  /// See [Scaffold.resizeToAvoidBottomInset] and [CupertinoPageScaffold.resizeToAvoidBottomInset]
-  final bool resizeToAvoidBottomInset;
-
-  final Color? backgroundColor;
-
-  Widget _androidBuilder(BuildContext context) {
-    return Scaffold(
-      resizeToAvoidBottomInset: resizeToAvoidBottomInset,
-      backgroundColor: backgroundColor,
-      appBar:
-          appBar != null
-              ? PreferredSize(preferredSize: const Size.fromHeight(kToolbarHeight), child: appBar!)
-              : null,
-      body: body,
-    );
-  }
-
-  Widget _iosBuilder(BuildContext context) {
-    return CupertinoPageScaffold(
-      resizeToAvoidBottomInset: resizeToAvoidBottomInset,
-      navigationBar: appBar != null ? _CupertinoNavBarWrapper(child: appBar!) : null,
-      backgroundColor: backgroundColor,
-      child: body,
-    );
-  }
-
-  @override
-  Widget build(BuildContext context) {
-    return FullScreenBackgroundTheme(
-      child: PlatformWidget(androidBuilder: _androidBuilder, iosBuilder: _iosBuilder),
-    );
   }
 }

--- a/lib/src/widgets/platform_scaffold.dart
+++ b/lib/src/widgets/platform_scaffold.dart
@@ -1,20 +1,17 @@
 import 'package:flutter/cupertino.dart';
 import 'package:flutter/material.dart';
-import 'package:lichess_mobile/src/widgets/background.dart';
 import 'package:lichess_mobile/src/widgets/platform.dart';
 
 const kCupertinoAppBarWithActionPadding = EdgeInsetsDirectional.only(start: 16.0, end: 8.0);
 
 /// A screen with a navigation bar and a body that adapts to the platform.
 ///
-/// It is also aware of the configured [FullScreenBackground].
-///
 /// On Android, this is a [Scaffold] with an [AppBar],
 /// on iOS a [CupertinoPageScaffold] with a [CupertinoNavigationBar].
 ///
 /// See [PlatformAppBar] for an app bar that adapts to the platform and needs to be passed to this widget.
-class PlatformThemedScaffold extends StatelessWidget {
-  const PlatformThemedScaffold({
+class PlatformScaffold extends StatelessWidget {
+  const PlatformScaffold({
     super.key,
     this.appBar,
     required this.body,
@@ -58,15 +55,13 @@ class PlatformThemedScaffold extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    return FullScreenBackground(
-      child: PlatformWidget(androidBuilder: _androidBuilder, iosBuilder: _iosBuilder),
-    );
+    return PlatformWidget(androidBuilder: _androidBuilder, iosBuilder: _iosBuilder);
   }
 }
 
 /// Displays an [AppBar] for Android and a [CupertinoNavigationBar] for iOS.
 ///
-/// Intended to be passed to [PlatformThemedScaffold].
+/// Intended to be passed to [PlatformScaffold].
 class PlatformAppBar extends StatelessWidget {
   const PlatformAppBar({
     super.key,

--- a/lib/src/widgets/settings.dart
+++ b/lib/src/widgets/settings.dart
@@ -262,8 +262,6 @@ class ChoicePicker<T> extends StatelessWidget {
         );
       case TargetPlatform.iOS:
         final tileConstructor = notchedTile ? CupertinoListTile.notched : CupertinoListTile.new;
-        final theme = Theme.of(context);
-        final colorScheme = theme.colorScheme;
         return Padding(
           padding: margin ?? Styles.bodySectionPadding,
           child: Opacity(
@@ -288,7 +286,7 @@ class ChoicePicker<T> extends StatelessWidget {
                       title: titleBuilder(value),
                       subtitle: subtitleBuilder?.call(value),
                       leading: leadingBuilder?.call(value),
-                      backgroundColorActivated: colorScheme.surfaceContainerHighest,
+                      backgroundColorActivated: Styles.backgroundActivated(context),
                       onTap:
                           onSelectedItemChanged != null
                               ? () => onSelectedItemChanged!(value)

--- a/lib/src/widgets/settings.dart
+++ b/lib/src/widgets/settings.dart
@@ -22,7 +22,8 @@ class SettingsListTile extends StatelessWidget {
   final Text settingsLabel;
 
   final String settingsValue;
-  final void Function() onTap;
+
+  final void Function()? onTap;
 
   /// The optional explanation of the settings.
   final String? explanation;

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -558,22 +558,6 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "0.70.2"
-  flex_color_scheme:
-    dependency: "direct main"
-    description:
-      name: flex_color_scheme
-      sha256: "09bea5d776f694c5a67f2229f2aa500cc7cce369322dc6500ab01cf9ad1b4e1a"
-      url: "https://pub.dev"
-    source: hosted
-    version: "8.1.0"
-  flex_seed_scheme:
-    dependency: transitive
-    description:
-      name: flex_seed_scheme
-      sha256: d3ba3c5c92d2d79d45e94b4c6c71d01fac3c15017da1545880c53864da5dfeb0
-      url: "https://pub.dev"
-    source: hosted
-    version: "3.5.0"
   flutter:
     dependency: "direct main"
     description: flutter

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -31,7 +31,6 @@ dependencies:
   firebase_crashlytics: ^4.0.0
   firebase_messaging: ^15.0.0
   fl_chart: ^0.70.0
-  flex_color_scheme: ^8.1.0
   flutter:
     sdk: flutter
   flutter_appauth: ^8.0.0+1

--- a/test/view/puzzle/streak_screen_test.dart
+++ b/test/view/puzzle/streak_screen_test.dart
@@ -227,7 +227,7 @@ void main() {
         tester,
         home: Builder(
           builder:
-              (context) => PlatformThemedScaffold(
+              (context) => PlatformScaffold(
                 appBar: const PlatformAppBar(title: Text('Test Streak Screen')),
                 body: FatButton(
                   semanticsLabel: 'Start Streak',

--- a/test/view/puzzle/streak_screen_test.dart
+++ b/test/view/puzzle/streak_screen_test.dart
@@ -227,7 +227,7 @@ void main() {
         tester,
         home: Builder(
           builder:
-              (context) => PlatformScaffold(
+              (context) => PlatformThemedScaffold(
                 appBar: const PlatformAppBar(title: Text('Test Streak Screen')),
                 body: FatButton(
                   semanticsLabel: 'Start Streak',

--- a/test/view/puzzle/streak_screen_test.dart
+++ b/test/view/puzzle/streak_screen_test.dart
@@ -233,11 +233,10 @@ void main() {
                   semanticsLabel: 'Start Streak',
                   child: const Text('Start Streak'),
                   onPressed:
-                      () => pushPlatformRoute(
+                      () => Navigator.of(
                         context,
                         rootNavigator: true,
-                        builder: (context) => const StreakScreen(),
-                      ),
+                      ).push(buildScreenRoute<void>(context, screen: const StreakScreen())),
                 ),
               ),
         ),


### PR DESCRIPTION
- Remove flex_color_scheme package, we'll stick to default flutter ColorScheme
- Default theme use the board as color seed
- iOS now use the colorscheme for its surfaces
- background image and colors are now applied to the entire app
- the way we build `Routes` has been entirely refactored, using the `buildScreenRoute` helper introduced in https://github.com/lichess-org/mobile/pull/1353 (which has been integrated in this PR).