### PR TITLE
feat: add haptic feedback for page refreshes

### DIFF
--- a/lib/src/view/account/profile_screen.dart
+++ b/lib/src/view/account/profile_screen.dart
@@ -74,7 +74,7 @@ class _ProfileScreenState extends ConsumerState<ProfileScreen> {
             edgeOffset: Theme.of(context).platform == TargetPlatform.iOS
                 ? MediaQuery.paddingOf(context).top + kToolbarHeight
                 : 0.0,
-            refreshIndicatorKey: _refreshIndicatorKey,
+            key: _refreshIndicatorKey,
             onRefresh: () => Future.wait([
               ref.refresh(accountProvider.future),
               ref.refresh(_accountActivityProvider.future),

--- a/lib/src/view/account/profile_screen.dart
+++ b/lib/src/view/account/profile_screen.dart
@@ -17,6 +17,7 @@ import 'package:lichess_mobile/src/view/user/user_activity.dart';
 import 'package:lichess_mobile/src/view/user/user_profile.dart';
 import 'package:lichess_mobile/src/widgets/buttons.dart';
 import 'package:lichess_mobile/src/widgets/feedback.dart';
+import 'package:lichess_mobile/src/widgets/haptic_refresh_indicator.dart';
 import 'package:lichess_mobile/src/widgets/list.dart';
 import 'package:lichess_mobile/src/widgets/platform.dart';
 import 'package:lichess_mobile/src/widgets/shimmer.dart';
@@ -69,11 +70,11 @@ class _ProfileScreenState extends ConsumerState<ProfileScreen> {
           final activity = ref.watch(_accountActivityProvider);
           final recentGames = ref.watch(myRecentGamesProvider);
           final nbOfGames = ref.watch(userNumberOfGamesProvider(null)).valueOrNull ?? 0;
-          return RefreshIndicator.adaptive(
+          return HapticRefreshIndicator(
             edgeOffset: Theme.of(context).platform == TargetPlatform.iOS
                 ? MediaQuery.paddingOf(context).top + kToolbarHeight
                 : 0.0,
-            key: _refreshIndicatorKey,
+            refreshIndicatorKey: _refreshIndicatorKey,
             onRefresh: () => Future.wait([
               ref.refresh(accountProvider.future),
               ref.refresh(_accountActivityProvider.future),

--- a/lib/src/view/broadcast/broadcast_list_screen.dart
+++ b/lib/src/view/broadcast/broadcast_list_screen.dart
@@ -9,6 +9,7 @@ import 'package:lichess_mobile/src/view/broadcast/broadcast_search_screen.dart';
 import 'package:lichess_mobile/src/widgets/adaptive_bottom_sheet.dart';
 import 'package:lichess_mobile/src/widgets/buttons.dart';
 import 'package:lichess_mobile/src/widgets/filter.dart';
+import 'package:lichess_mobile/src/widgets/haptic_refresh_indicator.dart';
 import 'package:lichess_mobile/src/widgets/list.dart';
 import 'package:lichess_mobile/src/widgets/misc.dart';
 
@@ -103,7 +104,7 @@ class _Body extends ConsumerWidget {
   Widget build(BuildContext context, WidgetRef ref) {
     final broadcastList = ref.watch(broadcastsPaginatorProvider);
 
-    return RefreshIndicator.adaptive(
+    return HapticRefreshIndicator(
       onRefresh: () => ref.refresh(broadcastsPaginatorProvider.future),
       child: broadcastList.when(
         data: (value) {

--- a/lib/src/view/home/home_tab_screen.dart
+++ b/lib/src/view/home/home_tab_screen.dart
@@ -49,6 +49,7 @@ import 'package:lichess_mobile/src/view/user/player_screen.dart';
 import 'package:lichess_mobile/src/view/user/recent_games.dart';
 import 'package:lichess_mobile/src/widgets/buttons.dart';
 import 'package:lichess_mobile/src/widgets/feedback.dart';
+import 'package:lichess_mobile/src/widgets/haptic_refresh_indicator.dart';
 import 'package:lichess_mobile/src/widgets/list.dart';
 import 'package:lichess_mobile/src/widgets/misc.dart';
 import 'package:lichess_mobile/src/widgets/platform.dart';
@@ -267,11 +268,11 @@ class _HomeScreenState extends ConsumerState<HomeTabScreen> {
               drawer: const AccountDrawer(),
               body: widget.editModeEnabled
                   ? content
-                  : RefreshIndicator.adaptive(
+                  : HapticRefreshIndicator(
                       edgeOffset: Theme.of(context).platform == TargetPlatform.iOS
                           ? MediaQuery.paddingOf(context).top + kToolbarHeight
                           : 0.0,
-                      key: _refreshKey,
+                      refreshIndicatorKey: _refreshKey,
                       onRefresh: () => _refreshData(isOnline: status.isOnline),
                       child: content,
                     ),

--- a/lib/src/view/home/home_tab_screen.dart
+++ b/lib/src/view/home/home_tab_screen.dart
@@ -272,7 +272,7 @@ class _HomeScreenState extends ConsumerState<HomeTabScreen> {
                       edgeOffset: Theme.of(context).platform == TargetPlatform.iOS
                           ? MediaQuery.paddingOf(context).top + kToolbarHeight
                           : 0.0,
-                      refreshIndicatorKey: _refreshKey,
+                      key: _refreshKey,
                       onRefresh: () => _refreshData(isOnline: status.isOnline),
                       child: content,
                     ),

--- a/lib/src/view/message/contacts_screen.dart
+++ b/lib/src/view/message/contacts_screen.dart
@@ -10,6 +10,7 @@ import 'package:lichess_mobile/src/utils/l10n_context.dart';
 import 'package:lichess_mobile/src/utils/navigation.dart';
 import 'package:lichess_mobile/src/utils/rate_limit.dart';
 import 'package:lichess_mobile/src/view/message/conversation_screen.dart';
+import 'package:lichess_mobile/src/widgets/haptic_refresh_indicator.dart';
 import 'package:lichess_mobile/src/widgets/platform_search_bar.dart';
 import 'package:lichess_mobile/src/widgets/user_full_name.dart';
 
@@ -107,7 +108,7 @@ class _ContactsScreenState extends ConsumerState<ContactsScreen> {
               loading: () => const Center(child: CircularProgressIndicator()),
               error: (e, st) => Center(child: Text('Error: $e')),
             )
-          : RefreshIndicator.adaptive(
+          : HapticRefreshIndicator(
               onRefresh: () => ref.refresh(contactsProvider.future),
               child: ContactsListView(openConvo: pushConversationScreen),
             ),

--- a/lib/src/view/play/correspondence_challenges_screen.dart
+++ b/lib/src/view/play/correspondence_challenges_screen.dart
@@ -17,6 +17,7 @@ import 'package:lichess_mobile/src/view/play/challenge_list_item.dart';
 import 'package:lichess_mobile/src/view/play/create_correspondence_game_bottom_sheet.dart';
 import 'package:lichess_mobile/src/widgets/adaptive_action_sheet.dart';
 import 'package:lichess_mobile/src/widgets/feedback.dart';
+import 'package:lichess_mobile/src/widgets/haptic_refresh_indicator.dart';
 import 'package:lichess_mobile/src/widgets/list.dart';
 
 class CorrespondenceChallengesScreen extends ConsumerStatefulWidget {
@@ -102,8 +103,8 @@ class _ChallengesBodyState extends ConsumerState<CorrespondenceChallengesScreen>
                 ),
             ],
           ),
-          body: RefreshIndicator.adaptive(
-            key: _refreshKey,
+          body: HapticRefreshIndicator(
+            refreshIndicatorKey: _refreshKey,
             onRefresh: () => ref.refresh(correspondenceChallengesProvider.future),
             child: ListView.separated(
               itemCount: supportedChallenges.length,

--- a/lib/src/view/play/correspondence_challenges_screen.dart
+++ b/lib/src/view/play/correspondence_challenges_screen.dart
@@ -104,7 +104,7 @@ class _ChallengesBodyState extends ConsumerState<CorrespondenceChallengesScreen>
             ],
           ),
           body: HapticRefreshIndicator(
-            refreshIndicatorKey: _refreshKey,
+            key: _refreshKey,
             onRefresh: () => ref.refresh(correspondenceChallengesProvider.future),
             child: ListView.separated(
               itemCount: supportedChallenges.length,

--- a/lib/src/view/settings/http_log_screen.dart
+++ b/lib/src/view/settings/http_log_screen.dart
@@ -7,6 +7,7 @@ import 'package:lichess_mobile/src/model/http_log/http_log_storage.dart';
 import 'package:lichess_mobile/src/styles/styles.dart';
 import 'package:lichess_mobile/src/utils/navigation.dart';
 import 'package:lichess_mobile/src/widgets/adaptive_action_sheet.dart';
+import 'package:lichess_mobile/src/widgets/haptic_refresh_indicator.dart';
 
 class HttpLogScreen extends ConsumerStatefulWidget {
   const HttpLogScreen({super.key});
@@ -114,8 +115,8 @@ class _HttpLogListState extends ConsumerState<_HttpLogList> {
         ),
       );
     }
-    return RefreshIndicator.adaptive(
-      key: widget.refreshIndicatorKey,
+    return HapticRefreshIndicator(
+      refreshIndicatorKey: widget.refreshIndicatorKey,
       onRefresh: widget.onRefresh,
       child: ListView.separated(
         controller: widget.scrollController,

--- a/lib/src/view/settings/http_log_screen.dart
+++ b/lib/src/view/settings/http_log_screen.dart
@@ -116,7 +116,7 @@ class _HttpLogListState extends ConsumerState<_HttpLogList> {
       );
     }
     return HapticRefreshIndicator(
-      refreshIndicatorKey: widget.refreshIndicatorKey,
+      key: widget.refreshIndicatorKey,
       onRefresh: widget.onRefresh,
       child: ListView.separated(
         controller: widget.scrollController,

--- a/lib/src/view/tournament/tournament_list_screen.dart
+++ b/lib/src/view/tournament/tournament_list_screen.dart
@@ -13,6 +13,7 @@ import 'package:lichess_mobile/src/utils/l10n_context.dart';
 import 'package:lichess_mobile/src/utils/navigation.dart';
 import 'package:lichess_mobile/src/view/tournament/tournament_faq.dart';
 import 'package:lichess_mobile/src/view/tournament/tournament_screen.dart';
+import 'package:lichess_mobile/src/widgets/haptic_refresh_indicator.dart';
 import 'package:lichess_mobile/src/widgets/list.dart';
 import 'package:lichess_mobile/src/widgets/platform.dart';
 import 'package:lichess_mobile/src/widgets/shimmer.dart';
@@ -214,11 +215,11 @@ class _TournamentListBodyState extends ConsumerState<_TournamentListBody> {
       ...userTours.map((tournament) => _TournamentListItem(tournament: tournament)),
     ];
 
-    return RefreshIndicator.adaptive(
+    return HapticRefreshIndicator(
       edgeOffset: Theme.of(context).platform == TargetPlatform.iOS
           ? MediaQuery.paddingOf(context).top + kToolbarHeight
           : 0.0,
-      key: _refreshIndicatorKey,
+      refreshIndicatorKey: _refreshIndicatorKey,
       onRefresh: () async => ref.refresh(tournamentsProvider),
       child: ListView.separated(
         shrinkWrap: true,

--- a/lib/src/view/tournament/tournament_list_screen.dart
+++ b/lib/src/view/tournament/tournament_list_screen.dart
@@ -219,7 +219,7 @@ class _TournamentListBodyState extends ConsumerState<_TournamentListBody> {
       edgeOffset: Theme.of(context).platform == TargetPlatform.iOS
           ? MediaQuery.paddingOf(context).top + kToolbarHeight
           : 0.0,
-      refreshIndicatorKey: _refreshIndicatorKey,
+      key: _refreshIndicatorKey,
       onRefresh: () async => ref.refresh(tournamentsProvider),
       child: ListView.separated(
         shrinkWrap: true,

--- a/lib/src/view/watch/watch_tab_screen.dart
+++ b/lib/src/view/watch/watch_tab_screen.dart
@@ -99,7 +99,7 @@ class _WatchScreenState extends ConsumerState<WatchTabScreen> {
                     edgeOffset: Theme.of(context).platform == TargetPlatform.iOS
                         ? MediaQuery.paddingOf(context).top + kToolbarHeight
                         : 0.0,
-                    refreshIndicatorKey: _androidRefreshKey,
+                    key: _androidRefreshKey,
                     onRefresh: _refreshData,
                     child: _Body(orientation),
                   );

--- a/lib/src/view/watch/watch_tab_screen.dart
+++ b/lib/src/view/watch/watch_tab_screen.dart
@@ -23,6 +23,7 @@ import 'package:lichess_mobile/src/view/broadcast/broadcast_list_screen.dart';
 import 'package:lichess_mobile/src/view/watch/live_tv_channels_screen.dart';
 import 'package:lichess_mobile/src/view/watch/streamer_screen.dart';
 import 'package:lichess_mobile/src/view/watch/tv_screen.dart';
+import 'package:lichess_mobile/src/widgets/haptic_refresh_indicator.dart';
 import 'package:lichess_mobile/src/widgets/list.dart';
 import 'package:lichess_mobile/src/widgets/platform.dart';
 import 'package:lichess_mobile/src/widgets/shimmer.dart';
@@ -94,11 +95,11 @@ class _WatchScreenState extends ConsumerState<WatchTabScreen> {
         body: isOnline
             ? OrientationBuilder(
                 builder: (context, orientation) {
-                  return RefreshIndicator.adaptive(
+                  return HapticRefreshIndicator(
                     edgeOffset: Theme.of(context).platform == TargetPlatform.iOS
                         ? MediaQuery.paddingOf(context).top + kToolbarHeight
                         : 0.0,
-                    key: _androidRefreshKey,
+                    refreshIndicatorKey: _androidRefreshKey,
                     onRefresh: _refreshData,
                     child: _Body(orientation),
                   );

--- a/lib/src/widgets/haptic_refresh_indicator.dart
+++ b/lib/src/widgets/haptic_refresh_indicator.dart
@@ -2,6 +2,7 @@ import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 
+/// A wrapper widget over RefreshIndicator to provide haptic feedback on iOS
 class HapticRefreshIndicator extends StatelessWidget {
   final Widget child;
   final double edgeOffset;

--- a/lib/src/widgets/haptic_refresh_indicator.dart
+++ b/lib/src/widgets/haptic_refresh_indicator.dart
@@ -1,0 +1,31 @@
+import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
+
+class HapticRefreshIndicator extends StatelessWidget {
+  final Key? refreshIndicatorKey;
+  final Widget child;
+  final double edgeOffset;
+  final RefreshCallback onRefresh;
+
+  const HapticRefreshIndicator({
+    this.refreshIndicatorKey,
+    required this.child,
+    this.edgeOffset = 0.0,
+    required this.onRefresh,
+  });
+
+  Future<void> _onRefreshWithHaptics() async {
+    HapticFeedback.lightImpact();
+    await onRefresh();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return RefreshIndicator.adaptive(
+      key: refreshIndicatorKey,
+      edgeOffset: edgeOffset,
+      onRefresh: _onRefreshWithHaptics,
+      child: child,
+    );
+  }
+}

--- a/lib/src/widgets/haptic_refresh_indicator.dart
+++ b/lib/src/widgets/haptic_refresh_indicator.dart
@@ -1,3 +1,4 @@
+import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 
@@ -15,7 +16,10 @@ class HapticRefreshIndicator extends StatelessWidget {
   });
 
   Future<void> _onRefreshWithHaptics() async {
-    HapticFeedback.lightImpact();
+    if (defaultTargetPlatform == TargetPlatform.iOS) {
+      HapticFeedback.lightImpact();
+    }
+
     await onRefresh();
   }
 

--- a/lib/src/widgets/haptic_refresh_indicator.dart
+++ b/lib/src/widgets/haptic_refresh_indicator.dart
@@ -3,13 +3,12 @@ import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 
 class HapticRefreshIndicator extends StatelessWidget {
-  final Key? refreshIndicatorKey;
   final Widget child;
   final double edgeOffset;
   final RefreshCallback onRefresh;
 
   const HapticRefreshIndicator({
-    this.refreshIndicatorKey,
+    super.key,
     required this.child,
     this.edgeOffset = 0.0,
     required this.onRefresh,
@@ -26,7 +25,6 @@ class HapticRefreshIndicator extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     return RefreshIndicator.adaptive(
-      key: refreshIndicatorKey,
       edgeOffset: edgeOffset,
       onRefresh: _onRefreshWithHaptics,
       child: child,


### PR DESCRIPTION
Add haptic feedback when refreshing pages. 

This is done by creating a wrapper, `HapticRefreshIndicator`, around the normal `RefreshIndicator`. This wrapper then triggers haptic feedback when the refresh takes place.

This wrapper can be used as an (almost) drop-in replacement for `RefreshIndicator`.

Closes #2025