### PR TITLE
remove leading 0 in crosstable scores

### DIFF
--- a/lib/src/view/game/game_player.dart
+++ b/lib/src/view/game/game_player.dart
@@ -287,7 +287,10 @@ class ConfirmMove extends StatelessWidget {
 String _scoreDisplay(double score) {
   final integerPart = score.truncate();
   final decimalPart = score - integerPart;
-  return '$integerPart${decimalPart == 0.5 ? '½' : ''}';
+
+  return integerPart == 0 && decimalPart == 0.5
+      ? '½'
+      : '$integerPart${decimalPart == 0.5 ? '½' : ''}';
 }
 
 class MoveExpiration extends ConsumerStatefulWidget {

--- a/lib/src/view/user/user_screen.dart
+++ b/lib/src/view/user/user_screen.dart
@@ -141,7 +141,10 @@ class _UserProfileListView extends ConsumerWidget {
   String _scoreDisplay(double score) {
     final integerPart = score.truncate();
     final decimalPart = score - integerPart;
-    return '$integerPart${decimalPart == 0.5 ? '½' : ''}';
+
+    return integerPart == 0 && decimalPart == 0.5
+        ? '½'
+        : '$integerPart${decimalPart == 0.5 ? '½' : ''}';
   }
 
   @override


### PR DESCRIPTION
Avoid showing` 0 ½ - 1 ½` instead show `½-1 ½` . I think it looks cleaner