### PR TITLE
Make clockOrientation nullable and update related references for impr…

### DIFF
--- a/lib/src/model/clock/clock_tool_controller.dart
+++ b/lib/src/model/clock/clock_tool_controller.dart
@@ -44,7 +44,7 @@ class ClockToolController extends _$ClockToolController {
       whiteTime: _clock.whiteTime,
       blackTime: _clock.blackTime,
       activeSide: Side.white,
-      clockOrientation: ClockOrientation.portraitUp,
+      clockOrientation: null,
     );
   }
 
@@ -169,7 +169,7 @@ class ClockToolController extends _$ClockToolController {
     state = state.copyWith(paused: false);
   }
 
-  void toggleOrientation(ClockOrientation clockOrientation) {
+  void toggleOrientation(ClockOrientation? clockOrientation) {
     state = state.copyWith(clockOrientation: clockOrientation);
   }
 }
@@ -218,7 +218,7 @@ class ClockState with _$ClockState {
     @Default(false) bool paused,
     @Default(0) int whiteMoves,
     @Default(0) int blackMoves,
-    required ClockOrientation clockOrientation,
+    required ClockOrientation? clockOrientation,
   }) = _ClockState;
 
   ValueListenable<Duration> getDuration(Side playerType) =>

--- a/lib/src/view/clock/clock_settings.dart
+++ b/lib/src/view/clock/clock_settings.dart
@@ -32,13 +32,13 @@ class ClockSettings extends ConsumerWidget {
         children: [
           Expanded(
             child: RotatedBox(
-              quarterTurns: clockOrientation.quarterTurns,
+              quarterTurns: clockOrientation?.quarterTurns ?? 0,
               child: const _PlayResumeButton(_iconSize),
             ),
           ),
           Expanded(
             child: RotatedBox(
-              quarterTurns: clockOrientation.quarterTurns,
+              quarterTurns: clockOrientation?.quarterTurns ?? 0,
               child: IconButton(
                 padding: _kIconPadding,
                 tooltip: context.l10n.reset,
@@ -55,7 +55,7 @@ class ClockSettings extends ConsumerWidget {
           ),
           Expanded(
             child: RotatedBox(
-              quarterTurns: clockOrientation.quarterTurns,
+              quarterTurns: clockOrientation?.quarterTurns ?? 0,
               child: IconButton(
                 padding: _kIconPadding,
                 tooltip: context.l10n.settingsSettings,
@@ -97,7 +97,7 @@ class ClockSettings extends ConsumerWidget {
           ),
           Expanded(
             child: RotatedBox(
-              quarterTurns: clockOrientation.quarterTurns,
+              quarterTurns: clockOrientation?.quarterTurns ?? 0,
               child: IconButton(
                 padding: _kIconPadding,
                 iconSize: _iconSize,
@@ -108,25 +108,26 @@ class ClockSettings extends ConsumerWidget {
               ),
             ),
           ),
-          Expanded(
-            child: RotatedBox(
-              quarterTurns: clockOrientation.quarterTurns,
-              child: IconButton(
-                padding: _kIconPadding,
-                iconSize: _iconSize,
-                // TODO: translate
-                tooltip: 'Flip clock',
-                onPressed:
-                    () => ref
-                        .read(clockToolControllerProvider.notifier)
-                        .toggleOrientation(clockOrientation.toggle),
-                icon: const Icon(Icons.screen_rotation),
+          if (clockOrientation != null)
+            Expanded(
+              child: RotatedBox(
+                quarterTurns: clockOrientation.quarterTurns,
+                child: IconButton(
+                  padding: _kIconPadding,
+                  iconSize: _iconSize,
+                  // TODO: translate
+                  tooltip: 'Flip clock',
+                  onPressed:
+                      () => ref
+                          .read(clockToolControllerProvider.notifier)
+                          .toggleOrientation(clockOrientation.toggle),
+                  icon: const Icon(Icons.screen_rotation),
+                ),
               ),
             ),
-          ),
           Expanded(
             child: RotatedBox(
-              quarterTurns: clockOrientation.quarterTurns,
+              quarterTurns: clockOrientation?.quarterTurns ?? 0,
               child: IconButton(
                 padding: _kIconPadding,
                 tooltip: context.l10n.close,


### PR DESCRIPTION
closes https://github.com/lichess-org/mobile/issues/1573

This PR addresses an issue caused by commit b13152d. While that commit resolved the disappearing turn button in portrait mode, it inadvertently broke the tablet mode view. Additionally, as discussed in PR [#1531](https://github.com/lichess-org/mobile/pull/1531#issuecomment-2709984560) the use of systemChrome has been complicating the code structure.