### PR TITLE
fix: reset scroll when navigating study chapters

### DIFF
--- a/lib/src/view/study/study_gamebook.dart
+++ b/lib/src/view/study/study_gamebook.dart
@@ -26,14 +26,26 @@ class StudyGamebook extends StatelessWidget {
   }
 }
 
-class _Comment extends ConsumerWidget {
+class _Comment extends ConsumerStatefulWidget {
   const _Comment({required this.id});
-
   final StudyId id;
 
   @override
-  Widget build(BuildContext context, WidgetRef ref) {
-    final state = ref.watch(studyControllerProvider(id)).requireValue;
+  ConsumerState<_Comment> createState() => _CommentState();
+}
+
+class _CommentState extends ConsumerState<_Comment> {
+  final ScrollController _scrollController = ScrollController();
+
+  @override
+  void didUpdateWidget(covariant _Comment oldWidget) {
+    super.didUpdateWidget(oldWidget);
+    _scrollController.jumpTo(0);
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final state = ref.watch(studyControllerProvider(widget.id)).requireValue;
 
     final comment =
         state.gamebookComment ??
@@ -47,7 +59,9 @@ class _Comment extends ConsumerWidget {
 
     return Expanded(
       child: Scrollbar(
+        controller: _scrollController,
         child: SingleChildScrollView(
+          controller: _scrollController,
           child: Padding(
             padding: const EdgeInsets.only(right: 5),
             child: Linkify(


### PR DESCRIPTION
The scroll position in the study comment persists even after the text is changed. 

This results in behaviour that results in the user having to manually scroll to the top of the comment if they want to read the text.

This PR resets the scroll position when the widget changes, to save the user having to manually scroll.