### PR TITLE
add support to deep link a specific ply/orientation to game analysis

### DIFF
--- a/lib/src/app_links.dart
+++ b/lib/src/app_links.dart
@@ -46,7 +46,8 @@ Route<dynamic>? resolveAppLinkUri(BuildContext context, Uri appLinkUri) {
       );
     case _:
       final gameId = GameId(appLinkUri.pathSegments[0]);
-      final orientation = appLinkUri.pathSegments.getOrNull(2);
+      final orientation = appLinkUri.pathSegments.getOrNull(1);
+      final int ply = int.tryParse(appLinkUri.fragment) ?? 0;
       // The game id can also be a challenge. Challenge by link is not supported yet so let's ignore it.
       if (gameId.isValid) {
         return AnalysisScreen.buildRoute(
@@ -54,7 +55,7 @@ Route<dynamic>? resolveAppLinkUri(BuildContext context, Uri appLinkUri) {
           AnalysisOptions.archivedGame(
             orientation: orientation == 'black' ? Side.black : Side.white,
             gameId: gameId,
-            initialMoveCursor: 0,
+            initialMoveCursor: ply,
           ),
         );
       }


### PR DESCRIPTION
Closes #2133 
Also, there was existing bug because of which the analysis screen was always opening from white's POV only, fixed that as well.
Tested this using the command
`./adb shell am start -a android.intent.action.VIEW -d "https://lichess.org/sOFJLM0J/black\#30" org.lichess.mobileV2.debug`