### PR TITLE
Fix(a11y): Merge semantics for welcome message to prevent TalkBack skipping text

### DIFF
--- a/lib/src/widgets/misc.dart
+++ b/lib/src/widgets/misc.dart
@@ -108,9 +108,11 @@ class _LichessMessageState extends State<LichessMessage> {
       spans.add(TextSpan(text: trans));
     }
 
-    return Text.rich(
-      TextSpan(style: widget.style, children: spans),
-      textAlign: widget.textAlign,
+    return MergeSemantics(
+      child: Text.rich(
+        TextSpan(style: widget.style, children: spans),
+        textAlign: widget.textAlign,
+      ),
     );
   }
 }


### PR DESCRIPTION
**Problem:** On the welcome screen (signed out), TalkBack focused directly on the second half ("libre, no-adds..."), skipping the beginning of the sentence entirely ("Lichess is a free...")

**Fix:** Wrapped the text in MergeSemantics. This forces screen readers to group the text spans and read the full sentence.

**Verified:** Tested manually with TalkBack on Android. The entire sentence is now read correctly.