### PR TITLE
Prevent Users seeing their own Profile as UserScreen

### DIFF
--- a/lib/src/app_links.dart
+++ b/lib/src/app_links.dart
@@ -12,7 +12,7 @@ import 'package:lichess_mobile/src/view/broadcast/broadcast_round_screen.dart';
 import 'package:lichess_mobile/src/view/puzzle/puzzle_screen.dart';
 import 'package:lichess_mobile/src/view/study/study_screen.dart';
 import 'package:lichess_mobile/src/view/tournament/tournament_screen.dart';
-import 'package:lichess_mobile/src/view/user/user_screen.dart';
+import 'package:lichess_mobile/src/view/user/user_or_profile_screen.dart';
 import 'package:linkify/linkify.dart';
 import 'package:url_launcher/url_launcher.dart';
 
@@ -80,7 +80,10 @@ void onLinkifyOpen(BuildContext context, LinkableElement link) {
   } else if (link.originText.startsWith('@')) {
     final username = link.originText.substring(1);
     Navigator.of(context).push(
-      UserScreen.buildRoute(context, LightUser(id: UserId.fromUserName(username), name: username)),
+      UserOrProfileScreen.buildRoute(
+        context,
+        LightUser(id: UserId.fromUserName(username), name: username),
+      ),
     );
   } else {
     launchUrl(Uri.parse(link.url));

--- a/lib/src/view/analysis/analysis_screen.dart
+++ b/lib/src/view/analysis/analysis_screen.dart
@@ -32,7 +32,7 @@ import 'package:lichess_mobile/src/view/engine/engine_lines.dart';
 import 'package:lichess_mobile/src/view/explorer/explorer_view.dart';
 import 'package:lichess_mobile/src/view/game/game_common_widgets.dart';
 import 'package:lichess_mobile/src/view/settings/toggle_sound_button.dart';
-import 'package:lichess_mobile/src/view/user/user_screen.dart';
+import 'package:lichess_mobile/src/view/user/user_or_profile_screen.dart';
 import 'package:lichess_mobile/src/widgets/adaptive_action_sheet.dart';
 import 'package:lichess_mobile/src/widgets/bottom_bar.dart';
 import 'package:lichess_mobile/src/widgets/buttons.dart';
@@ -443,8 +443,9 @@ class _PlayerWidget extends StatelessWidget {
                 provisional: player.provisional,
                 aiLevel: player.aiLevel,
                 style: const TextStyle(fontWeight: FontWeight.bold),
-                onTap: () =>
-                    Navigator.of(context).push(UserScreen.buildRoute(context, player.user!)),
+                onTap: () => Navigator.of(
+                  context,
+                ).push(UserOrProfileScreen.buildRoute(context, player.user!)),
               ),
             )
           else

--- a/lib/src/view/chat/chat_screen.dart
+++ b/lib/src/view/chat/chat_screen.dart
@@ -10,7 +10,7 @@ import 'package:lichess_mobile/src/tab_scaffold.dart';
 import 'package:lichess_mobile/src/utils/l10n_context.dart';
 import 'package:lichess_mobile/src/utils/navigation.dart';
 import 'package:lichess_mobile/src/view/chat/chat_context_menu.dart';
-import 'package:lichess_mobile/src/view/user/user_screen.dart';
+import 'package:lichess_mobile/src/view/user/user_or_profile_screen.dart';
 import 'package:lichess_mobile/src/widgets/adaptive_bottom_sheet.dart';
 import 'package:lichess_mobile/src/widgets/bottom_bar.dart';
 import 'package:lichess_mobile/src/widgets/buttons.dart';
@@ -205,8 +205,9 @@ class _MessageBubble extends ConsumerWidget {
                       fontWeight: FontWeight.bold,
                       color: _textColor(context, brightness),
                     ),
-                    onTap: () =>
-                        Navigator.of(context).push(UserScreen.buildRoute(context, message.user!)),
+                    onTap: () => Navigator.of(
+                      context,
+                    ).push(UserOrProfileScreen.buildRoute(context, message.user!)),
                   ),
                 Linkify(
                   onOpen: (link) => onLinkifyOpen(context, link),

--- a/lib/src/view/game/game_player.dart
+++ b/lib/src/view/game/game_player.dart
@@ -18,9 +18,8 @@ import 'package:lichess_mobile/src/styles/styles.dart';
 import 'package:lichess_mobile/src/utils/l10n_context.dart';
 import 'package:lichess_mobile/src/utils/lichess_assets.dart';
 import 'package:lichess_mobile/src/utils/screen.dart';
-import 'package:lichess_mobile/src/view/account/profile_screen.dart';
 import 'package:lichess_mobile/src/view/account/rating_pref_aware.dart';
-import 'package:lichess_mobile/src/view/user/user_screen.dart';
+import 'package:lichess_mobile/src/view/user/user_or_profile_screen.dart';
 import 'package:lichess_mobile/src/widgets/buttons.dart';
 import 'package:lichess_mobile/src/widgets/user.dart';
 
@@ -217,11 +216,9 @@ class GamePlayer extends StatelessWidget {
                                   if (mePlaying) {
                                     ref.invalidate(accountProvider);
                                   }
-                                  Navigator.of(context).push(
-                                    mePlaying
-                                        ? ProfileScreen.buildRoute(context)
-                                        : UserScreen.buildRoute(context, player.user!),
-                                  );
+                                  Navigator.of(
+                                    context,
+                                  ).push(UserOrProfileScreen.buildRoute(context, player.user!));
                                 }
                               : null,
                           child: playerWidget,

--- a/lib/src/view/message/conversation_screen.dart
+++ b/lib/src/view/message/conversation_screen.dart
@@ -12,7 +12,7 @@ import 'package:lichess_mobile/src/tab_scaffold.dart';
 import 'package:lichess_mobile/src/utils/l10n_context.dart';
 import 'package:lichess_mobile/src/utils/navigation.dart';
 import 'package:lichess_mobile/src/view/chat/chat_context_menu.dart';
-import 'package:lichess_mobile/src/view/user/user_screen.dart';
+import 'package:lichess_mobile/src/view/user/user_or_profile_screen.dart';
 import 'package:lichess_mobile/src/widgets/user.dart';
 
 sealed class DisplayItem {}
@@ -84,7 +84,7 @@ class _ConversationScreenState extends ConsumerState<ConversationScreen> with Ro
           showPatron: true,
           shouldShowOnline: true,
           onTap: () {
-            Navigator.push(context, UserScreen.buildRoute(context, widget.user));
+            Navigator.push(context, UserOrProfileScreen.buildRoute(context, widget.user));
           },
         ),
       ),

--- a/lib/src/view/relation/friend_screen.dart
+++ b/lib/src/view/relation/friend_screen.dart
@@ -12,7 +12,7 @@ import 'package:lichess_mobile/src/styles/styles.dart';
 import 'package:lichess_mobile/src/utils/l10n_context.dart';
 import 'package:lichess_mobile/src/utils/navigation.dart';
 import 'package:lichess_mobile/src/view/user/user_context_menu.dart';
-import 'package:lichess_mobile/src/view/user/user_screen.dart';
+import 'package:lichess_mobile/src/view/user/user_or_profile_screen.dart';
 import 'package:lichess_mobile/src/view/watch/tv_screen.dart';
 import 'package:lichess_mobile/src/widgets/feedback.dart';
 import 'package:lichess_mobile/src/widgets/list.dart';
@@ -149,7 +149,7 @@ class _OnlineFriendListTile extends ConsumerWidget {
               icon: const Icon(Icons.live_tv),
             )
           : null,
-      onTap: () => Navigator.of(context).push(UserScreen.buildRoute(context, user)),
+      onTap: () => Navigator.of(context).push(UserOrProfileScreen.buildRoute(context, user)),
       onLongPress: () => showModalBottomSheet<void>(
         context: context,
         useRootNavigator: true,
@@ -234,8 +234,7 @@ class _Following extends ConsumerWidget {
                         backgroundColor: context.lichessColors.error,
                         foregroundColor: Colors.white,
                         icon: Icons.person_remove,
-                        // TODO translate
-                        label: 'Unfollow',
+                        label: context.l10n.unfollow,
                       ),
                     ],
                   ),
@@ -243,7 +242,9 @@ class _Following extends ConsumerWidget {
                     user,
                     _isOnline(user, value.$2),
                     onTap: () => {
-                      Navigator.of(context).push(UserScreen.buildRoute(context, user.lightUser)),
+                      Navigator.of(
+                        context,
+                      ).push(UserOrProfileScreen.buildRoute(context, user.lightUser)),
                     },
                   ),
                 );

--- a/lib/src/view/study/study_screen.dart
+++ b/lib/src/view/study/study_screen.dart
@@ -29,7 +29,7 @@ import 'package:lichess_mobile/src/view/study/study_bottom_bar.dart';
 import 'package:lichess_mobile/src/view/study/study_gamebook.dart';
 import 'package:lichess_mobile/src/view/study/study_settings.dart';
 import 'package:lichess_mobile/src/view/study/study_tree_view.dart';
-import 'package:lichess_mobile/src/view/user/user_screen.dart';
+import 'package:lichess_mobile/src/view/user/user_or_profile_screen.dart';
 import 'package:lichess_mobile/src/widgets/adaptive_action_sheet.dart';
 import 'package:lichess_mobile/src/widgets/adaptive_bottom_sheet.dart';
 import 'package:lichess_mobile/src/widgets/feedback.dart';
@@ -599,7 +599,7 @@ class _StudyMembersSheet extends ConsumerWidget {
           ListTile(
             title: UserFullNameWidget(user: member.user),
             onTap: () {
-              Navigator.of(context).push(UserScreen.buildRoute(context, member.user));
+              Navigator.of(context).push(UserOrProfileScreen.buildRoute(context, member.user));
             },
           ),
       ],

--- a/lib/src/view/tournament/tournament_screen.dart
+++ b/lib/src/view/tournament/tournament_screen.dart
@@ -31,7 +31,7 @@ import 'package:lichess_mobile/src/view/analysis/analysis_screen.dart';
 import 'package:lichess_mobile/src/view/chat/chat_screen.dart';
 import 'package:lichess_mobile/src/view/game/game_screen.dart';
 import 'package:lichess_mobile/src/view/game/game_screen_providers.dart';
-import 'package:lichess_mobile/src/view/user/user_screen.dart';
+import 'package:lichess_mobile/src/view/user/user_or_profile_screen.dart';
 import 'package:lichess_mobile/src/view/watch/tv_screen.dart';
 import 'package:lichess_mobile/src/widgets/board_thumbnail.dart';
 import 'package:lichess_mobile/src/widgets/bottom_bar.dart';
@@ -1041,7 +1041,7 @@ class _TournamentPlayerDetails extends ConsumerWidget {
                         onTap: tournamentState.valueOrNull?.isSpectator == true
                             ? () => Navigator.of(
                                 context,
-                              ).push(UserScreen.buildRoute(context, player.user))
+                              ).push(UserOrProfileScreen.buildRoute(context, player.user))
                             : null,
                       ),
                     ),

--- a/lib/src/view/user/leaderboard_screen.dart
+++ b/lib/src/view/user/leaderboard_screen.dart
@@ -9,7 +9,7 @@ import 'package:lichess_mobile/src/styles/lichess_icons.dart';
 import 'package:lichess_mobile/src/styles/styles.dart';
 import 'package:lichess_mobile/src/utils/l10n_context.dart';
 import 'package:lichess_mobile/src/utils/navigation.dart';
-import 'package:lichess_mobile/src/view/user/user_screen.dart';
+import 'package:lichess_mobile/src/view/user/user_or_profile_screen.dart';
 import 'package:lichess_mobile/src/widgets/list.dart';
 import 'package:lichess_mobile/src/widgets/user.dart';
 
@@ -100,7 +100,7 @@ class LeaderboardListTile extends StatelessWidget {
   }
 
   void _handleTap(BuildContext context) {
-    Navigator.of(context).push(UserScreen.buildRoute(context, user.lightUser));
+    Navigator.of(context).push(UserOrProfileScreen.buildRoute(context, user.lightUser));
   }
 }
 

--- a/lib/src/view/user/player_screen.dart
+++ b/lib/src/view/user/player_screen.dart
@@ -11,7 +11,7 @@ import 'package:lichess_mobile/src/view/relation/friend_screen.dart';
 import 'package:lichess_mobile/src/view/user/leaderboard_widget.dart';
 import 'package:lichess_mobile/src/view/user/online_bots_screen.dart';
 import 'package:lichess_mobile/src/view/user/search_screen.dart';
-import 'package:lichess_mobile/src/view/user/user_screen.dart';
+import 'package:lichess_mobile/src/view/user/user_or_profile_screen.dart';
 import 'package:lichess_mobile/src/widgets/platform.dart';
 import 'package:lichess_mobile/src/widgets/platform_search_bar.dart';
 
@@ -60,7 +60,7 @@ class _Body extends ConsumerWidget {
               SearchScreen.buildRoute(
                 context,
                 onUserTap: (user) {
-                  Navigator.of(context).push(UserScreen.buildRoute(context, user));
+                  Navigator.of(context).push(UserOrProfileScreen.buildRoute(context, user));
                 },
               ),
             ),

--- a/lib/src/view/user/user_context_menu.dart
+++ b/lib/src/view/user/user_context_menu.dart
@@ -9,6 +9,7 @@ import 'package:lichess_mobile/src/model/user/user_repository_providers.dart';
 import 'package:lichess_mobile/src/styles/lichess_icons.dart';
 import 'package:lichess_mobile/src/styles/styles.dart';
 import 'package:lichess_mobile/src/utils/l10n_context.dart';
+import 'package:lichess_mobile/src/view/user/user_or_profile_screen.dart';
 import 'package:lichess_mobile/src/view/user/user_screen.dart';
 import 'package:lichess_mobile/src/view/watch/tv_screen.dart';
 import 'package:lichess_mobile/src/widgets/adaptive_bottom_sheet.dart';
@@ -60,7 +61,9 @@ class UserContextMenu extends ConsumerWidget {
               children: [
                 BottomSheetContextMenuAction(
                   onPressed: () {
-                    Navigator.of(context).push(UserScreen.buildRoute(context, value.lightUser));
+                    Navigator.of(
+                      context,
+                    ).push(UserOrProfileScreen.buildRoute(context, value.lightUser));
                   },
                   icon: Icons.person,
                   child: Text(context.l10n.profile),

--- a/lib/src/view/user/user_or_profile_screen.dart
+++ b/lib/src/view/user/user_or_profile_screen.dart
@@ -1,0 +1,24 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:lichess_mobile/src/model/auth/auth_session.dart';
+import 'package:lichess_mobile/src/model/user/user.dart';
+import 'package:lichess_mobile/src/utils/navigation.dart';
+import 'package:lichess_mobile/src/view/account/profile_screen.dart';
+import 'package:lichess_mobile/src/view/user/user_screen.dart';
+
+class UserOrProfileScreen extends ConsumerWidget {
+  const UserOrProfileScreen({required this.user, super.key});
+  final LightUser user;
+
+  static Route<dynamic> buildRoute(BuildContext context, LightUser user) {
+    return buildScreenRoute(context, screen: UserOrProfileScreen(user: user));
+  }
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final session = ref.watch(authSessionProvider);
+    return session != null && session.user.id == user.id
+        ? const ProfileScreen()
+        : UserScreen(user: user);
+  }
+}


### PR DESCRIPTION
Fix #2270. I made a wrapper around `UserScreen `and `ProfileScreen `similar as I did in the `ExplorerView`, to prevent the User seeing their own Profile as a `UserScreen`.