### PR TITLE
Add a workflow to build and upload F-Droid APKs as a Github artifact

### DIFF
--- a/.github/workflows/upload_fdroid_github.yml
+++ b/.github/workflows/upload_fdroid_github.yml
@@ -8,6 +8,7 @@ permissions: read-all
 jobs:
   github-upload:
     runs-on: ubuntu-latest
+    if: github.ref == 'refs/heads/fdroid'  # only runs if on the 'fdroid' branch
     steps:
       - name: Set up JDK 17
         uses: actions/setup-java@v5


### PR DESCRIPTION
I tried to add this workflow on the fdroid branch but it didn't appear in the Github interface so I think we have to add it on the main branch.

This was asked by the F-Droid team (https://gitlab.com/fdroid/fdroiddata/-/merge_requests/29372#note_2927842381) to check if it is easy to have reproducible builds.