### PR TITLE
Fix rounding error

### DIFF
--- a/lib/src/widgets/rating.dart
+++ b/lib/src/widgets/rating.dart
@@ -20,7 +20,7 @@ class RatingWidget extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     return Text(
-      '${rating.round()}${provisional == true || deviation > kProvisionalDeviation ? '?' : ''}',
+      '${rating.floor()}${provisional == true || deviation > kProvisionalDeviation ? '?' : ''}',
       style: style,
     );
   }


### PR DESCRIPTION
closes #1928 Round downwards, to be consistent with the app itself and the website.