### PR TITLE
Add the native debug symbols in the AAB

### DIFF
--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -81,6 +81,9 @@ android {
               'proguard-rules.pro'
             )
             signingConfig signingConfigs.release
+            ndk {
+                debugSymbolLevel 'FULL'
+            }
         }
         debug {
             applicationIdSuffix ".debug"


### PR DESCRIPTION
Add the native debug symbols in the Android App Bundle of the app with debug symbol level full.

See the following Android documentation about native symbols https://developer.android.com/build/include-native-symbols for more information.