### PR TITLE
feat: add change password and 2FA buttons to account settings

### DIFF
--- a/lib/l10n/app_af.arb
+++ b/lib/l10n/app_af.arb
@@ -1579,5 +1579,6 @@
   "timeagoNbMonthsAgo": "{count, plural, =1{{count} maand gelede} other{{count} maande gelede}}",
   "timeagoNbYearsAgo": "{count, plural, =1{{count} jaar gelede} other{{count} jare gelede}}",
   "timeagoNbMinutesRemaining": "{count, plural, =1{nog {count} minuut oor} other{nog {count} minute oor}}",
-  "timeagoNbHoursRemaining": "{count, plural, =1{nog {count} uur oor} other{nog {count} ure oor}}"
+  "timeagoNbHoursRemaining": "{count, plural, =1{nog {count} uur oor} other{nog {count} ure oor}}",
+  "tfaTwoFactorAuth": "Tweeledige verifikasie"
 }

--- a/lib/l10n/app_ar.arb
+++ b/lib/l10n/app_ar.arb
@@ -1719,5 +1719,6 @@
   "timeagoNbMonthsAgo": "{count, plural, =0{منذ {count} شهر} =1{منذ {count} شهر} =2{منذ {count} شهر} few{منذ {count} شهر} many{منذ {count} شهر} other{منذ {count} شهر}}",
   "timeagoNbYearsAgo": "{count, plural, =0{منذ {count} سنة} =1{منذ {count} سنة} =2{منذ {count} سنة} few{منذ {count} سنة} many{منذ {count} سنة} other{منذ {count} سنة}}",
   "timeagoNbMinutesRemaining": "{count, plural, =0{{count} دقيقة متبقية} =1{{count} دقيقة متبقية} =2{{count} دقيقة متبقية} few{{count} دقيقة متبقية} many{{count} دقيقة متبقية} other{{count} دقيقة متبقية}}",
-  "timeagoNbHoursRemaining": "{count, plural, =0{{count} ساعة متبقية} =1{{count} ساعة متبقية} =2{{count} ساعة متبقية} few{{count} ساعة متبقية} many{{count} ساعة متبقية} other{{count} ساعة متبقية}}"
+  "timeagoNbHoursRemaining": "{count, plural, =0{{count} ساعة متبقية} =1{{count} ساعة متبقية} =2{{count} ساعة متبقية} few{{count} ساعة متبقية} many{{count} ساعة متبقية} other{{count} ساعة متبقية}}",
+  "tfaTwoFactorAuth": "التوثيق ذو العاملين"
 }

--- a/lib/l10n/app_az.arb
+++ b/lib/l10n/app_az.arb
@@ -1303,5 +1303,6 @@
   "studyNbMembers": "{count, plural, =1{{count} Üzv} other{{count} Üzv}}",
   "studyPasteYourPgnTextHereUpToNbGames": "{count, plural, =1{PGN mətninizi bura yapışdırın, ən çox {count} oyuna qədər} other{PGN mətninizi bura yapışdırın, ən çox {count} oyuna qədər}}",
   "timeagoJustNow": "elə indi",
-  "timeagoRightNow": "indicə"
+  "timeagoRightNow": "indicə",
+  "tfaTwoFactorAuth": "2 mərhələli təsdiqləmə"
 }

--- a/lib/l10n/app_be.arb
+++ b/lib/l10n/app_be.arb
@@ -1468,5 +1468,6 @@
   "timeagoNbMonthsAgo": "{count, plural, =1{{count} месяц таму} few{{count} месяцы таму} many{{count} месяцаў таму} other{{count} месяцаў таму}}",
   "timeagoNbYearsAgo": "{count, plural, =1{{count} год таму} few{{count} гады таму} many{{count} гадоў таму} other{{count} гадоў таму}}",
   "timeagoNbMinutesRemaining": "{count, plural, =1{Засталася {count} хвіліна} few{Засталося {count} хвіліны} many{Засталося {count} хвілін} other{Засталося {count} хвіліны}}",
-  "timeagoNbHoursRemaining": "{count, plural, =1{Засталася {count} гадзіна} few{Засталося {count} гадзіны} many{Засталося {count} гадзін} other{Засталося {count} гадзіны}}"
+  "timeagoNbHoursRemaining": "{count, plural, =1{Засталася {count} гадзіна} few{Засталося {count} гадзіны} many{Засталося {count} гадзін} other{Засталося {count} гадзіны}}",
+  "tfaTwoFactorAuth": "Двухфактарная аўтэнтыфікацыя"
 }

--- a/lib/l10n/app_bg.arb
+++ b/lib/l10n/app_bg.arb
@@ -1610,5 +1610,6 @@
   "timeagoNbMonthsAgo": "{count, plural, =1{преди {count} месец} other{преди {count} месеца}}",
   "timeagoNbYearsAgo": "{count, plural, =1{преди {count} година} other{преди {count} години}}",
   "timeagoNbMinutesRemaining": "{count, plural, =1{остава {count} минутa} other{остават {count} минути}}",
-  "timeagoNbHoursRemaining": "{count, plural, =1{остава {count} час} other{остават {count} часа}}"
+  "timeagoNbHoursRemaining": "{count, plural, =1{остава {count} час} other{остават {count} часа}}",
+  "tfaTwoFactorAuth": "Двуфакторно удостоверяване"
 }

--- a/lib/l10n/app_bn.arb
+++ b/lib/l10n/app_bn.arb
@@ -1337,5 +1337,6 @@
   "timeagoNbMonthsAgo": "{count, plural, =1{{count} মাস আগে} other{{count} মাস আগে}}",
   "timeagoNbYearsAgo": "{count, plural, =1{{count} বছর আগে} other{{count} বছর আগে}}",
   "timeagoNbMinutesRemaining": "{count, plural, =1{{count} মিনিট বাকি} other{{count} মিনিট বাকি}}",
-  "timeagoNbHoursRemaining": "{count, plural, =1{{count} ঘন্টা বাকি} other{{count} ঘন্টা বাকি}}"
+  "timeagoNbHoursRemaining": "{count, plural, =1{{count} ঘন্টা বাকি} other{{count} ঘন্টা বাকি}}",
+  "tfaTwoFactorAuth": "টু-ফ্যাক্টর অথেন্টিকেশন"
 }

--- a/lib/l10n/app_bs.arb
+++ b/lib/l10n/app_bs.arb
@@ -1722,5 +1722,6 @@
   "timeagoNbMonthsAgo": "{count, plural, =1{prije {count} mjesec} few{prije {count} mjeseca} other{prije {count} mjeseci}}",
   "timeagoNbYearsAgo": "{count, plural, =1{prije {count} godinu} few{prije {count} godine} other{prije {count} godina}}",
   "timeagoNbMinutesRemaining": "{count, plural, =1{Preostala je {count} minuta} few{Preostalo je {count} minuta} other{Preostalo je {count} minuta}}",
-  "timeagoNbHoursRemaining": "{count, plural, =1{Preostao je {count} sat} few{Preostalo je {count} sata} other{Preostalo je {count} sati}}"
+  "timeagoNbHoursRemaining": "{count, plural, =1{Preostao je {count} sat} few{Preostalo je {count} sata} other{Preostalo je {count} sati}}",
+  "tfaTwoFactorAuth": "Dvofaktorska provjera autentičnosti"
 }

--- a/lib/l10n/app_ca.arb
+++ b/lib/l10n/app_ca.arb
@@ -1722,5 +1722,6 @@
   "timeagoNbMonthsAgo": "{count, plural, =1{fa {count} mes} other{fa {count} mesos}}",
   "timeagoNbYearsAgo": "{count, plural, =1{fa {count} any} other{fa {count} anys}}",
   "timeagoNbMinutesRemaining": "{count, plural, =1{Queda {count} minut} other{Queden {count} minuts}}",
-  "timeagoNbHoursRemaining": "{count, plural, =1{Queda {count} hora} other{Queden {count} hores}}"
+  "timeagoNbHoursRemaining": "{count, plural, =1{Queda {count} hora} other{Queden {count} hores}}",
+  "tfaTwoFactorAuth": "Autenticació de dos factors"
 }

--- a/lib/l10n/app_cs.arb
+++ b/lib/l10n/app_cs.arb
@@ -1686,5 +1686,6 @@
   "timeagoNbMonthsAgo": "{count, plural, =1{před {count} měsícem} few{před {count} měsíci} many{před {count} měsíci} other{před {count} měsíci}}",
   "timeagoNbYearsAgo": "{count, plural, =1{před {count} rokem} few{před {count} lety} many{před {count} lety} other{před {count} lety}}",
   "timeagoNbMinutesRemaining": "{count, plural, =1{Zbývá {count} minuta} few{Zbývají {count} minuty} many{Zbývá {count} minut} other{Zbývá {count} minut}}",
-  "timeagoNbHoursRemaining": "{count, plural, =1{Zbývá {count} hodina} few{Zbývají {count} hodiny} many{Zbývá {count} hodin} other{Zbývá {count} hodin}}"
+  "timeagoNbHoursRemaining": "{count, plural, =1{Zbývá {count} hodina} few{Zbývají {count} hodiny} many{Zbývá {count} hodin} other{Zbývá {count} hodin}}",
+  "tfaTwoFactorAuth": "Dvoufázové ověření"
 }

--- a/lib/l10n/app_da.arb
+++ b/lib/l10n/app_da.arb
@@ -1722,5 +1722,6 @@
   "timeagoNbMonthsAgo": "{count, plural, =1{{count} måned siden} other{{count} måneder siden}}",
   "timeagoNbYearsAgo": "{count, plural, =1{{count} år siden} other{{count} år siden}}",
   "timeagoNbMinutesRemaining": "{count, plural, =1{{count} minut tilbage} other{{count} minutter tilbage}}",
-  "timeagoNbHoursRemaining": "{count, plural, =1{{count} time tilbage} other{{count} timer tilbage}}"
+  "timeagoNbHoursRemaining": "{count, plural, =1{{count} time tilbage} other{{count} timer tilbage}}",
+  "tfaTwoFactorAuth": "To-faktor-godkendelse"
 }

--- a/lib/l10n/app_de.arb
+++ b/lib/l10n/app_de.arb
@@ -1722,5 +1722,6 @@
   "timeagoNbMonthsAgo": "{count, plural, =1{vor {count} Monat} other{vor {count} Monaten}}",
   "timeagoNbYearsAgo": "{count, plural, =1{vor {count} Jahr} other{vor {count} Jahren}}",
   "timeagoNbMinutesRemaining": "{count, plural, =1{{count} Minute verbleibend} other{{count} Minuten verbleibend}}",
-  "timeagoNbHoursRemaining": "{count, plural, =1{{count} Stunde verbleiben} other{{count} Stunden verbleiben}}"
+  "timeagoNbHoursRemaining": "{count, plural, =1{{count} Stunde verbleiben} other{{count} Stunden verbleiben}}",
+  "tfaTwoFactorAuth": "Zwei-Faktor-Authentifizierung"
 }

--- a/lib/l10n/app_el.arb
+++ b/lib/l10n/app_el.arb
@@ -1671,5 +1671,6 @@
   "timeagoNbMonthsAgo": "{count, plural, =1{{count} μήνα πριν} other{{count} μήνες πριν}}",
   "timeagoNbYearsAgo": "{count, plural, =1{{count} χρόνο πριν} other{{count} χρόνια πριν}}",
   "timeagoNbMinutesRemaining": "{count, plural, =1{απομένει {count} λεπτό} other{απομένουν {count} λεπτά}}",
-  "timeagoNbHoursRemaining": "{count, plural, =1{απομένει {count} ώρα} other{απομένουν {count} ώρες}}"
+  "timeagoNbHoursRemaining": "{count, plural, =1{απομένει {count} ώρα} other{απομένουν {count} ώρες}}",
+  "tfaTwoFactorAuth": "Έλεγχος ταυτότητας δύο παραγόντων"
 }

--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -3553,5 +3553,6 @@
         "type": "int"
       }
     }
-  }
+  },
+  "tfaTwoFactorAuth": "Two-factor authentication"
 }

--- a/lib/l10n/app_en_US.arb
+++ b/lib/l10n/app_en_US.arb
@@ -1722,5 +1722,6 @@
   "timeagoNbMonthsAgo": "{count, plural, =1{{count} month ago} other{{count} months ago}}",
   "timeagoNbYearsAgo": "{count, plural, =1{{count} year ago} other{{count} years ago}}",
   "timeagoNbMinutesRemaining": "{count, plural, =1{{count} minute remaining} other{{count} minutes remaining}}",
-  "timeagoNbHoursRemaining": "{count, plural, =1{{count} hour remaining} other{{count} hours remaining}}"
+  "timeagoNbHoursRemaining": "{count, plural, =1{{count} hour remaining} other{{count} hours remaining}}",
+  "tfaTwoFactorAuth": "Two-factor authentication"
 }

--- a/lib/l10n/app_eo.arb
+++ b/lib/l10n/app_eo.arb
@@ -1562,5 +1562,6 @@
   "timeagoNbMonthsAgo": "{count, plural, =1{antaŭ {count} monato} other{antaŭ {count} monatoj}}",
   "timeagoNbYearsAgo": "{count, plural, =1{antaŭ {count} jaro} other{antaŭ {count} jaroj}}",
   "timeagoNbMinutesRemaining": "{count, plural, =1{{count} minuto restas} other{{count} minutoj restas}}",
-  "timeagoNbHoursRemaining": "{count, plural, =1{{count} horo restas} other{{count} horoj restas}}"
+  "timeagoNbHoursRemaining": "{count, plural, =1{{count} horo restas} other{{count} horoj restas}}",
+  "tfaTwoFactorAuth": "Dufaza aŭtentigo"
 }

--- a/lib/l10n/app_es.arb
+++ b/lib/l10n/app_es.arb
@@ -1722,5 +1722,6 @@
   "timeagoNbMonthsAgo": "{count, plural, =1{hace {count} mes} other{hace {count} meses}}",
   "timeagoNbYearsAgo": "{count, plural, =1{hace {count} año} other{hace {count} años}}",
   "timeagoNbMinutesRemaining": "{count, plural, =1{{count} minuto restante} other{{count} minutos restantes}}",
-  "timeagoNbHoursRemaining": "{count, plural, =1{{count} hora restante} other{{count} horas restantes}}"
+  "timeagoNbHoursRemaining": "{count, plural, =1{{count} hora restante} other{{count} horas restantes}}",
+  "tfaTwoFactorAuth": "Autenticación en dos pasos"
 }

--- a/lib/l10n/app_et.arb
+++ b/lib/l10n/app_et.arb
@@ -1384,5 +1384,6 @@
   "timeagoNbMonthsAgo": "{count, plural, =1{{count} kuu tagasi} other{{count} kuud tagasi}}",
   "timeagoNbYearsAgo": "{count, plural, =1{{count} aasta tagasi} other{{count} aastat tagasi}}",
   "timeagoNbMinutesRemaining": "{count, plural, =1{{count} minut jäänud} other{{count} minutit jäänud}}",
-  "timeagoNbHoursRemaining": "{count, plural, =1{{count} tund jäänud} other{{count} tundi jäänud}}"
+  "timeagoNbHoursRemaining": "{count, plural, =1{{count} tund jäänud} other{{count} tundi jäänud}}",
+  "tfaTwoFactorAuth": "Kaheastmeline autentimine"
 }

--- a/lib/l10n/app_eu.arb
+++ b/lib/l10n/app_eu.arb
@@ -1722,5 +1722,6 @@
   "timeagoNbMonthsAgo": "{count, plural, =1{orain dela hilabete {count}} other{orain dela {count} hilabete}}",
   "timeagoNbYearsAgo": "{count, plural, =1{orain dela urte {count}} other{orain dela {count} urte}}",
   "timeagoNbMinutesRemaining": "{count, plural, =1{Minutu {count} falta da} other{{count} minutu falta dira}}",
-  "timeagoNbHoursRemaining": "{count, plural, =1{Ordu {count} falta da} other{{count} ordu falta dira}}"
+  "timeagoNbHoursRemaining": "{count, plural, =1{Ordu {count} falta da} other{{count} ordu falta dira}}",
+  "tfaTwoFactorAuth": "Bi faktoreko autentifikazioa"
 }

--- a/lib/l10n/app_fa.arb
+++ b/lib/l10n/app_fa.arb
@@ -1722,5 +1722,6 @@
   "timeagoNbMonthsAgo": "{count, plural, =1{{count} ماه پیش} other{{count} ماه پیش}}",
   "timeagoNbYearsAgo": "{count, plural, =1{{count} سال پیش} other{{count} سال پیش}}",
   "timeagoNbMinutesRemaining": "{count, plural, =1{{count} دقیقه باقی مانده} other{{count} دقیقه باقی مانده}}",
-  "timeagoNbHoursRemaining": "{count, plural, =1{{count} ساعت باقی مانده} other{{count} ساعت باقی مانده}}"
+  "timeagoNbHoursRemaining": "{count, plural, =1{{count} ساعت باقی مانده} other{{count} ساعت باقی مانده}}",
+  "tfaTwoFactorAuth": "راستین‌آزمایی دوعاملی"
 }

--- a/lib/l10n/app_fi.arb
+++ b/lib/l10n/app_fi.arb
@@ -1722,5 +1722,6 @@
   "timeagoNbMonthsAgo": "{count, plural, =1{{count} kuukausi sitten} other{{count} kuukautta sitten}}",
   "timeagoNbYearsAgo": "{count, plural, =1{{count} vuosi sitten} other{{count} vuotta sitten}}",
   "timeagoNbMinutesRemaining": "{count, plural, =1{{count} minuutti jäljellä} other{{count} minuuttia jäljellä}}",
-  "timeagoNbHoursRemaining": "{count, plural, =1{{count} tunti jäljellä} other{{count} tuntia jäljellä}}"
+  "timeagoNbHoursRemaining": "{count, plural, =1{{count} tunti jäljellä} other{{count} tuntia jäljellä}}",
+  "tfaTwoFactorAuth": "Kaksivaiheinen tunnistautuminen"
 }

--- a/lib/l10n/app_fr.arb
+++ b/lib/l10n/app_fr.arb
@@ -1722,5 +1722,6 @@
   "timeagoNbMonthsAgo": "{count, plural, =1{il y a {count} mois} other{il y a {count} mois}}",
   "timeagoNbYearsAgo": "{count, plural, =1{il y a {count} an} other{il y a {count} ans}}",
   "timeagoNbMinutesRemaining": "{count, plural, =1{{count} minute restante} other{{count} minutes restantes}}",
-  "timeagoNbHoursRemaining": "{count, plural, =1{{count} heure restante} other{{count} heures restantes}}"
+  "timeagoNbHoursRemaining": "{count, plural, =1{{count} heure restante} other{{count} heures restantes}}",
+  "tfaTwoFactorAuth": "Authentification à deux facteurs"
 }

--- a/lib/l10n/app_gl.arb
+++ b/lib/l10n/app_gl.arb
@@ -1722,5 +1722,6 @@
   "timeagoNbMonthsAgo": "{count, plural, =1{hai {count} mes} other{hai {count} meses}}",
   "timeagoNbYearsAgo": "{count, plural, =1{hai {count} ano} other{hai {count} anos}}",
   "timeagoNbMinutesRemaining": "{count, plural, =1{{count} minuto restante} other{{count} minutos restantes}}",
-  "timeagoNbHoursRemaining": "{count, plural, =1{{count} hora restante} other{{count} horas restantes}}"
+  "timeagoNbHoursRemaining": "{count, plural, =1{{count} hora restante} other{{count} horas restantes}}",
+  "tfaTwoFactorAuth": "Autenticación en dous pasos"
 }

--- a/lib/l10n/app_gsw.arb
+++ b/lib/l10n/app_gsw.arb
@@ -1722,5 +1722,6 @@
   "timeagoNbMonthsAgo": "{count, plural, =1{vor {count} Monet} other{vor {count} Mönet}}",
   "timeagoNbYearsAgo": "{count, plural, =1{vor {count} Jahr} other{vor {count} Jahr}}",
   "timeagoNbMinutesRemaining": "{count, plural, =1{{count} Minute blibt} other{{count} Minute blibed}}",
-  "timeagoNbHoursRemaining": "{count, plural, =1{{count} Schtund blibt} other{{count} Schtunde blibed}}"
+  "timeagoNbHoursRemaining": "{count, plural, =1{{count} Schtund blibt} other{{count} Schtunde blibed}}",
+  "tfaTwoFactorAuth": "Zwei-Faktor-Autentifizierig"
 }

--- a/lib/l10n/app_he.arb
+++ b/lib/l10n/app_he.arb
@@ -1633,5 +1633,6 @@
   "timeagoNbMonthsAgo": "{count, plural, =1{לפני חודש {count}} =2{לפני {count} חודשים} many{לפני {count} חודשים} other{לפני {count} חודשים}}",
   "timeagoNbYearsAgo": "{count, plural, =1{לפני שנה {count}} =2{לפני {count} שנים} many{לפני {count} שנים} other{לפני {count} שנים}}",
   "timeagoNbMinutesRemaining": "{count, plural, =1{דקה {count} נותרה} =2{{count} דקות נותרו} many{{count} דקות נותרו} other{{count} דקות נותרו}}",
-  "timeagoNbHoursRemaining": "{count, plural, =1{שעה {count} נותרה} =2{{count} שעות נותרו} many{{count} שעות נותרו} other{{count} שעות נותרו}}"
+  "timeagoNbHoursRemaining": "{count, plural, =1{שעה {count} נותרה} =2{{count} שעות נותרו} many{{count} שעות נותרו} other{{count} שעות נותרו}}",
+  "tfaTwoFactorAuth": "אימות דו־שלבי"
 }

--- a/lib/l10n/app_hi.arb
+++ b/lib/l10n/app_hi.arb
@@ -1516,5 +1516,6 @@
   "timeagoNbMonthsAgo": "{count, plural, =1{{count} महीने पहले} other{{count} महीने पहले}}",
   "timeagoNbYearsAgo": "{count, plural, =1{{count} वर्ष पहले} other{{count} वर्षों पहले}}",
   "timeagoNbMinutesRemaining": "{count, plural, =1{{count} मिनट बचा है} other{{count} मिनट बचे हैं}}",
-  "timeagoNbHoursRemaining": "{count, plural, =1{{count} घंटा बचा है} other{{count} घंटे बचे हैं}}"
+  "timeagoNbHoursRemaining": "{count, plural, =1{{count} घंटा बचा है} other{{count} घंटे बचे हैं}}",
+  "tfaTwoFactorAuth": "दो-चरण प्रमाणीकरण"
 }

--- a/lib/l10n/app_hr.arb
+++ b/lib/l10n/app_hr.arb
@@ -1616,5 +1616,6 @@
   "timeagoNbMonthsAgo": "{count, plural, =1{prije {count} mjesec} few{prije {count} mjeseca} other{prije {count} mjeseci}}",
   "timeagoNbYearsAgo": "{count, plural, =1{prije {count} godinu} few{prije {count} godine} other{prije {count} godina}}",
   "timeagoNbMinutesRemaining": "{count, plural, =1{Preostala {count} minuta} few{Preostale {count} minute} other{Preostalo {count} minuta}}",
-  "timeagoNbHoursRemaining": "{count, plural, =1{Preostao {count} sat} few{Preostala {count} sata} other{Preostalo {count} sati}}"
+  "timeagoNbHoursRemaining": "{count, plural, =1{Preostao {count} sat} few{Preostala {count} sata} other{Preostalo {count} sati}}",
+  "tfaTwoFactorAuth": "Dvofaktorska provjera autentičnosti"
 }

--- a/lib/l10n/app_hu.arb
+++ b/lib/l10n/app_hu.arb
@@ -1578,5 +1578,6 @@
   "timeagoNbMonthsAgo": "{count, plural, =1{{count} hónapja} other{{count} hónapja}}",
   "timeagoNbYearsAgo": "{count, plural, =1{{count} éve} other{{count} éve}}",
   "timeagoNbMinutesRemaining": "{count, plural, =1{{count} perc van hátra} other{{count} perc van hátra}}",
-  "timeagoNbHoursRemaining": "{count, plural, =1{{count} óra van hátra} other{{count} óra van hátra}}"
+  "timeagoNbHoursRemaining": "{count, plural, =1{{count} óra van hátra} other{{count} óra van hátra}}",
+  "tfaTwoFactorAuth": "Kétlépcsős azonosítás"
 }

--- a/lib/l10n/app_hy.arb
+++ b/lib/l10n/app_hy.arb
@@ -1462,5 +1462,6 @@
   "timeagoNbDaysAgo": "{count, plural, =1{{count} օր առաջ} other{{count} օր առաջ}}",
   "timeagoNbWeeksAgo": "{count, plural, =1{{count} շաբաթ առաջ} other{{count} շաբաթ առաջ}}",
   "timeagoNbMonthsAgo": "{count, plural, =1{{count} ամիս առաջ} other{{count} ամիս առաջ}}",
-  "timeagoNbYearsAgo": "{count, plural, =1{{count} տարի առաջ} other{{count} տարի առաջ}}"
+  "timeagoNbYearsAgo": "{count, plural, =1{{count} տարի առաջ} other{{count} տարի առաջ}}",
+  "tfaTwoFactorAuth": "Երկգործոն նույնականացում"
 }

--- a/lib/l10n/app_id.arb
+++ b/lib/l10n/app_id.arb
@@ -1501,5 +1501,6 @@
   "timeagoNbMonthsAgo": "{count, plural, other{{count} bulan yang lalu}}",
   "timeagoNbYearsAgo": "{count, plural, other{{count} tahun yang lalu}}",
   "timeagoNbMinutesRemaining": "{count, plural, other{{count} menit tersisa}}",
-  "timeagoNbHoursRemaining": "{count, plural, other{{count} jam tersisa}}"
+  "timeagoNbHoursRemaining": "{count, plural, other{{count} jam tersisa}}",
+  "tfaTwoFactorAuth": "Autentikasi dua-langkah"
 }

--- a/lib/l10n/app_it.arb
+++ b/lib/l10n/app_it.arb
@@ -1709,5 +1709,6 @@
   "timeagoNbMonthsAgo": "{count, plural, =1{{count} mese fa} other{{count} mesi fa}}",
   "timeagoNbYearsAgo": "{count, plural, =1{{count} anno fa} other{{count} anni fa}}",
   "timeagoNbMinutesRemaining": "{count, plural, =1{{count} minuto rimanente} other{{count} minuti rimanenti}}",
-  "timeagoNbHoursRemaining": "{count, plural, =1{{count} ora rimanente} other{{count} ore rimanenti}}"
+  "timeagoNbHoursRemaining": "{count, plural, =1{{count} ora rimanente} other{{count} ore rimanenti}}",
+  "tfaTwoFactorAuth": "Autenticazione a due fattori"
 }

--- a/lib/l10n/app_ja.arb
+++ b/lib/l10n/app_ja.arb
@@ -1694,5 +1694,6 @@
   "timeagoNbMonthsAgo": "{count, plural, other{{count} か月前}}",
   "timeagoNbYearsAgo": "{count, plural, other{{count} 年前}}",
   "timeagoNbMinutesRemaining": "{count, plural, other{残り {count} 分}}",
-  "timeagoNbHoursRemaining": "{count, plural, other{残り {count} 時間}}"
+  "timeagoNbHoursRemaining": "{count, plural, other{残り {count} 時間}}",
+  "tfaTwoFactorAuth": "2 要素認証"
 }

--- a/lib/l10n/app_kk.arb
+++ b/lib/l10n/app_kk.arb
@@ -1581,5 +1581,6 @@
   "timeagoNbMonthsAgo": "{count, plural, =1{{count} ай бұрын} other{{count} ай бұрын}}",
   "timeagoNbYearsAgo": "{count, plural, =1{{count} жыл бұрын} other{{count} жыл бұрын}}",
   "timeagoNbMinutesRemaining": "{count, plural, =1{{count} минут қалды} other{{count} минут қалды}}",
-  "timeagoNbHoursRemaining": "{count, plural, =1{{count} сағат қалды} other{{count} сағат қалды}}"
+  "timeagoNbHoursRemaining": "{count, plural, =1{{count} сағат қалды} other{{count} сағат қалды}}",
+  "tfaTwoFactorAuth": "Екісатылы өкіл-растау"
 }

--- a/lib/l10n/app_ko.arb
+++ b/lib/l10n/app_ko.arb
@@ -1708,5 +1708,6 @@
   "timeagoNbMonthsAgo": "{count, plural, other{{count}개월 전}}",
   "timeagoNbYearsAgo": "{count, plural, other{{count}년 전}}",
   "timeagoNbMinutesRemaining": "{count, plural, other{{count}분 남음}}",
-  "timeagoNbHoursRemaining": "{count, plural, other{{count}시간 남음}}"
+  "timeagoNbHoursRemaining": "{count, plural, other{{count}시간 남음}}",
+  "tfaTwoFactorAuth": "2단계 인증"
 }

--- a/lib/l10n/app_lt.arb
+++ b/lib/l10n/app_lt.arb
@@ -1605,5 +1605,6 @@
   "timeagoNbMonthsAgo": "{count, plural, =1{Prieš {count} mėnesį} few{Prieš {count} mėnesius} many{Prieš {count} mėnesio} other{Prieš {count} mėnesių}}",
   "timeagoNbYearsAgo": "{count, plural, =1{Prieš {count} metus} few{Prieš {count} metus} many{Prieš {count} metų} other{Prieš {count} metų}}",
   "timeagoNbMinutesRemaining": "{count, plural, =1{Liko {count} minutė} few{Liko {count} minutės} many{Liko {count} minučių} other{Liko {count} minučių}}",
-  "timeagoNbHoursRemaining": "{count, plural, =1{Liko {count} valanda} few{Liko {count} valandos} many{Liko {count} valandų} other{Liko {count} valandų}}"
+  "timeagoNbHoursRemaining": "{count, plural, =1{Liko {count} valanda} few{Liko {count} valandos} many{Liko {count} valandų} other{Liko {count} valandų}}",
+  "tfaTwoFactorAuth": "Dviejų lygių tapatumo nustatymas"
 }

--- a/lib/l10n/app_lv.arb
+++ b/lib/l10n/app_lv.arb
@@ -1500,5 +1500,6 @@
   "timeagoNbDaysAgo": "{count, plural, =0{pirms {count} dienām} =1{pirms {count} dienas} other{pirms {count} dienām}}",
   "timeagoNbWeeksAgo": "{count, plural, =0{pirms {count} nedēļām} =1{pirms {count} nedēļas} other{pirms {count} nedēļām}}",
   "timeagoNbMonthsAgo": "{count, plural, =0{pirms {count} mēnešiem} =1{pirms {count} mēneša} other{pirms {count} mēnešiem}}",
-  "timeagoNbYearsAgo": "{count, plural, =0{pirms {count} gadiem} =1{pirms {count} gada} other{pirms {count} gadiem}}"
+  "timeagoNbYearsAgo": "{count, plural, =0{pirms {count} gadiem} =1{pirms {count} gada} other{pirms {count} gadiem}}",
+  "tfaTwoFactorAuth": "Divfaktoru autentifikācija"
 }

--- a/lib/l10n/app_mk.arb
+++ b/lib/l10n/app_mk.arb
@@ -1100,5 +1100,6 @@
   "timeagoNbMonthsAgo": "{count, plural, =1{Пред {count} месец} other{Пред {count} месеци}}",
   "timeagoNbYearsAgo": "{count, plural, =1{Пред {count} година} other{Пред {count} години}}",
   "timeagoNbMinutesRemaining": "{count, plural, =1{преостанува {count} минута} other{преостануваат {count} минути}}",
-  "timeagoNbHoursRemaining": "{count, plural, =1{преостанува {count} час} other{преостануваат {count} часови}}"
+  "timeagoNbHoursRemaining": "{count, plural, =1{преостанува {count} час} other{преостануваат {count} часови}}",
+  "tfaTwoFactorAuth": "Двофакторна автентикација"
 }

--- a/lib/l10n/app_nb.arb
+++ b/lib/l10n/app_nb.arb
@@ -1707,5 +1707,6 @@
   "timeagoNbMonthsAgo": "{count, plural, =1{for {count} måned siden} other{for {count} måneder siden}}",
   "timeagoNbYearsAgo": "{count, plural, =1{for {count} år siden} other{for {count} år siden}}",
   "timeagoNbMinutesRemaining": "{count, plural, =1{{count} minutt igjen} other{{count} minutter igjen}}",
-  "timeagoNbHoursRemaining": "{count, plural, =1{{count} time igjen} other{{count} timer igjen}}"
+  "timeagoNbHoursRemaining": "{count, plural, =1{{count} time igjen} other{{count} timer igjen}}",
+  "tfaTwoFactorAuth": "Tofaktorautentisering"
 }

--- a/lib/l10n/app_nl.arb
+++ b/lib/l10n/app_nl.arb
@@ -1722,5 +1722,6 @@
   "timeagoNbMonthsAgo": "{count, plural, =1{{count} maand geleden} other{{count} maanden geleden}}",
   "timeagoNbYearsAgo": "{count, plural, =1{{count} jaar geleden} other{{count} jaar geleden}}",
   "timeagoNbMinutesRemaining": "{count, plural, =1{{count} minuut resterend} other{{count} minuten resterend}}",
-  "timeagoNbHoursRemaining": "{count, plural, =1{{count} uur resterend} other{{count} uur resterend}}"
+  "timeagoNbHoursRemaining": "{count, plural, =1{{count} uur resterend} other{{count} uur resterend}}",
+  "tfaTwoFactorAuth": "Tweestapsverificatie"
 }

--- a/lib/l10n/app_pl.arb
+++ b/lib/l10n/app_pl.arb
@@ -1722,5 +1722,6 @@
   "timeagoNbMonthsAgo": "{count, plural, =1{{count} miesiąc temu} few{{count} miesiące temu} many{{count} miesięcy temu} other{{count} miesięcy temu}}",
   "timeagoNbYearsAgo": "{count, plural, =1{{count} rok temu} few{{count} lata temu} many{{count} lat temu} other{{count} lat temu}}",
   "timeagoNbMinutesRemaining": "{count, plural, =1{Pozostała {count} minuta} few{Pozostały {count} minuty} many{Pozostało {count} minut} other{Pozostało {count} minut}}",
-  "timeagoNbHoursRemaining": "{count, plural, =1{Pozostała {count} godzina} few{Pozostały {count} godziny} many{Pozostało {count} godzin} other{Pozostało {count} godzin}}"
+  "timeagoNbHoursRemaining": "{count, plural, =1{Pozostała {count} godzina} few{Pozostały {count} godziny} many{Pozostało {count} godzin} other{Pozostało {count} godzin}}",
+  "tfaTwoFactorAuth": "Uwierzytelnianie dwuskładnikowe"
 }

--- a/lib/l10n/app_pt.arb
+++ b/lib/l10n/app_pt.arb
@@ -1714,5 +1714,6 @@
   "timeagoNbMonthsAgo": "{count, plural, =1{há {count} mês} other{há {count} meses}}",
   "timeagoNbYearsAgo": "{count, plural, =1{há {count} ano} other{há {count} anos}}",
   "timeagoNbMinutesRemaining": "{count, plural, =1{{count} minuto restante} other{{count} minutos restantes}}",
-  "timeagoNbHoursRemaining": "{count, plural, =1{{count} hora restante} other{{count} horas restantes}}"
+  "timeagoNbHoursRemaining": "{count, plural, =1{{count} hora restante} other{{count} horas restantes}}",
+  "tfaTwoFactorAuth": "Autenticação de dois fatores"
 }

--- a/lib/l10n/app_pt_BR.arb
+++ b/lib/l10n/app_pt_BR.arb
@@ -1722,5 +1722,6 @@
   "timeagoNbMonthsAgo": "{count, plural, =1{{count} mês atrás} other{{count} meses atrás}}",
   "timeagoNbYearsAgo": "{count, plural, =1{{count} ano atrás} other{{count} anos atrás}}",
   "timeagoNbMinutesRemaining": "{count, plural, =1{{count} minuto restante} other{{count} minutos restantes}}",
-  "timeagoNbHoursRemaining": "{count, plural, =1{{count} hora restante} other{{count} horas restantes}}"
+  "timeagoNbHoursRemaining": "{count, plural, =1{{count} hora restante} other{{count} horas restantes}}",
+  "tfaTwoFactorAuth": "Autenticação de dois fatores"
 }

--- a/lib/l10n/app_ro.arb
+++ b/lib/l10n/app_ro.arb
@@ -1722,5 +1722,6 @@
   "timeagoNbMonthsAgo": "{count, plural, =1{cu o lună în urmă} few{cu {count} luni în urmă} other{cu {count} de luni în urmă}}",
   "timeagoNbYearsAgo": "{count, plural, =1{cu un an în urmă} few{cu {count} ani în urmă} other{cu {count} de ani în urmă}}",
   "timeagoNbMinutesRemaining": "{count, plural, =1{un minut rămas} few{{count} minute rămase} other{{count} de minute rămase}}",
-  "timeagoNbHoursRemaining": "{count, plural, =1{o oră rămasă} few{{count} ore rămase} other{{count} de ore rămase}}"
+  "timeagoNbHoursRemaining": "{count, plural, =1{o oră rămasă} few{{count} ore rămase} other{{count} de ore rămase}}",
+  "tfaTwoFactorAuth": "Autentificare în doi pași"
 }

--- a/lib/l10n/app_ru.arb
+++ b/lib/l10n/app_ru.arb
@@ -1722,5 +1722,6 @@
   "timeagoNbMonthsAgo": "{count, plural, =1{{count} месяц назад} few{{count} месяца назад} many{{count} месяцев назад} other{{count} месяцев назад}}",
   "timeagoNbYearsAgo": "{count, plural, =1{{count} год назад} few{{count} года назад} many{{count} лет назад} other{{count} лет назад}}",
   "timeagoNbMinutesRemaining": "{count, plural, =1{осталась {count} минута} few{осталось {count} минуты} many{осталось {count} минут} other{осталось {count} минут}}",
-  "timeagoNbHoursRemaining": "{count, plural, =1{остался {count} час} few{осталось {count} часа} many{осталось {count} часов} other{осталось {count} часов}}"
+  "timeagoNbHoursRemaining": "{count, plural, =1{остался {count} час} few{осталось {count} часа} many{осталось {count} часов} other{осталось {count} часов}}",
+  "tfaTwoFactorAuth": "Двухфакторная аутентификация"
 }

--- a/lib/l10n/app_sk.arb
+++ b/lib/l10n/app_sk.arb
@@ -1718,5 +1718,6 @@
   "timeagoNbMonthsAgo": "{count, plural, =1{pred {count} mesiacom} few{pred {count} mesiacmi} many{pred {count} mesiacmi} other{pred {count} mesiacmi}}",
   "timeagoNbYearsAgo": "{count, plural, =1{pred {count} rokom} few{pred {count} rokmi} many{pred {count} rokmi} other{pred {count} rokmi}}",
   "timeagoNbMinutesRemaining": "{count, plural, =1{ostáva {count} minúta} few{ostávajú {count} minúty} many{ostáva {count} minút} other{ostáva {count} minút}}",
-  "timeagoNbHoursRemaining": "{count, plural, =1{ostáva {count} hodina} few{ostávajú {count} hodiny} many{ostáva {count} hodín} other{ostáva {count} hodín}}"
+  "timeagoNbHoursRemaining": "{count, plural, =1{ostáva {count} hodina} few{ostávajú {count} hodiny} many{ostáva {count} hodín} other{ostáva {count} hodín}}",
+  "tfaTwoFactorAuth": "Dvojstupňové overenie"
 }

--- a/lib/l10n/app_sl.arb
+++ b/lib/l10n/app_sl.arb
@@ -1722,5 +1722,6 @@
   "timeagoNbMonthsAgo": "{count, plural, =1{Pred {count} mesecem} =2{Pred {count} mesecema} few{Pred {count} meseci} other{Pred {count} meseci}}",
   "timeagoNbYearsAgo": "{count, plural, =1{Pred {count} letom} =2{Pred {count} letoma} few{Pred {count} leti} other{Pred {count} leti}}",
   "timeagoNbMinutesRemaining": "{count, plural, =1{še {count} minuta} =2{še {count} minuti} few{še {count} minute} other{še {count} minut}}",
-  "timeagoNbHoursRemaining": "{count, plural, =1{še {count} ura} =2{še {count} uri} few{še {count} ure} other{še {count} ur}}"
+  "timeagoNbHoursRemaining": "{count, plural, =1{še {count} ura} =2{še {count} uri} few{še {count} ure} other{še {count} ur}}",
+  "tfaTwoFactorAuth": "Dvojna avtentikacija"
 }

--- a/lib/l10n/app_sq.arb
+++ b/lib/l10n/app_sq.arb
@@ -1660,5 +1660,6 @@
   "timeagoNbMonthsAgo": "{count, plural, =1{{count} muaj më parë} other{para {count} muajve}}",
   "timeagoNbYearsAgo": "{count, plural, =1{{count} vit më parë} other{para {count} viteve}}",
   "timeagoNbMinutesRemaining": "{count, plural, =1{Edhe {count} minutë} other{Edhe {count} minuta}}",
-  "timeagoNbHoursRemaining": "{count, plural, =1{Edhe {count} orë} other{Edhe {count} orë}}"
+  "timeagoNbHoursRemaining": "{count, plural, =1{Edhe {count} orë} other{Edhe {count} orë}}",
+  "tfaTwoFactorAuth": "Mirëfilltësim dyfaktorësh"
 }

--- a/lib/l10n/app_sr.arb
+++ b/lib/l10n/app_sr.arb
@@ -1385,5 +1385,6 @@
   "timeagoJustNow": "управо сада",
   "timeagoRightNow": "управо сад",
   "timeagoCompleted": "завршено",
-  "timeagoInNbSeconds": "{count, plural, =1{за {count} секунди} few{за {count} сати} other{за {count} дана}}"
+  "timeagoInNbSeconds": "{count, plural, =1{за {count} секунди} few{за {count} сати} other{за {count} дана}}",
+  "tfaTwoFactorAuth": "Двофакторска аутентификација"
 }

--- a/lib/l10n/app_sv.arb
+++ b/lib/l10n/app_sv.arb
@@ -1686,5 +1686,6 @@
   "timeagoNbMonthsAgo": "{count, plural, =1{{count} månad sedan} other{{count} månader sedan}}",
   "timeagoNbYearsAgo": "{count, plural, =1{{count} år sedan} other{{count} år sedan}}",
   "timeagoNbMinutesRemaining": "{count, plural, =1{{count} minut återstår} other{{count} minuter återstår}}",
-  "timeagoNbHoursRemaining": "{count, plural, =1{{count} timme återstår} other{{count} timmar återstår}}"
+  "timeagoNbHoursRemaining": "{count, plural, =1{{count} timme återstår} other{{count} timmar återstår}}",
+  "tfaTwoFactorAuth": "Tvåfaktorsautentisering"
 }

--- a/lib/l10n/app_tr.arb
+++ b/lib/l10n/app_tr.arb
@@ -1716,5 +1716,6 @@
   "timeagoNbMonthsAgo": "{count, plural, =1{{count} ay önce} other{{count} ay önce}}",
   "timeagoNbYearsAgo": "{count, plural, =1{{count} yıl önce} other{{count} yıl önce}}",
   "timeagoNbMinutesRemaining": "{count, plural, =1{{count} dakika kaldı} other{{count} dakika kaldı}}",
-  "timeagoNbHoursRemaining": "{count, plural, =1{{count} saat kaldı} other{{count} saat kaldı}}"
+  "timeagoNbHoursRemaining": "{count, plural, =1{{count} saat kaldı} other{{count} saat kaldı}}",
+  "tfaTwoFactorAuth": "İki faktörlü kimlik doğrulama"
 }

--- a/lib/l10n/app_uk.arb
+++ b/lib/l10n/app_uk.arb
@@ -1722,5 +1722,6 @@
   "timeagoNbMonthsAgo": "{count, plural, =1{{count} місяць тому} few{{count} місяці тому} many{{count} місяців тому} other{{count} місяця тому}}",
   "timeagoNbYearsAgo": "{count, plural, =1{{count} рік тому} few{{count} роки тому} many{{count} років тому} other{{count} року тому}}",
   "timeagoNbMinutesRemaining": "{count, plural, =1{залишилася {count} хвилина} few{залишилося {count} хвилини} many{залишилося {count} хвилин} other{залишилося {count} хвилини}}",
-  "timeagoNbHoursRemaining": "{count, plural, =1{залишилася {count} година} few{залишилося {count} години} many{залишилося {count} годин} other{залишилося {count} години}}"
+  "timeagoNbHoursRemaining": "{count, plural, =1{залишилася {count} година} few{залишилося {count} години} many{залишилося {count} годин} other{залишилося {count} години}}",
+  "tfaTwoFactorAuth": "Двофакторна автентифікація"
 }

--- a/lib/l10n/app_vi.arb
+++ b/lib/l10n/app_vi.arb
@@ -1722,5 +1722,6 @@
   "timeagoNbMonthsAgo": "{count, plural, other{{count} tháng trước}}",
   "timeagoNbYearsAgo": "{count, plural, other{{count} năm trước}}",
   "timeagoNbMinutesRemaining": "{count, plural, other{còn {count} phút}}",
-  "timeagoNbHoursRemaining": "{count, plural, other{còn {count} giờ}}"
+  "timeagoNbHoursRemaining": "{count, plural, other{còn {count} giờ}}",
+  "tfaTwoFactorAuth": "Xác thực 2 bước"
 }

--- a/lib/l10n/app_zh.arb
+++ b/lib/l10n/app_zh.arb
@@ -1722,5 +1722,6 @@
   "timeagoNbMonthsAgo": "{count, plural, other{{count} 月前}}",
   "timeagoNbYearsAgo": "{count, plural, other{{count} 年前}}",
   "timeagoNbMinutesRemaining": "{count, plural, other{还剩 {count} 分钟}}",
-  "timeagoNbHoursRemaining": "{count, plural, other{还剩 {count} 小时}}"
+  "timeagoNbHoursRemaining": "{count, plural, other{还剩 {count} 小时}}",
+  "tfaTwoFactorAuth": "双重认证"
 }

--- a/lib/l10n/app_zh_TW.arb
+++ b/lib/l10n/app_zh_TW.arb
@@ -1658,5 +1658,6 @@
   "timeagoNbMonthsAgo": "{count, plural, other{{count}個月前}}",
   "timeagoNbYearsAgo": "{count, plural, other{{count}年前}}",
   "timeagoNbMinutesRemaining": "{count, plural, other{剩下 {count} 分鐘}}",
-  "timeagoNbHoursRemaining": "{count, plural, other{剩下 {count} 小時}}"
+  "timeagoNbHoursRemaining": "{count, plural, other{剩下 {count} 小時}}",
+  "tfaTwoFactorAuth": "兩步驟驗證"
 }

--- a/lib/l10n/l10n.dart
+++ b/lib/l10n/l10n.dart
@@ -10537,6 +10537,12 @@ abstract class AppLocalizations {
   /// In en, this message translates to:
   /// **'{count, plural, =1{{count} hour remaining} other{{count} hours remaining}}'**
   String timeagoNbHoursRemaining(int count);
+
+  /// No description provided for @tfaTwoFactorAuth.
+  ///
+  /// In en, this message translates to:
+  /// **'Two-factor authentication'**
+  String get tfaTwoFactorAuth;
 }
 
 class _AppLocalizationsDelegate extends LocalizationsDelegate<AppLocalizations> {

--- a/lib/l10n/l10n_af.dart
+++ b/lib/l10n/l10n_af.dart
@@ -6219,4 +6219,7 @@ class AppLocalizationsAf extends AppLocalizations {
     );
     return '$_temp0';
   }
+
+  @override
+  String get tfaTwoFactorAuth => 'Tweeledige verifikasie';
 }

--- a/lib/l10n/l10n_ar.dart
+++ b/lib/l10n/l10n_ar.dart
@@ -6595,4 +6595,7 @@ class AppLocalizationsAr extends AppLocalizations {
     );
     return '$_temp0';
   }
+
+  @override
+  String get tfaTwoFactorAuth => 'التوثيق ذو العاملين';
 }

--- a/lib/l10n/l10n_az.dart
+++ b/lib/l10n/l10n_az.dart
@@ -6217,4 +6217,7 @@ class AppLocalizationsAz extends AppLocalizations {
     );
     return '$_temp0';
   }
+
+  @override
+  String get tfaTwoFactorAuth => '2 mərhələli təsdiqləmə';
 }

--- a/lib/l10n/l10n_be.dart
+++ b/lib/l10n/l10n_be.dart
@@ -6395,4 +6395,7 @@ class AppLocalizationsBe extends AppLocalizations {
     );
     return '$_temp0';
   }
+
+  @override
+  String get tfaTwoFactorAuth => 'Двухфактарная аўтэнтыфікацыя';
 }

--- a/lib/l10n/l10n_bg.dart
+++ b/lib/l10n/l10n_bg.dart
@@ -6219,4 +6219,7 @@ class AppLocalizationsBg extends AppLocalizations {
     );
     return '$_temp0';
   }
+
+  @override
+  String get tfaTwoFactorAuth => 'Двуфакторно удостоверяване';
 }

--- a/lib/l10n/l10n_bn.dart
+++ b/lib/l10n/l10n_bn.dart
@@ -6219,4 +6219,7 @@ class AppLocalizationsBn extends AppLocalizations {
     );
     return '$_temp0';
   }
+
+  @override
+  String get tfaTwoFactorAuth => 'টু-ফ্যাক্টর অথেন্টিকেশন';
 }

--- a/lib/l10n/l10n_bs.dart
+++ b/lib/l10n/l10n_bs.dart
@@ -6313,4 +6313,7 @@ class AppLocalizationsBs extends AppLocalizations {
     );
     return '$_temp0';
   }
+
+  @override
+  String get tfaTwoFactorAuth => 'Dvofaktorska provjera autentičnosti';
 }

--- a/lib/l10n/l10n_ca.dart
+++ b/lib/l10n/l10n_ca.dart
@@ -6219,4 +6219,7 @@ class AppLocalizationsCa extends AppLocalizations {
     );
     return '$_temp0';
   }
+
+  @override
+  String get tfaTwoFactorAuth => 'Autenticació de dos factors';
 }

--- a/lib/l10n/l10n_cs.dart
+++ b/lib/l10n/l10n_cs.dart
@@ -6405,4 +6405,7 @@ class AppLocalizationsCs extends AppLocalizations {
     );
     return '$_temp0';
   }
+
+  @override
+  String get tfaTwoFactorAuth => 'Dvoufázové ověření';
 }

--- a/lib/l10n/l10n_da.dart
+++ b/lib/l10n/l10n_da.dart
@@ -6219,4 +6219,7 @@ class AppLocalizationsDa extends AppLocalizations {
     );
     return '$_temp0';
   }
+
+  @override
+  String get tfaTwoFactorAuth => 'To-faktor-godkendelse';
 }

--- a/lib/l10n/l10n_de.dart
+++ b/lib/l10n/l10n_de.dart
@@ -6219,4 +6219,7 @@ class AppLocalizationsDe extends AppLocalizations {
     );
     return '$_temp0';
   }
+
+  @override
+  String get tfaTwoFactorAuth => 'Zwei-Faktor-Authentifizierung';
 }

--- a/lib/l10n/l10n_el.dart
+++ b/lib/l10n/l10n_el.dart
@@ -6219,4 +6219,7 @@ class AppLocalizationsEl extends AppLocalizations {
     );
     return '$_temp0';
   }
+
+  @override
+  String get tfaTwoFactorAuth => 'Έλεγχος ταυτότητας δύο παραγόντων';
 }

--- a/lib/l10n/l10n_en.dart
+++ b/lib/l10n/l10n_en.dart
@@ -6217,6 +6217,9 @@ class AppLocalizationsEn extends AppLocalizations {
     );
     return '$_temp0';
   }
+
+  @override
+  String get tfaTwoFactorAuth => 'Two-factor authentication';
 }
 
 /// The translations for English, as used in the United States (`en_US`).
@@ -12434,4 +12437,7 @@ class AppLocalizationsEnUs extends AppLocalizationsEn {
     );
     return '$_temp0';
   }
+
+  @override
+  String get tfaTwoFactorAuth => 'Two-factor authentication';
 }

--- a/lib/l10n/l10n_eo.dart
+++ b/lib/l10n/l10n_eo.dart
@@ -6219,4 +6219,7 @@ class AppLocalizationsEo extends AppLocalizations {
     );
     return '$_temp0';
   }
+
+  @override
+  String get tfaTwoFactorAuth => 'Dufaza aŭtentigo';
 }

--- a/lib/l10n/l10n_es.dart
+++ b/lib/l10n/l10n_es.dart
@@ -6219,4 +6219,7 @@ class AppLocalizationsEs extends AppLocalizations {
     );
     return '$_temp0';
   }
+
+  @override
+  String get tfaTwoFactorAuth => 'Autenticación en dos pasos';
 }

--- a/lib/l10n/l10n_et.dart
+++ b/lib/l10n/l10n_et.dart
@@ -6219,4 +6219,7 @@ class AppLocalizationsEt extends AppLocalizations {
     );
     return '$_temp0';
   }
+
+  @override
+  String get tfaTwoFactorAuth => 'Kaheastmeline autentimine';
 }

--- a/lib/l10n/l10n_eu.dart
+++ b/lib/l10n/l10n_eu.dart
@@ -6219,4 +6219,7 @@ class AppLocalizationsEu extends AppLocalizations {
     );
     return '$_temp0';
   }
+
+  @override
+  String get tfaTwoFactorAuth => 'Bi faktoreko autentifikazioa';
 }

--- a/lib/l10n/l10n_fa.dart
+++ b/lib/l10n/l10n_fa.dart
@@ -6219,4 +6219,7 @@ class AppLocalizationsFa extends AppLocalizations {
     );
     return '$_temp0';
   }
+
+  @override
+  String get tfaTwoFactorAuth => 'راستین‌آزمایی دوعاملی';
 }

--- a/lib/l10n/l10n_fi.dart
+++ b/lib/l10n/l10n_fi.dart
@@ -6219,4 +6219,7 @@ class AppLocalizationsFi extends AppLocalizations {
     );
     return '$_temp0';
   }
+
+  @override
+  String get tfaTwoFactorAuth => 'Kaksivaiheinen tunnistautuminen';
 }

--- a/lib/l10n/l10n_fr.dart
+++ b/lib/l10n/l10n_fr.dart
@@ -6219,4 +6219,7 @@ class AppLocalizationsFr extends AppLocalizations {
     );
     return '$_temp0';
   }
+
+  @override
+  String get tfaTwoFactorAuth => 'Authentification à deux facteurs';
 }

--- a/lib/l10n/l10n_gl.dart
+++ b/lib/l10n/l10n_gl.dart
@@ -6219,4 +6219,7 @@ class AppLocalizationsGl extends AppLocalizations {
     );
     return '$_temp0';
   }
+
+  @override
+  String get tfaTwoFactorAuth => 'Autenticación en dous pasos';
 }

--- a/lib/l10n/l10n_gsw.dart
+++ b/lib/l10n/l10n_gsw.dart
@@ -6219,4 +6219,7 @@ class AppLocalizationsGsw extends AppLocalizations {
     );
     return '$_temp0';
   }
+
+  @override
+  String get tfaTwoFactorAuth => 'Zwei-Faktor-Autentifizierig';
 }

--- a/lib/l10n/l10n_he.dart
+++ b/lib/l10n/l10n_he.dart
@@ -6403,4 +6403,7 @@ class AppLocalizationsHe extends AppLocalizations {
     );
     return '$_temp0';
   }
+
+  @override
+  String get tfaTwoFactorAuth => 'אימות דו־שלבי';
 }

--- a/lib/l10n/l10n_hi.dart
+++ b/lib/l10n/l10n_hi.dart
@@ -6217,4 +6217,7 @@ class AppLocalizationsHi extends AppLocalizations {
     );
     return '$_temp0';
   }
+
+  @override
+  String get tfaTwoFactorAuth => 'दो-चरण प्रमाणीकरण';
 }

--- a/lib/l10n/l10n_hr.dart
+++ b/lib/l10n/l10n_hr.dart
@@ -6311,4 +6311,7 @@ class AppLocalizationsHr extends AppLocalizations {
     );
     return '$_temp0';
   }
+
+  @override
+  String get tfaTwoFactorAuth => 'Dvofaktorska provjera autentičnosti';
 }

--- a/lib/l10n/l10n_hu.dart
+++ b/lib/l10n/l10n_hu.dart
@@ -6219,4 +6219,7 @@ class AppLocalizationsHu extends AppLocalizations {
     );
     return '$_temp0';
   }
+
+  @override
+  String get tfaTwoFactorAuth => 'Kétlépcsős azonosítás';
 }

--- a/lib/l10n/l10n_hy.dart
+++ b/lib/l10n/l10n_hy.dart
@@ -6219,4 +6219,7 @@ class AppLocalizationsHy extends AppLocalizations {
     );
     return '$_temp0';
   }
+
+  @override
+  String get tfaTwoFactorAuth => 'Երկգործոն նույնականացում';
 }

--- a/lib/l10n/l10n_id.dart
+++ b/lib/l10n/l10n_id.dart
@@ -6129,4 +6129,7 @@ class AppLocalizationsId extends AppLocalizations {
     );
     return '$_temp0';
   }
+
+  @override
+  String get tfaTwoFactorAuth => 'Autentikasi dua-langkah';
 }

--- a/lib/l10n/l10n_it.dart
+++ b/lib/l10n/l10n_it.dart
@@ -6219,4 +6219,7 @@ class AppLocalizationsIt extends AppLocalizations {
     );
     return '$_temp0';
   }
+
+  @override
+  String get tfaTwoFactorAuth => 'Autenticazione a due fattori';
 }

--- a/lib/l10n/l10n_ja.dart
+++ b/lib/l10n/l10n_ja.dart
@@ -6125,4 +6125,7 @@ class AppLocalizationsJa extends AppLocalizations {
     );
     return '$_temp0';
   }
+
+  @override
+  String get tfaTwoFactorAuth => '2 要素認証';
 }

--- a/lib/l10n/l10n_kk.dart
+++ b/lib/l10n/l10n_kk.dart
@@ -6219,4 +6219,7 @@ class AppLocalizationsKk extends AppLocalizations {
     );
     return '$_temp0';
   }
+
+  @override
+  String get tfaTwoFactorAuth => 'Екісатылы өкіл-растау';
 }

--- a/lib/l10n/l10n_ko.dart
+++ b/lib/l10n/l10n_ko.dart
@@ -6125,4 +6125,7 @@ class AppLocalizationsKo extends AppLocalizations {
     );
     return '$_temp0';
   }
+
+  @override
+  String get tfaTwoFactorAuth => '2단계 인증';
 }

--- a/lib/l10n/l10n_lt.dart
+++ b/lib/l10n/l10n_lt.dart
@@ -6405,4 +6405,7 @@ class AppLocalizationsLt extends AppLocalizations {
     );
     return '$_temp0';
   }
+
+  @override
+  String get tfaTwoFactorAuth => 'Dviejų lygių tapatumo nustatymas';
 }

--- a/lib/l10n/l10n_lv.dart
+++ b/lib/l10n/l10n_lv.dart
@@ -6307,4 +6307,7 @@ class AppLocalizationsLv extends AppLocalizations {
     );
     return '$_temp0';
   }
+
+  @override
+  String get tfaTwoFactorAuth => 'Divfaktoru autentifikācija';
 }

--- a/lib/l10n/l10n_mk.dart
+++ b/lib/l10n/l10n_mk.dart
@@ -6219,4 +6219,7 @@ class AppLocalizationsMk extends AppLocalizations {
     );
     return '$_temp0';
   }
+
+  @override
+  String get tfaTwoFactorAuth => 'Двофакторна автентикација';
 }

--- a/lib/l10n/l10n_nb.dart
+++ b/lib/l10n/l10n_nb.dart
@@ -6219,4 +6219,7 @@ class AppLocalizationsNb extends AppLocalizations {
     );
     return '$_temp0';
   }
+
+  @override
+  String get tfaTwoFactorAuth => 'Tofaktorautentisering';
 }

--- a/lib/l10n/l10n_nl.dart
+++ b/lib/l10n/l10n_nl.dart
@@ -6219,4 +6219,7 @@ class AppLocalizationsNl extends AppLocalizations {
     );
     return '$_temp0';
   }
+
+  @override
+  String get tfaTwoFactorAuth => 'Tweestapsverificatie';
 }

--- a/lib/l10n/l10n_pl.dart
+++ b/lib/l10n/l10n_pl.dart
@@ -6407,4 +6407,7 @@ class AppLocalizationsPl extends AppLocalizations {
     );
     return '$_temp0';
   }
+
+  @override
+  String get tfaTwoFactorAuth => 'Uwierzytelnianie dwuskładnikowe';
 }

--- a/lib/l10n/l10n_pt.dart
+++ b/lib/l10n/l10n_pt.dart
@@ -6219,6 +6219,9 @@ class AppLocalizationsPt extends AppLocalizations {
     );
     return '$_temp0';
   }
+
+  @override
+  String get tfaTwoFactorAuth => 'Autenticação de dois fatores';
 }
 
 /// The translations for Portuguese, as used in Brazil (`pt_BR`).
@@ -12436,4 +12439,7 @@ class AppLocalizationsPtBr extends AppLocalizationsPt {
     );
     return '$_temp0';
   }
+
+  @override
+  String get tfaTwoFactorAuth => 'Autenticação de dois fatores';
 }

--- a/lib/l10n/l10n_ro.dart
+++ b/lib/l10n/l10n_ro.dart
@@ -6313,4 +6313,7 @@ class AppLocalizationsRo extends AppLocalizations {
     );
     return '$_temp0';
   }
+
+  @override
+  String get tfaTwoFactorAuth => 'Autentificare în doi pași';
 }

--- a/lib/l10n/l10n_ru.dart
+++ b/lib/l10n/l10n_ru.dart
@@ -6407,4 +6407,7 @@ class AppLocalizationsRu extends AppLocalizations {
     );
     return '$_temp0';
   }
+
+  @override
+  String get tfaTwoFactorAuth => 'Двухфакторная аутентификация';
 }

--- a/lib/l10n/l10n_sk.dart
+++ b/lib/l10n/l10n_sk.dart
@@ -6407,4 +6407,7 @@ class AppLocalizationsSk extends AppLocalizations {
     );
     return '$_temp0';
   }
+
+  @override
+  String get tfaTwoFactorAuth => 'Dvojstupňové overenie';
 }

--- a/lib/l10n/l10n_sl.dart
+++ b/lib/l10n/l10n_sl.dart
@@ -6407,4 +6407,7 @@ class AppLocalizationsSl extends AppLocalizations {
     );
     return '$_temp0';
   }
+
+  @override
+  String get tfaTwoFactorAuth => 'Dvojna avtentikacija';
 }

--- a/lib/l10n/l10n_sq.dart
+++ b/lib/l10n/l10n_sq.dart
@@ -6219,4 +6219,7 @@ class AppLocalizationsSq extends AppLocalizations {
     );
     return '$_temp0';
   }
+
+  @override
+  String get tfaTwoFactorAuth => 'Mirëfilltësim dyfaktorësh';
 }

--- a/lib/l10n/l10n_sr.dart
+++ b/lib/l10n/l10n_sr.dart
@@ -6282,4 +6282,7 @@ class AppLocalizationsSr extends AppLocalizations {
     );
     return '$_temp0';
   }
+
+  @override
+  String get tfaTwoFactorAuth => 'Двофакторска аутентификација';
 }

--- a/lib/l10n/l10n_sv.dart
+++ b/lib/l10n/l10n_sv.dart
@@ -6219,4 +6219,7 @@ class AppLocalizationsSv extends AppLocalizations {
     );
     return '$_temp0';
   }
+
+  @override
+  String get tfaTwoFactorAuth => 'Tvåfaktorsautentisering';
 }

--- a/lib/l10n/l10n_tr.dart
+++ b/lib/l10n/l10n_tr.dart
@@ -6219,4 +6219,7 @@ class AppLocalizationsTr extends AppLocalizations {
     );
     return '$_temp0';
   }
+
+  @override
+  String get tfaTwoFactorAuth => 'İki faktörlü kimlik doğrulama';
 }

--- a/lib/l10n/l10n_uk.dart
+++ b/lib/l10n/l10n_uk.dart
@@ -6407,4 +6407,7 @@ class AppLocalizationsUk extends AppLocalizations {
     );
     return '$_temp0';
   }
+
+  @override
+  String get tfaTwoFactorAuth => 'Двофакторна автентифікація';
 }

--- a/lib/l10n/l10n_vi.dart
+++ b/lib/l10n/l10n_vi.dart
@@ -6125,4 +6125,7 @@ class AppLocalizationsVi extends AppLocalizations {
     );
     return '$_temp0';
   }
+
+  @override
+  String get tfaTwoFactorAuth => 'Xác thực 2 bước';
 }

--- a/lib/l10n/l10n_zh.dart
+++ b/lib/l10n/l10n_zh.dart
@@ -6125,6 +6125,9 @@ class AppLocalizationsZh extends AppLocalizations {
     );
     return '$_temp0';
   }
+
+  @override
+  String get tfaTwoFactorAuth => '双重认证';
 }
 
 /// The translations for Chinese, as used in Taiwan (`zh_TW`).
@@ -12026,4 +12029,7 @@ class AppLocalizationsZhTw extends AppLocalizationsZh {
     );
     return '$_temp0';
   }
+
+  @override
+  String get tfaTwoFactorAuth => '兩步驟驗證';
 }

--- a/lib/src/view/settings/account_preferences_screen.dart
+++ b/lib/src/view/settings/account_preferences_screen.dart
@@ -324,22 +324,22 @@ class _AccountPreferencesScreenState extends ConsumerState<AccountPreferencesScr
               header: const SettingsSectionTitle('Security'),
               hasLeading: true,
               children: [
-                  ListTile(
-                    leading: const Icon(Icons.lock),
-                    title: const Text('Change password'),
-                    trailing: const _OpenInNewIcon(),
-                    onTap: () {
-                      launchUrl(lichessUri('/account/passwd'));
-                    }
-                  ),
-                  ListTile(
-                    leading: const Icon(Icons.security),
-                    title: const Text('Two-factor authentication'),
-                    trailing: const _OpenInNewIcon(),
-                    onTap: () {
-                      launchUrl(lichessUri('/account/twofactor'));
-                    }
-                  )
+                ListTile(
+                  leading: const Icon(Icons.lock),
+                  title: const Text('Change password'),
+                  trailing: const _OpenInNewIcon(),
+                  onTap: () {
+                    launchUrl(lichessUri('/account/passwd'));
+                  },
+                ),
+                ListTile(
+                  leading: const Icon(Icons.security),
+                  title: const Text('Two-factor authentication'),
+                  trailing: const _OpenInNewIcon(),
+                  onTap: () {
+                    launchUrl(lichessUri('/account/twofactor'));
+                  },
+                ),
               ],
             ),
             ListSection(

--- a/lib/src/view/settings/account_preferences_screen.dart
+++ b/lib/src/view/settings/account_preferences_screen.dart
@@ -321,7 +321,7 @@ class _AccountPreferencesScreenState extends ConsumerState<AccountPreferencesScr
               ],
             ),
             ListSection(
-              header: const SettingsSectionTitle('Authentication'),
+              header: const SettingsSectionTitle('Security'),
               hasLeading: true,
               children: [
                   ListTile(
@@ -332,6 +332,14 @@ class _AccountPreferencesScreenState extends ConsumerState<AccountPreferencesScr
                       launchUrl(lichessUri('/account/passwd'));
                     }
                   ),
+                  ListTile(
+                    leading: const Icon(Icons.security),
+                    title: const Text('Two-factor authentication'),
+                    trailing: const _OpenInNewIcon(),
+                    onTap: () {
+                      launchUrl(lichessUri('/account/twofactor'));
+                    }
+                  )
               ],
             ),
             ListSection(

--- a/lib/src/view/settings/account_preferences_screen.dart
+++ b/lib/src/view/settings/account_preferences_screen.dart
@@ -321,12 +321,12 @@ class _AccountPreferencesScreenState extends ConsumerState<AccountPreferencesScr
               ],
             ),
             ListSection(
-              header: const SettingsSectionTitle('Security'),
+              header: SettingsSectionTitle(context.l10n.security),
               hasLeading: true,
               children: [
                 ListTile(
                   leading: const Icon(Icons.lock),
-                  title: const Text('Change password'),
+                  title: Text(context.l10n.changePassword),
                   trailing: const _OpenInNewIcon(),
                   onTap: () {
                     launchUrl(lichessUri('/account/passwd'));
@@ -334,7 +334,7 @@ class _AccountPreferencesScreenState extends ConsumerState<AccountPreferencesScr
                 ),
                 ListTile(
                   leading: const Icon(Icons.security),
-                  title: const Text('Two-factor authentication'),
+                  title: Text(context.l10n.tfaTwoFactorAuth),
                   trailing: const _OpenInNewIcon(),
                   onTap: () {
                     launchUrl(lichessUri('/account/twofactor'));

--- a/lib/src/view/settings/account_preferences_screen.dart
+++ b/lib/src/view/settings/account_preferences_screen.dart
@@ -321,6 +321,20 @@ class _AccountPreferencesScreenState extends ConsumerState<AccountPreferencesScr
               ],
             ),
             ListSection(
+              header: const SettingsSectionTitle('Authentication'),
+              hasLeading: true,
+              children: [
+                  ListTile(
+                    leading: const Icon(Icons.lock),
+                    title: const Text('Change password'),
+                    trailing: const _OpenInNewIcon(),
+                    onTap: () {
+                      launchUrl(lichessUri('/account/passwd'));
+                    }
+                  ),
+              ],
+            ),
+            ListSection(
               header: const SettingsSectionTitle('Danger zone'),
               hasLeading: true,
               children: [

--- a/scripts/gen-arb.mjs
+++ b/scripts/gen-arb.mjs
@@ -37,6 +37,7 @@ const modules = [
   'streamer',
   'study',
   'timeago',
+  'tfa',
 ]
 
 // list of keys (per module) to include in the ARB file
@@ -46,6 +47,7 @@ const whiteLists = {
   'contact': ['contact', 'contactLichess'],
   'search': ['search'],
   'streamer': ['lichessStreamers'],
+  'tfa': ['twoFactorAuth']
 }
 
 // Order of locales with variants matters: the fallback must always be first


### PR DESCRIPTION
Add change password and two-factor authentication buttons to the account settings page, linking to `/account/passwd` and `/account/twofactor` respectively.

Closes #1873
Closes #1874