### PR TITLE
Better filter cloud evals

### DIFF
--- a/lib/src/model/analysis/analysis_controller.dart
+++ b/lib/src/model/analysis/analysis_controller.dart
@@ -710,14 +710,11 @@ class AnalysisState with _$AnalysisState implements EvaluationMixinState {
     IList<PgnComment>? pgnRootComments,
   }) = _AnalysisState;
 
+  @override
+  bool get alwaysRequestCloudEval => currentPosition.ply < 15;
+
   /// Whether the analysis is for a lichess game.
   bool get isLichessGameAnalysis => gameId != null;
-
-  /// Whether to delay the local engine evaluation.
-  ///
-  /// Cloud evaluations are most likely available for the opening moves.
-  @override
-  bool get delayLocalEngine => variant != Variant.fromPosition && currentPosition.ply < 20;
 
   /// Whether the user can request server analysis.
   ///

--- a/lib/src/model/broadcast/broadcast_analysis_controller.dart
+++ b/lib/src/model/broadcast/broadcast_analysis_controller.dart
@@ -590,10 +590,9 @@ class BroadcastAnalysisState with _$BroadcastAnalysisState implements Evaluation
   /// If the game is new the path will be empty.
   UciPath? get broadcastLivePath => isNewOrOngoing ? broadcastPath : null;
 
-  /// In a broadcast analysis, the cloud evals are most likely available, so we always want to delay
-  /// the local engine evaluation to save battery.
+  /// In a broadcast analysis, the cloud evals are most likely available.
   @override
-  bool get delayLocalEngine => true;
+  bool get alwaysRequestCloudEval => true;
 
   /// Whether an evaluation can be available
   bool hasAvailableEval(EngineEvaluationPrefState prefs) =>

--- a/lib/src/model/common/chess.dart
+++ b/lib/src/model/common/chess.dart
@@ -21,6 +21,14 @@ class SanMove with _$SanMove {
 
   bool get isCheck => san.contains('+');
   bool get isCapture => san.contains('x');
+
+  bool isIrreversible(Variant variant) {
+    if (isCheck) return true;
+    if (variant == Variant.crazyhouse) return false;
+    if (isCapture) return true;
+    if (san[0].toLowerCase() == san[0]) return true; // pawn move
+    return variant == Variant.threeCheck && isCheck;
+  }
 }
 
 class MoveConverter implements JsonConverter<Move, String> {
@@ -43,6 +51,11 @@ bool isPromotionPawnMove(Position position, NormalMove move) {
       position.board.roleAt(move.from) == Role.pawn &&
       ((move.to.rank == Rank.first && position.turn == Side.black) ||
           (move.to.rank == Rank.eighth && position.turn == Side.white));
+}
+
+String fenToEpd(String fen) {
+  // EPD is FEN without the halfmove clock and fullmove number
+  return fen.split(' ').take(4).join(' ');
 }
 
 /// Set of supported variants for reading a game (not playing).

--- a/lib/src/model/engine/evaluation_mixin.dart
+++ b/lib/src/model/engine/evaluation_mixin.dart
@@ -23,13 +23,11 @@ import 'package:meta/meta.dart';
 const kRequestEvalDebounceDelay = Duration(milliseconds: 250);
 
 /// The debounce delay for starting the local engine evaluation in case we assume the cloud eval
-/// will be available.
+/// will be available (broadcasts).
 ///
-/// This is superior to the `kRequestEvalDebounceDelay` to avoid running the local engine
-/// when the cloud evaluation is available. The delay is thus increased to ensure that the socket
-/// 'evalGet/evalHit' round trip gets a chance to complete before starting the local engine, even
-/// with reasonably high network latency.
-const kStartLocalEngineDebounceDelay = Duration(milliseconds: 600);
+/// This is superior to the `kRequestEvalDebounceDelay` to avoid running the local engine too soon
+/// to get a chance to get the cloud eval first.
+const kLocalEngineAfterCloudEvalDelay = Duration(milliseconds: 500);
 
 /// Interface for Notifiers's State that uses [EngineEvaluationMixin].
 abstract class EvaluationMixinState {
@@ -48,20 +46,8 @@ abstract class EvaluationMixinState {
   /// found in studies.
   Position? get currentPosition;
 
-  /// Whether to delay the local engine evaluation to give time to get the cloud eval.
-  ///
-  /// By default, this should be `false`, which means the local engine evaluation is started at the
-  /// same time as the cloud evaluation is requested, after a debounce delay.
-  ///
-  /// This is the most common use case, because most of the time the cloud eval is not available
-  /// except on opening positions.
-  ///
-  /// However, on some cases, we know the cloud evaluations are available, as for instance in a broadcast.
-  /// So this can be set to `true` to delay the local engine evaluation in order to save battery.
-  /// The local engine will be started with a higher delay which gives time to get the cloud
-  /// eval during a socket round trip. If the cloud eval is available the [EvaluationService] will
-  /// detect it and not run the local engine.
-  bool get delayLocalEngine;
+  /// Whether to always request a cloud evaluation, regardless of the current ply.
+  bool get alwaysRequestCloudEval;
 }
 
 /// A mixin to provide engine evaluation functionality to an [AsyncNotifier].
@@ -95,7 +81,7 @@ mixin EngineEvaluationMixin {
   Node get positionTree;
 
   final _cloudEvalGetDebounce = Debouncer(kRequestEvalDebounceDelay);
-  final _engineEvalDebounce = Debouncer(kStartLocalEngineDebounceDelay);
+  final _engineEvalDebounce = Debouncer(kLocalEngineAfterCloudEvalDelay);
 
   StreamSubscription<SocketEvent>? _subscription;
 
@@ -177,7 +163,7 @@ mixin EngineEvaluationMixin {
   /// This sends an `evalGet` event to the server to get the cloud evaluation and starts the local
   /// engine evaluation.
   ///
-  /// If [EvaluationMixinState.delayLocalEngine] is `true`, the local engine evaluation will be
+  /// If [EvaluationMixinState.alwaysRequestCloudEval] is `true`, the local engine evaluation will be
   /// delayed to give time to get the cloud eval.
   ///
   /// The evaluation will not be requested if the engine is not available by the context or the
@@ -191,12 +177,12 @@ mixin EngineEvaluationMixin {
 
     _cloudEvalGetDebounce(() {
       _sendEvalGetEvent();
-      if (!evaluationState.delayLocalEngine) {
+      if (!evaluationState.alwaysRequestCloudEval) {
         _startEngineEval();
       }
     });
 
-    if (evaluationState.delayLocalEngine) {
+    if (evaluationState.alwaysRequestCloudEval) {
       _engineEvalDebounce(() {
         _startEngineEval();
       });
@@ -214,6 +200,10 @@ mixin EngineEvaluationMixin {
   void _handleEvalHitEvent(SocketEvent event) {
     final path = pick(event.data, 'path').asUciPathOrThrow();
     final depth = pick(event.data, 'depth').asIntOrThrow();
+    if (depth < evaluationPrefs.cloudEvalDepthAcceptThreshold) {
+      return;
+    }
+
     final pvs =
         pick(event.data, 'pvs')
             .asListOrThrow(
@@ -228,6 +218,11 @@ mixin EngineEvaluationMixin {
     bool isSameEvalString = true;
     positionTree.updateAt(path, (node) {
       final eval = CloudEval(depth: depth, pvs: pvs, position: node.position);
+      final nodeDepth = node.eval?.depth;
+      if (nodeDepth != null && nodeDepth >= depth) {
+        // don't override the local eval if it's deeper than the cloud eval
+        return;
+      }
       isSameEvalString = eval.evalString == node.eval?.evalString;
       node.eval = eval;
     });
@@ -241,6 +236,10 @@ mixin EngineEvaluationMixin {
     if (!evaluationState.isEngineAvailable(evaluationPrefs)) return;
     final curPosition = evaluationState.currentPosition;
     if (curPosition == null) return;
+    if (evaluationState.currentPosition!.ply >= 15 && !evaluationState.alwaysRequestCloudEval) {
+      return;
+    }
+    if (positionTree.nodeAt(evaluationState.currentPath).eval is CloudEval) return;
 
     final numEvalLines = evaluationPrefs.numEvalLines;
 

--- a/lib/src/model/engine/evaluation_mixin.dart
+++ b/lib/src/model/engine/evaluation_mixin.dart
@@ -200,9 +200,6 @@ mixin EngineEvaluationMixin {
   void _handleEvalHitEvent(SocketEvent event) {
     final path = pick(event.data, 'path').asUciPathOrThrow();
     final depth = pick(event.data, 'depth').asIntOrThrow();
-    if (depth < evaluationPrefs.cloudEvalDepthAcceptThreshold) {
-      return;
-    }
 
     final pvs =
         pick(event.data, 'pvs')

--- a/lib/src/model/engine/evaluation_preferences.dart
+++ b/lib/src/model/engine/evaluation_preferences.dart
@@ -49,10 +49,6 @@ class EngineEvaluationPreferences extends _$EngineEvaluationPreferences
   Future<void> setEngineSearchTime(Duration engineSearchTime) {
     return save(state.copyWith(engineSearchTime: engineSearchTime));
   }
-
-  Future<void> setCloudEvalDepthAcceptThreshold(int cloudEvalDepthAcceptThreshold) {
-    return save(state.copyWith(cloudEvalDepthAcceptThreshold: cloudEvalDepthAcceptThreshold));
-  }
 }
 
 @Freezed(fromJson: true, toJson: true)
@@ -70,11 +66,6 @@ class EngineEvaluationPrefState with _$EngineEvaluationPrefState implements Seri
       toJson: _searchTimeToJson,
     )
     required Duration engineSearchTime,
-
-    /// Only accept cloud evaluation if the depth is equal or more than this value.
-    @Assert('cloudEvalDepthAcceptThreshold == null || cloudEvalDepthAcceptThreshold >= 0')
-    @JsonKey(defaultValue: 20)
-    required int cloudEvalDepthAcceptThreshold,
   }) = _EngineEvaluationPrefState;
 
   static const defaults = EngineEvaluationPrefState(
@@ -82,7 +73,6 @@ class EngineEvaluationPrefState with _$EngineEvaluationPrefState implements Seri
     numEvalLines: 2,
     numEngineCores: 1,
     engineSearchTime: Duration(seconds: 6),
-    cloudEvalDepthAcceptThreshold: 20,
   );
 
   factory EngineEvaluationPrefState.fromJson(Map<String, dynamic> json) {

--- a/lib/src/model/engine/evaluation_preferences.dart
+++ b/lib/src/model/engine/evaluation_preferences.dart
@@ -106,5 +106,7 @@ const kAvailableEngineSearchTimes = [
   Duration(seconds: 30),
 
   /// Displayed as infinity in the UI.
-  Duration(hours: 1),
+  kMaxEngineSearchTime,
 ];
+
+const kMaxEngineSearchTime = Duration(hours: 1);

--- a/lib/src/model/engine/evaluation_preferences.dart
+++ b/lib/src/model/engine/evaluation_preferences.dart
@@ -49,6 +49,10 @@ class EngineEvaluationPreferences extends _$EngineEvaluationPreferences
   Future<void> setEngineSearchTime(Duration engineSearchTime) {
     return save(state.copyWith(engineSearchTime: engineSearchTime));
   }
+
+  Future<void> setCloudEvalDepthAcceptThreshold(int cloudEvalDepthAcceptThreshold) {
+    return save(state.copyWith(cloudEvalDepthAcceptThreshold: cloudEvalDepthAcceptThreshold));
+  }
 }
 
 @Freezed(fromJson: true, toJson: true)
@@ -66,6 +70,11 @@ class EngineEvaluationPrefState with _$EngineEvaluationPrefState implements Seri
       toJson: _searchTimeToJson,
     )
     required Duration engineSearchTime,
+
+    /// Only accept cloud evaluation if the depth is equal or more than this value.
+    @Assert('cloudEvalDepthAcceptThreshold == null || cloudEvalDepthAcceptThreshold >= 0')
+    @JsonKey(defaultValue: 20)
+    required int cloudEvalDepthAcceptThreshold,
   }) = _EngineEvaluationPrefState;
 
   static const defaults = EngineEvaluationPrefState(
@@ -73,6 +82,7 @@ class EngineEvaluationPrefState with _$EngineEvaluationPrefState implements Seri
     numEvalLines: 2,
     numEngineCores: 1,
     engineSearchTime: Duration(seconds: 6),
+    cloudEvalDepthAcceptThreshold: 20,
   );
 
   factory EngineEvaluationPrefState.fromJson(Map<String, dynamic> json) {

--- a/lib/src/model/puzzle/puzzle_controller.dart
+++ b/lib/src/model/puzzle/puzzle_controller.dart
@@ -430,7 +430,7 @@ class PuzzleState with _$PuzzleState implements EvaluationMixinState {
   }) = _PuzzleState;
 
   @override
-  bool get delayLocalEngine => false;
+  bool get alwaysRequestCloudEval => false;
 
   @override
   bool isEngineAvailable(EngineEvaluationPrefState _) =>

--- a/lib/src/model/study/study_controller.dart
+++ b/lib/src/model/study/study_controller.dart
@@ -504,7 +504,7 @@ class StudyState with _$StudyState implements EvaluationMixinState {
   }) = _StudyState;
 
   @override
-  bool get delayLocalEngine => false;
+  bool get alwaysRequestCloudEval => false;
 
   /// Whether the engine is available for evaluation
   @override

--- a/lib/src/view/analysis/analysis_settings_screen.dart
+++ b/lib/src/view/analysis/analysis_settings_screen.dart
@@ -4,7 +4,7 @@ import 'package:lichess_mobile/src/model/analysis/analysis_controller.dart';
 import 'package:lichess_mobile/src/model/analysis/analysis_preferences.dart';
 import 'package:lichess_mobile/src/utils/l10n_context.dart';
 import 'package:lichess_mobile/src/utils/navigation.dart';
-import 'package:lichess_mobile/src/view/analysis/stockfish_settings.dart';
+import 'package:lichess_mobile/src/view/analysis/engine_settings_widget.dart';
 import 'package:lichess_mobile/src/view/opening_explorer/opening_explorer_settings.dart';
 import 'package:lichess_mobile/src/widgets/adaptive_bottom_sheet.dart';
 import 'package:lichess_mobile/src/widgets/feedback.dart';
@@ -119,7 +119,7 @@ class AnalysisSettingsScreen extends ConsumerWidget {
                         ? CrossFadeState.showSecond
                         : CrossFadeState.showFirst,
                 firstChild: const SizedBox.shrink(),
-                secondChild: StockfishSettingsWidget(
+                secondChild: EngineSettingsWidget(
                   onSetEngineSearchTime: (value) {
                     ref.read(ctrlProvider.notifier).setEngineSearchTime(value);
                   },

--- a/lib/src/view/analysis/engine_settings_widget.dart
+++ b/lib/src/view/analysis/engine_settings_widget.dart
@@ -2,7 +2,6 @@ import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:lichess_mobile/src/model/engine/evaluation_preferences.dart';
 import 'package:lichess_mobile/src/model/engine/evaluation_service.dart';
-import 'package:lichess_mobile/src/styles/styles.dart';
 import 'package:lichess_mobile/src/utils/l10n_context.dart';
 import 'package:lichess_mobile/src/widgets/list.dart';
 import 'package:lichess_mobile/src/widgets/non_linear_slider.dart';
@@ -41,40 +40,6 @@ class EngineSettingsWidget extends ConsumerWidget {
               ),
             ],
           ),
-        ListSection(
-          header: SettingsSectionTitle(context.l10n.cloudAnalysis),
-          children: [
-            ListTile(
-              title: Text.rich(
-                TextSpan(
-                  text: 'Cloud evaluation min depth: ',
-                  style: const TextStyle(fontWeight: FontWeight.normal),
-                  children: [
-                    TextSpan(
-                      style: const TextStyle(fontWeight: FontWeight.bold, fontSize: 18),
-                      text: prefs.cloudEvalDepthAcceptThreshold.toString(),
-                    ),
-                    TextSpan(
-                      style: TextTheme.of(
-                        context,
-                      ).labelMedium?.copyWith(color: textShade(context, 0.7)),
-                      text: '\nEvals below this depth will be ignored.',
-                    ),
-                  ],
-                ),
-              ),
-              subtitle: NonLinearSlider(
-                value: prefs.cloudEvalDepthAcceptThreshold.toDouble(),
-                values: const [15, 20, 25, 30, 35, 40, 45, 50, 55, 60, 80, 100],
-                onChangeEnd: (value) {
-                  ref
-                      .read(engineEvaluationPreferencesProvider.notifier)
-                      .setCloudEvalDepthAcceptThreshold(value.toInt());
-                },
-              ),
-            ),
-          ],
-        ),
         ListSection(
           header: const SettingsSectionTitle('Stockfish'),
           children: [

--- a/lib/src/view/analysis/engine_settings_widget.dart
+++ b/lib/src/view/analysis/engine_settings_widget.dart
@@ -2,13 +2,14 @@ import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:lichess_mobile/src/model/engine/evaluation_preferences.dart';
 import 'package:lichess_mobile/src/model/engine/evaluation_service.dart';
+import 'package:lichess_mobile/src/styles/styles.dart';
 import 'package:lichess_mobile/src/utils/l10n_context.dart';
 import 'package:lichess_mobile/src/widgets/list.dart';
 import 'package:lichess_mobile/src/widgets/non_linear_slider.dart';
 import 'package:lichess_mobile/src/widgets/settings.dart';
 
-class StockfishSettingsWidget extends ConsumerWidget {
-  const StockfishSettingsWidget({
+class EngineSettingsWidget extends ConsumerWidget {
+  const EngineSettingsWidget({
     this.onToggleLocalEvaluation,
     required this.onSetEngineSearchTime,
     required this.onSetNumEvalLines,
@@ -40,6 +41,40 @@ class StockfishSettingsWidget extends ConsumerWidget {
               ),
             ],
           ),
+        ListSection(
+          header: SettingsSectionTitle(context.l10n.cloudAnalysis),
+          children: [
+            ListTile(
+              title: Text.rich(
+                TextSpan(
+                  text: 'Cloud evaluation min depth: ',
+                  style: const TextStyle(fontWeight: FontWeight.normal),
+                  children: [
+                    TextSpan(
+                      style: const TextStyle(fontWeight: FontWeight.bold, fontSize: 18),
+                      text: prefs.cloudEvalDepthAcceptThreshold.toString(),
+                    ),
+                    TextSpan(
+                      style: TextTheme.of(
+                        context,
+                      ).labelMedium?.copyWith(color: textShade(context, 0.7)),
+                      text: '\nEvals below this depth will be ignored.',
+                    ),
+                  ],
+                ),
+              ),
+              subtitle: NonLinearSlider(
+                value: prefs.cloudEvalDepthAcceptThreshold.toDouble(),
+                values: const [15, 20, 25, 30, 35, 40, 45, 50, 55, 60, 80, 100],
+                onChangeEnd: (value) {
+                  ref
+                      .read(engineEvaluationPreferencesProvider.notifier)
+                      .setCloudEvalDepthAcceptThreshold(value.toInt());
+                },
+              ),
+            ),
+          ],
+        ),
         ListSection(
           header: const SettingsSectionTitle('Stockfish'),
           children: [

--- a/lib/src/view/broadcast/broadcast_game_settings_screen.dart
+++ b/lib/src/view/broadcast/broadcast_game_settings_screen.dart
@@ -5,7 +5,7 @@ import 'package:lichess_mobile/src/model/broadcast/broadcast_analysis_controller
 import 'package:lichess_mobile/src/model/common/id.dart';
 import 'package:lichess_mobile/src/utils/l10n_context.dart';
 import 'package:lichess_mobile/src/utils/navigation.dart';
-import 'package:lichess_mobile/src/view/analysis/stockfish_settings.dart';
+import 'package:lichess_mobile/src/view/analysis/engine_settings_widget.dart';
 import 'package:lichess_mobile/src/view/opening_explorer/opening_explorer_settings.dart';
 import 'package:lichess_mobile/src/widgets/adaptive_bottom_sheet.dart';
 import 'package:lichess_mobile/src/widgets/list.dart';
@@ -114,7 +114,7 @@ class BroadcastGameSettingsScreen extends ConsumerWidget {
                     ? CrossFadeState.showSecond
                     : CrossFadeState.showFirst,
             firstChild: const SizedBox.shrink(),
-            secondChild: StockfishSettingsWidget(
+            secondChild: EngineSettingsWidget(
               onSetEngineSearchTime:
                   (value) => ref.read(controller.notifier).setEngineSearchTime(value),
               onSetNumEvalLines: (value) => ref.read(controller.notifier).setNumEvalLines(value),

--- a/lib/src/view/settings/engine_settings_screen.dart
+++ b/lib/src/view/settings/engine_settings_screen.dart
@@ -2,7 +2,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:lichess_mobile/src/model/engine/evaluation_preferences.dart';
 import 'package:lichess_mobile/src/utils/navigation.dart';
-import 'package:lichess_mobile/src/view/analysis/stockfish_settings.dart';
+import 'package:lichess_mobile/src/view/analysis/engine_settings_widget.dart';
 
 class EngineSettingsScreen extends StatelessWidget {
   const EngineSettingsScreen({super.key});
@@ -22,7 +22,7 @@ class _Body extends ConsumerWidget {
   Widget build(BuildContext context, WidgetRef ref) {
     return ListView(
       children: [
-        StockfishSettingsWidget(
+        EngineSettingsWidget(
           onSetEngineSearchTime: (value) {
             ref.read(engineEvaluationPreferencesProvider.notifier).setEngineSearchTime(value);
           },

--- a/lib/src/view/study/study_settings.dart
+++ b/lib/src/view/study/study_settings.dart
@@ -7,7 +7,7 @@ import 'package:lichess_mobile/src/model/study/study_controller.dart';
 import 'package:lichess_mobile/src/model/study/study_preferences.dart';
 import 'package:lichess_mobile/src/utils/l10n_context.dart';
 import 'package:lichess_mobile/src/utils/navigation.dart';
-import 'package:lichess_mobile/src/view/analysis/stockfish_settings.dart';
+import 'package:lichess_mobile/src/view/analysis/engine_settings_widget.dart';
 import 'package:lichess_mobile/src/view/opening_explorer/opening_explorer_settings.dart';
 import 'package:lichess_mobile/src/widgets/adaptive_bottom_sheet.dart';
 import 'package:lichess_mobile/src/widgets/list.dart';
@@ -72,7 +72,7 @@ class StudySettingsScreen extends ConsumerWidget {
             ],
           ),
           if (isComputerAnalysisAllowed)
-            StockfishSettingsWidget(
+            EngineSettingsWidget(
               onToggleLocalEvaluation: () => ref.read(studyController.notifier).toggleEngine(),
               onSetEngineSearchTime:
                   (value) => ref.read(studyController.notifier).setEngineSearchTime(value),

--- a/test/view/analysis/analysis_screen_test.dart
+++ b/test/view/analysis/analysis_screen_test.dart
@@ -475,10 +475,10 @@ void main() {
         await makeEngineTestApp(tester, isCloudEvalEnabled: false);
         await playMove(tester, 'e2', 'e4');
         expect(find.byType(InlineMove), findsOne);
-        await tester.pump(kStartLocalEngineDebounceDelay + kEngineEvalEmissionThrottleDelay);
+        await tester.pump(kLocalEngineAfterCloudEvalDelay + kEngineEvalEmissionThrottleDelay);
         expect(find.widgetWithText(InlineMove, '+0.2'), findsOne);
         await playMove(tester, 'e7', 'e5');
-        await tester.pump(kStartLocalEngineDebounceDelay + kEngineEvalEmissionThrottleDelay);
+        await tester.pump(kLocalEngineAfterCloudEvalDelay + kEngineEvalEmissionThrottleDelay);
         expect(find.widgetWithText(InlineMove, '+0.2'), findsNWidgets(2));
       });
     });

--- a/test/view/engine/engine_depth_test.dart
+++ b/test/view/engine/engine_depth_test.dart
@@ -88,7 +88,7 @@ void main() {
       expect(find.widgetWithText(EngineDepth, '36'), findsOne);
     });
 
-    testWidgets('Local engine will not override cloud eval', (tester) async {
+    testWidgets('Local engine will not override cloud eval with greater depth', (tester) async {
       // Simulates a connection lag that will make the local engine come 100ms after the cloud eval
       final connectionLag =
           kLocalEngineAfterCloudEvalDelay -

--- a/test/view/engine/engine_depth_test.dart
+++ b/test/view/engine/engine_depth_test.dart
@@ -43,7 +43,7 @@ void main() {
       expect(find.widgetWithText(EngineDepth, '36'), findsOne);
 
       // Wait for local engine delay
-      await tester.pump(kStartLocalEngineDebounceDelay + kEngineEvalEmissionThrottleDelay);
+      await tester.pump(kLocalEngineAfterCloudEvalDelay + kEngineEvalEmissionThrottleDelay);
       // Local engine has not even started
       expect(find.widgetWithText(EngineDepth, '36'), findsOne);
     });
@@ -66,20 +66,20 @@ void main() {
       expect(isCloudEvalDisplayed(), isFalse);
 
       // Now wait for local engine
-      await tester.pump(kStartLocalEngineDebounceDelay + kEngineEvalEmissionThrottleDelay);
+      await tester.pump(kLocalEngineAfterCloudEvalDelay + kEngineEvalEmissionThrottleDelay);
       expect(find.widgetWithText(EngineDepth, '16'), findsOne);
     });
 
     testWidgets('Cloud eval will override local engine eval', (tester) async {
       // Simulates a connection lag that will make the cloud eval come 300ms after the local engine
       final connectionLag =
-          kStartLocalEngineDebounceDelay -
+          kLocalEngineAfterCloudEvalDelay -
           kRequestEvalDebounceDelay +
           const Duration(milliseconds: 300);
       await makeEngineTestApp(tester, connectionLag: connectionLag);
 
       // Wait for local engine eval
-      await tester.pump(kStartLocalEngineDebounceDelay);
+      await tester.pump(kLocalEngineAfterCloudEvalDelay);
       expect(find.widgetWithText(EngineDepth, '15'), findsOne);
 
       // cloud eval will be available 300ms after the local engine eval
@@ -91,13 +91,13 @@ void main() {
     testWidgets('Local engine will not override cloud eval', (tester) async {
       // Simulates a connection lag that will make the local engine come 100ms after the cloud eval
       final connectionLag =
-          kStartLocalEngineDebounceDelay -
+          kLocalEngineAfterCloudEvalDelay -
           kRequestEvalDebounceDelay +
           const Duration(milliseconds: 100);
       await makeEngineTestApp(tester, connectionLag: connectionLag);
 
       // Wait for local engine eval
-      await tester.pump(kStartLocalEngineDebounceDelay);
+      await tester.pump(kLocalEngineAfterCloudEvalDelay);
       expect(find.widgetWithText(EngineDepth, '15'), findsOne);
 
       // Cloud eval will be available 100ms after the first local engine eval emission


### PR DESCRIPTION
Partially adresses #1623

Changes:
- cloud evals are not requested if ply > 15 (unless for broadcasts)
- cloud eval don't override anymore deeper local eval
- deeper local eval will not override cloud eval
- local eval will always override cloud eval if search time settings is set to 'infinity'
- cloud eval will not be requested if a threefold repetition pattern is detected
- 