### PR TITLE
Allow to disable server analysis and use the local engine at the same time

### DIFF
--- a/lib/src/model/analysis/analysis_controller.dart
+++ b/lib/src/model/analysis/analysis_controller.dart
@@ -390,25 +390,6 @@ class AnalysisController extends _$AnalysisController
     _setPath(path.penultimate, shouldRecomputeRootView: true);
   }
 
-  /// Toggles the computer analysis on/off.
-  ///
-  /// Acts both on engine evaluation and server analysis.
-  Future<void> toggleComputerAnalysis() async {
-    await ref.read(analysisPreferencesProvider.notifier).toggleEnableComputerAnalysis();
-
-    final curState = state.requireValue;
-    final engineWasAvailable = curState.isEngineAvailable(evaluationPrefs);
-
-    state = AsyncData(
-      curState.copyWith(isComputerAnalysisEnabled: !curState.isComputerAnalysisEnabled),
-    );
-
-    final computerAllowed = state.requireValue.isComputerAnalysisEnabled;
-    if (!computerAllowed && engineWasAvailable) {
-      toggleEngine();
-    }
-  }
-
   void updatePgnHeader(String key, String value) {
     final headers = state.requireValue.pgnHeaders.add(key, value);
     state = AsyncData(state.requireValue.copyWith(pgnHeaders: headers));
@@ -770,7 +751,7 @@ sealed class AnalysisState with _$AnalysisState implements EvaluationMixinState 
 
   /// Whether the engine is allowed for this analysis and variant.
   bool get isEngineAllowed =>
-      isComputerAnalysisAllowedAndEnabled && engineSupportedVariants.contains(variant);
+      isComputerAnalysisAllowed && engineSupportedVariants.contains(variant);
 
   @override
   bool isEngineAvailable(EngineEvaluationPrefState prefs) => isEngineAllowed && prefs.isEnabled;

--- a/lib/src/model/broadcast/broadcast_analysis_controller.dart
+++ b/lib/src/model/broadcast/broadcast_analysis_controller.dart
@@ -416,25 +416,6 @@ class BroadcastAnalysisController extends _$BroadcastAnalysisController
     _setPath(path.penultimate, shouldRecomputeRootView: true);
   }
 
-  /// Toggles the computer analysis on/off.
-  ///
-  /// Acts both on engine evaluation and server analysis.
-  Future<void> toggleComputerAnalysis() async {
-    await ref.read(broadcastPreferencesProvider.notifier).toggleEnableComputerAnalysis();
-
-    final curState = state.requireValue;
-    final engineWasAvailable = curState.isEngineAvailable(evaluationPrefs);
-
-    state = AsyncData(
-      curState.copyWith(isComputerAnalysisEnabled: !curState.isComputerAnalysisEnabled),
-    );
-
-    final computerAllowed = state.requireValue.isComputerAnalysisEnabled;
-    if (!computerAllowed && engineWasAvailable) {
-      toggleEngine();
-    }
-  }
-
   void _setPath(
     UciPath path, {
     bool shouldForceShowVariation = false,
@@ -556,7 +537,7 @@ sealed class BroadcastAnalysisState with _$BroadcastAnalysisState implements Eva
 
     /// Whether the user has enabled computer analysis.
     ///
-    /// This is a user preference and acts both on local and server analysis.
+    /// This is a user preference and acts on server analysis.
     required bool isComputerAnalysisEnabled,
 
     required EvaluationContext evaluationContext,
@@ -600,8 +581,7 @@ sealed class BroadcastAnalysisState with _$BroadcastAnalysisState implements Eva
       isEngineAvailable(prefs) || (isComputerAnalysisEnabled && currentNode.serverEval != null);
 
   @override
-  bool isEngineAvailable(EngineEvaluationPrefState prefs) =>
-      isComputerAnalysisEnabled && prefs.isEnabled;
+  bool isEngineAvailable(EngineEvaluationPrefState prefs) => prefs.isEnabled;
 
   @override
   Position get currentPosition => currentNode.position;

--- a/lib/src/view/analysis/analysis_settings_screen.dart
+++ b/lib/src/view/analysis/analysis_settings_screen.dart
@@ -58,63 +58,46 @@ class AnalysisSettingsScreen extends ConsumerWidget {
                   ),
                 ],
               ),
-              if (value.isComputerAnalysisAllowed)
+              if (value.isComputerAnalysisAllowed) ...[
                 ListSection(
-                  header: SettingsSectionTitle(context.l10n.computerAnalysis),
                   children: [
                     SwitchSettingTile(
-                      title: Text(context.l10n.enable),
+                      title: Text(context.l10n.computerAnalysis),
                       value: prefs.enableComputerAnalysis,
                       onChanged: (_) {
-                        ref.read(ctrlProvider.notifier).toggleComputerAnalysis();
+                        ref
+                            .read(analysisPreferencesProvider.notifier)
+                            .toggleEnableComputerAnalysis();
                       },
                     ),
-                    AnimatedCrossFade(
-                      duration: const Duration(milliseconds: 300),
-                      crossFadeState: value.isComputerAnalysisAllowedAndEnabled
-                          ? CrossFadeState.showSecond
-                          : CrossFadeState.showFirst,
-                      firstChild: const SizedBox.shrink(),
-                      secondChild: Column(
-                        children: [
-                          SwitchSettingTile(
-                            title: Text(context.l10n.evaluationGauge),
-                            value: prefs.showEvaluationGauge,
-                            onChanged: (value) => ref
-                                .read(analysisPreferencesProvider.notifier)
-                                .toggleShowEvaluationGauge(),
-                          ),
-                          SwitchSettingTile(
-                            title: Text(context.l10n.toggleGlyphAnnotations),
-                            value: prefs.showAnnotations,
-                            onChanged: (_) =>
-                                ref.read(analysisPreferencesProvider.notifier).toggleAnnotations(),
-                          ),
-                          SwitchSettingTile(
-                            title: Text(context.l10n.mobileShowComments),
-                            value: prefs.showPgnComments,
-                            onChanged: (_) =>
-                                ref.read(analysisPreferencesProvider.notifier).togglePgnComments(),
-                          ),
-                          SwitchSettingTile(
-                            title: Text(context.l10n.bestMoveArrow),
-                            value: prefs.showBestMoveArrow,
-                            onChanged: (value) => ref
-                                .read(analysisPreferencesProvider.notifier)
-                                .toggleShowBestMoveArrow(),
-                          ),
-                        ],
-                      ),
+                    SwitchSettingTile(
+                      title: Text(context.l10n.evaluationGauge),
+                      value: prefs.showEvaluationGauge,
+                      onChanged: (value) => ref
+                          .read(analysisPreferencesProvider.notifier)
+                          .toggleShowEvaluationGauge(),
+                    ),
+                    SwitchSettingTile(
+                      title: Text(context.l10n.toggleGlyphAnnotations),
+                      value: prefs.showAnnotations,
+                      onChanged: (_) =>
+                          ref.read(analysisPreferencesProvider.notifier).toggleAnnotations(),
+                    ),
+                    SwitchSettingTile(
+                      title: Text(context.l10n.mobileShowComments),
+                      value: prefs.showPgnComments,
+                      onChanged: (_) =>
+                          ref.read(analysisPreferencesProvider.notifier).togglePgnComments(),
+                    ),
+                    SwitchSettingTile(
+                      title: Text(context.l10n.bestMoveArrow),
+                      value: prefs.showBestMoveArrow,
+                      onChanged: (value) =>
+                          ref.read(analysisPreferencesProvider.notifier).toggleShowBestMoveArrow(),
                     ),
                   ],
                 ),
-              AnimatedCrossFade(
-                duration: const Duration(milliseconds: 300),
-                crossFadeState: value.isComputerAnalysisAllowedAndEnabled
-                    ? CrossFadeState.showSecond
-                    : CrossFadeState.showFirst,
-                firstChild: const SizedBox.shrink(),
-                secondChild: EngineSettingsWidget(
+                EngineSettingsWidget(
                   onSetEngineSearchTime: (value) {
                     ref.read(ctrlProvider.notifier).setEngineSearchTime(value);
                   },
@@ -125,7 +108,7 @@ class AnalysisSettingsScreen extends ConsumerWidget {
                     ref.read(ctrlProvider.notifier).setNumEvalLines(value);
                   },
                 ),
-              ),
+              ],
             ],
           ),
         );

--- a/lib/src/view/analysis/server_analysis.dart
+++ b/lib/src/view/analysis/server_analysis.dart
@@ -45,7 +45,7 @@ class ServerAnalysisSummary extends ConsumerWidget {
               if (canShowGameSummary)
                 FilledButton.tonal(
                   onPressed: () {
-                    ref.read(ctrlProvider.notifier).toggleComputerAnalysis();
+                    ref.read(analysisPreferencesProvider.notifier).toggleEnableComputerAnalysis();
                   },
                   child: Text(context.l10n.enable),
                 ),

--- a/lib/src/view/broadcast/broadcast_game_screen.dart
+++ b/lib/src/view/broadcast/broadcast_game_screen.dart
@@ -642,7 +642,6 @@ class _BroadcastGameBottomBar extends ConsumerWidget {
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
-    final broadcastPrefs = ref.watch(broadcastPreferencesProvider);
     final enginePrefs = ref.watch(engineEvaluationPreferencesProvider);
     final ctrlProvider = broadcastAnalysisControllerProvider(roundId, gameId);
     final broadcastAnalysisState = ref.watch(ctrlProvider).requireValue;
@@ -664,9 +663,7 @@ class _BroadcastGameBottomBar extends ConsumerWidget {
               builder: (context, snapshot) {
                 return BottomBarButton(
                   label: context.l10n.toggleLocalEvaluation,
-                  onTap:
-                      broadcastPrefs.enableComputerAnalysis &&
-                          snapshot.connectionState != ConnectionState.waiting
+                  onTap: snapshot.connectionState != ConnectionState.waiting
                       ? () async {
                           toggleFuture = ref.read(ctrlProvider.notifier).toggleEngine();
                           try {

--- a/lib/src/view/broadcast/broadcast_game_settings_screen.dart
+++ b/lib/src/view/broadcast/broadcast_game_settings_screen.dart
@@ -62,65 +62,45 @@ class BroadcastGameSettingsScreen extends ConsumerWidget {
             ],
           ),
           ListSection(
-            header: SettingsSectionTitle(context.l10n.computerAnalysis),
             children: [
               SwitchSettingTile(
-                title: Text(context.l10n.enable),
+                title: Text(context.l10n.computerAnalysis),
                 value: broadcastPrefs.enableComputerAnalysis,
                 onChanged: (_) {
-                  ref.read(controller.notifier).toggleComputerAnalysis();
+                  ref.read(broadcastPreferencesProvider.notifier).toggleEnableComputerAnalysis();
                 },
               ),
-              AnimatedCrossFade(
-                duration: const Duration(milliseconds: 300),
-                crossFadeState: broadcastPrefs.enableComputerAnalysis
-                    ? CrossFadeState.showSecond
-                    : CrossFadeState.showFirst,
-                firstChild: const SizedBox.shrink(),
-                secondChild: Column(
-                  children: [
-                    SwitchSettingTile(
-                      title: Text(context.l10n.evaluationGauge),
-                      value: broadcastPrefs.showEvaluationGauge,
-                      onChanged: (value) => ref
-                          .read(broadcastPreferencesProvider.notifier)
-                          .toggleShowEvaluationGauge(),
-                    ),
-                    SwitchSettingTile(
-                      title: Text(context.l10n.toggleGlyphAnnotations),
-                      value: broadcastPrefs.showAnnotations,
-                      onChanged: (_) =>
-                          ref.read(broadcastPreferencesProvider.notifier).toggleAnnotations(),
-                    ),
-                    SwitchSettingTile(
-                      title: Text(context.l10n.mobileShowComments),
-                      value: broadcastPrefs.showPgnComments,
-                      onChanged: (_) =>
-                          ref.read(broadcastPreferencesProvider.notifier).togglePgnComments(),
-                    ),
-                    SwitchSettingTile(
-                      title: Text(context.l10n.bestMoveArrow),
-                      value: broadcastPrefs.showBestMoveArrow,
-                      onChanged: (value) =>
-                          ref.read(broadcastPreferencesProvider.notifier).toggleShowBestMoveArrow(),
-                    ),
-                  ],
-                ),
+              SwitchSettingTile(
+                title: Text(context.l10n.evaluationGauge),
+                value: broadcastPrefs.showEvaluationGauge,
+                onChanged: (value) =>
+                    ref.read(broadcastPreferencesProvider.notifier).toggleShowEvaluationGauge(),
+              ),
+              SwitchSettingTile(
+                title: Text(context.l10n.toggleGlyphAnnotations),
+                value: broadcastPrefs.showAnnotations,
+                onChanged: (_) =>
+                    ref.read(broadcastPreferencesProvider.notifier).toggleAnnotations(),
+              ),
+              SwitchSettingTile(
+                title: Text(context.l10n.mobileShowComments),
+                value: broadcastPrefs.showPgnComments,
+                onChanged: (_) =>
+                    ref.read(broadcastPreferencesProvider.notifier).togglePgnComments(),
+              ),
+              SwitchSettingTile(
+                title: Text(context.l10n.bestMoveArrow),
+                value: broadcastPrefs.showBestMoveArrow,
+                onChanged: (value) =>
+                    ref.read(broadcastPreferencesProvider.notifier).toggleShowBestMoveArrow(),
               ),
             ],
           ),
-          AnimatedCrossFade(
-            duration: const Duration(milliseconds: 300),
-            crossFadeState: broadcastPrefs.enableComputerAnalysis
-                ? CrossFadeState.showSecond
-                : CrossFadeState.showFirst,
-            firstChild: const SizedBox.shrink(),
-            secondChild: EngineSettingsWidget(
-              onSetEngineSearchTime: (value) =>
-                  ref.read(controller.notifier).setEngineSearchTime(value),
-              onSetNumEvalLines: (value) => ref.read(controller.notifier).setNumEvalLines(value),
-              onSetEngineCores: (value) => ref.read(controller.notifier).setEngineCores(value),
-            ),
+          EngineSettingsWidget(
+            onSetEngineSearchTime: (value) =>
+                ref.read(controller.notifier).setEngineSearchTime(value),
+            onSetNumEvalLines: (value) => ref.read(controller.notifier).setNumEvalLines(value),
+            onSetEngineCores: (value) => ref.read(controller.notifier).setEngineCores(value),
           ),
         ],
       ),

--- a/lib/src/widgets/pgn.dart
+++ b/lib/src/widgets/pgn.dart
@@ -309,7 +309,10 @@ bool _displaySideLineAsInline(ViewBranch node, [int depth = 0]) {
 bool _hasNonInlineSideLine(ViewNode node, _PgnTreeViewParams params, {required bool isMainline}) {
   final children = _filteredChildren(node, params.shouldShowComputerAnalysis);
   return isMainline && params.displayMode == PgnTreeDisplayMode.twoColumn
-      ? children.length >= 2 || node.children.firstOrNull?.hasTextComment == true
+      ? children.length >= 2 ||
+            (params.shouldShowComputerAnalysis &&
+                params.shouldShowComments &&
+                children.firstOrNull?.hasTextComment == true)
       : children.length > 2 || (children.length == 2 && !_displaySideLineAsInline(children[1]));
 }
 
@@ -402,16 +405,19 @@ class _PgnTreeViewState extends State<_PgnTreeView> {
 
           if (fullRebuild || subtrees[i].containsCurrentMove || containsCurrentMove) {
             // Skip the first node which is the continuation of the mainline
-            final sidelineNodes = mainlineNodes.last.children.skip(1);
+            final filteredSidelineNodes = _filteredChildren(
+              mainlineNodes.last,
+              widget.params.shouldShowComputerAnalysis,
+            ).skip(1);
             return (
               mainLinePart: _MainLinePart(
                 params: widget.params,
                 initialPath: mainlineInitialPath,
                 nodes: mainlineNodes,
               ),
-              sidelines: sidelineNodes.isNotEmpty
+              sidelines: filteredSidelineNodes.isNotEmpty
                   ? _IndentedSideLines(
-                      sidelineNodes,
+                      filteredSidelineNodes,
                       parent: mainlineNodes.last,
                       params: widget.params,
                       initialPath: sidelineInitialPath,

--- a/test/view/analysis/analysis_screen_test.dart
+++ b/test/view/analysis/analysis_screen_test.dart
@@ -497,8 +497,15 @@ void main() {
         expect(find.byType(Engineline), findsNothing);
       });
 
-      testWidgets('are not displayed if computer analysis is not enabled', (tester) async {
-        await makeEngineTestApp(tester, isComputerAnalysisEnabled: false);
+      testWidgets('are not displayed if computer analysis is not enabled (on an analysed game)', (
+        tester,
+      ) async {
+        await makeEngineTestApp(
+          tester,
+          gameId: const GameId('xze7RH66'),
+          isComputerAnalysisEnabled: false,
+          isEngineEnabled: false,
+        );
         // ensure that the eval is displayed and pending eval throttle time is over
         await tester.pump(kRequestEvalDebounceDelay + kEngineEvalEmissionThrottleDelay);
         expect(find.byType(Engineline), findsNothing);
@@ -527,10 +534,13 @@ void main() {
         expect(find.byType(EngineGauge), findsNothing);
       });
 
-      testWidgets('is not displayed if computer analysis is not enabled', (tester) async {
+      testWidgets('is not displayed if computer analysis is not enabled (on an analysed game)', (
+        tester,
+      ) async {
         await makeEngineTestApp(
           tester,
           isComputerAnalysisEnabled: false,
+          isEngineEnabled: false,
           gameId: const GameId('xze7RH66'),
         );
         // ensure that the eval is displayed and pending eval throttle time is over
@@ -577,13 +587,6 @@ void main() {
 
       testWidgets('is not displayed if computer analysis is not allowed', (tester) async {
         await makeEngineTestApp(tester, isComputerAnalysisAllowed: false);
-        // ensure that the eval is displayed and pending eval throttle time is over
-        await tester.pump(kRequestEvalDebounceDelay + kEngineEvalEmissionThrottleDelay);
-        expect(find.byType(BoardShapeWidget), findsNothing);
-      });
-
-      testWidgets('is not displayed if computer analysis is not enabled', (tester) async {
-        await makeEngineTestApp(tester, isComputerAnalysisEnabled: false);
         // ensure that the eval is displayed and pending eval throttle time is over
         await tester.pump(kRequestEvalDebounceDelay + kEngineEvalEmissionThrottleDelay);
         expect(find.byType(BoardShapeWidget), findsNothing);

--- a/test/view/broadcast/broadcast_game_screen_test.dart
+++ b/test/view/broadcast/broadcast_game_screen_test.dart
@@ -112,6 +112,7 @@ void main() {
           tester,
           broadcastGame: (_tournamentId, _roundId, _gameId),
           isComputerAnalysisEnabled: false,
+          isEngineEnabled: false,
         );
         await tester.pump(kRequestEvalDebounceDelay + kFakeWebSocketConnectionLag);
         expect(find.byType(Engineline), findsNothing);
@@ -144,6 +145,7 @@ void main() {
           tester,
           broadcastGame: (_tournamentId, _roundId, _gameIdWithServerAnalysis),
           isComputerAnalysisEnabled: false,
+          isEngineEnabled: false,
         );
         await tester.pump(kRequestEvalDebounceDelay + kFakeWebSocketConnectionLag);
         expect(find.byType(EngineGauge), findsNothing);
@@ -186,16 +188,6 @@ void main() {
           tester,
           broadcastGame: (_tournamentId, _roundId, _gameId),
           showBestMoveArrow: false,
-        );
-        await tester.pump(kRequestEvalDebounceDelay + kFakeWebSocketConnectionLag);
-        expect(find.byType(BoardShapeWidget), findsNothing);
-      });
-
-      testWidgets('is not displayed if computer analysis is not enabled', (tester) async {
-        await makeEngineTestApp(
-          tester,
-          broadcastGame: (_tournamentId, _roundId, _gameId),
-          isComputerAnalysisEnabled: false,
         );
         await tester.pump(kRequestEvalDebounceDelay + kFakeWebSocketConnectionLag);
         expect(find.byType(BoardShapeWidget), findsNothing);


### PR DESCRIPTION
This PR changes the behaviour of the "Computer analysis" switch in analysis (and broadcast) settings.

The reason: some people don't want to be spoiled by the automatic server analysis (which can be requested by anyone). So we want a switch to disable it completely, but still allowing the local engine on demand.

Before:
- computer analysis OFF would disable both server analysis (variations, evals, annotations) AND local analysis

Now:
- computer analysis OFF will only disable server analysis; that is, the local engine is still available

This PR also fixes a bug where in the default two columns move list notation, the server analysis variations where displayed even if the switch was off.

![Screenshot_1752142275](https://github.com/user-attachments/assets/a18999ea-9cdb-4e5f-af52-3d1fca7545c1)

