### PR TITLE
Add opening name to Landscape Layout of  Opening Explorer

### DIFF
--- a/lib/src/view/opening_explorer/opening_explorer_screen.dart
+++ b/lib/src/view/opening_explorer/opening_explorer_screen.dart
@@ -106,6 +106,9 @@ class _Body extends ConsumerWidget {
                                 semanticContainer: false,
                                 child: OpeningExplorerView(
                                   position: state.currentPosition,
+                                  opening: state.currentNode.isRoot
+                                      ? LightOpening(eco: '', name: context.l10n.startPosition)
+                                      : state.currentNode.opening ?? state.currentBranchOpening,
                                   onMoveSelected: (move) {
                                     ref
                                         .read(analysisControllerProvider(options).notifier)


### PR DESCRIPTION
Fix #1774
![grafik](https://github.com/user-attachments/assets/77a1ed21-1746-4cfd-889a-eee4e28ba11b)
