### PR TITLE
Discard piece after tapping square again in Editor

### DIFF
--- a/lib/src/model/board_editor/board_editor_controller.dart
+++ b/lib/src/model/board_editor/board_editor_controller.dart
@@ -52,7 +52,12 @@ class BoardEditorController extends _$BoardEditorController {
   void editSquare(Square square) {
     final piece = state.pieceToAddOnEdit;
     if (piece != null) {
-      _updatePosition(state.pieces.add(square, piece));
+      final existingPiece = state.pieces[square];
+      if (existingPiece == piece) {
+        discardPiece(square);
+      } else {
+        _updatePosition(state.pieces.add(square, piece));
+      }
     } else {
       discardPiece(square);
     }

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -205,10 +205,10 @@ packages:
     dependency: "direct main"
     description:
       name: chessground
-      sha256: "874891af44787740175e03ee6f81e3cde3f3c6d9fa64633bf0d429174f7d8ee7"
+      sha256: "61f95b9186eef3e232c2e95789b5631342c8019542c5529e181f72da37857684"
       url: "https://pub.dev"
     source: hosted
-    version: "7.1.6"
+    version: "7.2.0"
   ci:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -14,7 +14,7 @@ dependencies:
   async: ^2.10.0
   auto_size_text: ^3.0.0
   cached_network_image: ^3.2.2
-  chessground: ^7.1.0
+  chessground: ^7.2.0
   clock: ^1.1.1
   collection: ^1.17.0
   connectivity_plus: ^7.0.0
@@ -130,7 +130,7 @@ flutter:
       fonts:
         - asset: assets/fonts/SocialIcons.ttf
     - family: ChessFont
-      fonts: 
+      fonts:
         - asset: assets/fonts/ChessSansPiratf.ttf
     - family: LichessPuzzleIcons
       fonts:
@@ -144,9 +144,8 @@ flutter_native_splash:
   ios: true
   web: false
 
-  color: '#ffffff'
+  color: "#ffffff"
   image: assets/images/logo-black.png
 
-  color_dark: '#000000'
+  color_dark: "#000000"
   image_dark: assets/images/logo-white.png
-

--- a/test/view/board_editor/board_editor_screen_test.dart
+++ b/test/view/board_editor/board_editor_screen_test.dart
@@ -248,6 +248,30 @@ void main() {
       );
     });
 
+    testWidgets('Delete pieces with tapping square again', (tester) async {
+      final app = await makeTestProviderScopeApp(tester, home: const BoardEditorScreen());
+      await tester.pumpWidget(app);
+
+      final container = ProviderScope.containerOf(tester.element(find.byType(ChessboardEditor)));
+      final controllerProvider = boardEditorControllerProvider(null);
+
+      await tester.tap(find.byKey(const Key('piece-button-white-queen')));
+      await tester.pump();
+
+      await tapSquare(tester, 'e2');
+      expect(
+        container.read(controllerProvider).fen,
+        'rnbqkbnr/pppppppp/8/8/8/8/PPPPQPPP/RNBQKBNR w KQkq - 0 1',
+      );
+      //Tap d1 square with the white Queen still in hand, empties the square
+      await tapSquare(tester, 'd1');
+
+      expect(
+        container.read(controllerProvider).fen,
+        'rnbqkbnr/pppppppp/8/8/8/8/PPPPQPPP/RNB1KBNR w KQkq - 0 1',
+      );
+    });
+
     testWidgets('Add pieces via tap and pan', (tester) async {
       final app = await makeTestProviderScopeApp(tester, home: const BoardEditorScreen());
       await tester.pumpWidget(app);


### PR DESCRIPTION
Small UX improvement for the editor: 
Empties the square after tapping it again with the same piece in hand. This is possible on the website too.
Tests failing is expected, needs chessground changes.