### PR TITLE
Update Flutter version

### DIFF
--- a/pubspec.lock
+++ b/pubspec.lock
@@ -1789,5 +1789,5 @@ packages:
     source: hosted
     version: "3.1.3"
 sdks:
-  dart: ">=3.8.0-70.0 <4.0.0"
-  flutter: ">=3.30.0-0.1"
+  dart: ">=3.8.0-171.0.dev <4.0.0"
+  flutter: ">=3.31.0-0.1.pre"

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -5,9 +5,9 @@ publish_to: "none"
 version: 0.14.14+001414 # See README.md for details about versioning
 
 environment:
-  sdk: '^3.8.0-70.0'
+  sdk: ^3.8.0-171.0.dev
   # We're using the beta channel for the flutter version
-  flutter: "3.30.0-0.1"
+  flutter: 3.31.0-0.1.pre
 
 dependencies:
   app_settings: ^5.1.1


### PR DESCRIPTION
I was wondering if we want to pin the Dart version since we are doing it for the Flutter version or if we prefer to use `^`.