### PR TITLE
Consistent input limits and fields for profile editor

### DIFF
--- a/lib/src/model/user/profile.dart
+++ b/lib/src/model/user/profile.dart
@@ -17,6 +17,9 @@ sealed class Profile with _$Profile {
     int? fideRating,
     int? uscfRating,
     int? ecfRating,
+    int? rcfRating,
+    int? cfcRating,
+    int? dsbRating,
     IList<SocialLink>? links,
   }) = _Profile;
 
@@ -38,6 +41,9 @@ sealed class Profile with _$Profile {
       fideRating: pick('fideRating').asIntOrNull(),
       uscfRating: pick('uscfRating').asIntOrNull(),
       ecfRating: pick('ecfRating').asIntOrNull(),
+      rcfRating: pick('rcfRating').asIntOrNull(),
+      cfcRating: pick('cfcRating').asIntOrNull(),
+      dsbRating: pick('dsbRating').asIntOrNull(),
       links: rawLinks
           ?.where((e) => e.trim().isNotEmpty)
           .map((e) {

--- a/lib/src/view/account/edit_profile_screen.dart
+++ b/lib/src/view/account/edit_profile_screen.dart
@@ -40,6 +40,9 @@ class _EditProfileScreenState extends ConsumerState<EditProfileScreen> {
     'fideRating': null,
     'uscfRating': null,
     'ecfRating': null,
+    'rcfRating': null,
+    'cfcRating': null,
+    'dsbRating': null,
     'links': null,
   };
 
@@ -56,6 +59,9 @@ class _EditProfileScreenState extends ConsumerState<EditProfileScreen> {
             _formData['fideRating'] != user.profile?.fideRating ||
             _formData['uscfRating'] != user.profile?.uscfRating ||
             _formData['ecfRating'] != user.profile?.ecfRating ||
+            _formData['rcfRating'] != user.profile?.rcfRating ||
+            _formData['cfcRating'] != user.profile?.cfcRating ||
+            _formData['dsbRating'] != user.profile?.dsbRating ||
             _formData['links'] != user.profile?.links?.map((e) => e.url).join('\r\n');
       }
     }
@@ -391,6 +397,42 @@ class _EditProfileFormState extends ConsumerState<_EditProfileForm> {
             label: context.l10n.xRating('ECF'),
             initialValue: widget.user.profile?.ecfRating,
             formKey: 'ecfRating',
+            formData: widget.formData,
+            validator: (value) {
+              if (value != null && (value < 0 || value > 3000)) {
+                return 'Rating must be between 0 and 3000';
+              }
+              return null;
+            },
+          ),
+          _NumericField(
+            label: context.l10n.xRating('RCF'),
+            initialValue: widget.user.profile?.rcfRating,
+            formKey: 'rcfRating',
+            formData: widget.formData,
+            validator: (value) {
+              if (value != null && (value < 0 || value > 3000)) {
+                return 'Rating must be between 0 and 3000';
+              }
+              return null;
+            },
+          ),
+          _NumericField(
+            label: context.l10n.xRating('CFC'),
+            initialValue: widget.user.profile?.cfcRating,
+            formKey: 'cfcRating',
+            formData: widget.formData,
+            validator: (value) {
+              if (value != null && (value < 200 || value > 3000)) {
+                return 'Rating must be between 200 and 3000';
+              }
+              return null;
+            },
+          ),
+          _NumericField(
+            label: context.l10n.xRating('DSB'),
+            initialValue: widget.user.profile?.dsbRating,
+            formKey: 'dsbRating',
             formData: widget.formData,
             validator: (value) {
               if (value != null && (value < 0 || value > 3000)) {

--- a/lib/src/view/account/edit_profile_screen.dart
+++ b/lib/src/view/account/edit_profile_screen.dart
@@ -360,7 +360,7 @@ class _EditProfileFormState extends ConsumerState<_EditProfileForm> {
             initialValue: widget.user.profile?.realName,
             formKey: 'realName',
             formData: widget.formData,
-            maxLength: 20,
+            maxLength: 100,
           ),
 
           _NumericField(

--- a/lib/src/view/user/user_profile.dart
+++ b/lib/src/view/user/user_profile.dart
@@ -100,6 +100,21 @@ class UserProfileWidget extends ConsumerWidget {
                 padding: const EdgeInsets.only(bottom: 5),
                 child: Text('${context.l10n.xRating('ECF')}: ${user.profile!.ecfRating}'),
               ),
+            if (user.profile?.rcfRating != null)
+              Padding(
+                padding: const EdgeInsets.only(bottom: 5),
+                child: Text('${context.l10n.xRating('RCF')}: ${user.profile!.rcfRating}'),
+              ),
+            if (user.profile?.cfcRating != null)
+              Padding(
+                padding: const EdgeInsets.only(bottom: 5),
+                child: Text('${context.l10n.xRating('CFC')}: ${user.profile!.cfcRating}'),
+              ),
+            if (user.profile?.dsbRating != null)
+              Padding(
+                padding: const EdgeInsets.only(bottom: 5),
+                child: Text('${context.l10n.xRating('DSB')}: ${user.profile!.dsbRating}'),
+              ),
             if (user.profile != null)
               Padding(
                 padding: const EdgeInsets.only(bottom: 5),


### PR DESCRIPTION
Closes #1977

- Set the `maxLength` value for the real name field in the profile editor to be 100 characters. This is the same as the website for consistency.
- Add input fields for RCF, CFC, and DSB ratings, which are available through the website, but have not yet been added in the new app.
