### PR TITLE
fix: immediately hide best move arrows from previous position when making a move in analysis board

### DIFF
--- a/lib/src/view/analysis/analysis_board.dart
+++ b/lib/src/view/analysis/analysis_board.dart
@@ -44,23 +44,39 @@ class AnalysisBoardState extends ConsumerState<AnalysisBoard> {
     final analysisPrefs = ref.watch(analysisPreferencesProvider);
     final enginePrefs = ref.watch(engineEvaluationPreferencesProvider);
 
-    final showBestMoveArrow =
-        analysisState.isEngineAvailable(enginePrefs) && analysisPrefs.showBestMoveArrow;
     final showAnnotations =
         analysisState.isComputerAnalysisAllowed &&
         analysisState.isServerAnalysisEnabled &&
         analysisPrefs.showAnnotations;
     final currentNode = analysisState.currentNode;
 
-    final bestMoves = showBestMoveArrow
-        ? pickBestClientEval(
-            localEval: ref.watch(engineEvaluationProvider.select((value) => value.eval)),
-            savedEval: currentNode.eval,
-          )?.bestMoves
-        : null;
-    final ISet<Shape> bestMoveShapes = bestMoves != null
-        ? computeBestMoveShapes(bestMoves, currentNode.position.turn, boardPrefs.pieceSet.assets)
-        : ISet();
+    ISet<Shape> bestMoveShapes() {
+      final showBestMoveArrow =
+          analysisState.isEngineAvailable(enginePrefs) && analysisPrefs.showBestMoveArrow;
+      if (!showBestMoveArrow) {
+        return ISet();
+      }
+
+      final eval = pickBestClientEval(
+        localEval: ref.watch(engineEvaluationProvider.select((value) => value.eval)),
+        savedEval: currentNode.eval,
+      );
+      if (eval == null) {
+        return ISet();
+      }
+
+      if (eval.position.fen != currentNode.position.fen) {
+        // Eval is out of sync, this usually happens after making a move on the board.
+        // While waiting for the updated eval we don't want to show the best moves from the previous position.
+        return ISet();
+      }
+
+      return computeBestMoveShapes(
+        eval.bestMoves,
+        currentNode.position.turn,
+        boardPrefs.pieceSet.assets,
+      );
+    }
 
     final annotation = showAnnotations ? makeAnnotation(currentNode.nags) : null;
     final sanMove = currentNode.sanMove;
@@ -84,7 +100,7 @@ class AnalysisBoardState extends ConsumerState<AnalysisBoard> {
             .onUserMove(move, shouldReplace: widget.shouldReplaceChildOnUserMove),
         onPromotionSelection: (role) => ref.read(ctrlProvider.notifier).onPromotionSelection(role),
       ),
-      shapes: userShapes.union(bestMoveShapes),
+      shapes: userShapes.union(bestMoveShapes()),
       annotations: sanMove != null && annotation != null
           ? altCastles.containsKey(sanMove.move.uci)
                 ? IMap({Move.parse(altCastles[sanMove.move.uci]!)!.to: annotation})


### PR DESCRIPTION
Before: (note how when making a move, the arrows from the previous position stay until the board while the evaluation is loading)

[before.webm](https://github.com/user-attachments/assets/c08da5cb-56ae-41b8-b197-952aec825056)

After: (arrows now disappear immediately after making a move)

[after.webm](https://github.com/user-attachments/assets/c67fcc8c-9c4d-45b7-8642-b7a496f57aab)
