### PR TITLE
Fix: Enable 'Back to Tournament' navigation during ongoing tournaments (#2521)

### DIFF
--- a/lib/src/view/game/game_body.dart
+++ b/lib/src/view/game/game_body.dart
@@ -713,7 +713,7 @@ class _GameBottomBar extends ConsumerWidget {
             makeLabel: (context) => Text(context.l10n.newOpponent),
             onPressed: () => onNewOpponentCallback(gameState.game),
           ),
-        if (gameState.tournament?.isFinished == true)
+        if (gameState.tournament != null)
           BottomSheetAction(
             makeLabel: (context) => Text(context.l10n.backToTournament),
             onPressed: () {

--- a/lib/src/view/game/game_result_dialog.dart
+++ b/lib/src/view/game/game_result_dialog.dart
@@ -164,7 +164,7 @@ class _GameResultDialogState extends ConsumerState<GameResultDialog> {
                     : null,
                 child: Text(context.l10n.newOpponent, textAlign: TextAlign.center),
               ),
-            if (value.tournament?.isOngoing == true) ...[
+            if (value.tournament != null) ...[
               FilledButton.icon(
                 icon: const Icon(Icons.play_arrow),
                 onPressed: () {
@@ -177,22 +177,24 @@ class _GameResultDialogState extends ConsumerState<GameResultDialog> {
                 },
                 label: Text(context.l10n.backToTournament, textAlign: TextAlign.center),
               ),
-              FilledButton.tonalIcon(
-                icon: const Icon(Icons.pause),
-                onPressed: () {
-                  // Pause the tournament
-                  ref
-                      .read(tournamentControllerProvider(value.tournament!.id).notifier)
-                      .joinOrPause();
-                  // Close the dialog
-                  Navigator.of(context).popUntil((route) => route is! PopupRoute);
-                  // Close the game screen
-                  WidgetsBinding.instance.addPostFrameCallback((_) {
-                    Navigator.of(context).pop(); // Pop the screen after frame
-                  });
-                },
-                label: Text(context.l10n.pause, textAlign: TextAlign.center),
-              ),
+              // Only show Pause if the tournament is actually ongoing
+              if (value.tournament!.isOngoing)
+                FilledButton.tonalIcon(
+                  icon: const Icon(Icons.pause),
+                  onPressed: () {
+                    // Pause the tournament
+                    ref
+                        .read(tournamentControllerProvider(value.tournament!.id).notifier)
+                        .joinOrPause();
+                    // Close the dialog
+                    Navigator.of(context).popUntil((route) => route is! PopupRoute);
+                    // Close the game screen
+                    WidgetsBinding.instance.addPostFrameCallback((_) {
+                      Navigator.of(context).pop(); // Pop the screen after frame
+                    });
+                  },
+                  label: Text(context.l10n.pause, textAlign: TextAlign.center),
+                ),
             ],
             if (value.game.userAnalysable)
               FilledButton.tonal(


### PR DESCRIPTION
**In game_body.dart:** Changed the condition from isFinished to tournament != null. This ensures "Back to Tournament" is accessible during ongoing tournaments.

**In game_result_dialog.dart:** Decoupled navigation logic from pause logic.
- "Back to Tournament" is now visible for all tournament games.
- "Pause" remains restricted to isOngoing tournaments only.