### PR TITLE
Add all drawables resources in the keep file

### DIFF
--- a/android/app/src/main/res/raw/org_lichess_mobile_keep.xml
+++ b/android/app/src/main/res/raw/org_lichess_mobile_keep.xml
@@ -1,3 +1,3 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources xmlns:tools="http://schemas.android.com/tools"
-  tools:keep="@drawable/tick,@drawable/cross" />
+  tools:keep="@drawable/*" />


### PR DESCRIPTION
Add all drawables resources in the keep file so that Android doesn't shrink them in APK builds.

I don't understand why it is a problem for the version I built [here](https://github.com/julien4215/mobile/actions/runs/16815684659) but not the ones that are released on this repository.