### PR TITLE
Revert "use FadeForwardsPageTransitionBuilder"

### DIFF
--- a/lib/src/theme.dart
+++ b/lib/src/theme.dart
@@ -164,12 +164,6 @@ ThemeData _makeDefaultTheme(
     menuTheme: isIOS ? _kCupertinoMenuThemeData : null,
     bottomSheetTheme: isIOS ? _kCupertinoBottomSheetTheme : null,
     sliderTheme: kSliderTheme,
-    pageTransitionsTheme: const PageTransitionsTheme(
-      builders: {
-        TargetPlatform.android: FadeForwardsPageTransitionsBuilder(),
-        TargetPlatform.iOS: CupertinoPageTransitionsBuilder(),
-      },
-    ),
     extensions: [lichessCustomColors.harmonized(theme.colorScheme)],
   );
 }
@@ -262,12 +256,12 @@ ThemeData _makeBackgroundImageTheme({
       elevation: isIOS ? 0 : null,
     ),
     splashFactory: isIOS ? NoSplash.splashFactory : null,
-    pageTransitionsTheme: const PageTransitionsTheme(
+    pageTransitionsTheme: PageTransitionsTheme(
       builders: {
-        TargetPlatform.android: FadeForwardsPageTransitionsBuilder(
-          backgroundColor: Colors.transparent,
+        TargetPlatform.android: ZoomPageTransitionsBuilder(
+          backgroundColor: seedColor.withValues(alpha: 0),
         ),
-        TargetPlatform.iOS: CupertinoPageTransitionsBuilder(),
+        TargetPlatform.iOS: const CupertinoPageTransitionsBuilder(),
       },
     ),
 


### PR DESCRIPTION
Reverts lichess-org/mobile#1685

Got feedback that transitions were really slow some times.

As is it still not included by default on flutter side, perhaps some improvements are still to be made.