### PR TITLE
fix: remove delay when entering analysis board

### DIFF
--- a/lib/src/widgets/pgn.dart
+++ b/lib/src/widgets/pgn.dart
@@ -1,5 +1,3 @@
-import 'dart:async';
-
 import 'package:chessground/chessground.dart';
 import 'package:collection/collection.dart';
 import 'package:dartchess/dartchess.dart';
@@ -176,31 +174,28 @@ class _DebouncedPgnTreeViewState extends ConsumerState<DebouncedPgnTreeView> {
   /// When widget.livePath changes rapidly, we debounce the change to avoid rebuilding the whole tree on every received move.
   late UciPath? pathToLiveMove;
 
-  Timer? _scrollTimer;
-
   @override
   void initState() {
     super.initState();
     pathToCurrentMove = widget.currentPath;
     pathToLiveMove = widget.livePath;
+
+    // Scrollable.ensureVisible breaks animation when swiping between tabs (see https://github.com/lichess-org/mobile/issues/1232)
+    // Explicitly use the Scrollable of our TreeView instead, so that it won't affect the TabController's state.
     WidgetsBinding.instance.addPostFrameCallback((_) {
-      _scrollTimer?.cancel();
-      _scrollTimer = Timer(const Duration(milliseconds: 500), () {
-        if (currentMoveKey.currentContext != null) {
-          Scrollable.ensureVisible(
-            currentMoveKey.currentContext!,
-            alignment: 0.5,
-            alignmentPolicy: ScrollPositionAlignmentPolicy.keepVisibleAtEnd,
-          );
-        }
-      });
+      if (currentMoveKey.currentContext != null) {
+        Scrollable.of(currentMoveKey.currentContext!).position.ensureVisible(
+          currentMoveKey.currentContext!.findRenderObject()!,
+          alignment: 0.5,
+          alignmentPolicy: ScrollPositionAlignmentPolicy.keepVisibleAtEnd,
+        );
+      }
     });
   }
 
   @override
   void dispose() {
     _debounce.cancel();
-    _scrollTimer?.cancel();
     super.dispose();
   }
 


### PR DESCRIPTION
This is an alternate fix for #1232 which does not need the 500ms delay.

When entering the analysis board, the delay of 500ms before scrolling to the current move is unexpected for users. With this solution, we can jump to the current move immediately.

Before (note the delay before we scroll to the last move)

[before.webm](https://github.com/user-attachments/assets/b5a3fe62-e726-4b45-9ca1-b3dfe617cdb4)

After (no delay, tab animation still works, so no regression of #1232)

[after.webm](https://github.com/user-attachments/assets/7efcd4ef-d62b-419c-bf6f-7fc0c50ba1c8)
