### PR TITLE
Enable ongoing games

### DIFF
--- a/devtools_options.yaml
+++ b/devtools_options.yaml
@@ -1,0 +1,3 @@
+description: This file stores settings for Dart & Flutter DevTools.
+documentation: https://docs.flutter.dev/tools/devtools/extensions#configure-extension-enablement-states
+extensions:

--- a/lib/src/model/settings/home_preferences.dart
+++ b/lib/src/model/settings/home_preferences.dart
@@ -25,9 +25,6 @@ class HomePreferences extends _$HomePreferences with PreferencesStorage<HomePref
   }
 
   Future<void> toggleWidget(EnabledWidget widget) {
-    if (widget == EnabledWidget.ongoingGames) {
-      return Future.value();
-    }
     final newState = state.copyWith(
       enabledWidgets:
           state.enabledWidgets.contains(widget)

--- a/lib/src/view/home/home_tab_screen.dart
+++ b/lib/src/view/home/home_tab_screen.dart
@@ -464,9 +464,7 @@ class _EditableWidget extends ConsumerWidget {
                   Checkbox.adaptive(
                     value: isEnabled,
                     onChanged:
-                        widget == EnabledWidget.ongoingGames
-                            ? null
-                            : (_) {
+                        (_) {
                               ref.read(homePreferencesProvider.notifier).toggleWidget(widget);
                             },
                   ),

--- a/lib/src/view/home/home_tab_screen.dart
+++ b/lib/src/view/home/home_tab_screen.dart
@@ -463,10 +463,9 @@ class _EditableWidget extends ConsumerWidget {
                     ),
                   Checkbox.adaptive(
                     value: isEnabled,
-                    onChanged:
-                        (_) {
-                              ref.read(homePreferencesProvider.notifier).toggleWidget(widget);
-                            },
+                    onChanged: (_) {
+                      ref.read(homePreferencesProvider.notifier).toggleWidget(widget);
+                    },
                   ),
                   if (index != null)
                     IconButton(


### PR DESCRIPTION
Ongoing games have been fully disabled, was this on purpose @veloce? I see that it's based on [this commit from last week](https://github.com/lichess-org/mobile/commit/41e7ebfca707007a241222123060304150a90f14).
I haven't been able to test ongoing games using my new accounts, but this allows us to see them.

Before

https://github.com/user-attachments/assets/3a167b77-0e6d-4448-95d7-6084080a6083

After

https://github.com/user-attachments/assets/6f52cfb3-b80d-4293-92f5-535493b42b84

