### PR TITLE
Rewrite the broadcast pagination mechanism

### DIFF
--- a/lib/src/model/broadcast/broadcast_providers.dart
+++ b/lib/src/model/broadcast/broadcast_providers.dart
@@ -13,24 +13,19 @@ part 'broadcast_providers.g.dart';
 @riverpod
 class BroadcastsPaginator extends _$BroadcastsPaginator {
   @override
-  Future<BroadcastList> build() async {
-    final broadcastList = await ref.withClient(
-      (client) => BroadcastRepository(client).getBroadcasts(),
-    );
-
-    return broadcastList;
+  Future<BroadcastList> build() {
+    return ref.withClient((client) => BroadcastRepository(client).getBroadcasts());
   }
 
+  /// This function should be called only if there are more pages.
   Future<void> next() async {
     final broadcastList = state.requireValue;
     final nextPage = broadcastList.nextPage;
 
-    if (nextPage == null || nextPage > 20) return;
-
-    state = const AsyncLoading();
+    assert(nextPage != null && nextPage <= 20);
 
     final broadcastListNewPage = await ref.withClient(
-      (client) => BroadcastRepository(client).getBroadcasts(page: nextPage),
+      (client) => BroadcastRepository(client).getBroadcasts(page: nextPage!),
     );
 
     state = AsyncData((
@@ -45,25 +40,22 @@ class BroadcastsPaginator extends _$BroadcastsPaginator {
 @riverpod
 class BroadcastsSearchPaginator extends _$BroadcastsSearchPaginator {
   @override
-  Future<BroadcastSearchList> build(String searchTerm) async {
-    final broadcastSearchList = await ref.withClient(
+  Future<BroadcastSearchList> build(String searchTerm) {
+    return ref.withClient(
       (client) => BroadcastRepository(client).searchBroadcasts(searchTerm: searchTerm),
     );
-
-    return broadcastSearchList;
   }
 
+  /// This function should be called only if there are more pages.
   Future<void> next() async {
     final broadcastSearchList = state.requireValue;
     final nextPage = broadcastSearchList.nextPage;
 
-    if (nextPage == null || nextPage > 20) return;
-
-    state = const AsyncLoading();
+    assert(nextPage != null && nextPage <= 20);
 
     final broadcastSearchListNewPage = await ref.withClient(
       (client) =>
-          BroadcastRepository(client).searchBroadcasts(searchTerm: searchTerm, page: nextPage),
+          BroadcastRepository(client).searchBroadcasts(searchTerm: searchTerm, page: nextPage!),
     );
 
     state = AsyncData((

--- a/lib/src/view/broadcast/broadcast_list_screen.dart
+++ b/lib/src/view/broadcast/broadcast_list_screen.dart
@@ -2,7 +2,6 @@ import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:lichess_mobile/l10n/l10n.dart';
 import 'package:lichess_mobile/src/model/broadcast/broadcast_providers.dart';
-import 'package:lichess_mobile/src/styles/styles.dart';
 import 'package:lichess_mobile/src/utils/l10n_context.dart';
 import 'package:lichess_mobile/src/utils/navigation.dart';
 import 'package:lichess_mobile/src/view/broadcast/broadcast_list_tile.dart';
@@ -12,7 +11,6 @@ import 'package:lichess_mobile/src/widgets/buttons.dart';
 import 'package:lichess_mobile/src/widgets/filter.dart';
 import 'package:lichess_mobile/src/widgets/list.dart';
 import 'package:lichess_mobile/src/widgets/misc.dart';
-import 'package:lichess_mobile/src/widgets/shimmer.dart';
 
 enum _BroadcastFilter {
   all,
@@ -96,117 +94,68 @@ class _BroadcastListScreenState extends State<BroadcastListScreen> {
   }
 }
 
-class _Body extends ConsumerStatefulWidget {
+class _Body extends ConsumerWidget {
   const _Body(this.filter);
 
   final _BroadcastFilter filter;
 
   @override
-  ConsumerState<ConsumerStatefulWidget> createState() => _BodyState();
-}
-
-class _BodyState extends ConsumerState<_Body> {
-  final ScrollController _scrollController = ScrollController();
-  final GlobalKey<RefreshIndicatorState> _refreshIndicatorKey = GlobalKey<RefreshIndicatorState>();
-
-  @override
-  void initState() {
-    super.initState();
-    _scrollController.addListener(_scrollListener);
-  }
-
-  @override
-  void dispose() {
-    _scrollController.removeListener(_scrollListener);
-    _scrollController.dispose();
-    super.dispose();
-  }
-
-  void _scrollListener() {
-    if (widget.filter == _BroadcastFilter.all &&
-        _scrollController.position.pixels >= _scrollController.position.maxScrollExtent - 300) {
-      final broadcastList = ref.read(broadcastsPaginatorProvider);
-
-      if (!broadcastList.isLoading) {
-        ref.read(broadcastsPaginatorProvider.notifier).next();
-      }
-    }
-  }
-
-  @override
-  Widget build(BuildContext context) {
+  Widget build(BuildContext context, WidgetRef ref) {
     final broadcastList = ref.watch(broadcastsPaginatorProvider);
 
-    if (!broadcastList.hasValue && broadcastList.isLoading) {
-      return const Center(child: CircularProgressIndicator.adaptive());
-    }
-
-    final sections = [
-      (
-        'ongoing',
-        context.l10n.broadcastOngoing,
-        broadcastList.requireValue.active
-            .where((b) => b.isLive || widget.filter != _BroadcastFilter.live)
-            .toList(),
-      ),
-      (
-        'past',
-        context.l10n.broadcastPastBroadcasts,
-        broadcastList.requireValue.past
-            .where((b) => widget.filter == _BroadcastFilter.all)
-            .toList(),
-      ),
-    ];
-
     return RefreshIndicator.adaptive(
-      key: _refreshIndicatorKey,
-      onRefresh: () async => ref.refresh(broadcastsPaginatorProvider),
-      child: CustomScrollView(
-        controller: _scrollController,
-        slivers: [
-          for (final section in sections)
-            SliverMainAxisGroup(
-              key: ValueKey(section.$1),
-              slivers: [
-                if (section.$3.isNotEmpty)
-                  SliverAppBar(
-                    centerTitle: false,
-                    backgroundColor: ColorScheme.of(
-                      context,
-                    ).surfaceContainerHigh.withValues(alpha: 1),
-                    automaticallyImplyLeading: false,
-                    primary: false,
-                    title: AppBarTitleText(section.$2),
-                    pinned: true,
-                  ),
-                SliverPadding(
-                  padding: Styles.sectionBottomPadding,
-                  sliver: SliverList.separated(
-                    separatorBuilder: (context, index) => PlatformDivider(
-                      height: 1,
-                      indent: BroadcastListTile.thumbnailSize(context) + 16.0 + 10.0,
-                    ),
-                    itemCount: section.$3.length,
-                    itemBuilder: (context, index) =>
-                        (section.$1 == 'past' &&
-                            broadcastList.isLoading &&
-                            index >= section.$3.length - 1)
-                        ? const Shimmer(
-                            child: ShimmerLoading(
-                              isLoading: true,
-                              child: BroadcastListTile.loading(),
-                            ),
-                          )
-                        : BroadcastListTile(broadcast: section.$3[index]),
-                  ),
-                ),
-              ],
+      onRefresh: () => ref.refresh(broadcastsPaginatorProvider.future),
+      child: broadcastList.when(
+        data: (value) {
+          final sections = [
+            (
+              'ongoing',
+              context.l10n.broadcastOngoing,
+              switch (filter) {
+                _BroadcastFilter.all => value.active,
+                _BroadcastFilter.live => value.active.where((b) => b.isLive),
+              }.toList(growable: false),
             ),
-          const SliverSafeArea(
-            top: false,
-            sliver: SliverToBoxAdapter(child: SizedBox(height: 16.0)),
-          ),
-        ],
+            if (filter == _BroadcastFilter.all)
+              ('past', context.l10n.broadcastPastBroadcasts, value.past.toList(growable: false)),
+          ];
+          final hasMorePages = value.nextPage != null && value.nextPage! <= 20;
+          final notifier = ref.read(broadcastsPaginatorProvider.notifier);
+
+          return CustomScrollView(
+            slivers: [
+              for (final section in sections)
+                SliverMainAxisGroup(
+                  key: ValueKey(section.$1),
+                  slivers: [
+                    if (section.$3.isNotEmpty)
+                      SliverAppBar(
+                        backgroundColor: Theme.of(
+                          context,
+                        ).appBarTheme.backgroundColor?.withValues(alpha: 1),
+                        automaticallyImplyLeading: false,
+                        primary: false,
+                        title: AppBarTitleText(section.$2),
+                        pinned: true,
+                      ),
+                    SliverList.separated(
+                      separatorBuilder: (context, index) => PlatformDivider(
+                        height: 1,
+                        indent: BroadcastListTile.thumbnailSize(context) + 16.0 + 10.0,
+                      ),
+                      itemCount: section.$3.length + (section.$1 == 'past' && hasMorePages ? 1 : 0),
+                      itemBuilder: (context, index) =>
+                          (section.$1 == 'past' && hasMorePages && index == section.$3.length)
+                          ? BroadcastNextPageTile(notifier.next)
+                          : BroadcastListTile(broadcast: section.$3[index]),
+                    ),
+                  ],
+                ),
+            ],
+          );
+        },
+        error: (_, _) => const Center(child: Text('Cannot load broadcasts')),
+        loading: () => const Center(child: CircularProgressIndicator.adaptive()),
       ),
     );
   }

--- a/lib/src/view/broadcast/broadcast_list_tile.dart
+++ b/lib/src/view/broadcast/broadcast_list_tile.dart
@@ -1,3 +1,4 @@
+import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 import 'package:lichess_mobile/src/model/broadcast/broadcast.dart';
 import 'package:lichess_mobile/src/model/common/id.dart';
@@ -7,6 +8,7 @@ import 'package:lichess_mobile/src/utils/l10n.dart';
 import 'package:lichess_mobile/src/utils/l10n_context.dart';
 import 'package:lichess_mobile/src/utils/screen.dart';
 import 'package:lichess_mobile/src/view/broadcast/broadcast_round_screen.dart';
+import 'package:lichess_mobile/src/widgets/shimmer.dart';
 
 const _kDefaultBroadcastImage = AssetImage('assets/images/broadcast_image.png');
 const _kHandsetThumbnailSize = 80.0;
@@ -207,6 +209,49 @@ class BroadcastListTile extends StatelessWidget {
           ],
         ),
       ),
+    );
+  }
+}
+
+class BroadcastNextPageTile extends StatefulWidget {
+  const BroadcastNextPageTile(this.nextPageFunction);
+
+  final Future<void> Function() nextPageFunction;
+
+  @override
+  State<BroadcastNextPageTile> createState() => _BroadcastNextPageTileState();
+}
+
+class _BroadcastNextPageTileState extends State<BroadcastNextPageTile> {
+  late Future<void> nextPageFuture;
+
+  @override
+  void initState() {
+    super.initState();
+    nextPageFuture = widget.nextPageFunction();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return FutureBuilder(
+      future: null,
+      builder: (context, snapshot) {
+        if (snapshot.hasError) {
+          if (kDebugMode) {
+            debugPrint(
+              'SEVERE: [BroadcastNextPageTile] could not load next page; ${snapshot.error}',
+            );
+          }
+          return const Padding(
+            padding: Styles.verticalBodyPadding,
+            child: Center(child: Text('Could not load the next broadcasts')),
+          );
+        }
+
+        return const Shimmer(
+          child: ShimmerLoading(isLoading: true, child: BroadcastListTile.loading()),
+        );
+      },
     );
   }
 }


### PR DESCRIPTION
Remove the need to use a `ScrollController` for the two broadcast screens that uses pagination.

I think this is more in line with Riverpod. See this Riverpod example https://github.com/rrousselGit/riverpod/tree/master/examples/pub.