### PR TITLE
feat: Add GitLab to LinkSite

### DIFF
--- a/lib/src/model/user/profile.dart
+++ b/lib/src/model/user/profile.dart
@@ -101,6 +101,7 @@ enum LinkSite {
   youtube('YouTube', IListConst(['youtube.com'])),
   twitch('Twitch', IListConst(['twitch.tv'])),
   github('GitHub', IListConst(['github.com'])),
+  gitlab('GitLab', IListConst(['gitlab.com'])),
   vkontakte('VKontakte', IListConst(['vk.com'])),
   chessCom('Chess.com', IListConst(['chess.com'])),
   chess24('Chess24', IListConst(['chess24.com'])),


### PR DESCRIPTION
Add 'GitLab' to the LinkSite instance in UserProfile for any URL matching 'https://gitlab.com/*'.
<table>
  <tr>
    <th>Before</th>
    <th>After</th>
  </tr>
  <tr>
    <td><img src="https://github.com/user-attachments/assets/88d51b00-244a-4128-805e-9c11ba9fc8c6" alt="Before" width="300"/></td>
    <td><img src="https://github.com/user-attachments/assets/d35bb47a-f081-434f-ace8-d019ed1b2f42" alt="After" width="300"/></td>
  </tr>
</table>