### PR TITLE
fix orientation incorrectly locked to portrait on tablet

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -19,10 +19,6 @@ Future<void> main() async {
 
   await lichessBinding.preloadSharedPreferences();
 
-  if (defaultTargetPlatform == TargetPlatform.android) {
-    await androidDisplayInitialization(widgetsBinding);
-  }
-
   await preloadPieceImages();
 
   await setupFirstLaunch();
@@ -34,6 +30,10 @@ Future<void> main() async {
   await initializeLocalNotifications(locale);
 
   await lichessBinding.initializeFirebase();
+
+  if (defaultTargetPlatform == TargetPlatform.android) {
+    await androidDisplayInitialization(widgetsBinding);
+  }
 
   runApp(ProviderScope(observers: [ProviderLogger()], child: const AppInitializationScreen()));
 }


### PR DESCRIPTION
When I run the app on a physical tablet device, the display size is reported as 0. This leads the app to incorrectly enforce portrait orientation. This is the relevant code snippet:
https://github.com/lichess-org/mobile/blob/83e6f4ad602a6418c2bfb18b5ac631f0db342dbf/lib/src/init.dart#L144-L149

According to the documentation in https://api.flutter.dev/flutter/dart-ui/FlutterView/physicalSize.html:

> At startup, the size of the view may not be known before Dart code runs. If this value is observed early in the application lifecycle, it may report [Size.zero](https://api.flutter.dev/flutter/dart-ui/Size/zero-constant.html).

Delaying the call to the androidDisplayInitialization function solves the problem.