### PR TITLE
remove duplicate button

### DIFF
--- a/lib/src/view/puzzle/puzzle_screen.dart
+++ b/lib/src/view/puzzle/puzzle_screen.dart
@@ -775,19 +775,6 @@ class _BottomBarState extends ConsumerState<_BottomBar> {
           },
         ),
         BottomSheetAction(
-          makeLabel: (context) => Text(context.l10n.analysis),
-          onPressed: () {
-            Navigator.of(context).push(
-              AnalysisScreen.buildRoute(
-                context,
-                puzzleState.makeAnalysisOptions(
-                  ref.read(puzzleControllerProvider(widget.initialPuzzleContext).notifier).makePgn,
-                ),
-              ),
-            );
-          },
-        ),
-        BottomSheetAction(
           makeLabel: (context) =>
               Text(context.l10n.puzzleFromGameLink(puzzleState.puzzle.game.id.value)),
           onPressed: () async {


### PR DESCRIPTION
There is already a button in the bottombar that is redirecting to the analysis board, no need for it to be in the menu too.