### PR TITLE
Refactor broadcast player classes

### DIFF
--- a/lib/src/model/broadcast/broadcast.dart
+++ b/lib/src/model/broadcast/broadcast.dart
@@ -225,12 +225,28 @@ class BroadcastPlayerWithResult extends BroadcastPlayer with _$BroadcastPlayerWi
 
 typedef BroadcastFideData = ({({int? standard, int? rapid, int? blitz}) ratings, int? birthYear});
 
-typedef BroadcastPlayerWithGames =
-    ({
-      BroadcastPlayerWithResult player,
-      BroadcastFideData fideData,
-      IList<BroadcastPlayerResultData> games,
-    });
+@freezed
+// ignore: freezed_missing_private_empty_constructor
+class BroadcastPlayerWithGames extends BroadcastPlayerWithResult with _$BroadcastPlayerWithGames {
+  const BroadcastPlayerWithGames({
+    required super.name,
+    required super.title,
+    required super.rating,
+    required super.federation,
+    required super.fideId,
+    required super.played,
+    required super.score,
+    required super.ratingDiff,
+    required super.performance,
+    required this.fideData,
+    required this.games,
+  });
+
+  // ignore: annotate_overrides
+  final BroadcastFideData fideData;
+  // ignore: annotate_overrides
+  final IList<BroadcastPlayerResultData> games;
+}
 
 enum BroadcastPoints { one, half, zero }
 

--- a/lib/src/model/broadcast/broadcast.dart
+++ b/lib/src/model/broadcast/broadcast.dart
@@ -140,7 +140,7 @@ sealed class BroadcastGame with _$BroadcastGame {
 
   const factory BroadcastGame({
     required BroadcastGameId id,
-    required IMap<Side, BroadcastPlayer> players,
+    required IMap<Side, BroadcastPlayerWithClock> players,
     required String fen,
     required Move? lastMove,
     required Duration? thinkTime,
@@ -158,37 +158,76 @@ sealed class BroadcastGame with _$BroadcastGame {
 }
 
 @freezed
+// ignore: freezed_missing_private_empty_constructor
 sealed class BroadcastPlayer with _$BroadcastPlayer {
-  const factory BroadcastPlayer({
-    required String name,
-    required String? title,
-    required int? rating,
-    required Duration? clock,
-    required String? federation,
-    required FideId? fideId,
-  }) = _BroadcastPlayer;
+  const BroadcastPlayer({
+    required this.name,
+    required this.title,
+    required this.rating,
+    required this.federation,
+    required this.fideId,
+  });
+
+  // ignore: annotate_overrides
+  final String name;
+  // ignore: annotate_overrides
+  final String? title;
+  // ignore: annotate_overrides
+  final int? rating;
+  // ignore: annotate_overrides
+  final String? federation;
+  // ignore: annotate_overrides
+  final FideId? fideId;
+
+  String get id => (fideId != null) ? fideId!.toString() : name;
 }
 
 @freezed
-sealed class BroadcastPlayerExtended with _$BroadcastPlayerExtended {
-  const factory BroadcastPlayerExtended({
-    required String name,
-    required String? title,
-    required int? rating,
-    required String? federation,
-    required FideId? fideId,
-    required int played,
-    required double? score,
-    required int? ratingDiff,
-    required int? performance,
-  }) = _BroadcastPlayerExtended;
+// ignore: freezed_missing_private_empty_constructor
+class BroadcastPlayerWithClock extends BroadcastPlayer with _$BroadcastPlayerWithClock {
+  const BroadcastPlayerWithClock({
+    required super.name,
+    required super.title,
+    required super.rating,
+    required this.clock,
+    required super.federation,
+    required super.fideId,
+  });
+
+  // ignore: annotate_overrides
+  final Duration? clock;
+}
+
+@freezed
+// ignore: freezed_missing_private_empty_constructor
+class BroadcastPlayerWithResult extends BroadcastPlayer with _$BroadcastPlayerWithResult {
+  const BroadcastPlayerWithResult({
+    required super.name,
+    required super.title,
+    required super.rating,
+    required super.federation,
+    required super.fideId,
+    required this.played,
+    required this.score,
+    required this.ratingDiff,
+    required this.performance,
+  });
+
+  // ignore: annotate_overrides
+  final int played;
+  // ignore: annotate_overrides
+  final double? score;
+  // ignore: annotate_overrides
+  final int? ratingDiff;
+  // ignore: annotate_overrides
+  final int? performance;
 }
 
 typedef BroadcastFideData = ({({int? standard, int? rapid, int? blitz}) ratings, int? birthYear});
 
-typedef BroadcastPlayerResults =
+typedef BroadcastPlayerWithGames =
     ({
-      BroadcastPlayerExtended player,
+      BroadcastPlayerWithResult player,
       BroadcastFideData fideData,
       IList<BroadcastPlayerResultData> games,
     });

--- a/lib/src/model/broadcast/broadcast.dart
+++ b/lib/src/model/broadcast/broadcast.dart
@@ -159,7 +159,7 @@ sealed class BroadcastGame with _$BroadcastGame {
 
 @freezed
 // ignore: freezed_missing_private_empty_constructor
-sealed class BroadcastPlayer with _$BroadcastPlayer {
+class BroadcastPlayer with _$BroadcastPlayer {
   const BroadcastPlayer({
     required this.name,
     required this.title,

--- a/lib/src/model/broadcast/broadcast_providers.dart
+++ b/lib/src/model/broadcast/broadcast_providers.dart
@@ -58,7 +58,7 @@ Future<BroadcastRoundResponse> broadcastRound(Ref ref, BroadcastRoundId roundId)
 }
 
 @riverpod
-Future<IList<BroadcastPlayerExtended>> broadcastPlayers(
+Future<IList<BroadcastPlayerWithResult>> broadcastPlayers(
   Ref ref,
   BroadcastTournamentId tournamentId,
 ) {
@@ -66,7 +66,7 @@ Future<IList<BroadcastPlayerExtended>> broadcastPlayers(
 }
 
 @riverpod
-Future<BroadcastPlayerResults> broadcastPlayerResult(
+Future<BroadcastPlayerWithGames> broadcastPlayerResult(
   Ref ref,
   BroadcastTournamentId broadcastTournamentId,
   String playerId,

--- a/lib/src/model/broadcast/broadcast_repository.dart
+++ b/lib/src/model/broadcast/broadcast_repository.dart
@@ -227,8 +227,18 @@ BroadcastPlayerWithResult _playerWithResultFromPick(RequiredPick pick) {
 }
 
 BroadcastPlayerWithGames _makePlayerResultsFromJson(Map<String, dynamic> json) {
-  return (
-    player: _playerWithResultFromPick(pick(json).required()),
+  final playerWithResult = _playerWithResultFromPick(pick(json).required());
+
+  return BroadcastPlayerWithGames(
+    name: playerWithResult.name,
+    title: playerWithResult.title,
+    rating: playerWithResult.rating,
+    federation: playerWithResult.federation,
+    fideId: playerWithResult.fideId,
+    played: playerWithResult.played,
+    score: playerWithResult.score,
+    ratingDiff: playerWithResult.ratingDiff,
+    performance: playerWithResult.performance,
     fideData: _fideDataFromPick(pick(json, 'fide')),
     games: pick(json, 'games').asListOrThrow(_makePlayerResultFromPick).toIList(),
   );

--- a/lib/src/model/broadcast/broadcast_repository.dart
+++ b/lib/src/model/broadcast/broadcast_repository.dart
@@ -40,14 +40,14 @@ class BroadcastRepository {
     return client.read(Uri(path: 'api/study/$roundId/$gameId.pgn'));
   }
 
-  Future<IList<BroadcastPlayerExtended>> getPlayers(BroadcastTournamentId tournamentId) {
+  Future<IList<BroadcastPlayerWithResult>> getPlayers(BroadcastTournamentId tournamentId) {
     return client.readJsonList(
       Uri(path: '/broadcast/$tournamentId/players'),
       mapper: _makePlayerFromJson,
     );
   }
 
-  Future<BroadcastPlayerResults> getPlayerResults(
+  Future<BroadcastPlayerWithGames> getPlayerResults(
     BroadcastTournamentId tournamentId,
     String playerId,
   ) {
@@ -191,14 +191,14 @@ MapEntry<BroadcastGameId, BroadcastGame> gameFromPick(RequiredPick pick) {
   );
 }
 
-BroadcastPlayer _playerFromPick(
+BroadcastPlayerWithClock _playerFromPick(
   RequiredPick pick, {
   required bool isPlaying,
   required Duration? thinkTime,
 }) {
   final clock = pick('clock').asDurationFromCentiSecondsOrNull();
   final updatedClock = clock != null && isPlaying ? clock - (thinkTime ?? Duration.zero) : clock;
-  return BroadcastPlayer(
+  return BroadcastPlayerWithClock(
     name: pick('name').asStringOrThrow(),
     title: pick('title').asStringOrNull(),
     rating: pick('rating').asIntOrNull(),
@@ -208,12 +208,12 @@ BroadcastPlayer _playerFromPick(
   );
 }
 
-BroadcastPlayerExtended _makePlayerFromJson(Map<String, dynamic> json) {
-  return _playerExtendedFromPick(pick(json).required());
+BroadcastPlayerWithResult _makePlayerFromJson(Map<String, dynamic> json) {
+  return _playerWithResultFromPick(pick(json).required());
 }
 
-BroadcastPlayerExtended _playerExtendedFromPick(RequiredPick pick) {
-  return BroadcastPlayerExtended(
+BroadcastPlayerWithResult _playerWithResultFromPick(RequiredPick pick) {
+  return BroadcastPlayerWithResult(
     name: pick('name').asStringOrThrow(),
     title: pick('title').asStringOrNull(),
     rating: pick('rating').asIntOrNull(),
@@ -226,9 +226,9 @@ BroadcastPlayerExtended _playerExtendedFromPick(RequiredPick pick) {
   );
 }
 
-BroadcastPlayerResults _makePlayerResultsFromJson(Map<String, dynamic> json) {
+BroadcastPlayerWithGames _makePlayerResultsFromJson(Map<String, dynamic> json) {
   return (
-    player: _playerExtendedFromPick(pick(json).required()),
+    player: _playerWithResultFromPick(pick(json).required()),
     fideData: _fideDataFromPick(pick(json, 'fide')),
     games: pick(json, 'games').asListOrThrow(_makePlayerResultFromPick).toIList(),
   );

--- a/lib/src/view/broadcast/broadcast_boards_tab.dart
+++ b/lib/src/view/broadcast/broadcast_boards_tab.dart
@@ -321,13 +321,7 @@ class _PlayerWidget extends StatelessWidget {
             mainAxisSize: MainAxisSize.min,
             mainAxisAlignment: MainAxisAlignment.spaceBetween,
             children: [
-              Expanded(
-                child: BroadcastPlayerWidget(
-                  federation: player.federation,
-                  title: player.title,
-                  name: player.name,
-                ),
-              ),
+              Expanded(child: BroadcastPlayerWidget(player: player, showRating: false)),
               const SizedBox(width: 5),
               if (game.isOver)
                 Text(

--- a/lib/src/view/broadcast/broadcast_game_screen.dart
+++ b/lib/src/view/broadcast/broadcast_game_screen.dart
@@ -441,20 +441,8 @@ class _PlayerWidget extends ConsumerWidget {
           onTap: () {
             Navigator.of(context).push(
               (tournamentId != null)
-                  ? BroadcastPlayerResultsScreen.buildRoute(
-                    context,
-                    tournamentId!,
-                    (player.fideId != null) ? player.fideId!.toString() : player.name,
-                    playerTitle: player.title,
-                    playerName: player.name,
-                  )
-                  : BroadcastPlayerResultsScreenLoading.buildRoute(
-                    context,
-                    roundId,
-                    (player.fideId != null) ? player.fideId!.toString() : player.name,
-                    playerTitle: player.title,
-                    playerName: player.name,
-                  ),
+                  ? BroadcastPlayerResultsScreen.buildRoute(context, tournamentId!, player)
+                  : BroadcastPlayerResultsScreenLoading.buildRoute(context, roundId, player),
             );
           },
           child: Container(
@@ -471,10 +459,7 @@ class _PlayerWidget extends ConsumerWidget {
                 ],
                 Expanded(
                   child: BroadcastPlayerWidget(
-                    federation: player.federation,
-                    title: player.title,
-                    name: player.name,
-                    rating: player.rating,
+                    player: player,
                     textStyle: const TextStyle().copyWith(fontWeight: FontWeight.bold),
                   ),
                 ),

--- a/lib/src/view/broadcast/broadcast_player_results_screen.dart
+++ b/lib/src/view/broadcast/broadcast_player_results_screen.dart
@@ -20,32 +20,18 @@ import 'package:lichess_mobile/src/widgets/stat_card.dart';
 
 class BroadcastPlayerResultsScreenLoading extends ConsumerWidget {
   final BroadcastRoundId roundId;
-  final String playerId;
-  final String? playerTitle;
-  final String playerName;
+  final BroadcastPlayer player;
 
-  const BroadcastPlayerResultsScreenLoading(
-    this.roundId,
-    this.playerId, {
-    required this.playerName,
-    this.playerTitle,
-  });
+  const BroadcastPlayerResultsScreenLoading({required this.roundId, required this.player});
 
   static Route<dynamic> buildRoute(
     BuildContext context,
     BroadcastRoundId roundId,
-    String playerId, {
-    String? playerTitle,
-    required String playerName,
-  }) {
+    BroadcastPlayer player,
+  ) {
     return buildScreenRoute(
       context,
-      screen: BroadcastPlayerResultsScreenLoading(
-        roundId,
-        playerId,
-        playerTitle: playerTitle,
-        playerName: playerName,
-      ),
+      screen: BroadcastPlayerResultsScreenLoading(roundId: roundId, player: player),
     );
   }
 
@@ -54,11 +40,9 @@ class BroadcastPlayerResultsScreenLoading extends ConsumerWidget {
     final tournamentId = ref.watch(broadcastTournamentIdProvider(roundId));
 
     return switch (tournamentId) {
-      AsyncData(:final value) => BroadcastPlayerResultsScreen(
-        value,
-        playerId,
-        playerTitle: playerTitle,
-        playerName: playerName,
+      AsyncData(value: final tournamentId) => BroadcastPlayerResultsScreen(
+        tournamentId: tournamentId,
+        player: player,
       ),
       AsyncError(:final error) => PlatformScaffold(
         appBarTitle: const Text(''),
@@ -74,40 +58,26 @@ class BroadcastPlayerResultsScreenLoading extends ConsumerWidget {
 
 class BroadcastPlayerResultsScreen extends StatelessWidget {
   final BroadcastTournamentId tournamentId;
-  final String playerId;
-  final String? playerTitle;
-  final String playerName;
+  final BroadcastPlayer player;
 
-  const BroadcastPlayerResultsScreen(
-    this.tournamentId,
-    this.playerId, {
-    required this.playerName,
-    this.playerTitle,
-  });
+  const BroadcastPlayerResultsScreen({required this.tournamentId, required this.player});
 
   static Route<dynamic> buildRoute(
     BuildContext context,
     BroadcastTournamentId tournamentId,
-    String playerId, {
-    String? playerTitle,
-    required String playerName,
-  }) {
+    BroadcastPlayer player,
+  ) {
     return buildScreenRoute(
       context,
-      screen: BroadcastPlayerResultsScreen(
-        tournamentId,
-        playerId,
-        playerTitle: playerTitle,
-        playerName: playerName,
-      ),
+      screen: BroadcastPlayerResultsScreen(tournamentId: tournamentId, player: player),
     );
   }
 
   @override
   Widget build(BuildContext context) {
     return PlatformScaffold(
-      appBarTitle: BroadcastPlayerWidget(title: playerTitle, name: playerName),
-      body: _Body(tournamentId, playerId),
+      appBarTitle: BroadcastPlayerWidget(player: player, showFederation: false, showRating: false),
+      body: _Body(tournamentId, player.id),
     );
   }
 }
@@ -288,11 +258,7 @@ class _Body extends ConsumerWidget {
                       ),
                       Expanded(
                         flex: 5,
-                        child: BroadcastPlayerWidget(
-                          federation: playerResult.opponent.federation,
-                          title: playerResult.opponent.title,
-                          name: playerResult.opponent.name,
-                        ),
+                        child: BroadcastPlayerWidget(player: player, showRating: false),
                       ),
                       Expanded(
                         flex: 3,

--- a/lib/src/view/broadcast/broadcast_player_results_screen.dart
+++ b/lib/src/view/broadcast/broadcast_player_results_screen.dart
@@ -92,20 +92,20 @@ class _Body extends ConsumerWidget {
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
-    final playersResults = ref.watch(broadcastPlayerResultProvider(tournamentId, playerId));
+    final player = ref.watch(broadcastPlayerResultProvider(tournamentId, playerId));
 
-    switch (playersResults) {
-      case AsyncData(value: final playerResults):
-        final player = playerResults.player;
-        final fideData = playerResults.fideData;
-        final showRatingDiff = playerResults.games.any((result) => result.ratingDiff != null);
+    switch (player) {
+      case AsyncData(value: final player):
+        final fideData = player.fideData;
+        final games = player.games;
+        final showRatingDiff = games.any((result) => result.ratingDiff != null);
         final statWidth =
             (MediaQuery.sizeOf(context).width - Styles.bodyPadding.horizontal - 10 * 2) / 3;
         const cardSpacing = 10.0;
-        final indexWidth = max(8.0 + playerResults.games.length.toString().length * 10.0, 28.0);
+        final indexWidth = max(8.0 + games.length.toString().length * 10.0, 28.0);
 
         return ListView.builder(
-          itemCount: playerResults.games.length + 1,
+          itemCount: games.length + 1,
           itemBuilder: (context, index) {
             if (index == 0) {
               return Padding(
@@ -228,7 +228,7 @@ class _Body extends ConsumerWidget {
               );
             }
 
-            final playerResult = playerResults.games[index - 1];
+            final playerResult = games[index - 1];
 
             return GestureDetector(
               onTap: () {

--- a/lib/src/view/broadcast/broadcast_player_widget.dart
+++ b/lib/src/view/broadcast/broadcast_player_widget.dart
@@ -1,33 +1,37 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:lichess_mobile/src/model/broadcast/broadcast.dart';
 import 'package:lichess_mobile/src/styles/styles.dart';
 
 class BroadcastPlayerWidget extends ConsumerWidget {
   const BroadcastPlayerWidget({
-    this.federation,
-    required this.title,
-    required this.name,
-    this.rating,
+    required this.player,
+    this.showFederation = true,
+    this.showRating = true,
     this.textStyle,
   });
 
-  final String? federation;
-  final String? title;
-  final int? rating;
-  final String name;
+  final BroadcastPlayer player;
+  final bool showFederation;
+  final bool showRating;
   final TextStyle? textStyle;
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
+    final federation = player.federation;
+    final title = player.title;
+    final name = player.name;
+    final rating = player.rating;
+
     return Row(
       children: [
-        if (federation != null) ...[
+        if (federation != null && showFederation) ...[
           Image.asset('assets/images/fide-fed/$federation.png', height: 12),
           const SizedBox(width: 5),
         ],
         if (title != null) ...[
           Text(
-            title!,
+            title,
             style: TextStyle(
               color: (title == 'BOT') ? context.lichessColors.fancy : context.lichessColors.brag,
               fontWeight: FontWeight.bold,
@@ -36,7 +40,7 @@ class BroadcastPlayerWidget extends ConsumerWidget {
           const SizedBox(width: 5),
         ],
         Flexible(child: Text(name, style: textStyle, overflow: TextOverflow.ellipsis)),
-        if (rating != null) ...[
+        if (rating != null && showRating) ...[
           const SizedBox(width: 5),
           Text(rating.toString(), overflow: TextOverflow.ellipsis),
         ],

--- a/lib/src/view/broadcast/broadcast_players_tab.dart
+++ b/lib/src/view/broadcast/broadcast_players_tab.dart
@@ -43,7 +43,7 @@ const _kHeaderTextStyle = TextStyle(fontWeight: FontWeight.bold, overflow: TextO
 class PlayersList extends ConsumerStatefulWidget {
   const PlayersList(this.players, this.tournamentId);
 
-  final IList<BroadcastPlayerExtended> players;
+  final IList<BroadcastPlayerWithResult> players;
   final BroadcastTournamentId tournamentId;
 
   @override
@@ -51,7 +51,7 @@ class PlayersList extends ConsumerStatefulWidget {
 }
 
 class _PlayersListState extends ConsumerState<PlayersList> {
-  late IList<BroadcastPlayerExtended> players;
+  late IList<BroadcastPlayerWithResult> players;
   late _SortingTypes currentSort;
   bool reverse = false;
 
@@ -76,13 +76,13 @@ class _PlayersListState extends ConsumerState<PlayersList> {
   void sort(_SortingTypes newSort, {bool toggleReverse = false}) {
     final compare = switch (newSort) {
       _SortingTypes.player =>
-        (BroadcastPlayerExtended a, BroadcastPlayerExtended b) => a.name.compareTo(b.name),
-      _SortingTypes.elo => (BroadcastPlayerExtended a, BroadcastPlayerExtended b) {
+        (BroadcastPlayerWithResult a, BroadcastPlayerWithResult b) => a.name.compareTo(b.name),
+      _SortingTypes.elo => (BroadcastPlayerWithResult a, BroadcastPlayerWithResult b) {
         if (a.rating == null) return 1;
         if (b.rating == null) return -1;
         return b.rating!.compareTo(a.rating!);
       },
-      _SortingTypes.score => (BroadcastPlayerExtended a, BroadcastPlayerExtended b) {
+      _SortingTypes.score => (BroadcastPlayerWithResult a, BroadcastPlayerWithResult b) {
         if (a.score == null) return 1;
         if (b.score == null) return -1;
 
@@ -177,15 +177,9 @@ class _PlayersListState extends ConsumerState<PlayersList> {
 
           return GestureDetector(
             onTap: () {
-              Navigator.of(context).push(
-                BroadcastPlayerResultsScreen.buildRoute(
-                  context,
-                  widget.tournamentId,
-                  player.fideId != null ? player.fideId.toString() : player.name,
-                  playerTitle: player.title,
-                  playerName: player.name,
-                ),
-              );
+              Navigator.of(
+                context,
+              ).push(BroadcastPlayerResultsScreen.buildRoute(context, widget.tournamentId, player));
             },
             child: ColoredBox(
               color: index.isEven ? context.lichessTheme.rowEven : context.lichessTheme.rowOdd,
@@ -195,11 +189,7 @@ class _PlayersListState extends ConsumerState<PlayersList> {
                   Expanded(
                     child: Padding(
                       padding: _kTableRowPadding,
-                      child: BroadcastPlayerWidget(
-                        federation: player.federation,
-                        title: player.title,
-                        name: player.name,
-                      ),
+                      child: BroadcastPlayerWidget(player: player, showRating: false),
                     ),
                   ),
                   SizedBox(


### PR DESCRIPTION
Refactor broadcast player classes so that they all share a same base class thanks to freezed support of classic classes.

I am not sure this is worth it especially the second commit but I wanted to attempt this now that we can extend freezed classes.