### PR TITLE
Fix broadcast eval bar not working when switching to a different round

### DIFF
--- a/lib/src/view/broadcast/broadcast_boards_tab.dart
+++ b/lib/src/view/broadcast/broadcast_boards_tab.dart
@@ -159,7 +159,7 @@ class BroadcastPreview extends ConsumerWidget {
           final playingSide = Setup.parseFen(game.fen).turn;
 
           return ObservedBoardThumbnail(
-            boardKey: Key('Board-$index'),
+            boardKey: ValueKey(game.id),
             roundId: roundId,
             game: game,
             title: title,


### PR DESCRIPTION
When switching to different round, the evals may not be updated until the view is scrolled. This problem was due to the key not being unique.