### PR TITLE
Prepare cloud eval

### DIFF
--- a/lib/src/model/analysis/analysis_controller.dart
+++ b/lib/src/model/analysis/analysis_controller.dart
@@ -813,7 +813,7 @@ class AnalysisCurrentNode with _$AnalysisCurrentNode {
     required bool isRoot,
     SanMove? sanMove,
     Opening? opening,
-    ClientEval? eval,
+    LocalEval? eval,
     IList<PgnComment>? lichessAnalysisComments,
     IList<PgnComment>? startingComments,
     IList<PgnComment>? comments,

--- a/lib/src/model/common/eval.dart
+++ b/lib/src/model/common/eval.dart
@@ -68,12 +68,12 @@ double _toWhiteWinningChances(int? cp, int? mate) {
   }
 }
 
-/// The eval from the client's own engine, typically stockfish.
+/// The eval from the Stockfish local engine
 @freezed
-class ClientEval with _$ClientEval implements Eval {
-  const ClientEval._();
+class LocalEval with _$LocalEval implements Eval {
+  const LocalEval._();
 
-  const factory ClientEval({
+  const factory LocalEval({
     required Position position,
     required int depth,
     required int nodes,
@@ -82,7 +82,7 @@ class ClientEval with _$ClientEval implements Eval {
     required Duration searchTime,
     int? cp,
     int? mate,
-  }) = _ClientEval;
+  }) = _LocalEval;
 
   double get knps => nodes / millis;
 

--- a/lib/src/model/common/node.dart
+++ b/lib/src/model/common/node.dart
@@ -23,8 +23,8 @@ abstract class Node {
 
   final Position position;
 
-  /// The client evaluation of the position.
-  ClientEval? eval;
+  /// The local evaluation of the position.
+  LocalEval? eval;
 
   /// The opening associated with this node.
   Opening? opening;
@@ -569,7 +569,7 @@ abstract class ViewNode {
   SanMove? get sanMove;
   Position get position;
   IList<ViewBranch> get children;
-  ClientEval? get eval;
+  LocalEval? get eval;
   Opening? get opening;
   IList<PgnComment>? get startingComments;
   IList<PgnComment>? get comments;
@@ -593,7 +593,7 @@ class ViewRoot extends ViewNode with _$ViewRoot {
   const factory ViewRoot({
     required Position position,
     required IList<ViewBranch> children,
-    ClientEval? eval,
+    LocalEval? eval,
   }) = _ViewRoot;
 
   @override
@@ -630,7 +630,7 @@ class ViewBranch extends ViewNode with _$ViewBranch {
     required IList<ViewBranch> children,
     @Default(false) bool isCollapsed,
     required bool isComputerVariation,
-    ClientEval? eval,
+    LocalEval? eval,
     IList<PgnComment>? lichessAnalysisComments,
     IList<PgnComment>? startingComments,
     IList<PgnComment>? comments,

--- a/lib/src/model/engine/evaluation_service.dart
+++ b/lib/src/model/engine/evaluation_service.dart
@@ -117,7 +117,7 @@ class EvaluationService {
   Stream<EvalResult>? start(
     UciPath path,
     Iterable<Step> steps, {
-    ClientEval? initialPositionEval,
+    LocalEval? initialPositionEval,
 
     /// A function that returns true if the evaluation should be emitted by the
     /// [EngineEvaluation] provider.
@@ -186,7 +186,7 @@ EvaluationService evaluationService(Ref ref) {
   return service;
 }
 
-typedef EngineEvaluationState = ({String engineName, EngineState state, ClientEval? eval});
+typedef EngineEvaluationState = ({String engineName, EngineState state, LocalEval? eval});
 
 /// A provider that holds the state of the engine and the current evaluation.
 @riverpod

--- a/lib/src/model/engine/uci_protocol.dart
+++ b/lib/src/model/engine/uci_protocol.dart
@@ -28,7 +28,7 @@ class UCIProtocol {
   Work? _nextWork;
   bool _stopRequested = false;
   void Function(String command)? _send;
-  ClientEval? _currentEval;
+  LocalEval? _currentEval;
   int _expectedPvs = 1;
 
   ValueListenable<bool> get isComputing => _isComputing;
@@ -136,7 +136,7 @@ class UCIProtocol {
       final pvData = PvData(moves: IList(moves), cp: isMate ? null : ev, mate: isMate ? ev : null);
 
       if (multiPv == 1) {
-        _currentEval = ClientEval(
+        _currentEval = LocalEval(
           position: _work!.position,
           searchTime: Duration(milliseconds: elapsedMs),
           depth: depth,

--- a/lib/src/model/engine/work.dart
+++ b/lib/src/model/engine/work.dart
@@ -8,7 +8,7 @@ import 'package:lichess_mobile/src/model/common/uci.dart';
 
 part 'work.freezed.dart';
 
-typedef EvalResult = (Work, ClientEval);
+typedef EvalResult = (Work, LocalEval);
 
 /// A work item for the engine.
 @freezed
@@ -33,14 +33,14 @@ class Work with _$Work {
   int get ply => steps.lastOrNull?.position.ply ?? initialPosition.ply;
 
   /// Cached eval for the work position.
-  ClientEval? get evalCache => steps.lastOrNull?.eval;
+  LocalEval? get evalCache => steps.lastOrNull?.eval;
 }
 
 @freezed
 class Step with _$Step {
   const Step._();
 
-  const factory Step({required Position position, required SanMove sanMove, ClientEval? eval}) =
+  const factory Step({required Position position, required SanMove sanMove, LocalEval? eval}) =
       _Step;
 
   factory Step.fromNode(Branch node) {

--- a/lib/src/model/study/study_controller.dart
+++ b/lib/src/model/study/study_controller.dart
@@ -663,7 +663,7 @@ class StudyCurrentNode with _$StudyCurrentNode {
     IList<PgnComment>? startingComments,
     IList<PgnComment>? comments,
     IList<int>? nags,
-    ClientEval? eval,
+    LocalEval? eval,
   }) = _StudyCurrentNode;
 
   factory StudyCurrentNode.illegalPosition() {

--- a/lib/src/view/analysis/analysis_screen.dart
+++ b/lib/src/view/analysis/analysis_screen.dart
@@ -211,7 +211,7 @@ class _Body extends ConsumerWidget {
           isEngineAvailable && numEvalLines > 0
               ? EngineLines(
                 onTapMove: ref.read(ctrlProvider.notifier).onUserMove,
-                clientEval: currentNode.eval,
+                localEval: currentNode.eval,
                 isGameOver: currentNode.position.isGameOver,
               )
               : null,

--- a/lib/src/view/broadcast/broadcast_game_screen.dart
+++ b/lib/src/view/broadcast/broadcast_game_screen.dart
@@ -205,7 +205,7 @@ class _Body extends ConsumerWidget {
           engineLines:
               isLocalEvaluationEnabled && numEvalLines > 0
                   ? EngineLines(
-                    clientEval: currentNode.eval,
+                    localEval: currentNode.eval,
                     isGameOver: currentNode.position.isGameOver,
                     onTapMove:
                         ref

--- a/lib/src/view/engine/engine_depth.dart
+++ b/lib/src/view/engine/engine_depth.dart
@@ -14,7 +14,7 @@ import 'package:popover/popover.dart';
 class EngineDepth extends ConsumerWidget {
   const EngineDepth({this.defaultEval});
 
-  final ClientEval? defaultEval;
+  final LocalEval? defaultEval;
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
@@ -73,7 +73,7 @@ class EngineDepth extends ConsumerWidget {
 class _StockfishInfo extends ConsumerWidget {
   const _StockfishInfo(this.defaultEval);
 
-  final ClientEval? defaultEval;
+  final LocalEval? defaultEval;
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {

--- a/lib/src/view/engine/engine_lines.dart
+++ b/lib/src/view/engine/engine_lines.dart
@@ -11,16 +11,16 @@ import 'package:lichess_mobile/src/view/engine/engine_gauge.dart';
 import 'package:lichess_mobile/src/widgets/buttons.dart';
 
 class EngineLines extends ConsumerWidget {
-  const EngineLines({required this.onTapMove, required this.clientEval, required this.isGameOver});
+  const EngineLines({required this.onTapMove, required this.localEval, required this.isGameOver});
   final void Function(NormalMove move) onTapMove;
-  final ClientEval? clientEval;
+  final LocalEval? localEval;
   final bool isGameOver;
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
     final numEvalLines = ref.watch(analysisPreferencesProvider.select((p) => p.numEvalLines));
     final engineEval = ref.watch(engineEvaluationProvider).eval;
-    final eval = engineEval ?? clientEval;
+    final eval = engineEval ?? localEval;
 
     final emptyLines = List.filled(numEvalLines, const Engineline.empty());
 

--- a/lib/src/view/study/study_screen.dart
+++ b/lib/src/view/study/study_screen.dart
@@ -417,7 +417,7 @@ class _Body extends ConsumerWidget {
       engineLines:
           isComputerAnalysisAllowed && isLocalEvaluationEnabled && numEvalLines > 0
               ? EngineLines(
-                clientEval: currentNode.eval,
+                localEval: currentNode.eval,
                 isGameOver: currentNode.position?.isGameOver ?? false,
                 onTapMove: ref.read(studyControllerProvider(id).notifier).onUserMove,
               )

--- a/test/model/common/node_test.dart
+++ b/test/model/common/node_test.dart
@@ -156,7 +156,7 @@ void main() {
 
       expect(root.branchesOn(nodePath!), equals([root.children.first, branch]));
 
-      final eval = ClientEval(
+      final eval = LocalEval(
         position: branch.position,
         searchTime: const Duration(seconds: 10),
         cp: 100,
@@ -180,7 +180,7 @@ void main() {
 
       expect(root.mainline.map((n) => n.eval), equals([null, null, null]));
 
-      final eval = ClientEval(
+      final eval = LocalEval(
         position: root.position,
         searchTime: const Duration(seconds: 10),
         cp: 100,
@@ -399,7 +399,7 @@ void main() {
 
         final root = Root.fromPgnGame(PgnGame.parsePgn(pgn));
         expect(root.mainline.length, equals(59));
-        final clientEval = ClientEval(
+        final localEval = LocalEval(
           position: Chess.initial,
           depth: 22,
           nodes: 100000,
@@ -408,7 +408,7 @@ void main() {
           searchTime: const Duration(milliseconds: 1230900),
           cp: 23,
         );
-        root.mainline.last.eval = clientEval;
+        root.mainline.last.eval = localEval;
 
         const pgn2 = '''
 1. d4 { [%clk 1:00:00] } Nf6 { [%clk 1:00:00] } 2. c4 { [%clk 1:00:00] } g6 { [%clk 1:00:00] } 3. Nc3 { [%clk 1:00:00] } Bg7 { [%clk 1:00:00] } 4. e4 { [%clk 1:00:00] } d6 { [%clk 1:00:00] } 5. f3 { [%clk 1:00:00] } O-O { [%clk 1:00:00] } 6. Be3 { [%clk 1:00:00] } e5 { [%clk 1:00:00] } 7. d5 { [%clk 1:00:00] } Nh5 { [%clk 1:00:00] } 8. Qd2 { [%clk 1:00:00] } Qh4+ { [%clk 1:00:00] } 9. g3 { [%clk 1:00:00] } Qe7 { [%clk 1:00:00] } 10. Nh3 { [%clk 1:00:00] } f5 { [%clk 0:56:44] } 11. exf5 { [%clk 0:58:18] } gxf5 { [%clk 0:55:20] } 12. O-O-O { [%clk 0:57:22] } Na6 { [%clk 0:52:30] } 13. Re1 { [%clk 0:52:22] } Nf6 { [%clk 0:48:20] } 14. Ng5 { [%clk 0:50:43] } c6 { [%clk 0:47:38] } 15. h4 { [%clk 0:50:01] } h6 { [%clk 0:46:10] } 16. Nh3 { [%clk 0:49:18] } cxd5 { [%clk 0:45:06] } 17. Bxh6 { [%clk 0:47:13] } Bxh6 { [%clk 0:44:17] } 18. Qxh6 { [%clk 0:45:59] } Bd7 { [%clk 0:43:34] } 19. cxd5 { [%clk 0:45:15] } Nc5 { [%clk 0:42:50] } 20. Kb1 { [%clk 0:44:14] } Qg7 { [%clk 0:41:29] } 21. Qd2 { [%clk 0:42:39] } e4 { [%clk 0:40:55] } 22. b4 { [%clk 0:40:31] } Na4 { [%clk 0:39:58] } 23. Nxa4 { [%clk 0:39:13] } Bxa4 { [%clk 0:38:39] } 24. Ng5 { [%clk 0:37:47] } Rfc8 { [%clk 0:37:14] } 25. Ne6 { [%clk 0:36:01] } Rc2 { [%clk 0:36:38] } 26. Qe3 { [%clk 0:34:49] } Nxd5 { [%clk 0:34:34] } 27. Nxg7 { [%clk 0:34:17] } Nxe3 { [%clk 0:34:04] } 28. Rxe3 { [%clk 0:33:12] } Kxg7 { [%clk 0:33:33] } 29. Ra3 { [%clk 0:31:18] } Rac8 { [%clk 0:32:46] } 30. Bh3 { [%clk 0:30:15] } Bd7 { [%clk 0:32:05] } 31. fxe4 { [%clk 0:29:38] } R8c4 { [%clk 0:31:11] } 32. Rxa7 { [%clk 0:27:46] } Bc6 { [%clk 0:30:37] } 33. Bxf5 { [%clk 0:27:20] } Re2 { [%clk 0:29:32] } 34. b5 { [%clk 0:26:56] } Rb4+ { [%clk 0:29:02] } 35. Ka1 { [%clk 0:25:59] } Rxb5 { [%clk 0:28:13] } 36. Rb1 { [%clk 0:25:17] } Rc5 { [%clk 0:27:47] } 37. h5 { [%clk 0:23:42] } Rh2 { [%clk 0:27:22] } 38. g4 { [%clk 0:22:55] } Kf6 { [%clk 0:26:59] } 39. Ra3 { [%clk 0:22:10] } Rc4 { [%clk 0:26:36] } 40. Re1 { [%eval 1.17,33] [%clk 0:19:30] } *
@@ -428,11 +428,11 @@ void main() {
         }
         // one new external eval
         expect(root2.mainline.where((n) => n.externalEval != null).length, equals(1));
-        // one old client eval preseved
+        // one old local eval preseved
         expect(root2.mainline.where((node) => node.eval != null).length, equals(1));
         expect(
           root2.mainline.firstWhereOrNull((node) => node.eval != null)?.eval,
-          equals(clientEval),
+          equals(localEval),
         );
       });
     });


### PR DESCRIPTION
- Rename the current `ClientEval` class to `LocalEval` so that we can add a new sealed class `ClientEval` that will have common properties between `CloudEval` and `LocalEval`. The website client also does something similar https://github.com/lichess-org/lila/blob/c51ca345338892a742d676bcda87de9a1e1e6c5e/ui/%40types/lichess/tree.d.ts#L20.
- Add the sealed class `ClientEval` and the class `CloudEval`
- Tweak doc comments on the eval classes