### PR TITLE
make promotion dialog dissapear if pressed back

### DIFF
--- a/lib/src/model/game/game_controller.dart
+++ b/lib/src/model/game/game_controller.dart
@@ -273,7 +273,11 @@ class GameController extends _$GameController {
       final curState = state.requireValue;
       if (curState.stepCursor < curState.game.steps.length - 1) {
         state = AsyncValue.data(
-          curState.copyWith(stepCursor: curState.stepCursor + 1, premove: null),
+          curState.copyWith(
+            stepCursor: curState.stepCursor + 1,
+            premove: null,
+            promotionMove: null,
+          ),
         );
         final san = curState.game.stepAt(curState.stepCursor + 1).sanMove?.san;
         if (san != null) {
@@ -292,6 +296,7 @@ class GameController extends _$GameController {
           newState.copyWith(
             stepCursor: didCancel ? newState.stepCursor : newState.stepCursor - 1,
             premove: null,
+            promotionMove: null,
           ),
         );
         final san = state.requireValue.game.stepAt(state.requireValue.stepCursor).sanMove?.san;

--- a/lib/src/model/over_the_board/over_the_board_game_controller.dart
+++ b/lib/src/model/over_the_board/over_the_board_game_controller.dart
@@ -107,13 +107,13 @@ class OverTheBoardGameController extends _$OverTheBoardGameController {
 
   void goForward() {
     if (state.canGoForward) {
-      state = state.copyWith(stepCursor: state.stepCursor + 1);
+      state = state.copyWith(stepCursor: state.stepCursor + 1, promotionMove: null);
     }
   }
 
   void goBack() {
     if (state.canGoBack) {
-      state = state.copyWith(stepCursor: state.stepCursor - 1);
+      state = state.copyWith(stepCursor: state.stepCursor - 1, promotionMove: null);
     }
   }
 

--- a/lib/src/view/correspondence/offline_correspondence_game_screen.dart
+++ b/lib/src/view/correspondence/offline_correspondence_game_screen.dart
@@ -303,6 +303,7 @@ class _BodyState extends ConsumerState<_Body> {
     if (stepCursor > 0) {
       setState(() {
         stepCursor = stepCursor - 1;
+        promotionMove = null;
       });
       _playReplayMoveSound();
     }
@@ -312,6 +313,7 @@ class _BodyState extends ConsumerState<_Body> {
     if (stepCursor < game.steps.length - 1) {
       setState(() {
         stepCursor = stepCursor + 1;
+        promotionMove = null;
       });
       _playReplayMoveSound();
     }


### PR DESCRIPTION
While testing https://github.com/lichess-org/flutter-chessground/pull/79 I noticed that the promotion dialog doesn't disappear when pressing back in the GameScreen, OTB Game Screen, and Offline Correspondence Screen. This can lead to strange behavior see the video below:

[strange-behavior-promotion.webm](https://github.com/user-attachments/assets/e4820c69-6927-47b2-bdc7-b86d059ef172)

This PR fixes the issue in all the affected screens I could find. In the analysis screens this is already handled correctly by the `_setPath` function.
