### PR TITLE
feat: highlight live move in correspondence analysis

### DIFF
--- a/lib/src/model/analysis/analysis_controller.dart
+++ b/lib/src/model/analysis/analysis_controller.dart
@@ -146,8 +146,10 @@ class AnalysisController extends _$AnalysisController
     final pgnHeaders = IMap(game.headers);
     final rootComments = IList(game.comments.map((c) => PgnComment.fromPgn(c)));
 
+    final isGameFinished = pgnHeaders['Result'] != '*';
+
     final isComputerAnalysisAllowed = options.isLichessGameAnalysis
-        ? pgnHeaders['Result'] != '*'
+        ? isGameFinished
         : options.standalone!.isComputerAnalysisAllowed;
 
     final List<Future<(UciPath, FullOpening)?>> openingFutures = [];
@@ -208,6 +210,7 @@ class AnalysisController extends _$AnalysisController
       gameId: options.gameId,
       archivedGame: archivedGame,
       currentPath: currentPath,
+      pathToLiveMove: isGameFinished ? null : _root.mainlinePath,
       isOnMainline: _root.isOnMainline(currentPath),
       root: _root.view,
       currentNode: AnalysisCurrentNode.fromNode(currentNode),
@@ -655,6 +658,9 @@ sealed class AnalysisState with _$AnalysisState implements EvaluationMixinState 
 
     /// The path to the current node in the analysis view.
     required UciPath currentPath,
+
+    /// If this is a correspondence game, the path to the last move that has been played.
+    required UciPath? pathToLiveMove,
 
     /// Whether the current path is on the mainline.
     required bool isOnMainline,

--- a/lib/src/view/analysis/tree_view.dart
+++ b/lib/src/view/analysis/tree_view.dart
@@ -28,6 +28,7 @@ class AnalysisTreeView extends ConsumerWidget {
           DebouncedPgnTreeView(
             root: analysisState.root,
             currentPath: analysisState.currentPath,
+            livePath: analysisState.pathToLiveMove,
             pgnRootComments: analysisState.pgnRootComments,
             notifier: ref.read(ctrlProvider.notifier),
             shouldShowComputerAnalysis: enableComputerAnalysis,

--- a/lib/src/view/broadcast/broadcast_game_screen.dart
+++ b/lib/src/view/broadcast/broadcast_game_screen.dart
@@ -246,7 +246,7 @@ class _BroadcastGameTreeView extends ConsumerWidget {
       child: DebouncedPgnTreeView(
         root: state.root,
         currentPath: state.currentPath,
-        broadcastLivePath: state.broadcastLivePath,
+        livePath: state.broadcastLivePath,
         pgnRootComments: state.pgnRootComments,
         shouldShowComputerAnalysis: analysisPrefs.enableComputerAnalysis,
         shouldShowComments: analysisPrefs.enableComputerAnalysis && analysisPrefs.showPgnComments,


### PR DESCRIPTION
Like web also does, and like we already do for broadcasts

[correspondenceLiveMove.webm](https://github.com/user-attachments/assets/69fddbcc-b9ad-422d-8e56-99dcd950fb56)
