### PR TITLE
Improved Focus handling on seeks

### DIFF
--- a/lib/src/view/game/game_loading_board.dart
+++ b/lib/src/view/game/game_loading_board.dart
@@ -287,9 +287,10 @@ class LoadingPlayerWidget extends StatelessWidget {
 }
 
 class LoadGameError extends StatelessWidget {
-  const LoadGameError(this.errorMessage);
+  const LoadGameError(this.errorMessage, {this.showBackButton = false});
 
   final String errorMessage;
+  final bool showBackButton;
 
   @override
   Widget build(BuildContext context) {
@@ -311,7 +312,7 @@ class LoadGameError extends StatelessWidget {
           children: [
             BottomBarButton(
               onTap: () => Navigator.of(context).pop(),
-              label: context.l10n.cancel,
+              label: showBackButton ? 'Back' : context.l10n.cancel,
               icon: CupertinoIcons.xmark,
               showLabel: true,
             ),

--- a/lib/src/view/game/game_loading_board.dart
+++ b/lib/src/view/game/game_loading_board.dart
@@ -287,10 +287,10 @@ class LoadingPlayerWidget extends StatelessWidget {
 }
 
 class LoadGameError extends StatelessWidget {
-  const LoadGameError(this.errorMessage, {this.showBackButton = false});
+  const LoadGameError(this.errorMessage, {this.showBottomBar = true});
 
   final String errorMessage;
-  final bool showBackButton;
+  final bool showBottomBar;
 
   @override
   Widget build(BuildContext context) {
@@ -310,12 +310,13 @@ class LoadGameError extends StatelessWidget {
         ),
         BottomBar(
           children: [
-            BottomBarButton(
-              onTap: () => Navigator.of(context).pop(),
-              label: showBackButton ? 'Back' : context.l10n.cancel,
-              icon: CupertinoIcons.xmark,
-              showLabel: true,
-            ),
+            if (showBottomBar)
+              BottomBarButton(
+                onTap: () => Navigator.of(context).pop(),
+                label: context.l10n.cancel,
+                icon: CupertinoIcons.xmark,
+                showLabel: true,
+              ),
           ],
         ),
       ],

--- a/lib/src/view/game/game_screen.dart
+++ b/lib/src/view/game/game_screen.dart
@@ -15,6 +15,7 @@ import 'package:lichess_mobile/src/model/settings/general_preferences.dart';
 import 'package:lichess_mobile/src/network/http.dart';
 import 'package:lichess_mobile/src/utils/duration.dart';
 import 'package:lichess_mobile/src/utils/gestures_exclusion.dart';
+import 'package:lichess_mobile/src/utils/immersive_mode.dart';
 import 'package:lichess_mobile/src/utils/l10n_context.dart';
 import 'package:lichess_mobile/src/utils/navigation.dart';
 import 'package:lichess_mobile/src/view/game/game_body.dart';
@@ -206,7 +207,7 @@ class _GameScreenState extends ConsumerState<GameScreen> {
               _ => const SizedBox.shrink(),
             },
           ),
-          body: PopScope(canPop: false, child: loadingBoard),
+          body: PopScope(canPop: false, child: WakelockWidget(child: loadingBoard)),
         );
     }
   }

--- a/lib/src/view/game/game_screen.dart
+++ b/lib/src/view/game/game_screen.dart
@@ -94,11 +94,9 @@ class _GameScreenState extends ConsumerState<GameScreen> {
     }
     switch (widget.source) {
       case LobbySource():
-        ref.read(gameScreenLoaderProvider(widget.source).notifier).cancelSeek();
-        await ref.read(createGameServiceProvider).cancelSeek();
+        await ref.read(gameScreenLoaderProvider(widget.source).notifier).cancelSeek();
       case UserChallengeSource():
-        ref.read(gameScreenLoaderProvider(widget.source).notifier).cancelChallenge();
-        await ref.read(createGameServiceProvider).cancelChallenge();
+        await ref.read(gameScreenLoaderProvider(widget.source).notifier).cancelChallenge();
       case ExistingGameSource():
         break;
     }
@@ -113,24 +111,24 @@ class _GameScreenState extends ConsumerState<GameScreen> {
         return Scaffold(
           resizeToAvoidBottomInset: false,
           appBar: AppBar(
-            leading: const SocketPingRatingIcon(),
+            leading: const BackButton(),
             title: switch (widget.source) {
               LobbySource(:final seek) => _LobbyGameTitle(seek: seek),
               _ => const SizedBox.shrink(),
             },
           ),
-          body: const LoadGameError('The game search was cancelled.', showBackButton: true),
+          body: const LoadGameError('The game search was cancelled.', showBottomBar: false),
         );
       case AsyncData(value: ChallengeCancelledState()):
         return Scaffold(
           resizeToAvoidBottomInset: false,
           appBar: AppBar(
-            leading: const SocketPingRatingIcon(),
+            leading: const BackButton(),
             title: _ChallengeGameTitle(
               challenge: (widget.source as UserChallengeSource).challengeRequest,
             ),
           ),
-          body: const LoadGameError('The challenge was cancelled.', showBackButton: true),
+          body: const LoadGameError('The challenge was cancelled.', showBottomBar: false),
         );
       case AsyncData(
         value: ChallengeDeclinedState(

--- a/lib/src/view/game/game_screen.dart
+++ b/lib/src/view/game/game_screen.dart
@@ -94,9 +94,11 @@ class _GameScreenState extends ConsumerState<GameScreen> {
     }
     switch (widget.source) {
       case LobbySource():
-        await ref.read(gameScreenLoaderProvider(widget.source).notifier).cancelSeek();
+        ref.read(gameScreenLoaderProvider(widget.source).notifier).cancelSeek();
+        await ref.read(createGameServiceProvider).cancelSeek();
       case UserChallengeSource():
-        await ref.read(gameScreenLoaderProvider(widget.source).notifier).cancelChallenge();
+        ref.read(gameScreenLoaderProvider(widget.source).notifier).cancelChallenge();
+        await ref.read(createGameServiceProvider).cancelChallenge();
       case ExistingGameSource():
         break;
     }
@@ -111,7 +113,6 @@ class _GameScreenState extends ConsumerState<GameScreen> {
         return Scaffold(
           resizeToAvoidBottomInset: false,
           appBar: AppBar(
-            leading: const BackButton(),
             title: switch (widget.source) {
               LobbySource(:final seek) => _LobbyGameTitle(seek: seek),
               _ => const SizedBox.shrink(),
@@ -123,7 +124,6 @@ class _GameScreenState extends ConsumerState<GameScreen> {
         return Scaffold(
           resizeToAvoidBottomInset: false,
           appBar: AppBar(
-            leading: const BackButton(),
             title: _ChallengeGameTitle(
               challenge: (widget.source as UserChallengeSource).challengeRequest,
             ),

--- a/lib/src/view/game/game_screen_providers.dart
+++ b/lib/src/view/game/game_screen_providers.dart
@@ -132,14 +132,12 @@ class GameScreenLoader extends _$GameScreenLoader {
     state = AsyncValue.data(GameCreatedState(id));
   }
 
-  Future<void> cancelSeek() async {
+  void cancelSeek() {
     state = const AsyncValue.data(SeekCancelledState());
-    await ref.read(createGameServiceProvider).cancelSeek();
   }
 
-  Future<void> cancelChallenge() async {
+  void cancelChallenge() {
     state = const AsyncValue.data(ChallengeCancelledState());
-    await ref.read(createGameServiceProvider).cancelChallenge();
   }
 }
 

--- a/lib/src/view/game/game_screen_providers.dart
+++ b/lib/src/view/game/game_screen_providers.dart
@@ -132,12 +132,14 @@ class GameScreenLoader extends _$GameScreenLoader {
     state = AsyncValue.data(GameCreatedState(id));
   }
 
-  void cancelSeek() {
+  Future<void> cancelSeek() async {
     state = const AsyncValue.data(SeekCancelledState());
+    await ref.read(createGameServiceProvider).cancelSeek();
   }
 
-  void cancelChallenge() {
+  Future<void> cancelChallenge() async {
     state = const AsyncValue.data(ChallengeCancelledState());
+    await ref.read(createGameServiceProvider).cancelChallenge();
   }
 }
 

--- a/lib/src/view/game/game_screen_providers.dart
+++ b/lib/src/view/game/game_screen_providers.dart
@@ -19,6 +19,8 @@ part 'game_screen_providers.freezed.dart';
 /// It can be:
 /// - [GameCreatedState]: A game has been created or loaded.
 /// - [ChallengeDeclinedState]: A real time challenge has been declined.
+/// - [SeekCancelledState]: A game seek has been cancelled.
+/// - [ChallengeCancelledState]: A real time challenge has been cancelled.
 sealed class GameScreenState {}
 
 /// Game screen state when a game has been created or loaded.
@@ -41,6 +43,22 @@ sealed class ChallengeDeclinedState with _$ChallengeDeclinedState implements Gam
 
   const factory ChallengeDeclinedState(ChallengeResponseDeclined response) =
       _ChallengeDeclinedState;
+}
+
+/// A game seek has been cancelled.
+@freezed
+sealed class SeekCancelledState with _$SeekCancelledState implements GameScreenState {
+  const SeekCancelledState._();
+
+  const factory SeekCancelledState() = _SeekCancelledState;
+}
+
+/// A real time challenge has been cancelled.
+@freezed
+sealed class ChallengeCancelledState with _$ChallengeCancelledState implements GameScreenState {
+  const ChallengeCancelledState._();
+
+  const factory ChallengeCancelledState() = _ChallengeCancelledState;
 }
 
 /// The source from which the [GameScreen] was opened.
@@ -112,6 +130,14 @@ class GameScreenLoader extends _$GameScreenLoader {
   /// Load a game from its id.
   void loadGame(GameFullId id) {
     state = AsyncValue.data(GameCreatedState(id));
+  }
+
+  void cancelSeek() {
+    state = const AsyncValue.data(SeekCancelledState());
+  }
+
+  void cancelChallenge() {
+    state = const AsyncValue.data(ChallengeCancelledState());
   }
 }
 


### PR DESCRIPTION
Fixes issue reported on lichess: https://lichess.org/forum/team-lichess-beta-testers/mobile-app-alpha?page=16#156
The issue was that while seeking a game the screen could lock or the user could switch to another app without cancelling the seek, which led to game aborts.
Implemented fix: 
- Cancel seek when focus is lost and navigate back (the option would be to try to recreate the challenge or seek instead)
- Added a Wakelock to prevent the screen from timing out during a seek that take a long time.