### PR TITLE
Broadcasts deeplinks improved

### DIFF
--- a/lib/src/app.dart
+++ b/lib/src/app.dart
@@ -129,14 +129,16 @@ class _AppState extends ConsumerState<Application> {
                 context,
               ).copyWith(height: isShortVerticalScreen(context) ? 60 : null),
       ),
-      onGenerateRoute: (settings) =>
-          settings.name != null ? resolveAppLinkUri(context, Uri.parse(settings.name!)) : null,
+      onGenerateRoute: (settings) => settings.name != null
+          ? resolveAppRoutes(context, Uri.parse(settings.name!), deepLinkWarmStart: true)?.last
+          : null,
       onGenerateInitialRoutes: (initialRoute) {
         final homeRoute = buildScreenRoute<void>(context, screen: const MainTabScaffold());
-        return <Route<dynamic>?>[
+        final routes = <Route<dynamic>?>[
           homeRoute,
-          resolveAppLinkUri(context, Uri.parse(initialRoute)),
+          ...?resolveAppRoutes(context, Uri.parse(initialRoute)),
         ].nonNulls.toList(growable: false);
+        return routes;
       },
       navigatorObservers: [rootNavPageRouteObserver],
     );

--- a/lib/src/app_links.dart
+++ b/lib/src/app_links.dart
@@ -14,49 +14,68 @@ import 'package:lichess_mobile/src/view/study/study_screen.dart';
 import 'package:lichess_mobile/src/view/tournament/tournament_screen.dart';
 import 'package:lichess_mobile/src/view/user/user_or_profile_screen.dart';
 import 'package:linkify/linkify.dart';
+import 'package:logging/logging.dart';
 import 'package:url_launcher/url_launcher.dart';
 
+final _logger = Logger('AppLinks');
+
 /// Resolves an app link [Uri] to a corresponding [Route].
-Route<dynamic>? resolveAppLinkUri(BuildContext context, Uri appLinkUri) {
+List<Route<dynamic>>? resolveAppRoutes(
+  BuildContext context,
+  Uri appLinkUri, {
+  bool deepLinkWarmStart = false,
+}) {
   if (appLinkUri.pathSegments.isEmpty) return null;
 
+  _logger.info('Resolving app link: $appLinkUri${deepLinkWarmStart ? ' (warm start)' : ''}');
   switch (appLinkUri.pathSegments[0]) {
     case 'study':
       final id = appLinkUri.pathSegments[1];
-      return StudyScreen.buildRoute(context, StudyId(id));
+      return [StudyScreen.buildRoute(context, StudyId(id))];
     case 'broadcast':
       final roundId = BroadcastRoundId(appLinkUri.pathSegments[3]);
       if (appLinkUri.pathSegments.length > 4) {
         final gameId = BroadcastGameId(appLinkUri.pathSegments[4]);
-        return BroadcastGameScreen.buildRoute(context, roundId: roundId, gameId: gameId);
+        return [
+          BroadcastRoundScreenLoading.buildRoute(
+            context,
+            roundId,
+            initialTab: BroadcastRoundTab.boards,
+          ),
+          BroadcastGameScreen.buildRoute(
+            context,
+            roundId: roundId,
+            gameId: gameId,
+            fromDeeplink: deepLinkWarmStart,
+          ),
+        ];
       } else {
         final tab = BroadcastRoundTab.tabOrNullFromString(appLinkUri.fragment);
-        return BroadcastRoundScreenLoading.buildRoute(context, roundId, initialTab: tab);
+        return [BroadcastRoundScreenLoading.buildRoute(context, roundId, initialTab: tab)];
       }
     case 'tournament':
       final tournamentId = TournamentId(appLinkUri.pathSegments[1]);
-      return TournamentScreen.buildRoute(context, tournamentId);
-
+      return [TournamentScreen.buildRoute(context, tournamentId)];
     case 'training':
       final id = appLinkUri.pathSegments[1];
-      return PuzzleScreen.buildRoute(
-        context,
-        angle: PuzzleAngle.fromKey('mix'),
-        puzzleId: PuzzleId(id),
-      );
+      return [
+        PuzzleScreen.buildRoute(context, angle: PuzzleAngle.fromKey('mix'), puzzleId: PuzzleId(id)),
+      ];
     case _:
       final gameId = GameId(appLinkUri.pathSegments[0]);
       final orientation = appLinkUri.pathSegments.getOrNull(2);
       // The game id can also be a challenge. Challenge by link is not supported yet so let's ignore it.
       if (gameId.isValid) {
-        return AnalysisScreen.buildRoute(
-          context,
-          AnalysisOptions.archivedGame(
-            orientation: orientation == 'black' ? Side.black : Side.white,
-            gameId: gameId,
-            initialMoveCursor: 0,
+        return [
+          AnalysisScreen.buildRoute(
+            context,
+            AnalysisOptions.archivedGame(
+              orientation: orientation == 'black' ? Side.black : Side.white,
+              gameId: gameId,
+              initialMoveCursor: 0,
+            ),
           ),
-        );
+        ];
       }
   }
 
@@ -70,9 +89,11 @@ void onLinkifyOpen(BuildContext context, LinkableElement link) {
   if (link is UrlElement && link.url.startsWith(RegExp('https?:\\/\\/$kLichessHost'))) {
     // Handle Lichess links specifically
     final appLinkUri = Uri.parse(link.url);
-    final route = resolveAppLinkUri(context, appLinkUri);
-    if (route != null) {
-      Navigator.of(context).push(route);
+    final routes = resolveAppRoutes(context, appLinkUri);
+    if (routes != null) {
+      for (final route in routes) {
+        Navigator.of(context).push(route);
+      }
     } else {
       // If the link is not recognized, open it in a browser
       launchUrl(appLinkUri);

--- a/lib/src/view/broadcast/broadcast_game_screen.dart
+++ b/lib/src/view/broadcast/broadcast_game_screen.dart
@@ -20,6 +20,7 @@ import 'package:lichess_mobile/src/view/broadcast/broadcast_game_screen_provider
 import 'package:lichess_mobile/src/view/broadcast/broadcast_game_settings_screen.dart';
 import 'package:lichess_mobile/src/view/broadcast/broadcast_player_results_screen.dart';
 import 'package:lichess_mobile/src/view/broadcast/broadcast_player_widget.dart';
+import 'package:lichess_mobile/src/view/broadcast/broadcast_round_screen.dart';
 import 'package:lichess_mobile/src/view/engine/engine_button.dart';
 import 'package:lichess_mobile/src/view/engine/engine_gauge.dart';
 import 'package:lichess_mobile/src/view/engine/engine_lines.dart';
@@ -41,6 +42,7 @@ class BroadcastGameScreen extends ConsumerStatefulWidget {
   final String? tournamentSlug;
   final String? roundSlug;
   final String? title;
+  final bool fromDeeplink;
 
   const BroadcastGameScreen({
     this.tournamentId,
@@ -49,6 +51,7 @@ class BroadcastGameScreen extends ConsumerStatefulWidget {
     this.tournamentSlug,
     this.roundSlug,
     this.title,
+    this.fromDeeplink = false,
   });
 
   static Route<dynamic> buildRoute(
@@ -59,6 +62,7 @@ class BroadcastGameScreen extends ConsumerStatefulWidget {
     String? tournamentSlug,
     String? roundSlug,
     String? title,
+    bool fromDeeplink = false,
   }) {
     return buildScreenRoute(
       context,
@@ -69,6 +73,7 @@ class BroadcastGameScreen extends ConsumerStatefulWidget {
         tournamentSlug: tournamentSlug,
         roundSlug: roundSlug,
         title: title,
+        fromDeeplink: fromDeeplink,
       ),
     );
   }
@@ -110,26 +115,40 @@ class _BroadcastGameScreenState extends ConsumerState<BroadcastGameScreen>
             _ => const SizedBox.shrink(),
           };
 
-    return Scaffold(
-      appBar: AppBar(
-        title: title,
-        actions: [
-          AppBarAnalysisTabIndicator(tabs: tabs, controller: _tabController),
-          _BroadcastGameMenu(
-            roundId: widget.roundId,
-            gameId: widget.gameId,
-            tournamentSlug: widget.tournamentSlug,
-            roundSlug: widget.roundSlug,
-          ),
-        ],
-      ),
-      body: _Body(
-        widget.tournamentId,
-        widget.roundId,
-        widget.gameId,
-        widget.tournamentSlug,
-        widget.roundSlug,
-        tabController: _tabController,
+    return PopScope(
+      canPop: !widget.fromDeeplink,
+      onPopInvokedWithResult: (didPop, result) {
+        if (!didPop && widget.fromDeeplink) {
+          Navigator.of(context).pushReplacement(
+            BroadcastRoundScreenLoading.buildRoute(
+              context,
+              widget.roundId,
+              initialTab: BroadcastRoundTab.boards,
+            ),
+          );
+        }
+      },
+      child: Scaffold(
+        appBar: AppBar(
+          title: title,
+          actions: [
+            AppBarAnalysisTabIndicator(tabs: tabs, controller: _tabController),
+            _BroadcastGameMenu(
+              roundId: widget.roundId,
+              gameId: widget.gameId,
+              tournamentSlug: widget.tournamentSlug,
+              roundSlug: widget.roundSlug,
+            ),
+          ],
+        ),
+        body: _Body(
+          widget.tournamentId,
+          widget.roundId,
+          widget.gameId,
+          widget.tournamentSlug,
+          widget.roundSlug,
+          tabController: _tabController,
+        ),
       ),
     );
   }


### PR DESCRIPTION
closes #2508

For cold starts and in-app links: `onGenerateInitialRoutes` pushes both the round screen and board screen.

For warm starts (app already running): `onGenerateRoute` pushes only the board screen with a `PopScope` that replaces itself with the round screen on back navigation.

I decided to use two approaches because if we push both screens avoids the back animation that would occur if we do  `PopScope` + `pushReplacement` 

This can in the future be applied to other deep links (profile stats, etc.) that need similar navigation stack handling.

Also:
- Added logger to `app_links.dart` 

Videos:
Cold start:

https://github.com/user-attachments/assets/168191d8-d3d9-4dd0-9ff8-b6df7301bd79

warm start:


https://github.com/user-attachments/assets/429216e4-c5d7-4c03-a178-dcf52d5980db

in app:

https://github.com/user-attachments/assets/2a5cd1ea-121d-4225-a998-aa14c20ec37e




