### PR TITLE
Add On Tap to UserFullNameWidget

### DIFF
--- a/lib/src/view/analysis/analysis_screen.dart
+++ b/lib/src/view/analysis/analysis_screen.dart
@@ -27,6 +27,7 @@ import 'package:lichess_mobile/src/view/engine/engine_lines.dart';
 import 'package:lichess_mobile/src/view/explorer/explorer_view.dart';
 import 'package:lichess_mobile/src/view/game/game_common_widgets.dart';
 import 'package:lichess_mobile/src/view/settings/toggle_sound_button.dart';
+import 'package:lichess_mobile/src/view/user/user_screen.dart';
 import 'package:lichess_mobile/src/widgets/adaptive_action_sheet.dart';
 import 'package:lichess_mobile/src/widgets/bottom_bar.dart';
 import 'package:lichess_mobile/src/widgets/buttons.dart';
@@ -344,6 +345,7 @@ class _PlayerWidget extends StatelessWidget {
               rating: player.rating,
               provisional: player.provisional,
               aiLevel: player.aiLevel,
+              onTap: () => Navigator.of(context).push(UserScreen.buildRoute(context, player.user!)),
             )
           else
             Text(player.fullName(context.l10n)),

--- a/lib/src/view/chat/chat_screen.dart
+++ b/lib/src/view/chat/chat_screen.dart
@@ -6,6 +6,7 @@ import 'package:lichess_mobile/src/model/chat/chat_controller.dart';
 import 'package:lichess_mobile/src/tab_scaffold.dart';
 import 'package:lichess_mobile/src/utils/l10n_context.dart';
 import 'package:lichess_mobile/src/utils/navigation.dart';
+import 'package:lichess_mobile/src/view/user/user_screen.dart';
 import 'package:lichess_mobile/src/widgets/bottom_bar.dart';
 import 'package:lichess_mobile/src/widgets/buttons.dart';
 import 'package:lichess_mobile/src/widgets/user_full_name.dart';
@@ -167,6 +168,8 @@ class _MessageBubble extends ConsumerWidget {
                     fontWeight: FontWeight.bold,
                     color: _textColor(context, brightness),
                   ),
+                  onTap: () =>
+                      Navigator.of(context).push(UserScreen.buildRoute(context, message.user!)),
                 ),
               Text(message.message, style: TextStyle(color: _textColor(context, brightness))),
             ],

--- a/lib/src/view/message/conversation_screen.dart
+++ b/lib/src/view/message/conversation_screen.dart
@@ -6,6 +6,7 @@ import 'package:lichess_mobile/src/model/message/message.dart';
 import 'package:lichess_mobile/src/model/user/user.dart';
 import 'package:lichess_mobile/src/utils/l10n_context.dart';
 import 'package:lichess_mobile/src/utils/navigation.dart';
+import 'package:lichess_mobile/src/view/user/user_screen.dart';
 import 'package:lichess_mobile/src/widgets/user_full_name.dart';
 
 sealed class DisplayItem {}
@@ -50,6 +51,9 @@ class ConversationScreen extends StatelessWidget {
           showFlair: true,
           showPatron: true,
           shouldShowOnline: true,
+          onTap: () {
+            Navigator.push(context, UserScreen.buildRoute(context, user));
+          },
         ),
       ),
       body: _Body(user: user),

--- a/lib/src/widgets/user_full_name.dart
+++ b/lib/src/widgets/user_full_name.dart
@@ -20,6 +20,7 @@ class UserFullNameWidget extends ConsumerWidget {
     this.showFlair = true,
     this.showPatron = true,
     this.style,
+    this.onTap,
     super.key,
   });
 
@@ -32,6 +33,7 @@ class UserFullNameWidget extends ConsumerWidget {
     this.showFlair = true,
     this.showPatron = true,
     this.style,
+    this.onTap,
     super.key,
   });
 
@@ -54,6 +56,9 @@ class UserFullNameWidget extends ConsumerWidget {
   /// If the user is a patron, show the patron icon in front of their name. Defaults to `true`.
   final bool showPatron;
 
+  /// Callback when the user taps on the name.
+  final VoidCallback? onTap;
+
   @override
   Widget build(BuildContext context, WidgetRef ref) {
     final provisionalStr = provisional == true ? '?' : '';
@@ -72,7 +77,7 @@ class UserFullNameWidget extends ConsumerWidget {
 
     final contextTextStyle = style ?? DefaultTextStyle.of(context).style;
 
-    return Row(
+    final content = Row(
       mainAxisSize: MainAxisSize.min,
       children: [
         if (user != null && shouldShowOnline == true)
@@ -131,5 +136,9 @@ class UserFullNameWidget extends ConsumerWidget {
         ],
       ],
     );
+    if (onTap != null) {
+      return GestureDetector(onTap: onTap, child: content);
+    }
+    return content;
   }
 }


### PR DESCRIPTION
Added a parameter onTap to the UserFullNameWidget. The following now all direct to the profile screen
- Analysis Screen: Player names in game analysis
- Tournament Chat Screen: Usernames above chat messages
- Conversation Screen: User in the app bar

closes #2020 and partly #1705 