### PR TITLE
Fix game loading in Landscape mode

### DIFF
--- a/lib/src/view/game/game_loading_board.dart
+++ b/lib/src/view/game/game_loading_board.dart
@@ -84,43 +84,43 @@ class _LobbyScreenLoadingContentState extends State<LobbyScreenLoadingContent> {
                   ),
                 ),
               ),
+              userActionsBar: BottomBar(
+                children: [
+                  FutureBuilder(
+                    future: _cancelGameCreationFuture,
+                    builder: (context, snapshot) {
+                      return BottomBarButton(
+                        onTap: snapshot.connectionState == ConnectionState.waiting
+                            ? null
+                            : () async {
+                                setState(() {
+                                  _cancelGameCreationFuture = widget.cancelGameCreation();
+                                });
+                                try {
+                                  await _cancelGameCreationFuture;
+                                } catch (_) {
+                                  if (context.mounted) {
+                                    showSnackBar(
+                                      context,
+                                      'Error cancelling game creation',
+                                      type: SnackBarType.error,
+                                    );
+                                  }
+                                }
+                                if (context.mounted) {
+                                  Navigator.of(context, rootNavigator: true).pop();
+                                }
+                              },
+                        label: context.l10n.cancel,
+                        showLabel: true,
+                        icon: CupertinoIcons.xmark,
+                      );
+                    },
+                  ),
+                ],
+              ),
             ),
           ),
-        ),
-        BottomBar(
-          children: [
-            FutureBuilder(
-              future: _cancelGameCreationFuture,
-              builder: (context, snapshot) {
-                return BottomBarButton(
-                  onTap: snapshot.connectionState == ConnectionState.waiting
-                      ? null
-                      : () async {
-                          setState(() {
-                            _cancelGameCreationFuture = widget.cancelGameCreation();
-                          });
-                          try {
-                            await _cancelGameCreationFuture;
-                          } catch (_) {
-                            if (context.mounted) {
-                              showSnackBar(
-                                context,
-                                'Error cancelling game creation',
-                                type: SnackBarType.error,
-                              );
-                            }
-                          }
-                          if (context.mounted) {
-                            Navigator.of(context, rootNavigator: true).pop();
-                          }
-                        },
-                  label: context.l10n.cancel,
-                  showLabel: true,
-                  icon: CupertinoIcons.xmark,
-                );
-              },
-            ),
-          ],
         ),
       ],
     );

--- a/lib/src/view/game/game_loading_board.dart
+++ b/lib/src/view/game/game_loading_board.dart
@@ -31,98 +31,89 @@ class _LobbyScreenLoadingContentState extends State<LobbyScreenLoadingContent> {
 
   @override
   Widget build(BuildContext context) {
-    return Column(
-      children: [
-        Expanded(
-          child: SafeArea(
-            child: GameLayout(
-              orientation: Side.white,
-              fen: kEmptyFen,
-              topTable: const SizedBox.shrink(),
-              bottomTable: const SizedBox.shrink(),
-              moves: const [],
-              boardOverlay: Card(
-                color: Theme.of(context).dialogTheme.backgroundColor,
-                elevation: 2.0,
-                child: Center(
-                  child: Column(
-                    mainAxisAlignment: MainAxisAlignment.center,
-                    crossAxisAlignment: CrossAxisAlignment.center,
-                    children: [
-                      Text(context.l10n.mobileWaitingForOpponentToJoin),
-                      const SizedBox(height: 26.0),
-                      Row(
-                        mainAxisAlignment: MainAxisAlignment.center,
-                        mainAxisSize: MainAxisSize.min,
-                        children: [
-                          Icon(
-                            widget.seek.perf.icon,
-                            color: DefaultTextStyle.of(context).style.color,
-                          ),
-                          const SizedBox(width: 8.0),
-                          Text(
-                            widget.seek.timeIncrement?.display ??
-                                '${context.l10n.daysPerTurn}: ${widget.seek.days}',
-                            style: TextTheme.of(context).titleLarge,
-                          ),
-                        ],
-                      ),
-                      //Do not show rating range if the default values (-500, +500) are used
-                      if (widget.seek.ratingRange != null &&
-                          !(widget.seek.ratingRange!.$1 + 1000 == widget.seek.ratingRange!.$2)) ...[
-                        const SizedBox(height: 8.0),
-                        RatingPrefAware(
-                          child: Text(
-                            '${widget.seek.ratingRange!.$1}-${widget.seek.ratingRange!.$2}',
-                            style: TextTheme.of(context).titleMedium,
-                          ),
-                        ),
-                      ],
-                      const SizedBox(height: 16.0),
-                      _LobbyNumbers(),
-                    ],
-                  ),
+    return SafeArea(
+      child: GameLayout(
+        orientation: Side.white,
+        fen: kEmptyFen,
+        topTable: const SizedBox.shrink(),
+        bottomTable: const SizedBox.shrink(),
+        moves: const [],
+        boardOverlay: Card(
+          color: Theme.of(context).dialogTheme.backgroundColor,
+          elevation: 2.0,
+          child: Center(
+            child: Column(
+              mainAxisAlignment: MainAxisAlignment.center,
+              crossAxisAlignment: CrossAxisAlignment.center,
+              children: [
+                Text(context.l10n.mobileWaitingForOpponentToJoin),
+                const SizedBox(height: 26.0),
+                Row(
+                  mainAxisAlignment: MainAxisAlignment.center,
+                  mainAxisSize: MainAxisSize.min,
+                  children: [
+                    Icon(widget.seek.perf.icon, color: DefaultTextStyle.of(context).style.color),
+                    const SizedBox(width: 8.0),
+                    Text(
+                      widget.seek.timeIncrement?.display ??
+                          '${context.l10n.daysPerTurn}: ${widget.seek.days}',
+                      style: TextTheme.of(context).titleLarge,
+                    ),
+                  ],
                 ),
-              ),
-              userActionsBar: BottomBar(
-                children: [
-                  FutureBuilder(
-                    future: _cancelGameCreationFuture,
-                    builder: (context, snapshot) {
-                      return BottomBarButton(
-                        onTap: snapshot.connectionState == ConnectionState.waiting
-                            ? null
-                            : () async {
-                                setState(() {
-                                  _cancelGameCreationFuture = widget.cancelGameCreation();
-                                });
-                                try {
-                                  await _cancelGameCreationFuture;
-                                } catch (_) {
-                                  if (context.mounted) {
-                                    showSnackBar(
-                                      context,
-                                      'Error cancelling game creation',
-                                      type: SnackBarType.error,
-                                    );
-                                  }
-                                }
-                                if (context.mounted) {
-                                  Navigator.of(context, rootNavigator: true).pop();
-                                }
-                              },
-                        label: context.l10n.cancel,
-                        showLabel: true,
-                        icon: CupertinoIcons.xmark,
-                      );
-                    },
+                //Do not show rating range if the default values (-500, +500) are used
+                if (widget.seek.ratingRange != null &&
+                    !(widget.seek.ratingRange!.$1 + 1000 == widget.seek.ratingRange!.$2)) ...[
+                  const SizedBox(height: 8.0),
+                  RatingPrefAware(
+                    child: Text(
+                      '${widget.seek.ratingRange!.$1}-${widget.seek.ratingRange!.$2}',
+                      style: TextTheme.of(context).titleMedium,
+                    ),
                   ),
                 ],
-              ),
+                const SizedBox(height: 16.0),
+                _LobbyNumbers(),
+              ],
             ),
           ),
         ),
-      ],
+        userActionsBar: BottomBar(
+          children: [
+            FutureBuilder(
+              future: _cancelGameCreationFuture,
+              builder: (context, snapshot) {
+                return BottomBarButton(
+                  onTap: snapshot.connectionState == ConnectionState.waiting
+                      ? null
+                      : () async {
+                          setState(() {
+                            _cancelGameCreationFuture = widget.cancelGameCreation();
+                          });
+                          try {
+                            await _cancelGameCreationFuture;
+                          } catch (_) {
+                            if (context.mounted) {
+                              showSnackBar(
+                                context,
+                                'Error cancelling game creation',
+                                type: SnackBarType.error,
+                              );
+                            }
+                          }
+                          if (context.mounted) {
+                            Navigator.of(context, rootNavigator: true).pop();
+                          }
+                        },
+                  label: context.l10n.cancel,
+                  showLabel: true,
+                  icon: CupertinoIcons.xmark,
+                );
+              },
+            ),
+          ],
+        ),
+      ),
     );
   }
 }
@@ -142,55 +133,49 @@ class _ChallengeLoadingContentState extends State<ChallengeLoadingContent> {
 
   @override
   Widget build(BuildContext context) {
-    return Column(
-      children: [
-        Expanded(
-          child: SafeArea(
-            child: GameLayout(
-              orientation: Side.white,
-              fen: kEmptyFen,
-              topTable: const SizedBox.shrink(),
-              bottomTable: const SizedBox.shrink(),
-              moves: const [],
-              boardOverlay: Card(
-                color: Theme.of(context).dialogTheme.backgroundColor,
-                elevation: 2.0,
-                child: Center(
-                  child: Column(
-                    mainAxisAlignment: MainAxisAlignment.center,
-                    crossAxisAlignment: CrossAxisAlignment.center,
-                    children: [
-                      Text(context.l10n.waitingForOpponent),
-                      const SizedBox(height: 16.0),
-                      UserFullNameWidget(
-                        user: widget.challenge.destUser,
-                        style: TextTheme.of(context).titleLarge,
-                      ),
-                      const SizedBox(height: 16.0),
-                      Row(
-                        mainAxisAlignment: MainAxisAlignment.center,
-                        mainAxisSize: MainAxisSize.min,
-                        children: [
-                          Icon(
-                            widget.challenge.perf.icon,
-                            color: DefaultTextStyle.of(context).style.color,
-                          ),
-                          const SizedBox(width: 8.0),
-                          Text(
-                            widget.challenge.timeIncrement?.display ??
-                                '${context.l10n.daysPerTurn}: ${widget.challenge.days}',
-                            style: TextTheme.of(context).titleLarge,
-                          ),
-                        ],
-                      ),
-                    ],
-                  ),
+    return SafeArea(
+      child: GameLayout(
+        orientation: Side.white,
+        fen: kEmptyFen,
+        topTable: const SizedBox.shrink(),
+        bottomTable: const SizedBox.shrink(),
+        moves: const [],
+        boardOverlay: Card(
+          color: Theme.of(context).dialogTheme.backgroundColor,
+          elevation: 2.0,
+          child: Center(
+            child: Column(
+              mainAxisAlignment: MainAxisAlignment.center,
+              crossAxisAlignment: CrossAxisAlignment.center,
+              children: [
+                Text(context.l10n.waitingForOpponent),
+                const SizedBox(height: 16.0),
+                UserFullNameWidget(
+                  user: widget.challenge.destUser,
+                  style: TextTheme.of(context).titleLarge,
                 ),
-              ),
+                const SizedBox(height: 16.0),
+                Row(
+                  mainAxisAlignment: MainAxisAlignment.center,
+                  mainAxisSize: MainAxisSize.min,
+                  children: [
+                    Icon(
+                      widget.challenge.perf.icon,
+                      color: DefaultTextStyle.of(context).style.color,
+                    ),
+                    const SizedBox(width: 8.0),
+                    Text(
+                      widget.challenge.timeIncrement?.display ??
+                          '${context.l10n.daysPerTurn}: ${widget.challenge.days}',
+                      style: TextTheme.of(context).titleLarge,
+                    ),
+                  ],
+                ),
+              ],
             ),
           ),
         ),
-        BottomBar(
+        userActionsBar: BottomBar(
           children: [
             FutureBuilder(
               future: _cancelChallengeFuture,
@@ -225,7 +210,7 @@ class _ChallengeLoadingContentState extends State<ChallengeLoadingContent> {
             ),
           ],
         ),
-      ],
+      ),
     );
   }
 }


### PR DESCRIPTION
Prevents the board from resizing in landscape mode after getting paired. This PR puts the cancel button to the right where the move list will be:
<img width="1274" height="757" alt="grafik" src="https://github.com/user-attachments/assets/62d44891-938a-4811-9f96-5e4d6d597347" />
