### PR TITLE
Fix elo chart 

### DIFF
--- a/lib/src/view/user/perf_stats_screen.dart
+++ b/lib/src/view/user/perf_stats_screen.dart
@@ -151,7 +151,7 @@ class _Body extends ConsumerWidget {
                   (element) => element.perf == perf,
                 );
 
-                if (ratingHistoryPerfData == null || ratingHistoryPerfData.points.isEmpty) {
+                if (ratingHistoryPerfData == null || ratingHistoryPerfData.points.length <= 1) {
                   return const SizedBox.shrink();
                 }
                 return PlatformCard(


### PR DESCRIPTION
Fix elo chart by not showing it if there is only one point.

The website still chooses to show the graph even if there is only one point but I think it is fine to not do it.