### PR TITLE
Share Observed Round in Broadcast

### DIFF
--- a/lib/src/view/broadcast/broadcast_carousel.dart
+++ b/lib/src/view/broadcast/broadcast_carousel.dart
@@ -466,7 +466,7 @@ class _BroadcastCardContent extends StatelessWidget {
                         : Icons.share_outlined,
                     label: context.l10n.studyShareAndExport,
                     onPressed: () {
-                      showBroadcastShareMenu(context, broadcast);
+                      showBroadcastShareMenu(context, broadcast.tour, broadcast.round);
                     },
                   ),
                 ],

--- a/lib/src/view/broadcast/broadcast_round_screen.dart
+++ b/lib/src/view/broadcast/broadcast_round_screen.dart
@@ -189,7 +189,7 @@ class _BroadcastRoundScreenState extends ConsumerState<BroadcastRoundScreen>
     AsyncValue<BroadcastRoundState> asyncRound,
   ) {
     return switch (asyncRound) {
-      AsyncData(value: final _) => PlatformScaffold(
+      AsyncData(value: final roundState) => PlatformScaffold(
         extendBody: Theme.of(context).platform == TargetPlatform.iOS,
         appBar: PlatformAppBar(
           title: AppBarTitleText(widget.broadcast.title, maxLines: 2),
@@ -218,7 +218,8 @@ class _BroadcastRoundScreenState extends ConsumerState<BroadcastRoundScreen>
             SemanticIconButton(
               icon: const PlatformShareIcon(),
               semanticsLabel: context.l10n.studyShareAndExport,
-              onPressed: () => showBroadcastShareMenu(context, widget.broadcast),
+              onPressed: () =>
+                  showBroadcastShareMenu(context, widget.broadcast.tour, roundState.round),
             ),
           ],
         ),

--- a/lib/src/view/broadcast/broadcast_share_menu.dart
+++ b/lib/src/view/broadcast/broadcast_share_menu.dart
@@ -7,41 +7,38 @@ import 'package:share_plus/share_plus.dart';
 
 Future<void> showBroadcastShareMenu(
   BuildContext context,
-  Broadcast broadcast,
+  BroadcastTournamentData broadcastData,
+  BroadcastRound round,
 ) => showAdaptiveActionSheet<void>(
   context: context,
   actions: [
     BottomSheetAction(
-      makeLabel: (context) => Text(broadcast.title),
+      makeLabel: (context) => Text(broadcastData.name),
       onPressed: () {
         launchShareDialog(
           context,
-          ShareParams(uri: lichessUri('/broadcast/${broadcast.tour.slug}/${broadcast.tour.id}')),
+          ShareParams(uri: lichessUri('/broadcast/${broadcastData.slug}/${broadcastData.id}')),
         );
       },
     ),
     BottomSheetAction(
-      makeLabel: (context) => Text(broadcast.round.name),
+      makeLabel: (context) => Text(round.name),
       onPressed: () {
         launchShareDialog(
           context,
           ShareParams(
-            uri: lichessUri(
-              '/broadcast/${broadcast.tour.slug}/${broadcast.round.slug}/${broadcast.round.id}',
-            ),
+            uri: lichessUri('/broadcast/${broadcastData.slug}/${round.slug}/${round.id}'),
           ),
         );
       },
     ),
     BottomSheetAction(
-      makeLabel: (context) => Text('${broadcast.round.name} PGN'),
+      makeLabel: (context) => Text('${round.name} PGN'),
       onPressed: () {
         launchShareDialog(
           context,
           ShareParams(
-            uri: lichessUri(
-              '/broadcast/${broadcast.tour.slug}/${broadcast.round.slug}/${broadcast.round.id}.pgn',
-            ),
+            uri: lichessUri('/broadcast/${broadcastData.slug}/${round.slug}/${round.id}.pgn'),
           ),
         );
       },


### PR DESCRIPTION
Allows spectators to share a link to the round they are currently viewing. Before shared links always pointed to the live/last round.

