### PR TITLE
Fix game seek rating and localize numbers

### DIFF
--- a/lib/src/view/game/game_loading_board.dart
+++ b/lib/src/view/game/game_loading_board.dart
@@ -7,6 +7,8 @@ import 'package:lichess_mobile/src/model/challenge/challenge.dart';
 import 'package:lichess_mobile/src/model/lobby/game_seek.dart';
 import 'package:lichess_mobile/src/model/lobby/lobby_numbers.dart';
 import 'package:lichess_mobile/src/utils/l10n_context.dart';
+import 'package:lichess_mobile/src/utils/string.dart';
+import 'package:lichess_mobile/src/view/account/rating_pref_aware.dart';
 import 'package:lichess_mobile/src/widgets/board_table.dart';
 import 'package:lichess_mobile/src/widgets/bottom_bar.dart';
 import 'package:lichess_mobile/src/widgets/feedback.dart';
@@ -63,11 +65,15 @@ class _LobbyScreenLoadingContentState extends State<LobbyScreenLoadingContent> {
                         ),
                       ],
                     ),
-                    if (widget.seek.ratingRange != null) ...[
+                    //Do not show rating range if the default values (-500, +500) are used
+                    if (widget.seek.ratingRange != null &&
+                        !(widget.seek.ratingRange!.$1 + 1000 == widget.seek.ratingRange!.$2)) ...[
                       const SizedBox(height: 8.0),
-                      Text(
-                        '${widget.seek.ratingRange!.$1}-${widget.seek.ratingRange!.$2}',
-                        style: TextTheme.of(context).titleMedium,
+                      RatingPrefAware(
+                        child: Text(
+                          '${widget.seek.ratingRange!.$1}-${widget.seek.ratingRange!.$2}',
+                          style: TextTheme.of(context).titleMedium,
+                        ),
                       ),
                     ],
                     const SizedBox(height: 16.0),
@@ -415,9 +421,9 @@ class _LobbyNumbers extends ConsumerWidget {
       return Column(
         crossAxisAlignment: CrossAxisAlignment.center,
         children: [
-          Text(context.l10n.nbPlayers(nbPlayers)),
+          Text(context.l10n.nbPlayers(nbPlayers).localizeNumbers()),
           const SizedBox(height: 8.0),
-          Text(context.l10n.nbGamesInPlay(nbGames)),
+          Text(context.l10n.nbGamesInPlay(nbGames).localizeNumbers()),
         ],
       );
     }

--- a/lib/src/view/user/game_history_screen.dart
+++ b/lib/src/view/user/game_history_screen.dart
@@ -14,6 +14,7 @@ import 'package:lichess_mobile/src/model/user/user_repository_providers.dart';
 import 'package:lichess_mobile/src/styles/styles.dart';
 import 'package:lichess_mobile/src/utils/l10n_context.dart';
 import 'package:lichess_mobile/src/utils/navigation.dart';
+import 'package:lichess_mobile/src/utils/string.dart';
 import 'package:lichess_mobile/src/view/analysis/analysis_screen.dart';
 import 'package:lichess_mobile/src/view/game/game_list_detail_tile.dart';
 import 'package:lichess_mobile/src/view/game/game_list_tile.dart';
@@ -67,7 +68,7 @@ class GameHistoryScreen extends ConsumerWidget {
         ? AppBarTitleText(context.l10n.resVsX(user!.name, gameFilter.opponent!.username))
         : filtersInUse.count == 0
         ? nbGamesAsync.when(
-            data: (nbGames) => AppBarTitleText(context.l10n.nbGames(nbGames)),
+            data: (nbGames) => AppBarTitleText(context.l10n.nbGames(nbGames).localizeNumbers()),
             loading: () => const ButtonLoadingIndicator(),
             error: (e, s) => AppBarTitleText(context.l10n.mobileAllGames),
           )


### PR DESCRIPTION
closes #2077 #2076 #2035
- Localizes the numbers on the game seek screen aswell as on the game history screen
- Makes the Rating Range RatingPrefAware
- If the default value for the rating range is used, the rating range it is not displayed