### PR TITLE
bring back streak rating on tablet

### DIFF
--- a/lib/src/view/puzzle/streak_screen.dart
+++ b/lib/src/view/puzzle/streak_screen.dart
@@ -227,10 +227,23 @@ class _BodyState extends ConsumerState<_Body> {
                                   mainAxisAlignment: MainAxisAlignment.spaceAround,
                                   children: [
                                     Center(
-                                      child: PuzzleFeedbackWidget(
-                                        puzzle: puzzleState.puzzle,
-                                        state: puzzleState,
-                                        onStreak: true,
+                                      child: Row(
+                                        mainAxisAlignment: MainAxisAlignment.spaceAround,
+                                        children: [
+                                          Expanded(
+                                            child: PuzzleFeedbackWidget(
+                                              puzzle: puzzleState.puzzle,
+                                              state: puzzleState,
+                                              onStreak: true,
+                                            ),
+                                          ),
+                                          Text(
+                                            context.l10n.puzzleRatingX(
+                                              puzzleState.puzzle.puzzle.rating.toString(),
+                                            ),
+                                          ),
+                                          const SizedBox(width: 16.0),
+                                        ],
                                       ),
                                     ),
                                     Padding(


### PR DESCRIPTION
Adds rating back to the streak screen in landscape view:

<img width="1892" height="1136" alt="grafik" src="https://github.com/user-attachments/assets/54459c03-c4a8-4b4a-93f1-8386aff37a70" />
