### PR TITLE
refactor: make AnalysisOptions a union type

### DIFF
--- a/lib/src/app_links.dart
+++ b/lib/src/app_links.dart
@@ -45,7 +45,7 @@ Route<dynamic>? resolveAppLinkUri(BuildContext context, Uri appLinkUri) {
       if (gameId.isValid) {
         return AnalysisScreen.buildRoute(
           context,
-          AnalysisOptions(
+          AnalysisOptions.archivedGame(
             orientation: orientation == 'black' ? Side.black : Side.white,
             gameId: gameId,
             initialMoveCursor: 0,

--- a/lib/src/model/game/game_controller.dart
+++ b/lib/src/model/game/game_controller.dart
@@ -1051,19 +1051,17 @@ sealed class GameState with _$GameState {
   String get analysisPgn => game.makePgn();
 
   AnalysisOptions get analysisOptions => game.finished
-      ? AnalysisOptions(
+      ? AnalysisOptions.archivedGame(
           orientation: game.youAre ?? Side.white,
           initialMoveCursor: stepCursor,
           gameId: gameFullId.gameId,
         )
-      : AnalysisOptions(
+      : AnalysisOptions.standalone(
           orientation: game.youAre ?? Side.white,
           initialMoveCursor: stepCursor,
-          standalone: (
-            pgn: game.makePgn(),
-            variant: game.meta.variant,
-            isComputerAnalysisAllowed: false,
-          ),
+          pgn: game.makePgn(),
+          variant: game.meta.variant,
+          isComputerAnalysisAllowed: false,
         );
 
   GameChatOptions? get chatOptions => isZenModeActive || game.meta.tournament != null

--- a/lib/src/view/account/game_bookmarks_screen.dart
+++ b/lib/src/view/account/game_bookmarks_screen.dart
@@ -137,7 +137,10 @@ class _BodyState extends ConsumerState<_Body> {
                                   Navigator.of(context, rootNavigator: true).push(
                                     AnalysisScreen.buildRoute(
                                       context,
-                                      AnalysisOptions(orientation: pov, gameId: game.id),
+                                      AnalysisOptions.archivedGame(
+                                        orientation: pov,
+                                        gameId: game.id,
+                                      ),
                                     ),
                                   );
                                 }

--- a/lib/src/view/analysis/analysis_screen.dart
+++ b/lib/src/view/analysis/analysis_screen.dart
@@ -76,7 +76,7 @@ class _AnalysisScreenState extends ConsumerState<_AnalysisScreen>
     tabs = [
       AnalysisTab.opening,
       AnalysisTab.moves,
-      if (widget.options.gameId != null) AnalysisTab.summary,
+      if (widget.options.isLichessGameAnalysis) AnalysisTab.summary,
     ];
 
     _tabController = TabController(vsync: this, initialIndex: 1, length: tabs.length);
@@ -313,7 +313,7 @@ class _Body extends ConsumerWidget {
           },
         ),
         AnalysisTreeView(options),
-        if (options.gameId != null) ServerAnalysisSummary(options),
+        if (options.isLichessGameAnalysis) ServerAnalysisSummary(options),
       ],
     );
   }

--- a/lib/src/view/board_editor/board_editor_screen.dart
+++ b/lib/src/view/board_editor/board_editor_screen.dart
@@ -316,13 +316,11 @@ class _BottomBar extends ConsumerWidget {
                   Navigator.of(context).push(
                     AnalysisScreen.buildRoute(
                       context,
-                      AnalysisOptions(
+                      AnalysisOptions.standalone(
                         orientation: editorState.orientation,
-                        standalone: (
-                          pgn: editorState.pgn!,
-                          isComputerAnalysisAllowed: true,
-                          variant: Variant.fromPosition,
-                        ),
+                        pgn: editorState.pgn!,
+                        isComputerAnalysisAllowed: true,
+                        variant: Variant.fromPosition,
                       ),
                     ),
                   );

--- a/lib/src/view/correspondence/offline_correspondence_game_screen.dart
+++ b/lib/src/view/correspondence/offline_correspondence_game_screen.dart
@@ -228,13 +228,11 @@ class _BodyState extends ConsumerState<_Body> {
                 Navigator.of(context).push(
                   AnalysisScreen.buildRoute(
                     context,
-                    AnalysisOptions(
+                    AnalysisOptions.standalone(
                       orientation: game.youAre!,
-                      standalone: (
-                        pgn: game.makePgn(),
-                        isComputerAnalysisAllowed: false,
-                        variant: game.variant,
-                      ),
+                      pgn: game.makePgn(),
+                      isComputerAnalysisAllowed: false,
+                      variant: game.variant,
                       initialMoveCursor: stepCursor,
                     ),
                   ),

--- a/lib/src/view/game/game_common_widgets.dart
+++ b/lib/src/view/game/game_common_widgets.dart
@@ -40,7 +40,11 @@ void openGameScreen(
             )
           : AnalysisScreen.buildRoute(
               context,
-              AnalysisOptions(orientation: orientation, gameId: game.id, initialMoveCursor: 0),
+              AnalysisOptions.archivedGame(
+                orientation: orientation,
+                gameId: game.id,
+                initialMoveCursor: 0,
+              ),
             ),
     );
   } else {

--- a/lib/src/view/game/game_list_tile.dart
+++ b/lib/src/view/game/game_list_tile.dart
@@ -260,7 +260,7 @@ class GameContextMenu extends ConsumerWidget {
                   Navigator.of(context).push(
                     AnalysisScreen.buildRoute(
                       context,
-                      AnalysisOptions(orientation: orientation, gameId: game.id),
+                      AnalysisOptions.archivedGame(orientation: orientation, gameId: game.id),
                     ),
                   );
                 }

--- a/lib/src/view/game/game_result_dialog.dart
+++ b/lib/src/view/game/game_result_dialog.dart
@@ -248,13 +248,11 @@ class OverTheBoardGameResultDialog extends StatelessWidget {
             Navigator.of(context).push(
               AnalysisScreen.buildRoute(
                 context,
-                AnalysisOptions(
+                AnalysisOptions.standalone(
                   orientation: Side.white,
-                  standalone: (
-                    pgn: game.makePgn(),
-                    isComputerAnalysisAllowed: true,
-                    variant: game.meta.variant,
-                  ),
+                  pgn: game.makePgn(),
+                  isComputerAnalysisAllowed: true,
+                  variant: game.meta.variant,
                 ),
               ),
             );

--- a/lib/src/view/more/load_position_screen.dart
+++ b/lib/src/view/more/load_position_screen.dart
@@ -125,13 +125,11 @@ class _BodyState extends State<_Body> {
       final pos = Chess.fromSetup(Setup.parseFen(textInput!.trim()));
       return (
         fen: pos.fen,
-        options: AnalysisOptions(
+        options: AnalysisOptions.standalone(
           orientation: Side.white,
-          standalone: (
-            pgn: '[FEN "${pos.fen}"]',
-            isComputerAnalysisAllowed: true,
-            variant: Variant.standard,
-          ),
+          pgn: '[FEN "${pos.fen}"]',
+          isComputerAnalysisAllowed: true,
+          variant: Variant.standard,
         ),
       );
     } catch (_) {}
@@ -157,13 +155,11 @@ class _BodyState extends State<_Body> {
 
       return (
         fen: lastPosition.fen,
-        options: AnalysisOptions(
+        options: AnalysisOptions.standalone(
           orientation: Side.white,
-          standalone: (
-            pgn: textInput!,
-            isComputerAnalysisAllowed: true,
-            variant: rule != null ? Variant.fromRule(rule) : Variant.standard,
-          ),
+          pgn: textInput!,
+          isComputerAnalysisAllowed: true,
+          variant: rule != null ? Variant.fromRule(rule) : Variant.standard,
           initialMoveCursor: mainlineMoves.isEmpty ? 0 : 1,
         ),
       );

--- a/lib/src/view/more/more_tab_screen.dart
+++ b/lib/src/view/more/more_tab_screen.dart
@@ -83,13 +83,11 @@ class _Body extends ConsumerWidget {
                 onTap: () => Navigator.of(context, rootNavigator: true).push(
                   AnalysisScreen.buildRoute(
                     context,
-                    const AnalysisOptions(
+                    const AnalysisOptions.standalone(
                       orientation: Side.white,
-                      standalone: (
-                        pgn: '',
-                        isComputerAnalysisAllowed: true,
-                        variant: Variant.standard,
-                      ),
+                      pgn: '',
+                      isComputerAnalysisAllowed: true,
+                      variant: Variant.standard,
                     ),
                   ),
                 ),
@@ -104,13 +102,11 @@ class _Body extends ConsumerWidget {
                 onTap: () => Navigator.of(context, rootNavigator: true).push(
                   OpeningExplorerScreen.buildRoute(
                     context,
-                    const AnalysisOptions(
+                    const AnalysisOptions.standalone(
                       orientation: Side.white,
-                      standalone: (
-                        pgn: '',
-                        isComputerAnalysisAllowed: false,
-                        variant: Variant.standard,
-                      ),
+                      pgn: '',
+                      isComputerAnalysisAllowed: false,
+                      variant: Variant.standard,
                     ),
                   ),
                 ),

--- a/lib/src/view/opening_explorer/opening_explorer_widgets.dart
+++ b/lib/src/view/opening_explorer/opening_explorer_widgets.dart
@@ -351,7 +351,7 @@ class _OpeningExplorerGameTileState extends ConsumerState<OpeningExplorerGameTil
           Navigator.of(context).push(
             AnalysisScreen.buildRoute(
               context,
-              AnalysisOptions(
+              AnalysisOptions.archivedGame(
                 orientation: Side.white,
                 gameId: widget.game.id,
                 initialMoveCursor: widget.ply,

--- a/lib/src/view/over_the_board/over_the_board_screen.dart
+++ b/lib/src/view/over_the_board/over_the_board_screen.dart
@@ -276,13 +276,11 @@ class _BottomBar extends ConsumerWidget {
             onPressed: () => Navigator.of(context).push(
               AnalysisScreen.buildRoute(
                 context,
-                AnalysisOptions(
+                AnalysisOptions.standalone(
                   orientation: Side.white,
-                  standalone: (
-                    pgn: gameState.game.makePgn(),
-                    isComputerAnalysisAllowed: true,
-                    variant: gameState.game.meta.variant,
-                  ),
+                  pgn: gameState.game.makePgn(),
+                  isComputerAnalysisAllowed: true,
+                  variant: gameState.game.meta.variant,
                 ),
               ),
             ),

--- a/lib/src/view/puzzle/puzzle_screen.dart
+++ b/lib/src/view/puzzle/puzzle_screen.dart
@@ -656,15 +656,13 @@ class _BottomBarState extends ConsumerState<_BottomBar> {
             Navigator.of(context).push(
               AnalysisScreen.buildRoute(
                 context,
-                AnalysisOptions(
+                AnalysisOptions.standalone(
                   orientation: puzzleState.pov,
-                  standalone: (
-                    pgn: ref
-                        .read(puzzleControllerProvider(widget.initialPuzzleContext).notifier)
-                        .makePgn(),
-                    isComputerAnalysisAllowed: true,
-                    variant: Variant.standard,
-                  ),
+                  pgn: ref
+                      .read(puzzleControllerProvider(widget.initialPuzzleContext).notifier)
+                      .makePgn(),
+                  isComputerAnalysisAllowed: true,
+                  variant: Variant.standard,
                   initialMoveCursor: 0,
                 ),
               ),
@@ -682,7 +680,7 @@ class _BottomBarState extends ConsumerState<_BottomBar> {
               Navigator.of(context).push(
                 AnalysisScreen.buildRoute(
                   context,
-                  AnalysisOptions(
+                  AnalysisOptions.archivedGame(
                     orientation: puzzleState.pov,
                     gameId: game.id,
                     initialMoveCursor: puzzleState.puzzle.puzzle.initialPly + 1,

--- a/lib/src/view/puzzle/streak_screen.dart
+++ b/lib/src/view/puzzle/streak_screen.dart
@@ -275,13 +275,11 @@ class _BottomBar extends ConsumerWidget {
               Navigator.of(context, rootNavigator: true).push(
                 AnalysisScreen.buildRoute(
                   context,
-                  AnalysisOptions(
+                  AnalysisOptions.standalone(
                     orientation: puzzleState.pov,
-                    standalone: (
-                      pgn: ref.read(ctrlProvider.notifier).makePgn(),
-                      isComputerAnalysisAllowed: true,
-                      variant: Variant.standard,
-                    ),
+                    pgn: ref.read(ctrlProvider.notifier).makePgn(),
+                    isComputerAnalysisAllowed: true,
+                    variant: Variant.standard,
                     initialMoveCursor: 0,
                   ),
                 ),

--- a/lib/src/view/study/study_bottom_bar.dart
+++ b/lib/src/view/study/study_bottom_bar.dart
@@ -162,13 +162,11 @@ class _GamebookBottomBar extends ConsumerWidget {
                 onTap: () => Navigator.of(context, rootNavigator: true).push(
                   AnalysisScreen.buildRoute(
                     context,
-                    AnalysisOptions(
+                    AnalysisOptions.standalone(
                       orientation: state.pov,
-                      standalone: (
-                        pgn: state.pgn,
-                        isComputerAnalysisAllowed: true,
-                        variant: state.variant,
-                      ),
+                      pgn: state.pgn,
+                      isComputerAnalysisAllowed: true,
+                      variant: state.variant,
                     ),
                   ),
                 ),

--- a/lib/src/view/user/game_history_screen.dart
+++ b/lib/src/view/user/game_history_screen.dart
@@ -276,7 +276,10 @@ class _BodyState extends ConsumerState<_Body> {
                                   Navigator.of(context, rootNavigator: true).push(
                                     AnalysisScreen.buildRoute(
                                       context,
-                                      AnalysisOptions(orientation: pov, gameId: game.id),
+                                      AnalysisOptions.archivedGame(
+                                        orientation: pov,
+                                        gameId: game.id,
+                                      ),
                                     ),
                                   );
                                 }

--- a/lib/src/view/user/perf_stats_screen.dart
+++ b/lib/src/view/user/perf_stats_screen.dart
@@ -627,7 +627,7 @@ class _GameListWidget extends ConsumerWidget {
                 Navigator.of(context, rootNavigator: true).push(
                   AnalysisScreen.buildRoute(
                     context,
-                    AnalysisOptions(
+                    AnalysisOptions.archivedGame(
                       orientation: user.id == gameData.white.user?.id ? Side.white : Side.black,
                       gameId: gameData.id,
                       initialMoveCursor: 0,

--- a/test/view/analysis/analysis_screen_test.dart
+++ b/test/view/analysis/analysis_screen_test.dart
@@ -32,13 +32,11 @@ void main() {
       final app = await makeTestProviderScopeApp(
         tester,
         home: AnalysisScreen(
-          options: AnalysisOptions(
+          options: AnalysisOptions.standalone(
             orientation: Side.white,
-            standalone: (
-              pgn: sanMoves,
-              isComputerAnalysisAllowed: false,
-              variant: Variant.standard,
-            ),
+            pgn: sanMoves,
+            isComputerAnalysisAllowed: false,
+            variant: Variant.standard,
           ),
         ),
       );
@@ -60,13 +58,11 @@ void main() {
       final app = await makeTestProviderScopeApp(
         tester,
         home: AnalysisScreen(
-          options: AnalysisOptions(
+          options: AnalysisOptions.standalone(
             orientation: Side.white,
-            standalone: (
-              pgn: sanMoves,
-              isComputerAnalysisAllowed: false,
-              variant: Variant.standard,
-            ),
+            pgn: sanMoves,
+            isComputerAnalysisAllowed: false,
+            variant: Variant.standard,
           ),
         ),
       );
@@ -112,9 +108,11 @@ void main() {
           ),
         },
         home: AnalysisScreen(
-          options: AnalysisOptions(
+          options: AnalysisOptions.standalone(
             orientation: Side.white,
-            standalone: (pgn: pgn, isComputerAnalysisAllowed: false, variant: Variant.standard),
+            pgn: pgn,
+            isComputerAnalysisAllowed: false,
+            variant: Variant.standard,
           ),
           enableDrawingShapes: false,
         ),
@@ -621,13 +619,11 @@ void main() {
             ),
           },
           home: const AnalysisScreen(
-            options: AnalysisOptions(
+            options: AnalysisOptions.standalone(
               orientation: Side.white,
-              standalone: (
-                pgn: castlingSetupPgn,
-                isComputerAnalysisAllowed: false,
-                variant: Variant.standard,
-              ),
+              pgn: castlingSetupPgn,
+              isComputerAnalysisAllowed: false,
+              variant: Variant.standard,
               initialMoveCursor: 14,
             ),
           ),
@@ -671,13 +667,11 @@ void main() {
           },
           home: AnalysisScreen(
             key: ValueKey(castlingMethod),
-            options: const AnalysisOptions(
+            options: const AnalysisOptions.standalone(
               orientation: Side.white,
-              standalone: (
-                pgn: castlingSetupPgn,
-                isComputerAnalysisAllowed: false,
-                variant: Variant.chess960,
-              ),
+              pgn: castlingSetupPgn,
+              isComputerAnalysisAllowed: false,
+              variant: Variant.chess960,
               initialMoveCursor: 14,
             ),
           ),

--- a/test/view/engine/test_engine_app.dart
+++ b/test/view/engine/test_engine_app.dart
@@ -130,17 +130,14 @@ Future<void> makeEngineTestApp(
             gameId: broadcastGame.$3,
           )
         : AnalysisScreen(
-            options: AnalysisOptions(
-              orientation: Side.white,
-              gameId: gameId,
-              standalone: gameId == null
-                  ? (
-                      pgn: '',
-                      isComputerAnalysisAllowed: isComputerAnalysisAllowed,
-                      variant: Variant.standard,
-                    )
-                  : null,
-            ),
+            options: gameId != null
+                ? AnalysisOptions.archivedGame(orientation: Side.white, gameId: gameId)
+                : AnalysisOptions.standalone(
+                    orientation: Side.white,
+                    pgn: '',
+                    isComputerAnalysisAllowed: isComputerAnalysisAllowed,
+                    variant: Variant.standard,
+                  ),
           ),
   );
 

--- a/test/view/opening_explorer/opening_explorer_screen_test.dart
+++ b/test/view/opening_explorer/opening_explorer_screen_test.dart
@@ -39,9 +39,11 @@ void main() {
     return mockResponse('', 404);
   });
 
-  const options = AnalysisOptions(
+  const options = AnalysisOptions.standalone(
     orientation: Side.white,
-    standalone: (pgn: '', isComputerAnalysisAllowed: false, variant: Variant.standard),
+    pgn: '',
+    isComputerAnalysisAllowed: false,
+    variant: Variant.standard,
   );
 
   const name = 'John';


### PR DESCRIPTION
The `gameId` and `standalone` properties have always been exclusive (exactly one of them had to be non-null), so I think this better expresses the intent.

Additionally, for analysing ongoing correspondence games, I'd introduce a new constructor in https://github.com/lichess-org/mobile/pull/1802 along the lines of

```
AnalysisOptions.ongoingCorrespondenceGame({
    required Side orientation,
    int? initialMoveCursor,
    required GameFullId gameId,
}) = OngoingCorrespondenceGame;
```