### PR TITLE
Add time-based greeting icon (☀️/🌙) #1619

### DIFF
--- a/lib/src/view/home/home_tab_screen.dart
+++ b/lib/src/view/home/home_tab_screen.dart
@@ -431,12 +431,12 @@ class _EditableWidget extends ConsumerWidget {
 class _HelloWidget extends ConsumerWidget {
   const _HelloWidget();
 
-/// Returns the string representing the current time of day
-/// Used in the greeting widget to provide visual time indicator
+  /// Returns the string representing the current time of day
+  /// Used in the greeting widget to provide visual time indicator
   String getTimeOfDayIcon() {
-  final hour = DateTime.now().hour;
-  return hour >= 6 && hour < 18 ? '☀️' : '🌙';
-}
+    final hour = DateTime.now().hour;
+    return hour >= 6 && hour < 18 ? '☀️' : '🌙';
+  }
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
@@ -466,10 +466,7 @@ class _HelloWidget extends ConsumerWidget {
           child: Row(
             mainAxisSize: MainAxisSize.min,
             children: [
-              Text(
-                getTimeOfDayIcon(),
-                style: const TextStyle(fontSize: iconSize, height: 1.0),
-              ),
+              Text(getTimeOfDayIcon(), style: const TextStyle(fontSize: iconSize, height: 1.0)),
               const SizedBox(width: 5.0),
               if (user != null)
                 Flexible(

--- a/lib/src/view/home/home_tab_screen.dart
+++ b/lib/src/view/home/home_tab_screen.dart
@@ -431,6 +431,13 @@ class _EditableWidget extends ConsumerWidget {
 class _HelloWidget extends ConsumerWidget {
   const _HelloWidget();
 
+/// Returns the string representing the current time of day
+/// Used in the greeting widget to provide visual time indicator
+  String getTimeOfDayIcon() {
+  final hour = DateTime.now().hour;
+  return hour >= 6 && hour < 18 ? '☀️' : '🌙';
+}
+
   @override
   Widget build(BuildContext context, WidgetRef ref) {
     final session = ref.watch(authSessionProvider);
@@ -459,7 +466,10 @@ class _HelloWidget extends ConsumerWidget {
           child: Row(
             mainAxisSize: MainAxisSize.min,
             children: [
-              Icon(Icons.wb_sunny, size: iconSize, color: context.lichessColors.brag),
+              Text(
+                getTimeOfDayIcon(),
+                style: const TextStyle(fontSize: iconSize, height: 1.0),
+              ),
               const SizedBox(width: 5.0),
               if (user != null)
                 Flexible(


### PR DESCRIPTION
#1619 Adds a dynamic icon to home screen greeting that changes based on the time of day:
- Displays ☀️ between 6:00 AM and 5:59 PM (generic daytime)
- Displays 🌙 between 6:00 PM and 5:59 AM (generic nighttime)

In a more advanced implementation, if the user's country is available in their profile, we could use the average latitude and longitude in combination with the current date to estimate these times more accurately. However, this might be an over-engineered solution for the current use case.
![Greeting Icon](https://github.com/user-attachments/assets/9067ff8f-ae4d-4d3f-8a23-2d33a3f78223)
