### PR TITLE
Fix: reset puzzle streak correctly when failing the first puzzle

### DIFF
--- a/lib/src/view/puzzle/streak_screen.dart
+++ b/lib/src/view/puzzle/streak_screen.dart
@@ -537,7 +537,6 @@ class _BottomBar extends ConsumerWidget {
             highlighted: true,
             label: context.l10n.puzzleNewStreak,
             icon: CupertinoIcons.play_arrow_solid,
-            key: const Key('puzzle-new-streak-button'), //added for quick access in unit test
           ),
       ],
     );

--- a/test/view/puzzle/streak_screen_test.dart
+++ b/test/view/puzzle/streak_screen_test.dart
@@ -339,7 +339,7 @@ void main() {
       //game over correctly appears
       expect(find.text('GAME OVER'), findsOneWidget);
 
-      final button = find.byKey(const Key('puzzle-new-streak-button'));
+      final button = find.byTooltip('New streak');
       await tester.tap(button);
       await tester.pumpAndSettle(const Duration(milliseconds: 500));
 


### PR DESCRIPTION
#1951 had a previous fix but issue has returned.

Previous fix checked if the puzzle id is the same or has changed, but there seems to be a separate issue where the same puzzle streak re-plays sometimes if you fail early. I logged that as a separate issue at #2455 

I replaced the puzzle id check with a check for if the value of `finished` is going from true to false. Also wrote a unit test to prevent further regression