### PR TITLE
Fix: add manual check highlight in spectator mode

### DIFF
--- a/lib/src/widgets/board.dart
+++ b/lib/src/widgets/board.dart
@@ -30,13 +30,14 @@ class BoardWidget extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    final Chess position = Chess.fromSetup(Setup.parseFen(fen));
+    final safeFen = fen.trim().isNotEmpty ? fen : Setup.standard.fen;
+    final Chess position = Chess.fromSetup(Setup.parseFen(safeFen));
     // ✅ Safe fallback for spectator mode
     final effectiveGameData =
         gameData ??
         GameData(
           playerSide: PlayerSide.none, // spectator cannot move
-          sideToMove: Side.white, // doesn’t matter, just required
+          sideToMove: position.turn, // doesn’t matter, just required
           validMoves: IMap(), // no valid moves
           promotionMove: null,
           isCheck: position.isCheck,
@@ -47,7 +48,7 @@ class BoardWidget extends StatelessWidget {
     final board = Chessboard(
       key: boardKey,
       size: size,
-      fen: fen,
+      fen: safeFen,
       orientation: orientation,
       game: effectiveGameData,
       lastMove: lastMove,

--- a/lib/src/widgets/board.dart
+++ b/lib/src/widgets/board.dart
@@ -30,33 +30,28 @@ class BoardWidget extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    final safeFen = fen.isNotEmpty ? fen : Setup.standard.fen;
-
-    ISet<Shape> allShapes = shapes ?? ISet();
-
-    // Add check highlight for spectator mode (no gameData)
-    if (gameData == null && safeFen.isNotEmpty) {
-      final position = Chess.fromSetup(Setup.parseFen(safeFen));
-      if (position.isCheck) {
-        final kingSquare = position.board.kingOf(position.turn);
-        if (kingSquare != null) {
-          final checkHighlight = Circle(
-            color: const Color(0xAA882020), // semi-transparent red
-            orig: kingSquare,
-          );
-          allShapes = allShapes.add(checkHighlight);
-        }
-      }
-    }
-
+    final Chess position = Chess.fromSetup(Setup.parseFen(fen));
+    // ✅ Safe fallback for spectator mode
+    final effectiveGameData =
+        gameData ??
+        GameData(
+          playerSide: PlayerSide.none, // spectator cannot move
+          sideToMove: Side.white, // doesn’t matter, just required
+          validMoves: IMap(), // no valid moves
+          promotionMove: null,
+          isCheck: position.isCheck,
+          premovable: null,
+          onMove: (_, {isDrop}) {}, // no-op
+          onPromotionSelection: (_) {}, // no-op
+        );
     final board = Chessboard(
       key: boardKey,
       size: size,
-      fen: safeFen,
+      fen: fen,
       orientation: orientation,
-      game: gameData,
+      game: effectiveGameData,
       lastMove: lastMove,
-      shapes: allShapes,
+      shapes: shapes,
       settings: settings,
     );
 

--- a/lib/src/widgets/board.dart
+++ b/lib/src/widgets/board.dart
@@ -30,11 +30,13 @@ class BoardWidget extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
+    final safeFen = fen.isNotEmpty ? fen : Setup.standard.fen;
+
     ISet<Shape> allShapes = shapes ?? ISet();
 
     // Add check highlight for spectator mode (no gameData)
-    if (gameData == null && fen.isNotEmpty) {
-      final position = Chess.fromSetup(Setup.parseFen(fen));
+    if (gameData == null && safeFen.isNotEmpty) {
+      final position = Chess.fromSetup(Setup.parseFen(safeFen));
       if (position.isCheck) {
         final kingSquare = position.board.kingOf(position.turn);
         if (kingSquare != null) {
@@ -50,7 +52,7 @@ class BoardWidget extends StatelessWidget {
     final board = Chessboard(
       key: boardKey,
       size: size,
-      fen: fen,
+      fen: safeFen,
       orientation: orientation,
       game: gameData,
       lastMove: lastMove,

--- a/lib/src/widgets/board.dart
+++ b/lib/src/widgets/board.dart
@@ -30,6 +30,23 @@ class BoardWidget extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
+    ISet<Shape> allShapes = shapes ?? ISet();
+
+    // Add check highlight for spectator mode (no gameData)
+    if (gameData == null && fen.isNotEmpty) {
+      final position = Chess.fromSetup(Setup.parseFen(fen));
+      if (position.isCheck) {
+        final kingSquare = position.board.kingOf(position.turn);
+        if (kingSquare != null) {
+          final checkHighlight = Circle(
+            color: const Color(0xAA882020), // semi-transparent red
+            orig: kingSquare,
+          );
+          allShapes = allShapes.add(checkHighlight);
+        }
+      }
+    }
+
     final board = Chessboard(
       key: boardKey,
       size: size,
@@ -37,7 +54,7 @@ class BoardWidget extends StatelessWidget {
       orientation: orientation,
       game: gameData,
       lastMove: lastMove,
-      shapes: shapes,
+      shapes: allShapes,
       settings: settings,
     );
 

--- a/lib/src/widgets/game_layout.dart
+++ b/lib/src/widgets/game_layout.dart
@@ -155,9 +155,7 @@ class _GameLayoutState extends ConsumerState<GameLayout> {
         final shapes = userShapes.union(widget.shapes ?? ISet());
         final slicedMoves = widget.moves?.asMap().entries.slices(2);
 
-        final fenCandidate = widget.interactiveBoardParams?.position.fen ?? widget.fen;
-        final fen = (fenCandidate?.isNotEmpty ?? false) ? fenCandidate! : Setup.standard.fen;
-
+        final fen = widget.interactiveBoardParams?.position.fen ?? widget.fen!;
         final gameData = widget.interactiveBoardParams != null
             ? boardPrefs.toGameData(
                 variant: widget.interactiveBoardParams!.variant,

--- a/lib/src/widgets/game_layout.dart
+++ b/lib/src/widgets/game_layout.dart
@@ -155,7 +155,9 @@ class _GameLayoutState extends ConsumerState<GameLayout> {
         final shapes = userShapes.union(widget.shapes ?? ISet());
         final slicedMoves = widget.moves?.asMap().entries.slices(2);
 
-        final fen = widget.interactiveBoardParams?.position.fen ?? widget.fen!;
+        final fenCandidate = widget.interactiveBoardParams?.position.fen ?? widget.fen;
+        final fen = (fenCandidate?.isNotEmpty ?? false) ? fenCandidate! : Setup.standard.fen;
+
         final gameData = widget.interactiveBoardParams != null
             ? boardPrefs.toGameData(
                 variant: widget.interactiveBoardParams!.variant,


### PR DESCRIPTION
The red check indicator was not visible when watching other players' games.
This is because gameData is null in spectator mode, and the Chessboard widget was not receiving any check information. As a result, spectators had no feedback that the king was under attack.
So I Updated Board.dart to manually detect check state when gameData == null.
It is using circular shape, not the exact internal check highlighting as we are not passing gameData.

<img width="754" height="1650" alt="image" src="https://github.com/user-attachments/assets/5d1eb028-845c-4d76-893b-fd2704144f2e" />
