### PR TITLE
add Team to Player Screen in Broadcasts

### DIFF
--- a/lib/src/model/broadcast/broadcast.dart
+++ b/lib/src/model/broadcast/broadcast.dart
@@ -204,6 +204,7 @@ sealed class BroadcastPlayerWithOverallResult with _$BroadcastPlayerWithOverallR
     required int? ratingDiff,
     required int? performance,
     required IList<BroadcastTieBreakDetail>? tieBreaks,
+    required String? team,
   }) = _BroadcastPlayerWithOverallResult;
 }
 

--- a/lib/src/model/broadcast/broadcast_repository.dart
+++ b/lib/src/model/broadcast/broadcast_repository.dart
@@ -283,6 +283,7 @@ BroadcastPlayerWithOverallResult _playerWithOverallResultFromPick(RequiredPick p
     ratingDiff: pick('ratingDiff').asIntOrNull(),
     performance: pick('performance').asIntOrNull(),
     tieBreaks: pick('tiebreaks').asListOrNull(_tieBreakDetailFromPick)?.toIList(),
+    team: pick('team').asStringOrNull(),
   );
 }
 

--- a/lib/src/view/broadcast/broadcast_player_results_screen.dart
+++ b/lib/src/view/broadcast/broadcast_player_results_screen.dart
@@ -210,8 +210,14 @@ class _OverallStatPlayer extends StatelessWidget {
         playerWithGameResults;
     final birthYear = fideData.birthYear;
     final (:standard, :rapid, :blitz) = fideData.ratings;
-    final BroadcastPlayerWithOverallResult(:player, :score, :played, :performance, :ratingDiff) =
-        playerWithOverallResult;
+    final BroadcastPlayerWithOverallResult(
+      :player,
+      :score,
+      :played,
+      :performance,
+      :ratingDiff,
+      :team,
+    ) = playerWithOverallResult;
     final BroadcastPlayer(:federation, :fideId) = player;
 
     final pic = player.fideId != null ? tournament.photos?.get(player.fideId!) : null;
@@ -265,6 +271,17 @@ class _OverallStatPlayer extends StatelessWidget {
                         ],
                       ),
                     const SizedBox(height: 16),
+                    if (team != null) ...[
+                      Row(
+                        children: [
+                          const SizedBox(width: 100, child: Text('Team')),
+                          Expanded(
+                            child: Text(team.trim(), style: Theme.of(context).textTheme.bodyLarge),
+                          ),
+                        ],
+                      ),
+                      const SizedBox(height: 16),
+                    ],
                     if (birthYear != null)
                       Row(
                         children: [


### PR DESCRIPTION
Adds the team field to the Player Screen for team tournaments.

There is no l10n for team, the website also uses the hardcoded `Team`

<img width="610" height="1307" alt="grafik" src="https://github.com/user-attachments/assets/e8fd78ca-ac87-4e3a-9cde-167c37e51b5e" />
