### PR TITLE
add the newly added insufficientMaterialClaim GameStatus

### DIFF
--- a/lib/src/model/game/game_status.dart
+++ b/lib/src/model/game/game_status.dart
@@ -29,6 +29,9 @@ enum GameStatus {
   /// We don't know why the game ended.
   unknownFinish(38),
 
+  /// If a player offers a draw and their opponent has insufficient material to win, the game is called a draw.
+  insufficientMaterialClaim(39),
+
   /// Chess variant special endings.
   variantEnd(60);
 

--- a/lib/src/view/game/status_l10n.dart
+++ b/lib/src/view/game/status_l10n.dart
@@ -31,6 +31,8 @@ String gameStatusL10n(
           : winner == Side.black
           ? context.l10n.whiteLeftTheGame
           : context.l10n.blackLeftTheGame;
+    case GameStatus.insufficientMaterialClaim:
+      return '${context.l10n.insufficientMaterial} • ${context.l10n.draw}';
     case GameStatus.draw:
       if (lastPosition.isInsufficientMaterial) {
         return '${context.l10n.insufficientMaterial} • ${context.l10n.draw}';

--- a/lib/src/view/tournament/tournament_screen.dart
+++ b/lib/src/view/tournament/tournament_screen.dart
@@ -1174,7 +1174,8 @@ class _PairingTile extends ConsumerWidget {
         ? context.lichessColors.brag
         : pairing.win == true
         ? context.lichessColors.good
-        : pairing.status == GameStatus.draw
+        : pairing.status == GameStatus.draw ||
+              pairing.status == GameStatus.insufficientMaterialClaim
         ? null
         : context.lichessColors.error;
 


### PR DESCRIPTION
fixes #2120 
Lila added a new GameStatus some time ago which lead to an error. 
We could add GameStatus.Unknown as a fallback option to safeguard against similar issues in the future. However, I do not expect GameStatus values to be introduced and if they would be introduced we might never realize.
Checked for this profile: https://lichess.org/@/goingvegan and works again with the fix.