### PR TITLE
Enable shrink resources on android release builds

### DIFF
--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -76,6 +76,7 @@ android {
     buildTypes {
         release {
             minifyEnabled true
+            shrinkResources true
             proguardFiles(
               getDefaultProguardFile('proguard-android-optimize.txt'),
               'proguard-rules.pro'


### PR DESCRIPTION
I don't know if there was a reason to enable only minify and not shrink resources but the [Android documentation](https://developer.android.com/topic/performance/app-optimization/enable-app-optimization) recommends to enable both.