### PR TITLE
Add Team View to Broadcasts

### DIFF
--- a/lib/src/model/broadcast/broadcast.dart
+++ b/lib/src/model/broadcast/broadcast.dart
@@ -93,6 +93,7 @@ sealed class BroadcastTournamentData with _$BroadcastTournamentData {
     required String? description,
     // PRIVATE=-1, NORMAL=3, HIGH=4, BEST=5
     int? tier,
+    bool? teamTable,
     required BroadcastTournamentInformation information,
   }) = _BroadcastTournamentData;
 }
@@ -214,3 +215,23 @@ sealed class BroadcastPlayerGameResult with _$BroadcastPlayerGameResult {
 }
 
 enum RoundStatus { live, finished, upcoming }
+
+@freezed
+sealed class BroadcastTeam with _$BroadcastTeam {
+  const factory BroadcastTeam({required String name, required double points}) = _BroadcastTeam;
+}
+
+@freezed
+sealed class BroadcastTeamGame with _$BroadcastTeamGame {
+  const factory BroadcastTeamGame({required BroadcastGameId id, required Side pov}) =
+      _BroadcastTeamGame;
+}
+
+@freezed
+sealed class BroadcastTeamMatch with _$BroadcastTeamMatch {
+  const factory BroadcastTeamMatch({
+    required BroadcastTeam team1,
+    required BroadcastTeam team2,
+    required IList<BroadcastTeamGame> games,
+  }) = _BroadcastTeamMatch;
+}

--- a/lib/src/model/broadcast/broadcast_providers.dart
+++ b/lib/src/model/broadcast/broadcast_providers.dart
@@ -91,6 +91,11 @@ Future<BroadcastPlayerWithGameResults> broadcastPlayer(
   return ref.read(broadcastRepositoryProvider).getPlayerResults(broadcastTournamentId, playerId);
 }
 
+@riverpod
+Future<IList<BroadcastTeamMatch>> broadcastTeamMatches(Ref ref, BroadcastRoundId roundId) {
+  return ref.read(broadcastRepositoryProvider).getTeamMatches(roundId);
+}
+
 @Riverpod(keepAlive: true)
 BroadcastImageWorkerFactory broadcastImageWorkerFactory(Ref ref) {
   return const BroadcastImageWorkerFactory();

--- a/lib/src/view/broadcast/broadcast_teams_tab.dart
+++ b/lib/src/view/broadcast/broadcast_teams_tab.dart
@@ -1,0 +1,360 @@
+import 'package:dartchess/dartchess.dart';
+import 'package:fast_immutable_collections/fast_immutable_collections.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:lichess_mobile/src/model/broadcast/broadcast.dart';
+import 'package:lichess_mobile/src/model/broadcast/broadcast_preferences.dart';
+import 'package:lichess_mobile/src/model/broadcast/broadcast_providers.dart';
+import 'package:lichess_mobile/src/model/broadcast/broadcast_round_controller.dart';
+import 'package:lichess_mobile/src/model/common/eval.dart';
+import 'package:lichess_mobile/src/model/common/id.dart';
+import 'package:lichess_mobile/src/styles/styles.dart';
+import 'package:lichess_mobile/src/theme.dart';
+import 'package:lichess_mobile/src/utils/screen.dart';
+import 'package:lichess_mobile/src/view/broadcast/broadcast_game_screen.dart';
+import 'package:lichess_mobile/src/view/broadcast/broadcast_player_widget.dart';
+import 'package:lichess_mobile/src/view/engine/engine_gauge.dart';
+import 'package:visibility_detector/visibility_detector.dart';
+
+const _kScoreContainerWidth = 75.0;
+const _kTeamNameMaxLines = 3;
+
+const _kGameRowPadding = EdgeInsets.symmetric(vertical: 4.0, horizontal: 16);
+const _kTabletSpacing = 20.0;
+const _kPhoneSpacing = 8.0;
+
+const _kEvalBarWidth = 32.0;
+const _kEvalBarHeight = 14.0;
+const _kEvalBarDividerWidth = _kEvalBarWidth / 50;
+
+class BroadcastTeamsTab extends ConsumerWidget {
+  const BroadcastTeamsTab({
+    required this.roundId,
+    required this.tournamentId,
+    required this.tournamentSlug,
+  });
+
+  final BroadcastRoundId roundId;
+  final BroadcastTournamentId tournamentId;
+  final String tournamentSlug;
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final teams = ref.watch(broadcastTeamMatchesProvider(roundId));
+
+    return switch (teams) {
+      AsyncData(value: final teams) => BroadcastTeamsList(
+        teams,
+        roundId,
+        tournamentId,
+        tournamentSlug,
+      ),
+      AsyncError(:final error) => Center(child: Text('Cannot load teams data: $error')),
+      _ => const Center(child: CircularProgressIndicator.adaptive()),
+    };
+  }
+}
+
+class BroadcastTeamsList extends ConsumerWidget {
+  const BroadcastTeamsList(this.teamMatches, this.roundId, this.tournamentId, this.tournamentSlug);
+
+  final IList<BroadcastTeamMatch> teamMatches;
+  final BroadcastRoundId roundId;
+  final BroadcastTournamentId tournamentId;
+  final String tournamentSlug;
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final round = ref.watch(broadcastRoundControllerProvider(roundId));
+    final showEvaluationBar = ref.watch(
+      broadcastPreferencesProvider.select((value) => value.showEvaluationBar),
+    );
+
+    return switch (round) {
+      AsyncData(:final value) => ListView.builder(
+        itemCount: teamMatches.length,
+        itemBuilder: (context, index) {
+          final match = teamMatches[index];
+          return _TeamMatchCard(
+            match: match,
+            games: value.games,
+            tournamentId: tournamentId,
+            roundId: roundId,
+            tournamentSlug: tournamentSlug,
+            roundSlug: value.round.slug,
+            title: value.round.name,
+            showEvaluationBar: showEvaluationBar,
+          );
+        },
+      ),
+      AsyncError(:final error) => Center(child: Text('Cannot load games data: $error')),
+      _ => const Center(child: CircularProgressIndicator.adaptive()),
+    };
+  }
+}
+
+class _TeamMatchCard extends StatelessWidget {
+  const _TeamMatchCard({
+    required this.match,
+    required this.games,
+    required this.tournamentId,
+    required this.roundId,
+    required this.tournamentSlug,
+    required this.roundSlug,
+    required this.title,
+    required this.showEvaluationBar,
+  });
+
+  final BroadcastTeamMatch match;
+  final BroadcastRoundGames games;
+  final BroadcastTournamentId tournamentId;
+  final BroadcastRoundId roundId;
+  final String tournamentSlug;
+  final String roundSlug;
+  final String title;
+  final bool showEvaluationBar;
+
+  @override
+  Widget build(BuildContext context) {
+    return Card(
+      shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(16.0)),
+      elevation: 2,
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          ColoredBox(
+            color: ColorScheme.of(context).surfaceDim,
+            child: Padding(
+              padding: const EdgeInsets.symmetric(vertical: 12.0, horizontal: 16.0),
+              child: Row(
+                children: [
+                  Expanded(
+                    child: Text(
+                      match.team1.name,
+                      maxLines: _kTeamNameMaxLines,
+                      textAlign: TextAlign.center,
+                      style: const TextStyle(fontWeight: FontWeight.bold),
+                    ),
+                  ),
+                  Container(
+                    width: _kScoreContainerWidth,
+                    alignment: Alignment.center,
+                    child: Text(
+                      '${match.team1.points % 1 == 0 ? match.team1.points.toInt() : match.team1.points} - ${match.team2.points % 1 == 0 ? match.team2.points.toInt() : match.team2.points}',
+                      style: const TextStyle(fontWeight: FontWeight.bold),
+                    ),
+                  ),
+                  Expanded(
+                    child: Text(
+                      match.team2.name,
+                      maxLines: _kTeamNameMaxLines,
+                      textAlign: TextAlign.center,
+                      style: const TextStyle(fontWeight: FontWeight.bold),
+                    ),
+                  ),
+                ],
+              ),
+            ),
+          ),
+
+          ...match.games.asMap().entries.map((entry) {
+            final gameIndex = entry.key;
+            final teamGame = entry.value;
+            final game = games[teamGame.id];
+            if (game == null) return const SizedBox.shrink();
+
+            return _GameRow(
+              game: game,
+              teamGame: teamGame,
+              index: gameIndex,
+              tournamentId: tournamentId,
+              roundId: roundId,
+              tournamentSlug: tournamentSlug,
+              roundSlug: roundSlug,
+              title: title,
+              showEvaluationBar: showEvaluationBar,
+            );
+          }),
+        ],
+      ),
+    );
+  }
+}
+
+class _GameRow extends ConsumerStatefulWidget {
+  const _GameRow({
+    required this.game,
+    required this.teamGame,
+    required this.index,
+    required this.tournamentId,
+    required this.roundId,
+    required this.tournamentSlug,
+    required this.roundSlug,
+    required this.title,
+    required this.showEvaluationBar,
+  });
+
+  final BroadcastGame game;
+  final BroadcastTeamGame teamGame;
+  final int index;
+  final BroadcastTournamentId tournamentId;
+  final BroadcastRoundId roundId;
+  final String tournamentSlug;
+  final String roundSlug;
+  final String title;
+  final bool showEvaluationBar;
+  @override
+  ConsumerState<_GameRow> createState() => _GameRowState();
+}
+
+class _GameRowState extends ConsumerState<_GameRow> {
+  bool isGameVisible = false;
+
+  @override
+  Widget build(BuildContext context) {
+    final whitePlayer = widget.game.players[Side.white];
+    final blackPlayer = widget.game.players[Side.black];
+    final isTablet = isTabletOrLarger(context);
+
+    if (whitePlayer == null || blackPlayer == null) {
+      return const SizedBox.shrink();
+    }
+
+    final team1Player = widget.teamGame.pov == Side.white ? whitePlayer : blackPlayer;
+    final team2Player = widget.teamGame.pov == Side.white ? blackPlayer : whitePlayer;
+
+    final resultString = _getGameResult(widget.game, widget.teamGame.pov);
+
+    final whiteWinningChances =
+        widget.game.isOngoing && (widget.game.cp != null || widget.game.mate != null)
+        ? ExternalEval(cp: widget.game.cp, mate: widget.game.mate).winningChances(Side.white)
+        : null;
+
+    return VisibilityDetector(
+      key: Key('${widget.game.id}'),
+      onVisibilityChanged: (visibilityInfo) {
+        if (visibilityInfo.visibleFraction > 0.1) {
+          if (!isGameVisible && context.mounted) {
+            ref
+                .read(broadcastRoundControllerProvider(widget.roundId).notifier)
+                .addObservedGame(widget.game.id);
+            setState(() {
+              isGameVisible = true;
+            });
+          }
+        } else {
+          if (isGameVisible && context.mounted) {
+            ref
+                .read(broadcastRoundControllerProvider(widget.roundId).notifier)
+                .removeObservedGame(widget.game.id);
+            setState(() {
+              isGameVisible = false;
+            });
+          }
+        }
+      },
+      child: InkWell(
+        onTap: () {
+          Navigator.of(context).push(
+            BroadcastGameScreen.buildRoute(
+              context,
+              tournamentId: widget.tournamentId,
+              roundId: widget.roundId,
+              gameId: widget.game.id,
+              tournamentSlug: widget.tournamentSlug,
+              roundSlug: widget.roundSlug,
+              title: widget.title,
+            ),
+          );
+        },
+        child: ColoredBox(
+          color: widget.index.isEven ? context.lichessTheme.rowEven : context.lichessTheme.rowOdd,
+          child: Padding(
+            padding: _kGameRowPadding,
+            child: Row(
+              children: [
+                Expanded(
+                  child: BroadcastPlayerWidget(player: team1Player.player, showRating: isTablet),
+                ),
+                SizedBox(width: isTablet ? _kTabletSpacing : _kPhoneSpacing),
+                SizedBox(
+                  width: _kEvalBarWidth,
+                  child: widget.game.isOngoing && widget.showEvaluationBar
+                      ? whiteWinningChances != null
+                            ? _MiniEvalBar(
+                                whiteWinningChances: whiteWinningChances,
+                                pov: widget.teamGame.pov,
+                              )
+                            : Container(
+                                height: _kEvalBarHeight,
+                                width: _kEvalBarWidth,
+                                decoration: BoxDecoration(
+                                  borderRadius: BorderRadius.circular(_kEvalBarHeight / 2),
+                                  color: Colors.grey.withValues(alpha: 0.6),
+                                ),
+                              )
+                      : Container(alignment: Alignment.center, child: Text(resultString)),
+                ),
+                SizedBox(width: isTablet ? _kTabletSpacing : _kPhoneSpacing),
+                Expanded(
+                  child: BroadcastPlayerWidget(player: team2Player.player, showRating: isTablet),
+                ),
+              ],
+            ),
+          ),
+        ),
+      ),
+    );
+  }
+
+  String _getGameResult(BroadcastGame game, Side teamPov) {
+    if (!game.isOver) {
+      return '*';
+    }
+
+    final team1Result = game.status.resultToString(teamPov);
+    final team2Result = game.status.resultToString(teamPov.opposite);
+    return '$team1Result-$team2Result';
+  }
+}
+
+class _MiniEvalBar extends StatelessWidget {
+  const _MiniEvalBar({required this.whiteWinningChances, required this.pov});
+
+  final double whiteWinningChances;
+  final Side pov;
+
+  @override
+  Widget build(BuildContext context) {
+    final whiteBarWidth = _kEvalBarWidth * (whiteWinningChances + 1) / 2;
+
+    return Stack(
+      alignment: Alignment.center,
+      children: [
+        ClipRRect(
+          borderRadius: BorderRadius.circular(_kEvalBarHeight / 2),
+          child: Row(
+            children: [
+              Container(
+                width: pov == Side.white ? whiteBarWidth : _kEvalBarWidth - whiteBarWidth,
+                height: _kEvalBarHeight,
+                color: pov == Side.white
+                    ? EngineGauge.valueColor(context)
+                    : EngineGauge.backgroundColor(context),
+              ),
+              Container(
+                width: pov == Side.white ? _kEvalBarWidth - whiteBarWidth : whiteBarWidth,
+                height: _kEvalBarHeight,
+                color: pov == Side.white
+                    ? EngineGauge.backgroundColor(context)
+                    : EngineGauge.valueColor(context),
+              ),
+            ],
+          ),
+        ),
+
+        Container(width: _kEvalBarDividerWidth, height: _kEvalBarHeight, color: darken(Colors.red)),
+      ],
+    );
+  }
+}

--- a/test/view/broadcast/broadcast_round_screen_test.dart
+++ b/test/view/broadcast/broadcast_round_screen_test.dart
@@ -15,7 +15,9 @@ import '../../test_provider_scope.dart';
 
 void main() {
   group('Broadcast round screen', () {
-    testWidgets('Check that all tabs are present', variant: kPlatformVariant, (tester) async {
+    testWidgets('Check that all tabs except the teams tab are present', variant: kPlatformVariant, (
+      tester,
+    ) async {
       final app = await makeTestProviderScopeApp(
         tester,
         home: BroadcastRoundScreen(broadcast: _finishedBroadcast),
@@ -39,6 +41,7 @@ void main() {
       expect(find.text('Overview'), findsOneWidget);
       expect(find.text('Boards'), findsOneWidget);
       expect(find.text('Players'), findsOneWidget);
+      expect(find.text('Teams'), findsNothing);
     });
 
     testWidgets('Check that the screen can be loaded from round id', variant: kPlatformVariant, (
@@ -72,6 +75,7 @@ void main() {
       expect(find.text('Overview'), findsOneWidget);
       expect(find.text('Boards'), findsOneWidget);
       expect(find.text('Players'), findsOneWidget);
+      expect(find.text('Teams'), findsNothing);
     });
   });
 
@@ -407,6 +411,65 @@ void main() {
 
       expect(playersListReversed[0].playerWithOverallResult.player.name, 'Nepomniachtchi, Ian');
       expect(playersListReversed[1].playerWithOverallResult.player.name, 'Carlsen, Magnus');
+    });
+  });
+  group('Test teams tab', () {
+    testWidgets('Check that teams tab is present when teamTable is true', (tester) async {
+      final app = await makeTestProviderScopeApp(
+        tester,
+        home: BroadcastRoundScreen(broadcast: _liveTeamBroadcast),
+        overrides: [
+          lichessClientProvider.overrideWith((ref) => LichessClient(_liveTeamBroadcastClient, ref)),
+        ],
+      );
+
+      await tester.pumpWidget(app);
+
+      // Load the tournament
+      await tester.pump();
+
+      // Load the round
+      await tester.pump();
+
+      // Verify tabs
+      expect(find.text('Overview'), findsOneWidget);
+      expect(find.text('Boards'), findsOneWidget);
+      expect(find.text('Players'), findsOneWidget);
+      expect(find.text('Teams'), findsOneWidget);
+    });
+
+    testWidgets('Check teams tab content is displayed correctly', (tester) async {
+      final app = await makeTestProviderScopeApp(
+        tester,
+        home: BroadcastRoundScreen(
+          broadcast: _liveTeamBroadcast,
+          initialTab: BroadcastRoundTab.teams,
+        ),
+        overrides: [
+          lichessClientProvider.overrideWith((ref) => LichessClient(_liveTeamBroadcastClient, ref)),
+        ],
+      );
+
+      await tester.pumpWidget(app);
+
+      // Load the tournament
+      await tester.pump();
+
+      // Load the round
+      await tester.pump();
+
+      // Load the teams data
+      await tester.pump();
+
+      // Verify team names are displayed
+      expect(find.text('Team A'), findsOneWidget);
+      expect(find.text('Team B'), findsOneWidget);
+      expect(find.text('Team C'), findsOneWidget);
+      expect(find.text('Team D'), findsOneWidget);
+
+      expect(find.text('1 - 0'), findsOneWidget);
+
+      expect(find.byType(Card), findsNWidgets(2));
     });
   });
 }
@@ -1226,4 +1289,119 @@ const _livePlayersWithoutScoresResponse = '''
     "played": 4
   }
 ]
+''';
+
+final _liveTeamBroadcastClient = MockClient((request) {
+  if (request.url.path == '/api/broadcast/AAAAAAAA') {
+    return mockResponse(
+      _liveTeamTournamentResponse,
+      200,
+      headers: {'content-type': 'application/json; charset=utf-8'},
+    );
+  }
+  if (request.url.path == '/api/broadcast/-/-/00000000') {
+    return mockResponse(
+      _liveRoundResponse,
+      200,
+      headers: {'content-type': 'application/json; charset=utf-8'},
+    );
+  }
+  if (request.url.path == '/broadcast/AAAAAAAA/players') {
+    return mockResponse(
+      _livePlayersResponse,
+      200,
+      headers: {'content-type': 'application/json; charset=utf-8'},
+    );
+  }
+  if (request.url.path == '/broadcast/00000000/teams') {
+    return mockResponse(
+      _teamMatchesResponse,
+      200,
+      headers: {'content-type': 'application/json; charset=utf-8'},
+    );
+  }
+  return mockResponse('', 404);
+});
+
+const _liveTeamTournamentResponse = '''
+{
+  "tour": {
+    "id": "AAAAAAAA",
+    "name": "Test tournament",
+    "slug": "test-tournament",
+    "dates": [
+      1735671720000
+    ],
+    "image": "",
+    "teamTable": true
+  },
+  "rounds": [
+    {
+      "id": "00000000",
+      "name": "Test round",
+      "slug": "test-round",
+      "ongoing": "true"
+    }
+  ],
+  "defaultRoundId": "00000000"
+}
+''';
+
+final _liveTeamBroadcast = Broadcast(
+  tour: BroadcastTournamentData(
+    id: const BroadcastTournamentId('AAAAAAAA'),
+    name: 'Test tournament',
+    slug: 'test-tournament',
+    imageUrl: '',
+    description: null,
+    tier: null,
+    teamTable: true,
+    information: (
+      dates: (startsAt: DateTime.fromMillisecondsSinceEpoch(1735671720000), endsAt: null),
+      format: null,
+      location: null,
+      players: null,
+      website: null,
+      standings: null,
+      timeControl: null,
+    ),
+  ),
+  round: const BroadcastRound(
+    id: BroadcastRoundId('00000000'),
+    name: 'Test round',
+    slug: 'test-round',
+    status: RoundStatus.live,
+    startsAt: null,
+    finishedAt: null,
+    startsAfterPrevious: false,
+  ),
+  roundToLinkId: const BroadcastRoundId('00000000'),
+  group: null,
+);
+
+const _teamMatchesResponse = '''
+{
+  "table": [
+    {
+      "teams": [
+        {"name": "Team A", "points": 1},
+        {"name": "Team B", "points": 0}
+      ],
+      "games": [
+        {"id": "111111", "pov": "white"},
+        {"id": "222222", "pov": "black"}
+      ]
+    },
+    {
+      "teams": [
+        {"name": "Team C", "points": 0.5},
+        {"name": "Team D", "points": 1.5}
+      ],
+      "games": [
+        {"id": "3333333", "pov": "white"},
+        {"id": "4444444", "pov": "black"}
+      ]
+    }
+  ]
+}
 ''';


### PR DESCRIPTION
Add Team Tab to Team Tournaments
<details>
<summary>Screenshots</summary>

<img width="604" height="1291" alt="image" src="https://github.com/user-attachments/assets/eceaaabb-36b7-40b3-a233-a37d3b880f53" />


<img width="1909" height="1136" alt="Team Tab Screenshot 1" src="https://github.com/user-attachments/assets/9f9758ec-b4b2-41da-94b9-9b9c38413ac4" />

<img width="1186" height="1861" alt="Team Tab Screenshot 2" src="https://github.com/user-attachments/assets/f934d0d1-5cd3-41b9-b979-b3ee071be7ee" />

</details>

Remarks

- Uses the undocumented `broadcast/$roundId/teams` endpoint, as there is no official API available.
- No changes were made to the Analysis Board. (On the website, the team name is displayed next to the player name, but I think the space is very limited.)
- The layout looks slightly strange on landscape-oriented tables, with the long rows, but a two-column layout would likely look even stranger.
- Includes some basic tests.
