### PR TITLE
Remove NDK version from build file to let Android pick the latest one.

### DIFF
--- a/android/app/build.gradle.kts
+++ b/android/app/build.gradle.kts
@@ -19,8 +19,6 @@ if (keystorePropertiesFile.exists()) {
 android {
     namespace = "org.lichess.mobileV2"
     compileSdk = flutter.compileSdkVersion
-    ndkVersion = "27.0.12077973"
-    // ndkVersion = flutter.ndkVersion
 
     compileOptions {
         // Flag required by flutter_local_notifications package


### PR DESCRIPTION
Flutter plans to remove the NDK pinning in templates as said in this Github comment https://github.com/flutter/flutter/issues/139427#issuecomment-1989024985.