### PR TITLE
feat: add engine eval display in analysis for tablet landscape mode

### DIFF
--- a/lib/src/view/engine/engine_gauge.dart
+++ b/lib/src/view/engine/engine_gauge.dart
@@ -169,41 +169,38 @@ class _EvalGaugeState extends State<_EvalGauge> {
                         value: value,
                         textDirection: textDirection,
                       ),
-                child: widget.displayMode == EngineGaugeDisplayMode.vertical
-                    ? const SizedBox.shrink()
-                    : Stack(
-                        children: [
-                          Align(
-                            alignment: toValue >= 0.5
-                                ? Alignment.centerLeft
-                                : Alignment.centerRight,
-                            child: Padding(
-                              padding: const EdgeInsets.symmetric(horizontal: 4.0),
-                              child: Text(
-                                evalDisplay ?? '',
-                                style: TextStyle(
-                                  color: toValue >= 0.5 ? Colors.black : Colors.white,
-                                  fontSize: kEvalGaugeFontSize,
-                                  fontWeight: FontWeight.bold,
-                                ),
-                              ),
+                child: RotatedBox(
+                  quarterTurns: widget.displayMode == EngineGaugeDisplayMode.vertical ? 3 : 0,
+                  child: Stack(
+                    children: [
+                      Align(
+                        alignment: toValue >= 0.5 ? Alignment.centerLeft : Alignment.centerRight,
+                        child: Padding(
+                          padding: const EdgeInsets.symmetric(horizontal: 4.0),
+                          child: Text(
+                            evalDisplay ?? '',
+                            style: TextStyle(
+                              color: toValue >= 0.5 ? Colors.black : Colors.white,
+                              fontSize: kEvalGaugeFontSize,
+                              fontWeight: FontWeight.bold,
                             ),
                           ),
-                          if (widget.engineLinesState != null)
-                            Align(
-                              alignment: toValue >= 0.5
-                                  ? Alignment.centerRight
-                                  : Alignment.centerLeft,
-                              child: Icon(
-                                widget.engineLinesState == EngineLinesShowState.expanded
-                                    ? Icons.arrow_drop_up
-                                    : Icons.arrow_drop_down,
-                                color: Colors.grey,
-                                size: 24.0,
-                              ),
-                            ),
-                        ],
+                        ),
                       ),
+                      if (widget.engineLinesState != null)
+                        Align(
+                          alignment: toValue >= 0.5 ? Alignment.centerRight : Alignment.centerLeft,
+                          child: Icon(
+                            widget.engineLinesState == EngineLinesShowState.expanded
+                                ? Icons.arrow_drop_up
+                                : Icons.arrow_drop_down,
+                            color: Colors.grey,
+                            size: 24.0,
+                          ),
+                        ),
+                    ],
+                  ),
+                ),
               ),
             ),
           ),


### PR DESCRIPTION
Hello.

I enjoy using Lichess on my tablet. However, I was unable to check the engine evaluation when using the tablet in landscape mode during analysis.

| Portrait | Landscape |
| :-: | :-: |
| <img width="480" src="https://github.com/user-attachments/assets/44a34cdf-a393-40bf-ac4f-a348ae9be757" /> | <img width="720" src="https://github.com/user-attachments/assets/d194ff3f-ffe4-4134-812e-f57e7fde1ca9" /> |

So, I modified it to look like the following.

| White | Black |
| :-: | :-: |
| <img width="720" src="https://github.com/user-attachments/assets/2bb62a84-3d27-4924-9bad-9bc46666447b" /> | <img width="720" src="https://github.com/user-attachments/assets/756eca05-a8c0-446a-a43b-0d22c15929b1" /> |

The rotated text might be difficult to read slightly, but I think it is a decent choice because there are cases where long words (e.g., Checkmate) appear.

<img width="720" src="https://github.com/user-attachments/assets/d368641a-e613-4df3-b147-80dee20679d0" />

Thank you.