### PR TITLE
Fix another study loading issue

### DIFF
--- a/lib/src/model/study/study_controller.dart
+++ b/lib/src/model/study/study_controller.dart
@@ -144,7 +144,7 @@ class StudyController extends _$StudyController
         // since the position is illegal and `isComputerAnalysisAllowed` is false anyway.
         evaluationContext: EvaluationContext(
           variant: variant,
-          initialPosition: study.chapter.setup.variant.initialPosition,
+          initialPosition: Variant.standard.initialPosition,
         ),
         pgnRootComments: rootComments,
         pov: orientation,


### PR DESCRIPTION
Fixes a bug reported on discord. Problem appeared due to the variant of an illegal position being set to `fromPosition` and therefore having no initial position. 
Bugfix tested on this study: https://lichess.org/study/UUSBv8yN