### PR TITLE
Refactor opening fetching to use FEN instead of moves

### DIFF
--- a/lib/src/model/analysis/analysis_controller.dart
+++ b/lib/src/model/analysis/analysis_controller.dart
@@ -162,7 +162,7 @@ class AnalysisController extends _$AnalysisController
           lastMove = branch.sanMove.move;
         }
         if (isMainline && opening == null && branch.position.ply <= 10) {
-          openingFutures.add(_fetchOpening(root, path));
+          openingFutures.add(_fetchOpening(branch.position.fen, path));
         }
       },
     );
@@ -476,7 +476,7 @@ class AnalysisController extends _$AnalysisController
       }
 
       if (currentNode.opening == null && currentNode.position.ply <= 30) {
-        _fetchOpening(_root, path).then((value) {
+        _fetchOpening(currentNode.position.fen, path).then((value) {
           if (value != null) {
             final (path, opening) = value;
             _updateOpening(path, opening);
@@ -512,14 +512,10 @@ class AnalysisController extends _$AnalysisController
     if (pathChange) requestEval();
   }
 
-  Future<(UciPath, FullOpening)?> _fetchOpening(Node fromNode, UciPath path) async {
+  Future<(UciPath, FullOpening)?> _fetchOpening(String fen, UciPath path) async {
     if (!kOpeningAllowedVariants.contains(_variant)) return null;
 
-    final moves = fromNode.branchesOn(path).map((node) => node.sanMove.move);
-    if (moves.isEmpty) return null;
-    if (moves.length > 40) return null;
-
-    final opening = await ref.read(openingServiceProvider).fetchFromMoves(moves);
+    final opening = await ref.read(openingServiceProvider).fetchFromFen(fen);
     if (opening != null) {
       return (path, opening);
     }

--- a/lib/src/model/analysis/opening_service.dart
+++ b/lib/src/model/analysis/opening_service.dart
@@ -1,4 +1,3 @@
-import 'package:dartchess/dartchess.dart';
 import 'package:fast_immutable_collections/fast_immutable_collections.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:lichess_mobile/src/db/openings_database.dart';
@@ -27,12 +26,10 @@ class OpeningService {
 
   Future<Database> get _db => _ref.read(openingsDatabaseProvider.future);
 
-  Future<FullOpening?> fetchFromMoves(Iterable<Move> moves) async {
+  Future<FullOpening?> fetchFromFen(String fen) async {
     final db = await _db;
-    final movesString = moves
-        .map((move) => altCastles.containsKey(move.uci) ? altCastles[move.uci] : move.uci)
-        .join(' ');
-    final list = await db.query('openings', where: 'uci = ?', whereArgs: [movesString]);
+    final epd = '${fen.split(' - ')[0]} -';
+    final list = await db.query('openings', where: 'epd = ?', whereArgs: [epd], limit: 1);
     final first = list.firstOrNull;
 
     if (first != null) {

--- a/test/model/analysis/fake_opening_service.dart
+++ b/test/model/analysis/fake_opening_service.dart
@@ -1,10 +1,9 @@
-import 'package:dartchess/src/models.dart';
 import 'package:lichess_mobile/src/model/analysis/opening_service.dart';
 import 'package:lichess_mobile/src/model/common/chess.dart';
 
 class FakeOpeningService implements OpeningService {
   @override
-  Future<FullOpening?> fetchFromMoves(Iterable<Move> moves) {
+  Future<FullOpening?> fetchFromFen(String fen) {
     // TODO: implement fetchFromMoves when needed
     return Future.value(null);
   }


### PR DESCRIPTION
closes https://github.com/lichess-org/mobile/issues/1495

Refactored opening fetching logic to use FEN instead of move sequences. This change ensures precise identification of chess openings on the analysis board and opening explorer, addressing issue 1495.