### PR TITLE
handle crazyhouse deeplinks

### DIFF
--- a/lib/src/model/analysis/analysis_controller.dart
+++ b/lib/src/model/analysis/analysis_controller.dart
@@ -74,6 +74,13 @@ sealed class AnalysisOptions with _$AnalysisOptions {
   };
 }
 
+class UnsupportedVariantException implements Exception {
+  final Variant variant;
+  final GameId gameId;
+
+  const UnsupportedVariantException(this.variant, this.gameId);
+}
+
 enum AnalysisGameResult {
   whiteWins,
   blackWins,
@@ -168,6 +175,9 @@ class AnalysisController extends _$AnalysisController
         {
           archivedGame = await ref.watch(archivedGameProvider(id: gameId).future);
           _variant = archivedGame!.meta.variant;
+          if (!_variant.isReadSupported) {
+            throw UnsupportedVariantException(_variant, gameId);
+          }
           pgn = archivedGame.makePgn();
           opening = archivedGame.data.opening;
           serverAnalysis = archivedGame.serverAnalysis;

--- a/test/view/analysis/analysis_screen_test.dart
+++ b/test/view/analysis/analysis_screen_test.dart
@@ -961,6 +961,7 @@ void main() {
       );
 
       await tester.pumpWidget(app);
+      await tester.pumpAndSettle();
 
       await switchToPremoveTab(tester);
 
@@ -1052,6 +1053,7 @@ void main() {
       );
 
       await tester.pumpWidget(app);
+      await tester.pumpAndSettle();
 
       await switchToPremoveTab(tester);
 
@@ -1195,7 +1197,7 @@ void main() {
       );
 
       await tester.pumpWidget(app);
-
+      await tester.pumpAndSettle();
       await switchToPremoveTab(tester);
 
       // Should be in starting position
@@ -1263,6 +1265,7 @@ void main() {
       );
 
       await tester.pumpWidget(app);
+      await tester.pumpAndSettle();
 
       await switchToPremoveTab(tester);
 

--- a/test/view/analysis/analysis_screen_test.dart
+++ b/test/view/analysis/analysis_screen_test.dart
@@ -961,7 +961,7 @@ void main() {
       );
 
       await tester.pumpWidget(app);
-      await tester.pumpAndSettle();
+      await tester.pump();
 
       await switchToPremoveTab(tester);
 
@@ -1053,7 +1053,7 @@ void main() {
       );
 
       await tester.pumpWidget(app);
-      await tester.pumpAndSettle();
+      await tester.pump();
 
       await switchToPremoveTab(tester);
 
@@ -1197,7 +1197,8 @@ void main() {
       );
 
       await tester.pumpWidget(app);
-      await tester.pumpAndSettle();
+      await tester.pump();
+
       await switchToPremoveTab(tester);
 
       // Should be in starting position
@@ -1265,7 +1266,7 @@ void main() {
       );
 
       await tester.pumpWidget(app);
-      await tester.pumpAndSettle();
+      await tester.pump();
 
       await switchToPremoveTab(tester);
 


### PR DESCRIPTION
Currently crazyhouse games can be opened via deeplinks (f.ex. https://lichess.org/KVB5HJjl/black) However, this leads to errors when replaying the game. As far as I can tell we cannot determine from the game ID alone whether the variant is supported, so the app itself must handle the error.
My suggestion is this: 
<img width="606" height="1290" alt="grafik" src="https://github.com/user-attachments/assets/fc047253-f618-4faf-8560-e4312961c4b8" />

The “Open game in your browser” option would strip the color after the slash so it wont be deeplinked again. The other option would be to open it in `LaunchMode.inAppWebView `.