### PR TITLE
Fix broadcast engine gauge 

### DIFF
--- a/lib/src/model/broadcast/broadcast_analysis_controller.dart
+++ b/lib/src/model/broadcast/broadcast_analysis_controller.dart
@@ -652,7 +652,7 @@ class BroadcastAnalysisState with _$BroadcastAnalysisState {
 
   EngineGaugeParams get engineGaugeParams => (
     orientation: pov,
-    isLocalEngineAvailable: isLocalEvaluationEnabled,
+    isLocalEngineAvailable: isComputerAnalysisEnabled,
     position: position,
     savedEval: currentNode.eval ?? currentNode.serverEval,
   );


### PR DESCRIPTION
Fix engine gauge on broadcast screen not shown when computer analysis is enabled with local evaluation disabled