### PR TITLE
fix studies with illegal positions not loading

### DIFF
--- a/lib/src/model/study/study_controller.dart
+++ b/lib/src/model/study/study_controller.dart
@@ -133,7 +133,7 @@ class StudyController extends _$StudyController
     try {
       _root = Root.fromPgnGame(game);
     } on PositionSetupException {
-      return StudyState(
+      final illegalPositionState = StudyState(
         variant: variant,
         study: study,
         currentPath: UciPath.empty,
@@ -152,6 +152,8 @@ class StudyController extends _$StudyController
         gamebookActive: false,
         pgn: pgn,
       );
+      state = AsyncData(illegalPositionState);
+      return illegalPositionState;
     }
 
     const currentPath = UciPath.empty;
@@ -221,6 +223,7 @@ class StudyController extends _$StudyController
     if (state.requireValue.isAtStartOfChapter &&
         state.requireValue.gamebookActive &&
         state.requireValue.gamebookComment == null &&
+        state.requireValue.currentPosition != null &&
         state.requireValue.currentPosition!.turn != state.requireValue.pov) {
       _opponentFirstMoveTimer = Timer(const Duration(milliseconds: 750), () {
         userNext();


### PR DESCRIPTION
Fixes #1727

The problem was that when encountering illegal positions in `_fetchChapter()`, we weren't immediately updating the state . This could lead to access to stale data, which caused some code to fail without giving an error.

After this PR, the state is updated correctly before continuing with the rest of the code.

I think the reason why issue #1662 appeared fixed at some point was that the offending chapter was chapter 1, so there was no prior state.

I tested the change with:
- https://lichess.org/study/ieCOdimW/1QYacAkq
- https://lichess.org/study/ygVnJzbX/q45se9Z6

and all chapters load correctly.