### PR TITLE
Support relative uri reference in broadcast markdown description

### DIFF
--- a/lib/src/view/broadcast/broadcast_overview_tab.dart
+++ b/lib/src/view/broadcast/broadcast_overview_tab.dart
@@ -84,7 +84,7 @@ class BroadcastOverviewTab extends ConsumerWidget {
                   data: description,
                   onTapLink: (text, url, title) {
                     if (url == null) return;
-                    launchUrl(Uri.parse(url));
+                    launchUrl(Uri.https('lichess.org').resolve(url));
                   },
                 ),
               ],


### PR DESCRIPTION
Opening a url might fail in the description of a broadcast overview if it is a relative url (e.g. /fide/1503014/-). This PR fixes it by using `Uri.resolve`