### PR TITLE
Make notation clickable in Lichess TV

### DIFF
--- a/lib/src/model/tv/tv_controller.dart
+++ b/lib/src/model/tv/tv_controller.dart
@@ -151,6 +151,15 @@ class TvController extends _$TvController {
     }
   }
 
+  void goToMove(int index) {
+    if (state.hasValue) {
+      final curState = state.requireValue;
+      if (index >= 0 && index < curState.game.steps.length) {
+        state = AsyncValue.data(curState.copyWith(stepCursor: index));
+      }
+    }
+  }
+
   void _playReplayMoveSound(String san) {
     final soundService = ref.read(soundServiceProvider);
     if (san.contains('x')) {

--- a/lib/src/view/watch/tv_screen.dart
+++ b/lib/src/view/watch/tv_screen.dart
@@ -150,6 +150,9 @@ class _TvScreenState extends ConsumerState<TvScreen> {
                           : blackPlayerWidget,
                       moves: game.steps.skip(1).map((e) => e.sanMove!.san).toList(growable: false),
                       currentMoveIndex: gameState.stepCursor,
+                      onSelectMove: (index) {
+                        ref.read(_tvGameCtrl.notifier).goToMove(index);
+                      },
                       lastMove: game.moveAt(gameState.stepCursor),
                     );
                   },


### PR DESCRIPTION
Allows to click the notation on top of the Lichess TV screen to quickly move through the game.