### PR TITLE
Only delay local engine evaluation if cloud eval is likely available

### DIFF
--- a/lib/src/model/analysis/analysis_controller.dart
+++ b/lib/src/model/analysis/analysis_controller.dart
@@ -717,6 +717,12 @@ class AnalysisState with _$AnalysisState implements EvaluationMixinState {
   IMap<Square, ISet<Square>> get validMoves =>
       makeLegalMoves(currentNode.position, isChess960: variant == Variant.chess960);
 
+  /// Whether to delay the local engine evaluation.
+  ///
+  /// Cloud evaluations are most likely available for the opening moves.
+  @override
+  bool get delayLocalEngine => variant != Variant.fromPosition && currentPosition.ply < 20;
+
   /// Whether the user can request server analysis.
   ///
   /// It must be a lichess game, which is finished and not already analyzed.

--- a/lib/src/model/broadcast/broadcast_analysis_controller.dart
+++ b/lib/src/model/broadcast/broadcast_analysis_controller.dart
@@ -582,6 +582,11 @@ class BroadcastAnalysisState with _$BroadcastAnalysisState implements Evaluation
   /// If the game is new the path will be empty.
   UciPath? get broadcastLivePath => isNewOrOngoing ? broadcastPath : null;
 
+  /// In a broadcast analysis, the cloud evals are most likely available, so we always want to delay
+  /// the local engine evaluation to save battery.
+  @override
+  bool get delayLocalEngine => true;
+
   /// Whether an evaluation can be available
   bool hasAvailableEval(EngineEvaluationPrefState prefs) =>
       isEngineAvailable(prefs) || currentNode.serverEval != null;

--- a/lib/src/model/puzzle/puzzle_controller.dart
+++ b/lib/src/model/puzzle/puzzle_controller.dart
@@ -535,6 +535,9 @@ class PuzzleState with _$PuzzleState implements EvaluationMixinState {
   }) = _PuzzleState;
 
   @override
+  bool get delayLocalEngine => false;
+
+  @override
   bool isEngineAvailable(EngineEvaluationPrefState prefs) =>
       mode == PuzzleMode.view && prefs.isEnabled;
 

--- a/lib/src/model/study/study_controller.dart
+++ b/lib/src/model/study/study_controller.dart
@@ -503,6 +503,9 @@ class StudyState with _$StudyState implements EvaluationMixinState {
   IMap<Square, ISet<Square>> get validMoves =>
       currentNode.position != null ? makeLegalMoves(currentNode.position!) : const IMap.empty();
 
+  @override
+  bool get delayLocalEngine => false;
+
   /// Whether the engine is available for evaluation
   @override
   bool isEngineAvailable(EngineEvaluationPrefState prefs) =>

--- a/lib/src/view/broadcast/broadcast_game_screen.dart
+++ b/lib/src/view/broadcast/broadcast_game_screen.dart
@@ -645,7 +645,7 @@ class _BroadcastGameBottomBar extends ConsumerWidget {
                   label: context.l10n.toggleLocalEvaluation,
                   onTap:
                       analysisPrefs.enableComputerAnalysis &&
-                              snapshot.connectionState == ConnectionState.done
+                              snapshot.connectionState != ConnectionState.waiting
                           ? () async {
                             toggleFuture = ref.read(ctrlProvider.notifier).toggleEngine();
                             try {

--- a/lib/src/view/engine/engine_depth.dart
+++ b/lib/src/view/engine/engine_depth.dart
@@ -95,18 +95,16 @@ class EngineDepth extends ConsumerWidget {
             ),
           ],
         ),
-        null => Stack(
-          children: [
-            cloudIcon,
-            SizedBox(
-              width: cloudSize,
-              height: cloudSize,
-              child: Align(
-                alignment: cloudIconAlignment,
-                child: Text('\u{2026}', style: iconTextStyle),
-              ),
+        null => SizedBox(
+          width: cloudSize,
+          height: cloudSize,
+          child: Align(
+            alignment: cloudIconAlignment,
+            child: Text(
+              '\u{2026}',
+              style: iconTextStyle.copyWith(color: ColorScheme.of(context).onSurface),
             ),
-          ],
+          ),
         ),
       },
     );

--- a/lib/src/widgets/buttons.dart
+++ b/lib/src/widgets/buttons.dart
@@ -274,10 +274,10 @@ class RepeatButton extends StatefulWidget {
     required this.onLongPress,
     required this.child,
     this.triggerDelays = const [
-      Duration(milliseconds: 250),
-      Duration(milliseconds: 150),
+      Duration(milliseconds: 200),
+      Duration(milliseconds: 180),
       Duration(milliseconds: 100),
-      Duration(milliseconds: 50),
+      Duration(milliseconds: 40),
     ],
     this.holdDelay = const Duration(milliseconds: 30),
   });
@@ -288,7 +288,6 @@ class RepeatButton extends StatefulWidget {
   final VoidCallback? onLongPress;
 
   /// Delays between callbacks at the beginning. Leave default to get an acceleration effect.
-  /// The maximum length of the list is 3
   final List<Duration> triggerDelays;
 
   /// Delay between callbacks
@@ -300,11 +299,11 @@ class RepeatButton extends StatefulWidget {
 
 class _RepeatButtonState extends State<RepeatButton> {
   bool _isPressed = false;
-  Timer? _timer;
+  Timer? _holdTimer;
 
   @override
   void dispose() {
-    _timer?.cancel();
+    _holdTimer?.cancel();
     super.dispose();
   }
 
@@ -321,7 +320,7 @@ class _RepeatButtonState extends State<RepeatButton> {
       widget.onLongPress?.call();
     }
 
-    _timer = Timer.periodic(widget.holdDelay, (_) {
+    _holdTimer = Timer.periodic(widget.holdDelay, (_) {
       if (_isPressed) {
         widget.onLongPress?.call();
       }
@@ -330,7 +329,7 @@ class _RepeatButtonState extends State<RepeatButton> {
 
   void _onPressEnd() {
     _isPressed = false;
-    _timer?.cancel();
+    _holdTimer?.cancel();
   }
 
   @override

--- a/test/view/analysis/analysis_screen_test.dart
+++ b/test/view/analysis/analysis_screen_test.dart
@@ -469,10 +469,10 @@ void main() {
       await makeEngineTestApp(tester, isCloudEvalEnabled: false);
       await playMove(tester, 'e2', 'e4');
       expect(find.byType(InlineMove), findsOne);
-      await tester.pump(kRequestEngineEvalDebounceDelay + kEngineEvalEmissionThrottleDelay);
+      await tester.pump(kStartLocalEngineDebounceDelay + kEngineEvalEmissionThrottleDelay);
       expect(find.widgetWithText(InlineMove, '+0.2'), findsOne);
       await playMove(tester, 'e7', 'e5');
-      await tester.pump(kRequestEngineEvalDebounceDelay + kEngineEvalEmissionThrottleDelay);
+      await tester.pump(kStartLocalEngineDebounceDelay + kEngineEvalEmissionThrottleDelay);
       expect(find.widgetWithText(InlineMove, '+0.2'), findsNWidgets(2));
     });
   });

--- a/test/view/engine/engine_depth_test.dart
+++ b/test/view/engine/engine_depth_test.dart
@@ -1,29 +1,32 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
+import 'package:lichess_mobile/src/model/common/id.dart';
 import 'package:lichess_mobile/src/model/engine/evaluation_mixin.dart';
 import 'package:lichess_mobile/src/model/engine/evaluation_service.dart';
 import 'package:lichess_mobile/src/view/engine/engine_depth.dart';
 
 import 'test_engine_app.dart';
 
+/// Checks if the cloud eval is displayed in the EngineDepth widget by looking for the cloud icon
+bool isCloudEvalDisplayed() {
+  return find
+      .descendant(of: find.byType(EngineDepth), matching: find.byIcon(Icons.cloud))
+      .evaluate()
+      .isNotEmpty;
+}
+
+/// Checks if the local engine eval is displayed in the EngineDepth widget by looking for the microchip icon
+bool isLocalEngineEvalDisplayed() {
+  TestAsyncUtils.guardSync();
+  return find
+      .descendant(of: find.byType(EngineDepth), matching: find.byType(CustomPaint))
+      .evaluate()
+      .map((w) => w.widget as CustomPaint)
+      .where((w) => w.painter is MicroChipPainter)
+      .isNotEmpty;
+}
+
 void main() {
-  bool isCloudEvalDisplayed() {
-    return find
-        .descendant(of: find.byType(EngineDepth), matching: find.byIcon(Icons.cloud))
-        .evaluate()
-        .isNotEmpty;
-  }
-
-  bool isLocalEngineEvalDisplayed() {
-    TestAsyncUtils.guardSync();
-    return find
-        .descendant(of: find.byType(EngineDepth), matching: find.byType(CustomPaint))
-        .evaluate()
-        .map((w) => w.widget as CustomPaint)
-        .where((w) => w.painter is MicroChipPainter)
-        .isNotEmpty;
-  }
-
   testWidgets('engine depth is not displayed if computer analysis is not allowed', (tester) async {
     await makeEngineTestApp(tester, isComputerAnalysisAllowed: false);
     expect(find.byType(EngineDepth), findsNothing);
@@ -36,78 +39,106 @@ void main() {
     expect(find.byType(EngineDepth), findsNothing);
   });
 
-  testWidgets('displays a cloud icon if cloud eval is available', (tester) async {
-    await makeEngineTestApp(tester);
+  // This test group is for the case where the local engine is delayed (which is the case for the
+  // first 20 plies of the game)
+  group('Local engine is delayed', () {
+    testWidgets('displays a cloud icon if cloud eval is available', (tester) async {
+      await makeEngineTestApp(tester);
 
-    // it always tries to fetch the cloud eval
-    expect(isCloudEvalDisplayed(), isTrue);
-    // displays loading indicator
-    expect(find.widgetWithText(EngineDepth, '\u{2026}'), findsOne);
-    await tester.pump(kRequestCloudEvalDebounceDelay);
-    expect(find.widgetWithText(EngineDepth, '36'), findsOne);
+      // displays loading indicator
+      expect(find.widgetWithText(EngineDepth, '\u{2026}'), findsOne);
+      await tester.pump(kRequestEvalDebounceDelay);
+      expect(isCloudEvalDisplayed(), isTrue);
+      expect(find.widgetWithText(EngineDepth, '36'), findsOne);
+
+      // Wait for local engine delay
+      await tester.pump(kStartLocalEngineDebounceDelay + kEngineEvalEmissionThrottleDelay);
+      // Local engine has not even started
+      expect(find.widgetWithText(EngineDepth, '36'), findsOne);
+      expect(isLocalEngineEvalDisplayed(), isFalse);
+    });
+
+    testWidgets('Displays a microchip for local engine if cloud eval is not available', (
+      tester,
+    ) async {
+      await makeEngineTestApp(tester, isCloudEvalEnabled: false);
+      expect(find.byType(EngineDepth), findsOne);
+      // displays loading indicator
+      expect(find.widgetWithText(EngineDepth, '\u{2026}'), findsOne);
+
+      await tester.pump(kRequestEvalDebounceDelay);
+      // cloud eval is not available, so it still displays loading indicator
+      expect(find.widgetWithText(EngineDepth, '\u{2026}'), findsOne);
+      // local engine eval still not available
+      expect(isLocalEngineEvalDisplayed(), isFalse);
+
+      // Now wait for local engine
+      await tester.pump(kStartLocalEngineDebounceDelay + kEngineEvalEmissionThrottleDelay);
+      expect(isLocalEngineEvalDisplayed(), isTrue);
+      expect(find.widgetWithText(EngineDepth, '16'), findsOne);
+    });
+
+    testWidgets('Cloud eval will override local engine eval', (tester) async {
+      // Simulates a connection lag that will make the cloud eval come 300ms after the local engine
+      final connectionLag =
+          kStartLocalEngineDebounceDelay -
+          kRequestEvalDebounceDelay +
+          const Duration(milliseconds: 300);
+      await makeEngineTestApp(tester, connectionLag: connectionLag);
+
+      // Wait for local engine eval
+      await tester.pump(kStartLocalEngineDebounceDelay);
+      expect(isLocalEngineEvalDisplayed(), isTrue);
+      expect(find.widgetWithText(EngineDepth, '15'), findsOne);
+
+      // cloud eval will be available 300ms after the local engine eval
+      await tester.pump(const Duration(milliseconds: 300));
+      expect(isCloudEvalDisplayed(), isTrue);
+      expect(find.widgetWithText(EngineDepth, '36'), findsOne);
+    });
+
+    testWidgets('Local engine will not override cloud eval', (tester) async {
+      // Simulates a connection lag that will make the local engine come 100ms after the cloud eval
+      final connectionLag =
+          kStartLocalEngineDebounceDelay -
+          kRequestEvalDebounceDelay +
+          const Duration(milliseconds: 100);
+      await makeEngineTestApp(tester, connectionLag: connectionLag);
+
+      // Wait for local engine eval
+      await tester.pump(kStartLocalEngineDebounceDelay);
+      expect(isLocalEngineEvalDisplayed(), isTrue);
+      expect(find.widgetWithText(EngineDepth, '15'), findsOne);
+
+      // Cloud eval will be available 100ms after the first local engine eval emission
+      await tester.pump(const Duration(milliseconds: 100));
+      expect(isCloudEvalDisplayed(), isTrue);
+      expect(find.widgetWithText(EngineDepth, '36'), findsOne);
+
+      // local engine is still running, but it will not override the cloud eval
+      // wait for the next local engine eval emission (after throttle delay minus the 100ms already waited)
+      await tester.pump(kEngineEvalEmissionThrottleDelay - const Duration(milliseconds: 100));
+      expect(isCloudEvalDisplayed(), isTrue);
+      expect(find.widgetWithText(EngineDepth, '36'), findsOne);
+    });
   });
 
-  testWidgets('Displays a microchip for local engine if cloud eval is not available', (
-    tester,
-  ) async {
-    await makeEngineTestApp(tester, isCloudEvalEnabled: false);
-    expect(find.byType(EngineDepth), findsOne);
-    // it always tries to fetch the cloud eval
-    expect(isCloudEvalDisplayed(), isTrue);
-    // displays loading indicator
-    expect(find.widgetWithText(EngineDepth, '\u{2026}'), findsOne);
+  // This test group is for the case where the local engine is not delayed (which is the common case)
+  group('Local engine is not delayed', () {
+    testWidgets('it starts immediately after the request eval delay', (tester) async {
+      // loads a finished game, disable cloud eval because it is ususally not availabe in mid/end game
+      await makeEngineTestApp(tester, isCloudEvalEnabled: false, gameId: const GameId('xze7RH66'));
 
-    await tester.pump(kRequestCloudEvalDebounceDelay);
-    // cloud eval is not available, so it still displays loading indicator
-    expect(find.widgetWithText(EngineDepth, '\u{2026}'), findsOne);
+      expect(find.byType(CircularProgressIndicator), findsOne);
+      // wait for the game to be loaded
+      await tester.pump(const Duration(milliseconds: 50));
 
-    // Now wait for local engine
-    await tester.pump(kRequestEngineEvalDebounceDelay);
-    expect(isLocalEngineEvalDisplayed(), isTrue);
-    expect(find.widgetWithText(EngineDepth, '16'), findsOne);
-  });
+      // engine not yet started, so it still displays loading indicator
+      expect(find.widgetWithText(EngineDepth, '\u{2026}'), findsOne);
 
-  testWidgets('Cloud eval will override local engine eval', (tester) async {
-    // Simulates a connection lag that will make the cloud eval come 300ms after the local engine
-    final connectionLag =
-        kRequestEngineEvalDebounceDelay -
-        kRequestCloudEvalDebounceDelay +
-        const Duration(milliseconds: 300);
-    await makeEngineTestApp(tester, connectionLag: connectionLag);
-
-    // Wait for local engine eval
-    await tester.pump(kRequestEngineEvalDebounceDelay);
-    expect(isLocalEngineEvalDisplayed(), isTrue);
-    expect(find.widgetWithText(EngineDepth, '15'), findsOne);
-
-    // cloud eval will be available 300ms after the local engine eval
-    await tester.pump(const Duration(milliseconds: 300));
-    expect(isCloudEvalDisplayed(), isTrue);
-    expect(find.widgetWithText(EngineDepth, '36'), findsOne);
-  });
-
-  testWidgets('Local engine will not override cloud eval', (tester) async {
-    // Simulates a connection lag that will make the local engine come 100ms after the cloud eval
-    final connectionLag =
-        kRequestEngineEvalDebounceDelay -
-        kRequestCloudEvalDebounceDelay +
-        const Duration(milliseconds: 100);
-    await makeEngineTestApp(tester, connectionLag: connectionLag);
-
-    // Wait for local engine eval
-    await tester.pump(kRequestEngineEvalDebounceDelay);
-    expect(isLocalEngineEvalDisplayed(), isTrue);
-    expect(find.widgetWithText(EngineDepth, '15'), findsOne);
-
-    // Cloud eval will be available 100ms after the first local engine eval emission
-    await tester.pump(const Duration(milliseconds: 100));
-    expect(isCloudEvalDisplayed(), isTrue);
-    expect(find.widgetWithText(EngineDepth, '36'), findsOne);
-
-    // local engine is still running, but it will not override the cloud eval
-    // wait for the next local engine eval emission (after throttle delay minus the 100ms already waited)
-    await tester.pump(kEngineEvalEmissionThrottleDelay - const Duration(milliseconds: 100));
-    expect(isCloudEvalDisplayed(), isTrue);
-    expect(find.widgetWithText(EngineDepth, '36'), findsOne);
+      // wait for engine
+      await tester.pump(kRequestEvalDebounceDelay + kEngineEvalEmissionThrottleDelay);
+      expect(find.widgetWithText(EngineDepth, '16'), findsOne);
+    });
   });
 }

--- a/test/view/engine/engine_gauge_test.dart
+++ b/test/view/engine/engine_gauge_test.dart
@@ -9,13 +9,13 @@ import 'test_engine_app.dart';
 void main() {
   testWidgets('engine gauge is not displayed if computer analysis is not allowed', (tester) async {
     await makeEngineTestApp(tester, isComputerAnalysisAllowed: false);
-    await tester.pump(kRequestCloudEvalDebounceDelay);
+    await tester.pump(kRequestEvalDebounceDelay);
     expect(find.byType(EngineGauge), findsNothing);
   });
 
   testWidgets('engine gauge is not displayed if computer analysis is not enabled', (tester) async {
     await makeEngineTestApp(tester, isComputerAnalysisEnabled: false);
-    await tester.pump(kRequestCloudEvalDebounceDelay);
+    await tester.pump(kRequestEvalDebounceDelay);
     expect(find.byType(EngineGauge), findsNothing);
   });
 
@@ -23,13 +23,13 @@ void main() {
     tester,
   ) async {
     await makeEngineTestApp(tester, isEngineEnabled: false);
-    await tester.pump(kRequestCloudEvalDebounceDelay);
+    await tester.pump(kRequestEvalDebounceDelay);
     expect(find.byType(EngineGauge), findsNothing);
   });
 
   testWidgets('engine gauge is displayed if engine is available', (tester) async {
     await makeEngineTestApp(tester);
-    await tester.pump(kRequestCloudEvalDebounceDelay);
+    await tester.pump(kRequestEvalDebounceDelay);
     expect(find.byType(EngineGauge), findsOne);
     expect(find.widgetWithText(EngineGauge, '+0.2'), findsOne);
   });

--- a/test/view/engine/engine_lines_test.dart
+++ b/test/view/engine/engine_lines_test.dart
@@ -7,20 +7,20 @@ import 'test_engine_app.dart';
 void main() {
   testWidgets('engine lines are displayed', (tester) async {
     await makeEngineTestApp(tester);
-    await tester.pump(kRequestCloudEvalDebounceDelay);
+    await tester.pump(kRequestEvalDebounceDelay);
     expect(find.byType(Engineline), findsOne);
     expect(find.widgetWithText(Engineline, '1. e4 e5 2. Nf3 Nc6 3. Bb5 Nf6 '), findsOne);
   });
 
   testWidgets('engine lines are not displayed if computer analysis is not allowed', (tester) async {
     await makeEngineTestApp(tester, isComputerAnalysisAllowed: false);
-    await tester.pump(kRequestCloudEvalDebounceDelay);
+    await tester.pump(kRequestEvalDebounceDelay);
     expect(find.byType(Engineline), findsNothing);
   });
 
   testWidgets('engine lines are not displayed if computer analysis is not enabled', (tester) async {
     await makeEngineTestApp(tester, isComputerAnalysisEnabled: false);
-    await tester.pump(kRequestCloudEvalDebounceDelay);
+    await tester.pump(kRequestEvalDebounceDelay);
     expect(find.byType(Engineline), findsNothing);
   });
 
@@ -28,7 +28,7 @@ void main() {
     tester,
   ) async {
     await makeEngineTestApp(tester, isEngineEnabled: false);
-    await tester.pump(kRequestCloudEvalDebounceDelay);
+    await tester.pump(kRequestEvalDebounceDelay);
     expect(find.byType(Engineline), findsNothing);
   });
 
@@ -36,7 +36,7 @@ void main() {
     tester,
   ) async {
     await makeEngineTestApp(tester, numEvalLines: 0);
-    await tester.pump(kRequestCloudEvalDebounceDelay);
+    await tester.pump(kRequestEvalDebounceDelay);
     expect(find.byType(Engineline), findsNothing);
   });
 }

--- a/test/view/engine/test_engine_app.dart
+++ b/test/view/engine/test_engine_app.dart
@@ -18,7 +18,7 @@ import '../../network/fake_websocket_channel.dart';
 import '../../test_helpers.dart';
 import '../../test_provider_scope.dart';
 
-/// Creates a test app to test engine evaluation with the [AnalysisScreen] and the given [testBody].
+/// Creates a test app to test engine evaluation with the [AnalysisScreen].
 Future<void> makeEngineTestApp(
   WidgetTester tester, {
   GameId? gameId,


### PR DESCRIPTION
Also fix the always disabled broadcast engine toggle button.