### PR TITLE
Fix broadcast game reload

### DIFF
--- a/lib/src/model/broadcast/broadcast_analysis_controller.dart
+++ b/lib/src/model/broadcast/broadcast_analysis_controller.dart
@@ -180,15 +180,22 @@ class BroadcastAnalysisController extends _$BroadcastAnalysisController
       final newRoot = Root.fromPgnGame(game, isLichessAnalysis: true);
 
       final broadcastPath = newRoot.mainlinePath;
-      final lastMove = newRoot.branchAt(newRoot.mainlinePath)?.sanMove.move;
+      final lastMove =
+          wasOnLivePath ? newRoot.branchAt(newRoot.mainlinePath)?.sanMove.move : curState.lastMove;
 
       newRoot.merge(_root);
 
       _root = newRoot;
 
       final newCurrentPath = wasOnLivePath ? broadcastPath : curState.currentPath;
+      final newCurrentNode =
+          wasOnLivePath
+              ? AnalysisCurrentNode.fromNode(_root.nodeAt(newCurrentPath))
+              : curState.currentNode;
+
       state = AsyncData(
         state.requireValue.copyWith(
+          currentNode: newCurrentNode,
           currentPath: newCurrentPath,
           pgnHeaders: pgnHeaders,
           pgnRootComments: rootComments,


### PR DESCRIPTION
Close #1443.

Fix broadcast game reload last move not updated correctly when not on broadcast path and fix current node not updated when on broadcast path.