### PR TITLE
Update gen-arb.mjs

### DIFF
--- a/scripts/gen-arb.mjs
+++ b/scripts/gen-arb.mjs
@@ -84,6 +84,7 @@ const locales = [
   'ja-JP',
   'kk-KZ',
   'ko-KR',
+  'lb-LU',
   'lt-LT',
   'lv-LV',
   'mk-MK',


### PR DESCRIPTION
Adding lb-LU to locales, as Luxembourgish is available on the old app and desktop, but as of now not on the new app, even though the mobile specific messages are translated at 100 %.