### PR TITLE
Fix: add manual check highlight in spectator mode + widget test  #2128

### DIFF
--- a/lib/src/widgets/board.dart
+++ b/lib/src/widgets/board.dart
@@ -51,7 +51,7 @@ class BoardWidget extends StatelessWidget {
               dimension: size,
               child: Center(
                 child: SizedBox(
-                  width: (size / 8) * 6.6,
+                  width: (size / 8) * 6.5,
                   height: (size / 8) * 4.6,
                   child: boardOverlay,
                 ),


### PR DESCRIPTION
The red check indicator was not visible when watching other players' games.
This is because gameData is null in spectator mode, and the Chessboard widget was not receiving any check information. As a result, spectators had no feedback that the king was under attack.
So I Updated Board.dart to manually detect check state when gameData == null.
It is using circular shape, not the exact internal check highlighting as we are not passing gameData.

<img width="377" height="825" alt="Screenshot 2025-09-18 at 1 13 59 AM" src="https://github.com/user-attachments/assets/f20a2ee7-9388-44fe-849e-4ffda22f2c8a" />
