### PR TITLE
indicate game results in tournament player view with colors

### DIFF
--- a/lib/src/view/tournament/tournament_screen.dart
+++ b/lib/src/view/tournament/tournament_screen.dart
@@ -1172,9 +1172,11 @@ class _PairingTile extends ConsumerWidget {
 
     final resultColor = pairing.score != null && pairing.score! >= 4
         ? context.lichessColors.brag
-        : pairing.score != null && pairing.score! > 1
+        : pairing.win == true
         ? context.lichessColors.good
-        : null;
+        : pairing.status == GameStatus.draw
+        ? null
+        : context.lichessColors.error;
 
     return ListTile(
       contentPadding: const EdgeInsetsDirectional.only(start: 16.0, end: 16.0),


### PR DESCRIPTION
Colors the results not according to points, but according to results, similar to what is done on the website now: 

<img width="678" height="1201" alt="grafik" src="https://github.com/user-attachments/assets/d57074cd-5a92-4d84-8b9e-edc93322de2b" />
