### PR TITLE
Fix count-seconds spacing in OpponentLeftCounter widget [#2289]

### DIFF
--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -2718,7 +2718,7 @@
   "search": "Search",
   "clearSearch": "Clear search",
   "tags": "Tags",
-  "opponentLeftCounter": "{count, plural, =1{Your opponent left the game. You can claim victory in {count} second.} other{Your opponent left the game. You can claim victory in {count} seconds.}}",
+  "opponentLeftCounter": "{count, plural, =1{Your opponent left the game. You can claim victory in {count} second.} other{Your opponent left the game. You can claim victory in {count} seconds.}}",
   "@opponentLeftCounter": {
     "placeholders": {
       "count": {

--- a/lib/l10n/l10n.dart
+++ b/lib/l10n/l10n.dart
@@ -8903,7 +8903,7 @@ abstract class AppLocalizations {
   /// No description provided for @opponentLeftCounter.
   ///
   /// In en, this message translates to:
-  /// **'{count, plural, =1{Your opponent left the game. You can claim victory in {count} second.} other{Your opponent left the game. You can claim victory in {count} seconds.}}'**
+  /// **'{count, plural, =1{Your opponent left the game. You can claim victory in {count} second.} other{Your opponent left the game. You can claim victory in {count} seconds.}}'**
   String opponentLeftCounter(int count);
 
   /// No description provided for @mateInXHalfMoves.

--- a/lib/l10n/l10n_en.dart
+++ b/lib/l10n/l10n_en.dart
@@ -4854,8 +4854,8 @@ class AppLocalizationsEn extends AppLocalizations {
     String _temp0 = intl.Intl.pluralLogic(
       count,
       locale: localeName,
-      other: 'Your opponent left the game. You can claim victory in $count seconds.',
-      one: 'Your opponent left the game. You can claim victory in $count second.',
+      other: 'Your opponent left the game. You can claim victory in $count seconds.',
+      one: 'Your opponent left the game. You can claim victory in $count second.',
     );
     return '$_temp0';
   }

--- a/translation/source/site.xml
+++ b/translation/source/site.xml
@@ -43,8 +43,8 @@
   <string name="whitePlays">White to play</string>
   <string name="blackPlays">Black to play</string>
   <plurals name="opponentLeftCounter">
-    <item quantity="one">Your opponent left the game. You can claim victory in %s second.</item>
-    <item quantity="other">Your opponent left the game. You can claim victory in %s seconds.</item>
+    <item quantity="one">Your opponent left the game. You can claim victory in %s&#xA0;second.</item>
+    <item quantity="other">Your opponent left the game. You can claim victory in %s&#xA0;seconds.</item>
   </plurals>
   <string name="opponentLeftChoices">Your opponent left the game. You can claim victory, call the game a draw, or wait.</string>
   <string name="forceResignation">Claim victory</string>


### PR DESCRIPTION
closes #2289 

* Updated opponentLeftCounter to use a non-breaking space between count and seconds

https://github.com/user-attachments/assets/56a84eac-9d94-4ce5-b37e-47cf681aefea

