### PR TITLE
fix: manually update the puzzle context when the puzzle changes

### DIFF
--- a/lib/src/view/puzzle/streak_screen.dart
+++ b/lib/src/view/puzzle/streak_screen.dart
@@ -104,6 +104,26 @@ class _BodyState extends ConsumerState<_Body> {
     );
     final puzzleState = ref.watch(ctrlProvider);
 
+    ref.listen(puzzleStreakControllerProvider, (previous, next) {
+      if (previous?.hasValue == true && next.hasValue) {
+        final currentPuzzle = next.requireValue.puzzle;
+        final previousPuzzle = previous!.requireValue.puzzle;
+
+        if (currentPuzzle.puzzle.id != previousPuzzle.puzzle.id) {
+          final session = ref.read(authSessionProvider);
+          ref
+              .read(ctrlProvider.notifier)
+              .onLoadPuzzle(
+                PuzzleContext(
+                  puzzle: currentPuzzle,
+                  angle: widget.initialPuzzleContext.angle,
+                  userId: session?.user.id,
+                ),
+              );
+        }
+      }
+    });
+
     ref.listen(ctrlProvider, (previous, next) {
       if (previous?.result != PuzzleResult.lose && next.result == PuzzleResult.lose) {
         ref.read(puzzleStreakControllerProvider.notifier).gameOver();


### PR DESCRIPTION
Closes #1951

This issue occurred because the `PuzzleController` was stuck in the `PuzzleMode.view` mode after an incorrect move. The  `PuzzleController` never transitions into `PuzzleMode.play`, which allows the puzzle to be played. This is because the `PuzzleController` and the `PuzzleStreakController` aren't properly synchronised. Under some scenarios, like when the very first move of a puzzle streak is incorrect, the `PuzzleController` retains the old state, and the puzzle does not advance properly.

This pull request adds a listener to detect when the state of the `PuzzleStreakController` changes, and updates it in `PuzzleController`, allowing the new puzzle to be played.