### PR TITLE
Profile Fixes

### DIFF
--- a/lib/src/view/account/profile_screen.dart
+++ b/lib/src/view/account/profile_screen.dart
@@ -6,9 +6,11 @@ import 'package:lichess_mobile/src/model/auth/auth_session.dart';
 import 'package:lichess_mobile/src/model/game/game_history.dart';
 import 'package:lichess_mobile/src/model/user/user.dart';
 import 'package:lichess_mobile/src/model/user/user_repository.dart';
+import 'package:lichess_mobile/src/network/http.dart';
 import 'package:lichess_mobile/src/styles/styles.dart';
 import 'package:lichess_mobile/src/utils/l10n_context.dart';
 import 'package:lichess_mobile/src/utils/navigation.dart';
+import 'package:lichess_mobile/src/utils/share.dart';
 import 'package:lichess_mobile/src/view/account/edit_profile_screen.dart';
 import 'package:lichess_mobile/src/view/account/game_bookmarks_screen.dart';
 import 'package:lichess_mobile/src/view/user/perf_cards.dart';
@@ -22,6 +24,7 @@ import 'package:lichess_mobile/src/widgets/list.dart';
 import 'package:lichess_mobile/src/widgets/platform.dart';
 import 'package:lichess_mobile/src/widgets/shimmer.dart';
 import 'package:lichess_mobile/src/widgets/user_full_name.dart';
+import 'package:share_plus/share_plus.dart';
 
 class ProfileScreen extends ConsumerStatefulWidget {
   const ProfileScreen({super.key});
@@ -59,6 +62,20 @@ class _ProfileScreenState extends ConsumerState<ProfileScreen> {
             icon: const Icon(Icons.edit),
             semanticsLabel: context.l10n.editProfile,
             onPressed: () => Navigator.of(context).push(EditProfileScreen.buildRoute(context)),
+          ),
+          account.when(
+            data: (user) => user == null
+                ? const SizedBox.shrink()
+                : SemanticIconButton(
+                    icon: const Icon(Icons.share),
+                    semanticsLabel: 'Share profile',
+                    onPressed: () => launchShareDialog(
+                      context,
+                      ShareParams(uri: lichessUri('/@/${user.username}')),
+                    ),
+                  ),
+            loading: () => const SizedBox.shrink(),
+            error: (error, _) => const SizedBox.shrink(),
           ),
         ],
       ),

--- a/lib/src/view/account/profile_screen.dart
+++ b/lib/src/view/account/profile_screen.dart
@@ -67,7 +67,7 @@ class _ProfileScreenState extends ConsumerState<ProfileScreen> {
             data: (user) => user == null
                 ? const SizedBox.shrink()
                 : SemanticIconButton(
-                    icon: const Icon(Icons.share),
+                    icon: const PlatformShareIcon(),
                     semanticsLabel: 'Share profile',
                     onPressed: () => launchShareDialog(
                       context,

--- a/lib/src/view/user/user_profile.dart
+++ b/lib/src/view/user/user_profile.dart
@@ -6,6 +6,7 @@ import 'package:intl/intl.dart';
 import 'package:lichess_mobile/l10n/l10n.dart';
 import 'package:lichess_mobile/src/app_links.dart';
 import 'package:lichess_mobile/src/constants.dart';
+import 'package:lichess_mobile/src/model/auth/auth_session.dart';
 import 'package:lichess_mobile/src/model/user/profile.dart';
 import 'package:lichess_mobile/src/model/user/user.dart';
 import 'package:lichess_mobile/src/styles/styles.dart';
@@ -19,7 +20,7 @@ import 'package:url_launcher/url_launcher.dart';
 const _userNameStyle = TextStyle(fontSize: 20, fontWeight: FontWeight.w500);
 
 class UserProfileWidget extends ConsumerWidget {
-  const UserProfileWidget({required this.user, this.bioMaxLines = 10});
+  const UserProfileWidget({required this.user, this.bioMaxLines = 15});
 
   final User user;
 
@@ -28,6 +29,7 @@ class UserProfileWidget extends ConsumerWidget {
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
+    final authSession = ref.watch(authSessionProvider);
     final userFullName = user.profile?.realName != null
         ? Text(user.profile!.realName!, style: _userNameStyle)
         : null;
@@ -39,7 +41,7 @@ class UserProfileWidget extends ConsumerWidget {
         child: Column(
           crossAxisAlignment: CrossAxisAlignment.start,
           children: [
-            if (user.tosViolation == true)
+            if (user.tosViolation == true && authSession?.user.id != user.id)
               Padding(
                 padding: const EdgeInsets.only(bottom: 5),
                 child: Row(
@@ -64,7 +66,7 @@ class UserProfileWidget extends ConsumerWidget {
               Linkify(
                 onOpen: (link) => onLinkifyOpen(context, link),
                 linkifiers: kLichessLinkifiers,
-                text: user.profile!.bio!.replaceAll('\n', ' '),
+                text: user.profile!.bio!,
                 maxLines: bioMaxLines,
                 style: bioStyle,
                 overflow: TextOverflow.ellipsis,

--- a/lib/src/view/user/user_screen.dart
+++ b/lib/src/view/user/user_screen.dart
@@ -15,6 +15,7 @@ import 'package:lichess_mobile/src/styles/lichess_icons.dart';
 import 'package:lichess_mobile/src/styles/styles.dart';
 import 'package:lichess_mobile/src/utils/l10n_context.dart';
 import 'package:lichess_mobile/src/utils/navigation.dart';
+import 'package:lichess_mobile/src/utils/share.dart';
 import 'package:lichess_mobile/src/view/message/conversation_screen.dart';
 import 'package:lichess_mobile/src/view/play/challenge_odd_bots_screen.dart';
 import 'package:lichess_mobile/src/view/play/create_challenge_bottom_sheet.dart';
@@ -24,11 +25,13 @@ import 'package:lichess_mobile/src/view/user/recent_games.dart';
 import 'package:lichess_mobile/src/view/user/user_activity.dart';
 import 'package:lichess_mobile/src/view/user/user_profile.dart';
 import 'package:lichess_mobile/src/view/watch/tv_screen.dart';
+import 'package:lichess_mobile/src/widgets/buttons.dart';
 import 'package:lichess_mobile/src/widgets/feedback.dart';
 import 'package:lichess_mobile/src/widgets/list.dart';
 import 'package:lichess_mobile/src/widgets/platform.dart';
 import 'package:lichess_mobile/src/widgets/text_badge.dart';
 import 'package:lichess_mobile/src/widgets/user_full_name.dart';
+import 'package:share_plus/share_plus.dart';
 import 'package:url_launcher/url_launcher.dart';
 
 final _userScreenDataProvider = FutureProvider.autoDispose.family<UserScreenData, UserId>(
@@ -93,12 +96,20 @@ class _UserScreenState extends ConsumerState<UserScreen> {
       orElse: () => null,
     );
     return Scaffold(
-      appBar: AppBar(
+      appBar: PlatformAppBar(
         title: UserFullNameWidget(
           user: updatedLightUser ?? widget.user,
           shouldShowOnline: updatedLightUser != null,
         ),
-        actions: [if (isLoading) const PlatformAppBarLoadingIndicator()],
+        actions: [
+          if (isLoading) const PlatformAppBarLoadingIndicator(),
+          SemanticIconButton(
+            icon: const Icon(Icons.share),
+            semanticsLabel: 'Share profile',
+            onPressed: () =>
+                launchShareDialog(context, ShareParams(uri: lichessUri('/@/${widget.user.name}'))),
+          ),
+        ],
       ),
       body: userScreenData.when(
         data: (data) => _UserProfileListView(data, isLoading, setIsLoading),

--- a/lib/src/view/user/user_screen.dart
+++ b/lib/src/view/user/user_screen.dart
@@ -104,7 +104,7 @@ class _UserScreenState extends ConsumerState<UserScreen> {
         actions: [
           if (isLoading) const PlatformAppBarLoadingIndicator(),
           SemanticIconButton(
-            icon: const Icon(Icons.share),
+            icon: const PlatformShareIcon(),
             semanticsLabel: 'Share profile',
             onPressed: () =>
                 launchShareDialog(context, ShareParams(uri: lichessUri('/@/${widget.user.name}'))),


### PR DESCRIPTION
closes #1514 
Some improvements to the profile screen: 
- Players cant see if they are shadowbanned in their own profile 
- Do not convert new lines into spaces anymore, as the behavior changed on the website
- Add a share button to the profile screen

<img width="466" height="961" alt="grafik" src="https://github.com/user-attachments/assets/e0990a96-13d4-463c-8ed2-6b17f6033d6f" />
