### PR TITLE
Fix Regression on profile screen.

### DIFF
--- a/lib/src/model/user/user_repository_providers.dart
+++ b/lib/src/model/user/user_repository_providers.dart
@@ -19,22 +19,8 @@ Future<User> user(Ref ref, {required UserId id}) {
 }
 
 @riverpod
-Future<(User, UserStatus)> userAndStatus(Ref ref, {required UserId id}) {
-  final repo = ref.read(userRepositoryProvider);
-  return Future.wait([
-    repo.getUser(id, withCanChallenge: true),
-    repo.getUsersStatuses({id}.lock),
-  ], eagerError: true).then((value) => (value[0] as User, (value[1] as IList<UserStatus>).first));
-}
-
-@riverpod
 Future<UserPerfStats> userPerfStats(Ref ref, {required UserId id, required Perf perf}) {
   return ref.read(userRepositoryProvider).getPerfStats(id, perf);
-}
-
-@riverpod
-Future<IList<UserStatus>> userStatuses(Ref ref, {required ISet<UserId> ids}) {
-  return ref.read(userRepositoryProvider).getUsersStatuses(ids);
 }
 
 @riverpod

--- a/lib/src/view/user/user_screen.dart
+++ b/lib/src/view/user/user_screen.dart
@@ -8,7 +8,6 @@ import 'package:lichess_mobile/src/model/game/game_filter.dart';
 import 'package:lichess_mobile/src/model/relation/relation_repository.dart';
 import 'package:lichess_mobile/src/model/user/user.dart';
 import 'package:lichess_mobile/src/model/user/user_repository.dart';
-import 'package:lichess_mobile/src/model/user/user_repository_providers.dart';
 import 'package:lichess_mobile/src/network/connectivity.dart';
 import 'package:lichess_mobile/src/network/http.dart';
 import 'package:lichess_mobile/src/styles/lichess_icons.dart';
@@ -125,7 +124,7 @@ class _UserScreenState extends ConsumerState<UserScreen> {
             );
           }
           return FullScreenRetryRequest(
-            onRetry: () => ref.invalidate(userProvider(id: widget.user.id)),
+            onRetry: () => ref.invalidate(_userScreenDataProvider(widget.user.id)),
           );
         },
       ),
@@ -166,9 +165,7 @@ class _UserProfileListView extends ConsumerWidget {
     Future<void> userAction(Future<void> Function(LichessClient client) action) async {
       setIsLoading(true);
       try {
-        await ref
-            .withClient(action)
-            .then((_) => ref.invalidate(userAndStatusProvider(id: user.id)));
+        await ref.withClient(action).then((_) => ref.invalidate(_userScreenDataProvider(user.id)));
       } finally {
         setIsLoading(false);
       }


### PR DESCRIPTION
fix #2309 
A provider that was not being watched was invalidated and because of that the screen did not reload on follow/unfollow. I think a similar issue might existed with the retry so I fixed it, but I haven’t tested it.

Also I removed two providers that are no longer used.
