### PR TITLE
Add button to share only game URL

### DIFF
--- a/lib/src/view/analysis/analysis_screen.dart
+++ b/lib/src/view/analysis/analysis_screen.dart
@@ -124,6 +124,7 @@ class _AnalysisScreenState extends ConsumerState<_AnalysisScreen>
 
 class _Title extends StatelessWidget {
   const _Title({required this.variant});
+
   final Variant variant;
 
   static const excludedIcons = [Variant.standard, Variant.fromPosition];
@@ -301,6 +302,7 @@ class _BottomBar extends ConsumerWidget {
 
   void _moveForward(WidgetRef ref) =>
       ref.read(analysisControllerProvider(options).notifier).userNext();
+
   void _moveBackward(WidgetRef ref) =>
       ref.read(analysisControllerProvider(options).notifier).userPrevious();
 
@@ -330,6 +332,14 @@ class _BottomBar extends ConsumerWidget {
               Navigator.of(
                 context,
               ).push(BoardEditorScreen.buildRoute(context, initialFen: boardFen));
+            },
+          ),
+        if (analysisState.gameId != null)
+          BottomSheetAction(
+            makeLabel: (context) => Text(context.l10n.mobileShareGameURL),
+            onPressed: () {
+              final boardUrl = lichessUri('/${analysisState.gameId}');
+              launchShareDialog(context, uri: boardUrl);
             },
           ),
         // PGN share can be used to quickly analyze a position, so engine must be allowed to access

--- a/lib/src/view/analysis/analysis_screen.dart
+++ b/lib/src/view/analysis/analysis_screen.dart
@@ -338,7 +338,7 @@ class _BottomBar extends ConsumerWidget {
           BottomSheetAction(
             makeLabel: (context) => Text(context.l10n.mobileShareGameURL),
             onPressed: () {
-              final boardUrl = lichessUri('/${analysisState.gameId}');
+              final boardUrl = lichessUri('/${analysisState.gameId}/${analysisState.pov.name}');
               launchShareDialog(context, uri: boardUrl);
             },
           ),


### PR DESCRIPTION
Currently the only options for sharing a game URL, from what I can tell are:

1. Share the PGN with the platform share activity, which includes the URL.
2. Manually copy the game URL

I often will want to share a game directly to a friend on Whatsapp for him to view on the website/app so an entire PGN is unnecessary.

This PR adds a new button to share the URL via the share activity directly from the main analysis board menu.