### PR TITLE
fix: clear shapes when loading new puzzle

### DIFF
--- a/lib/src/view/puzzle/streak_screen.dart
+++ b/lib/src/view/puzzle/streak_screen.dart
@@ -106,6 +106,7 @@ class _BodyState extends ConsumerState<_Body> {
         final previousPuzzle = previous!.requireValue.puzzle;
 
         if (currentPuzzle.puzzle.id != previousPuzzle.puzzle.id) {
+          _onClearShapes();
           final authUser = ref.read(authControllerProvider);
           ref
               .read(ctrlProvider.notifier)


### PR DESCRIPTION
Fixes #2385 