### PR TITLE
fix regression caused by #2255

### DIFF
--- a/lib/src/view/analysis/analysis_board.dart
+++ b/lib/src/view/analysis/analysis_board.dart
@@ -6,6 +6,7 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:lichess_mobile/src/constants.dart';
 import 'package:lichess_mobile/src/model/analysis/common_analysis_prefs.dart';
 import 'package:lichess_mobile/src/model/analysis/common_analysis_state.dart';
+import 'package:lichess_mobile/src/model/common/chess.dart';
 import 'package:lichess_mobile/src/model/common/eval.dart';
 import 'package:lichess_mobile/src/model/engine/evaluation_preferences.dart';
 import 'package:lichess_mobile/src/model/engine/evaluation_service.dart';
@@ -123,7 +124,10 @@ abstract class AnalysisBoardState<
           : null,
       shapes: userShapes.union(_bestMoveShapes(boardPrefs.pieceSet.assets)).union(extraShapes),
       annotations: sanMove != null && annotation != null
-          ? IMap({sanMove.move.to: annotation})
+          ? (sanMove.san == 'O-O' || sanMove.san == 'O-O-O') &&
+                    altCastles.containsKey(sanMove.move.uci)
+                ? IMap({Move.parse(altCastles[sanMove.move.uci]!)!.to: annotation})
+                : IMap({sanMove.move.to: annotation})
           : null,
       settings: boardPrefs.toBoardSettings().copyWith(
         borderRadius: widget.boardRadius,


### PR DESCRIPTION
I wrongly assumed that addMoveAt() already converts castling notation for us, but that function is only called when new nodes are added to the move tree in an active game, but not when parsing a study chapter.

This is why #2255 fixed the bug of a move being incorrectly interpreted as alt-castling, but it now broke the annotations if the move actually WAS a castling move.

Luckily, while in addMoveAt() there are some heuristics because we only have the UCI move, not the SAN move, in the AnalysisBoard we *do* have the SAN move, so we can just check for O-O/O-O-O to avoid false positives.

Resolves #2231