### PR TITLE
Fix Patron Icon size

### DIFF
--- a/lib/src/view/more/more_tab_screen.dart
+++ b/lib/src/view/more/more_tab_screen.dart
@@ -174,7 +174,7 @@ class _Body extends ConsumerWidget {
               hasLeading: true,
               children: [
                 ListTile(
-                  leading: const PatronIcon(color: 10),
+                  leading: PatronIcon(color: 10, size: IconTheme.of(context).size),
                   title: Text(context.l10n.patronDonate),
                   subtitle: Text(context.l10n.patronBecomePatron),
                   trailing: Theme.of(context).platform == TargetPlatform.iOS


### PR DESCRIPTION
Fix regression of Donate Icon size:
Fixed:
<img width="580" height="120" alt="grafik" src="https://github.com/user-attachments/assets/9c2f8016-cfdf-42b3-8557-7b5ca4b5331a" />
Before:
<img width="583" height="114" alt="grafik" src="https://github.com/user-attachments/assets/f187bd23-3149-42f9-871f-4ac173ec1836" />

