### PR TITLE
potential fix for notification issues on iOS

### DIFF
--- a/lib/src/model/notifications/notification_service.dart
+++ b/lib/src/model/notifications/notification_service.dart
@@ -95,18 +95,6 @@ class NotificationService {
   /// This method should be called once the app is ready to receive notifications,
   /// and after [LichessBinding.initializeNotifications] has been called.
   Future<void> start() async {
-    // listen for connectivity changes to register device once the app is online
-    _connectivitySubscription = _ref.listen(connectivityChangesProvider, (prev, current) async {
-      if (current.value?.isOnline == true && !_registeredDevice) {
-        try {
-          await registerDevice();
-          _registeredDevice = true;
-        } catch (e, st) {
-          _logger.severe('Could not setup push notifications; $e\n$st');
-        }
-      }
-    });
-
     // Listen for incoming messages while the app is in the foreground.
     LichessBinding.instance.firebaseMessagingOnMessage.listen((RemoteMessage message) {
       _processFcmMessage(message, fromBackground: false);
@@ -134,6 +122,20 @@ class NotificationService {
       String token,
     ) {
       _registerToken(token);
+    });
+
+    // listen for connectivity changes to register device once the app is online
+    // This needs to be done *after* via have gotten permission, otherwise on iOS
+    // getAPNSToken() might still return null.
+    _connectivitySubscription = _ref.listen(connectivityChangesProvider, (prev, current) async {
+      if (current.value?.isOnline == true && !_registeredDevice) {
+        try {
+          await registerDevice();
+          _registeredDevice = true;
+        } catch (e, st) {
+          _logger.severe('Could not setup push notifications; $e\n$st');
+        }
+      }
     });
 
     // Get any messages which caused the application to open from


### PR DESCRIPTION
getAPNSToken() is the only iOS specific thing that happens in this file, so I think there's a high probabillity that the issues are related to that.

According to
https://firebase.google.com/docs/cloud-messaging/flutter/get-started we need to get permission *before* calling getAPNSToken(). Currently it looks like there could be a race condition where the connectivity change listener fires before we call requestPermission(). Fix this by moving the ref.listen() below the requestPermission() call.