### PR TITLE
Over the board feats: Resign, Offer Draw and notification on threefold repetition

### DIFF
--- a/lib/src/model/game/over_the_board_game.dart
+++ b/lib/src/model/game/over_the_board_game.dart
@@ -42,13 +42,10 @@ abstract class OverTheBoardGame with _$OverTheBoardGame, BaseGame, IndexableStep
   @override
   GameId get id => const GameId('--------');
 
-  bool get abortable =>
-      playable &&
-      lastPosition.fullmoves <= 1 &&
-      (meta.rules == null || !meta.rules!.contains(GameRule.noAbort));
+  bool get abortable => playable && lastPosition.fullmoves <= 1;
 
   bool get resignable => playable && !abortable;
-  bool get drawable => playable && lastPosition.fullmoves >= 2 && !(me?.offeringDraw == true);
+  bool get drawable => playable && lastPosition.fullmoves >= 2;
 
   @Assert('steps.isNotEmpty')
   factory OverTheBoardGame({

--- a/lib/src/model/game/over_the_board_game.dart
+++ b/lib/src/model/game/over_the_board_game.dart
@@ -42,6 +42,14 @@ abstract class OverTheBoardGame with _$OverTheBoardGame, BaseGame, IndexableStep
   @override
   GameId get id => const GameId('--------');
 
+  bool get abortable =>
+      playable &&
+      lastPosition.fullmoves <= 1 &&
+      (meta.rules == null || !meta.rules!.contains(GameRule.noAbort));
+
+  bool get resignable => playable && !abortable;
+  bool get drawable => playable && lastPosition.fullmoves >= 2 && !(me?.offeringDraw == true);
+
   @Assert('steps.isNotEmpty')
   factory OverTheBoardGame({
     @JsonKey(fromJson: stepsFromJson, toJson: stepsToJson) required IList<GameStep> steps,

--- a/lib/src/model/over_the_board/over_the_board_game_controller.dart
+++ b/lib/src/model/over_the_board/over_the_board_game_controller.dart
@@ -32,6 +32,16 @@ class OverTheBoardGameController extends _$OverTheBoardGameController {
     state = OverTheBoardGameState.fromVariant(state.game.meta.variant, state.game.meta.speed);
   }
 
+  void resign() {
+    state = state.copyWith(
+      game: state.game.copyWith(status: GameStatus.resign, winner: state.turn.opposite),
+    );
+  }
+
+  void draw() {
+    state = state.copyWith(game: state.game.copyWith(status: GameStatus.draw));
+  }
+
   void makeMove(NormalMove move) {
     if (isPromotionPawnMove(state.currentPosition, move)) {
       state = state.copyWith(promotionMove: move);

--- a/lib/src/model/over_the_board/over_the_board_game_controller.dart
+++ b/lib/src/model/over_the_board/over_the_board_game_controller.dart
@@ -68,6 +68,13 @@ class OverTheBoardGameController extends _$OverTheBoardGameController {
       stepCursor: state.stepCursor + 1,
     );
 
+    // check for threefold repetition
+    if (state.game.steps.count((p) => p.position.board == newStep.position.board) == 3) {
+      state = state.copyWith(game: state.game.copyWith(isThreefoldRepetition: true));
+    } else {
+      state = state.copyWith(game: state.game.copyWith(isThreefoldRepetition: false));
+    }
+
     if (state.currentPosition.isCheckmate) {
       state = state.copyWith(
         game: state.game.copyWith(status: GameStatus.mate, winner: state.turn.opposite),

--- a/lib/src/view/over_the_board/over_the_board_screen.dart
+++ b/lib/src/view/over_the_board/over_the_board_screen.dart
@@ -249,8 +249,14 @@ class _BottomBar extends ConsumerWidget {
     return showAdaptiveActionSheet(
       context: context,
       actions: [
-        BottomSheetAction(makeLabel: (context) => const Text('New game'), onPressed: () {}),
-        BottomSheetAction(makeLabel: (context) => Text(context.l10n.flipBoard), onPressed: () {}),
+        BottomSheetAction(
+          makeLabel: (context) => const Text('New game'),
+          onPressed: () => showConfigureGameSheet(context, isDismissible: true),
+        ),
+        BottomSheetAction(
+          makeLabel: (context) => Text(context.l10n.flipBoard),
+          onPressed: onFlipBoard,
+        ),
         BottomSheetAction(makeLabel: (context) => Text(context.l10n.offerDraw), onPressed: () {}),
         BottomSheetAction(makeLabel: (context) => Text(context.l10n.resign), onPressed: () {}),
       ],

--- a/lib/src/view/over_the_board/over_the_board_screen.dart
+++ b/lib/src/view/over_the_board/over_the_board_screen.dart
@@ -219,12 +219,6 @@ class _BottomBar extends ConsumerWidget {
           },
           icon: Icons.menu,
         ),
-        BottomBarButton(
-          key: const Key('flip-button'),
-          label: context.l10n.flipBoard,
-          onTap: onFlipBoard,
-          icon: CupertinoIcons.arrow_2_squarepath,
-        ),
         if (!clock.timeIncrement.isInfinite)
           BottomBarButton(
             label: clock.active ? 'Pause' : 'Resume',

--- a/lib/src/view/over_the_board/over_the_board_screen.dart
+++ b/lib/src/view/over_the_board/over_the_board_screen.dart
@@ -98,6 +98,31 @@ class _BodyState extends ConsumerState<_Body> {
           }
         });
       }
+
+      if (previous?.game.isThreefoldRepetition == false &&
+          newGameState.game.isThreefoldRepetition == true) {
+        ref.read(overTheBoardClockProvider.notifier).pause();
+        Timer(const Duration(milliseconds: 500), () {
+          if (context.mounted) {
+            showAdaptiveDialog<void>(
+              context: context,
+              builder:
+                  (context) => YesNoDialog(
+                    title: Text(context.l10n.threefoldRepetition),
+                    content: const Text('Accept draw?'),
+                    onYes: () {
+                      Navigator.pop(context);
+                      ref.read(overTheBoardGameControllerProvider.notifier).draw();
+                    },
+                    onNo: () {
+                      Navigator.pop(context);
+                      ref.read(overTheBoardClockProvider.notifier).resume(previous!.turn);
+                    },
+                  ),
+            );
+          }
+        });
+      }
     });
 
     return WakelockWidget(

--- a/lib/src/view/over_the_board/over_the_board_screen.dart
+++ b/lib/src/view/over_the_board/over_the_board_screen.dart
@@ -182,11 +182,7 @@ class _BottomBar extends ConsumerWidget {
 
     return PlatformBottomBar(
       children: [
-        BottomBarButton(
-          label: 'Configure game',
-          onTap: () => showConfigureGameSheet(context, isDismissible: true),
-          icon: Icons.add,
-        ),
+        BottomBarButton(label: context.l10n.menu, onTap: () {}, icon: Icons.menu),
         BottomBarButton(
           key: const Key('flip-button'),
           label: context.l10n.flipBoard,

--- a/lib/src/view/over_the_board/over_the_board_screen.dart
+++ b/lib/src/view/over_the_board/over_the_board_screen.dart
@@ -103,9 +103,9 @@ class _BodyState extends ConsumerState<_Body> {
 
       if (previous?.game.isThreefoldRepetition == false &&
           newGameState.game.isThreefoldRepetition == true) {
-        ref.read(overTheBoardClockProvider.notifier).pause();
         Timer(const Duration(milliseconds: 500), () {
           if (context.mounted) {
+            ref.read(overTheBoardClockProvider.notifier).pause();
             showAdaptiveDialog<void>(
               context: context,
               builder:

--- a/lib/src/view/over_the_board/over_the_board_screen.dart
+++ b/lib/src/view/over_the_board/over_the_board_screen.dart
@@ -13,6 +13,7 @@ import 'package:lichess_mobile/src/model/settings/over_the_board_preferences.dar
 import 'package:lichess_mobile/src/utils/immersive_mode.dart';
 import 'package:lichess_mobile/src/utils/l10n_context.dart';
 import 'package:lichess_mobile/src/utils/navigation.dart';
+import 'package:lichess_mobile/src/utils/string.dart';
 import 'package:lichess_mobile/src/view/game/game_player.dart';
 import 'package:lichess_mobile/src/view/game/game_result_dialog.dart';
 import 'package:lichess_mobile/src/view/over_the_board/configure_over_the_board_game.dart';
@@ -23,6 +24,7 @@ import 'package:lichess_mobile/src/widgets/bottom_bar_button.dart';
 import 'package:lichess_mobile/src/widgets/buttons.dart';
 import 'package:lichess_mobile/src/widgets/clock.dart';
 import 'package:lichess_mobile/src/widgets/platform_scaffold.dart';
+import 'package:lichess_mobile/src/widgets/yes_no_dialog.dart';
 
 class OverTheBoardScreen extends StatelessWidget {
   const OverTheBoardScreen({super.key});
@@ -259,9 +261,45 @@ class _BottomBar extends ConsumerWidget {
           onPressed: onFlipBoard,
         ),
         if (gameState.game.drawable)
-          BottomSheetAction(makeLabel: (context) => Text(context.l10n.offerDraw), onPressed: () {}),
+          BottomSheetAction(
+            makeLabel: (context) => Text(context.l10n.offerDraw),
+            onPressed: () {
+              final offerer = gameState.turn.name.capitalize();
+              showAdaptiveDialog<void>(
+                context: context,
+                builder:
+                    (context) => YesNoDialog(
+                      title: Text('${context.l10n.draw}?'),
+                      content: Text('$offerer offers draw. Does opponent accept?'),
+                      onYes: () {
+                        Navigator.pop(context);
+                        ref.read(overTheBoardGameControllerProvider.notifier).draw();
+                      },
+                      onNo: () => Navigator.pop(context),
+                    ),
+              );
+            },
+          ),
         if (gameState.game.resignable)
-          BottomSheetAction(makeLabel: (context) => Text(context.l10n.resign), onPressed: () {}),
+          BottomSheetAction(
+            makeLabel: (context) => Text(context.l10n.resign),
+            onPressed: () {
+              final offerer = gameState.turn.name.capitalize();
+              showAdaptiveDialog<void>(
+                context: context,
+                builder:
+                    (context) => YesNoDialog(
+                      title: Text('${context.l10n.resign}?'),
+                      content: Text('Are you sure you want to resign as $offerer?'),
+                      onYes: () {
+                        Navigator.pop(context);
+                        ref.read(overTheBoardGameControllerProvider.notifier).resign();
+                      },
+                      onNo: () => Navigator.pop(context),
+                    ),
+              );
+            },
+          ),
       ],
     );
   }

--- a/lib/src/view/over_the_board/over_the_board_screen.dart
+++ b/lib/src/view/over_the_board/over_the_board_screen.dart
@@ -16,6 +16,7 @@ import 'package:lichess_mobile/src/utils/navigation.dart';
 import 'package:lichess_mobile/src/view/game/game_player.dart';
 import 'package:lichess_mobile/src/view/game/game_result_dialog.dart';
 import 'package:lichess_mobile/src/view/over_the_board/configure_over_the_board_game.dart';
+import 'package:lichess_mobile/src/widgets/adaptive_action_sheet.dart';
 import 'package:lichess_mobile/src/widgets/board_table.dart';
 import 'package:lichess_mobile/src/widgets/bottom_bar.dart';
 import 'package:lichess_mobile/src/widgets/bottom_bar_button.dart';
@@ -182,7 +183,13 @@ class _BottomBar extends ConsumerWidget {
 
     return PlatformBottomBar(
       children: [
-        BottomBarButton(label: context.l10n.menu, onTap: () {}, icon: Icons.menu),
+        BottomBarButton(
+          label: context.l10n.menu,
+          onTap: () {
+            _showOtbGameMenu(context, ref);
+          },
+          icon: Icons.menu,
+        ),
         BottomBarButton(
           key: const Key('flip-button'),
           label: context.l10n.flipBoard,
@@ -234,6 +241,18 @@ class _BottomBar extends ConsumerWidget {
                   : null,
           icon: CupertinoIcons.chevron_forward,
         ),
+      ],
+    );
+  }
+
+  Future<void> _showOtbGameMenu(BuildContext context, WidgetRef ref) {
+    return showAdaptiveActionSheet(
+      context: context,
+      actions: [
+        BottomSheetAction(makeLabel: (context) => const Text('New game'), onPressed: () {}),
+        BottomSheetAction(makeLabel: (context) => Text(context.l10n.flipBoard), onPressed: () {}),
+        BottomSheetAction(makeLabel: (context) => Text(context.l10n.offerDraw), onPressed: () {}),
+        BottomSheetAction(makeLabel: (context) => Text(context.l10n.resign), onPressed: () {}),
       ],
     );
   }

--- a/lib/src/view/over_the_board/over_the_board_screen.dart
+++ b/lib/src/view/over_the_board/over_the_board_screen.dart
@@ -6,6 +6,7 @@ import 'package:dartchess/dartchess.dart';
 import 'package:flutter/cupertino.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:lichess_mobile/src/model/analysis/analysis_controller.dart';
 import 'package:lichess_mobile/src/model/over_the_board/over_the_board_clock.dart';
 import 'package:lichess_mobile/src/model/over_the_board/over_the_board_game_controller.dart';
 import 'package:lichess_mobile/src/model/settings/board_preferences.dart';
@@ -14,6 +15,7 @@ import 'package:lichess_mobile/src/utils/immersive_mode.dart';
 import 'package:lichess_mobile/src/utils/l10n_context.dart';
 import 'package:lichess_mobile/src/utils/navigation.dart';
 import 'package:lichess_mobile/src/utils/string.dart';
+import 'package:lichess_mobile/src/view/analysis/analysis_screen.dart';
 import 'package:lichess_mobile/src/view/game/game_player.dart';
 import 'package:lichess_mobile/src/view/game/game_result_dialog.dart';
 import 'package:lichess_mobile/src/view/over_the_board/configure_over_the_board_game.dart';
@@ -281,6 +283,24 @@ class _BottomBar extends ConsumerWidget {
           makeLabel: (context) => const Text('New game'),
           onPressed: () => showConfigureGameSheet(context, isDismissible: true),
         ),
+        if (gameState.game.finished)
+          BottomSheetAction(
+            makeLabel: (context) => Text(context.l10n.analysis),
+            onPressed:
+                () => Navigator.of(context).push(
+                  AnalysisScreen.buildRoute(
+                    context,
+                    AnalysisOptions(
+                      orientation: Side.white,
+                      standalone: (
+                        pgn: gameState.game.makePgn(),
+                        isComputerAnalysisAllowed: true,
+                        variant: gameState.game.meta.variant,
+                      ),
+                    ),
+                  ),
+                ),
+          ),
         BottomSheetAction(
           makeLabel: (context) => Text(context.l10n.flipBoard),
           onPressed: onFlipBoard,

--- a/lib/src/view/over_the_board/over_the_board_screen.dart
+++ b/lib/src/view/over_the_board/over_the_board_screen.dart
@@ -246,6 +246,7 @@ class _BottomBar extends ConsumerWidget {
   }
 
   Future<void> _showOtbGameMenu(BuildContext context, WidgetRef ref) {
+    final gameState = ref.read(overTheBoardGameControllerProvider);
     return showAdaptiveActionSheet(
       context: context,
       actions: [
@@ -257,8 +258,10 @@ class _BottomBar extends ConsumerWidget {
           makeLabel: (context) => Text(context.l10n.flipBoard),
           onPressed: onFlipBoard,
         ),
-        BottomSheetAction(makeLabel: (context) => Text(context.l10n.offerDraw), onPressed: () {}),
-        BottomSheetAction(makeLabel: (context) => Text(context.l10n.resign), onPressed: () {}),
+        if (gameState.game.drawable)
+          BottomSheetAction(makeLabel: (context) => Text(context.l10n.offerDraw), onPressed: () {}),
+        if (gameState.game.resignable)
+          BottomSheetAction(makeLabel: (context) => Text(context.l10n.resign), onPressed: () {}),
       ],
     );
   }


### PR DESCRIPTION
This pr adds three new features to over the board games: resign, offer draw, and a notification on threefold repetition. No new widget or class was added, and these features were implemented much like they are in regular online games.

Fixes #1029 

**Changes made:**
- OverTheBoardGame model class: Added three new getters: abortable, resignable and drawable. Calculated the same way as in the Game model class.
- OverTheBoardGameController: Added two new functions: resign() and draw(). Also added a check for a threefold repetition on every move.
- OverTheBoardScreen: Added a hamburger menu to the UI, added listeners for the new controller functions, and used YesNoDialog to request user confirmations.

**Tests performed:**
- Ran flutter test. Some tests failed, but these were not due to any changes I made
- Ran flutter analyze. No issues
- Manually tested the new features - debug build on an Android device, API Level 31


https://github.com/user-attachments/assets/b3efe807-5a30-44e8-9e5b-e471c396a985


https://github.com/user-attachments/assets/69c24f2d-922c-4a24-b0f4-dc6b445541b5


https://github.com/user-attachments/assets/70f1c3d2-09cc-48ff-bbe8-909e574b2ec2

