### PR TITLE
Fix Display of Material Difference in TV

### DIFF
--- a/lib/src/view/watch/tv_screen.dart
+++ b/lib/src/view/watch/tv_screen.dart
@@ -113,7 +113,7 @@ class _TvScreenState extends ConsumerState<TvScreen> {
                               },
                             )
                           : null,
-                      materialDiff: game.lastMaterialDiffAt(Side.black),
+                      materialDiff: game.materialDiffAt(gameState.stepCursor, Side.black),
                     );
                     final whitePlayerWidget = GamePlayer(
                       game: game.copyWith(white: game.white.setOnGame(true)),
@@ -133,7 +133,7 @@ class _TvScreenState extends ConsumerState<TvScreen> {
                               },
                             )
                           : null,
-                      materialDiff: game.lastMaterialDiffAt(Side.white),
+                      materialDiff: game.materialDiffAt(gameState.stepCursor, Side.white),
                     );
 
                     return BoardTable(


### PR DESCRIPTION
fix #1941 Displays the Material Difference of the currently displayed position instead of the live position.