### PR TITLE
Add Player Details to the Tournament Screen

### DIFF
--- a/lib/src/model/game/game_status.dart
+++ b/lib/src/model/game/game_status.dart
@@ -54,6 +54,11 @@ extension GameExtension on Pick {
       if (gameStatus != null) {
         return gameStatus;
       }
+    } else if (value is int) {
+      return GameStatus.values.firstWhere(
+        (status) => status.value == value,
+        orElse: () => GameStatus.unknown,
+      );
     }
     throw PickException("value $value at $debugParsingExit can't be casted to GameStatus");
   }

--- a/lib/src/model/tournament/tournament.dart
+++ b/lib/src/model/tournament/tournament.dart
@@ -8,6 +8,7 @@ import 'package:lichess_mobile/src/model/common/chess.dart';
 import 'package:lichess_mobile/src/model/common/id.dart';
 import 'package:lichess_mobile/src/model/common/perf.dart';
 import 'package:lichess_mobile/src/model/common/time_increment.dart';
+import 'package:lichess_mobile/src/model/game/game_status.dart';
 import 'package:lichess_mobile/src/model/user/user.dart';
 import 'package:lichess_mobile/src/utils/json.dart';
 
@@ -441,4 +442,83 @@ extension TournamentExtension on Pick {
       return null;
     }
   }
+}
+
+typedef PlayerStats = ({int game, int berserk, int win});
+
+@freezed
+sealed class TournamentPlayer with _$TournamentPlayer {
+  const TournamentPlayer._();
+
+  factory TournamentPlayer({
+    required LightUser user,
+    required int rating,
+    required int score,
+    required bool fire,
+    required int? performance,
+    required int rank,
+    required PlayerStats stats,
+    required IList<TournamentPairing> pairings,
+  }) = _TournamentPlayer;
+  factory TournamentPlayer.fromServerJson(Map<String, Object?> json) =>
+      _tournamentPlayerFromPick(pick(json).required());
+}
+
+@freezed
+sealed class TournamentPairing with _$TournamentPairing {
+  const TournamentPairing._();
+
+  const factory TournamentPairing({
+    required GameId gameId,
+    required Side color,
+    required LightUser opponent,
+    required int opponentRating,
+    required bool? win,
+    required GameStatus? status,
+    required int? score,
+    required bool berserk,
+  }) = _TournamentPairing;
+}
+
+TournamentPlayer _tournamentPlayerFromPick(RequiredPick pick) {
+  final player = pick('player').required();
+  return TournamentPlayer(
+    user: LightUser(
+      id: UserId.fromUserName(player('id').asStringOrThrow()),
+      name: player('name').asStringOrThrow(),
+      title: player('title').asStringOrNull(),
+      flair: player('flair').asStringOrNull(),
+      isPatron: player('patron').asBoolOrNull(),
+    ),
+    rating: player('rating').asIntOrThrow(),
+    score: player('score').asIntOrThrow(),
+    fire: player('fire').asBoolOrFalse(),
+    stats: (
+      game: player('nb', 'game').asIntOrThrow(),
+      berserk: player('nb', 'berserk').asIntOrThrow(),
+      win: player('nb', 'win').asIntOrThrow(),
+    ),
+    performance: player('performance').asIntOrNull(),
+    rank: player('rank').asIntOrThrow(),
+    pairings: pick('pairings').asListOrThrow(_pairingFromPick).toIList(),
+  );
+}
+
+TournamentPairing _pairingFromPick(RequiredPick pick) {
+  return TournamentPairing(
+    gameId: pick('id').asGameIdOrThrow(),
+    color: pick('color').asSideOrThrow(),
+    opponent: LightUser(
+      id: UserId.fromUserName(pick('op', 'name').asStringOrThrow()),
+      name: pick('op', 'name').asStringOrThrow(),
+      title: pick('op', 'title').asStringOrNull(),
+      flair: pick('op', 'flair').asStringOrNull(),
+      isPatron: pick('op', 'patron').asBoolOrNull(),
+    ),
+    opponentRating: pick('op', 'rating').asIntOrThrow(),
+    win: pick('win').asBoolOrNull(),
+    status: pick('status').asGameStatusOrThrow(),
+    score: pick('score').asIntOrNull(),
+    berserk: pick('berserk').asBoolOrFalse(),
+  );
 }

--- a/lib/src/model/tournament/tournament_controller.dart
+++ b/lib/src/model/tournament/tournament_controller.dart
@@ -232,6 +232,9 @@ sealed class TournamentState with _$TournamentState {
   /// True if the user has joined the tournament and is not withdrawn.
   bool get joined => tournament.me != null && tournament.me!.withdraw != true;
 
+  bool get isSpectator =>
+      tournament.isFinished == true || tournament.me == null || tournament.me!.withdraw == true;
+
   ChatOptions? get chatOptions => tournament.chat != null
       ? TournamentChatOptions(id: tournament.id, writeable: tournament.chat!.writeable)
       : null;

--- a/lib/src/model/tournament/tournament_providers.dart
+++ b/lib/src/model/tournament/tournament_providers.dart
@@ -2,8 +2,10 @@ import 'dart:async';
 
 import 'package:fast_immutable_collections/fast_immutable_collections.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:lichess_mobile/src/model/common/id.dart';
 import 'package:lichess_mobile/src/model/tournament/tournament.dart';
 import 'package:lichess_mobile/src/model/tournament/tournament_repository.dart';
+import 'package:lichess_mobile/src/network/http.dart';
 import 'package:riverpod_annotation/riverpod_annotation.dart';
 
 part 'tournament_providers.g.dart';
@@ -16,4 +18,12 @@ Future<IList<LightTournament>> featuredTournaments(Ref ref) {
 @riverpod
 Future<TournamentLists> tournaments(Ref ref) {
   return ref.read(tournamentRepositoryProvider).getTournaments();
+}
+
+@riverpod
+Future<TournamentPlayer> tournamentPlayer(Ref ref, TournamentId tournamentId, UserId userId) {
+  return ref.withClientCacheFor(
+    (client) => ref.read(tournamentRepositoryProvider).getTournamentPlayer(tournamentId, userId),
+    const Duration(seconds: 10),
+  );
 }

--- a/lib/src/model/tournament/tournament_repository.dart
+++ b/lib/src/model/tournament/tournament_repository.dart
@@ -54,6 +54,14 @@ class TournamentRepository {
     );
   }
 
+  Future<TournamentPlayer> getTournamentPlayer(TournamentId tournamentId, UserId userId) {
+    return client.readJson(
+      Uri(path: '/tournament/$tournamentId/player/$userId'),
+      headers: {'Accept': 'application/json'},
+      mapper: (Map<String, dynamic> json) => TournamentPlayer.fromServerJson(json),
+    );
+  }
+
   Future<bool> downloadTournamentGames(TournamentId id, File file, {UserId? userId}) {
     final client = _ref.read(defaultClientProvider);
     return downloadFile(

--- a/lib/src/view/tournament/tournament_screen.dart
+++ b/lib/src/view/tournament/tournament_screen.dart
@@ -1168,18 +1168,11 @@ class _PairingTile extends ConsumerWidget {
   @override
   Widget build(BuildContext context, WidgetRef ref) {
     final tournamentState = ref.watch(tournamentControllerProvider(tournamentId));
-    final result = pairing.status == GameStatus.started
-        ? '*'
-        : pairing.status == GameStatus.draw
-        ? '½'
-        : pairing.win == true
-        ? '1'
-        : '0';
 
-    final resultColor = pairing.win == true
-        ? context.lichessColors.good
-        : pairing.win == false
-        ? context.lichessColors.error
+    final resultColor = pairing.score != null && pairing.score! >= 4
+        ? LichessColors.brag
+        : pairing.score != null && pairing.score! > 1
+        ? LichessColors.good
         : null;
 
     return ListTile(
@@ -1231,7 +1224,7 @@ class _PairingTile extends ConsumerWidget {
             height: 24,
             child: Center(
               child: Text(
-                result,
+                pairing.score?.toString() ?? '*',
                 style: TextStyle(fontWeight: FontWeight.bold, color: resultColor, fontSize: 15),
               ),
             ),

--- a/test/view/tournament/tournament_screen_test.dart
+++ b/test/view/tournament/tournament_screen_test.dart
@@ -577,4 +577,126 @@ void main() {
       expect(find.text('Steven'), findsOneWidget);
     });
   });
+  testWidgets('Shows player details when tapping on a player', (WidgetTester tester) async {
+    final mockClient = MockClient((request) {
+      if (request.url.path == '/api/tournament/82QbxlJb') {
+        return mockResponse(makeTournamentJson(standings: makeTestPlayers(10), nbPlayers: 11), 200);
+      }
+      if (request.url.path == '/tournament/82QbxlJb/player/player0') {
+        return mockResponse(testTournamentPlayerResponse, 200);
+      }
+      return mockResponse('', 404);
+    });
+
+    final app = await makeTestProviderScopeApp(
+      tester,
+      home: const TournamentScreen(id: TournamentId('82QbxlJb')),
+      overrides: [
+        lichessClientProvider.overrideWith((ref) {
+          return LichessClient(mockClient, ref);
+        }),
+      ],
+    );
+    await tester.pumpWidget(app);
+
+    // Wait for tournament data to load
+    await tester.pump();
+
+    // Find a player in the standings and tap on them
+    expect(find.text('player0'), findsOneWidget);
+    await tester.tap(find.text('player0'));
+    await tester.pump();
+
+    // Wait for the modal bottom sheet to appear
+    await tester.pumpAndSettle();
+
+    // Verify player details are shown
+    expect(find.text('#10'), findsOneWidget);
+    expect(find.text('TestPlayer'), findsOneWidget);
+    expect(find.text('2000'), findsOneWidget);
+
+    // Verify stats are shown
+    expect(find.text('Score'), findsOneWidget);
+    expect(find.text('5'), findsOneWidget);
+    expect(find.text('Performance'), findsOneWidget);
+    expect(find.text('2150'), findsOneWidget);
+    expect(find.text('Games played'), findsOneWidget);
+    expect(find.text('3'), findsOneWidget);
+    expect(find.text('Win rate'), findsOneWidget);
+    expect(find.text('67%'), findsOneWidget); // 2 wins out of 3 games
+    expect(find.text('Berserk rate'), findsOneWidget);
+    expect(find.text('33%'), findsOneWidget); // 1 berserk out of 3 games
+
+    // Verify pairings section
+    expect(find.text('Games'), findsOneWidget);
+    expect(find.text('Opponent1'), findsOneWidget);
+    expect(find.text('Opponent2'), findsOneWidget);
+    expect(find.text('Opponent3'), findsOneWidget);
+
+    // Verify average opponent rating
+    expect(find.text('Average opponent'), findsOneWidget);
+    expect(find.text('2200'), findsOneWidget); // (1800 + 2100 + 2700) / 3
+
+    // Test close button
+    await tester.tap(find.byIcon(Icons.close));
+    await tester.pumpAndSettle();
+
+    // Verify modal is closed
+    expect(find.text('TestPlayer'), findsNothing);
+  });
 }
+
+const testTournamentPlayerResponse = '''
+{
+  "player": {
+    "name": "TestPlayer",
+    "id": "testplayer",
+    "rating": 2000,
+    "score": 5,
+    "fire": true,
+    "nb": {
+      "game": 3,
+      "berserk": 1,
+      "win": 2
+    },
+    "performance": 2150,
+    "rank": 10
+  },
+  "pairings": [
+    {
+      "id": "3CRj4xh2",
+      "color": "white",
+      "op": {
+        "name": "Opponent1",
+        "rating": 1800
+      },
+      "win": true,
+      "status": 30,
+      "score": 3,
+      "berserk": true
+    },
+    {
+      "id": "ibw09iwJ",
+      "color": "black",
+      "op": {
+        "name": "Opponent2",
+        "rating": 2100
+      },
+      "win": true,
+      "status": 35,
+      "score": 2
+    },
+    {
+      "id": "ItAtgOBU",
+      "color": "black",
+      "op": {
+        "name": "Opponent3",
+        "rating": 2700
+      },
+      "win": false,
+      "status": 30,
+      "score": 0
+    }
+  ]
+}
+''';

--- a/test/view/tournament/tournament_screen_test.dart
+++ b/test/view/tournament/tournament_screen_test.dart
@@ -621,7 +621,7 @@ void main() {
     expect(find.text('Performance'), findsOneWidget);
     expect(find.text('2150'), findsOneWidget);
     expect(find.text('Games played'), findsOneWidget);
-    expect(find.text('3'), findsOneWidget);
+    expect(find.text('3'), findsAtLeast(1));
     expect(find.text('Win rate'), findsOneWidget);
     expect(find.text('67%'), findsOneWidget); // 2 wins out of 3 games
     expect(find.text('Berserk rate'), findsOneWidget);


### PR DESCRIPTION
Add Player Details tournament screen, closes #1707 
<details>
<summary>Screenshots</summary>

<img width="609" height="1319" alt="grafik" src="https://github.com/user-attachments/assets/13a36c54-9742-4c3f-a42d-7807c4af049b" />

<img width="1914" height="1186" alt="grafik" src="https://github.com/user-attachments/assets/f96549a6-572e-4c03-a6c2-c6a35b4d6f37" />

</details>

Considerations

- I choose a bottom sheet modal, to prevent the user from navigating away from the tournament screen, and making it intuitive that they are still joined in the tournament.
- Uses the undocumented `tournament/$tournament/player/$userId` endpoint, as there is no official API available.
- Navigating to the userprofiles and to the games is possible, except if the user checking the details is currently joined in the tournament to prevent them from navigating away from the tournament (Maybe we can also allow this, as on the website it is possible too. Not sure though if it will work flawlessly to get a new tournament pairing if the user is navigating away) If the player pauses the tournament they can investigate other games or players.
- Includes some basic tests.
