### PR TITLE
Revert allow using TvController w/o providing a channel

### DIFF
--- a/lib/src/model/tv/tv_controller.dart
+++ b/lib/src/model/tv/tv_controller.dart
@@ -30,8 +30,7 @@ class TvController extends _$TvController {
   int? _socketEventVersion;
 
   @override
-  Future<TvState> build(TvChannel? channel, (GameId id, Side orientation)? initialGame) {
-    assert(channel != null || initialGame != null, 'Either a channel or a game must be provided');
+  Future<TvState> build(TvChannel channel, (GameId id, Side orientation)? initialGame) {
     ref.onDispose(() {
       _socketSubscription?.cancel();
     });
@@ -59,7 +58,7 @@ class TvController extends _$TvController {
       orientation = game.$2;
     } else {
       final channels = await ref.withClient((client) => TvRepository(client).channels());
-      final channelGame = channels[channel!]!;
+      final channelGame = channels[channel]!;
       id = channelGame.id;
       orientation = channelGame.side ?? Side.white;
     }


### PR DESCRIPTION
Revert [allow using TvController w/o providing a channel](https://github.com/lichess-org/mobile/commit/cf31c4cb96d732bfa16f50db8d9aa6de0d0d53c5) because it is actually not possible to use the TV controller for the tournament featured game.