### PR TITLE
Remove the temporary Flutter version that was added in the F-Droid workflow

### DIFF
--- a/.github/workflows/upload_fdroid_github.yml
+++ b/.github/workflows/upload_fdroid_github.yml
@@ -18,8 +18,6 @@ jobs:
 
       - name: Install Flutter
         uses: subosito/flutter-action@v2
-        with:
-          flutter-version: 3.38.3
       - run: flutter doctor -v
 
       - name: Checkout mobile code


### PR DESCRIPTION
This was added to match the Flutter version that was used to build the APK in the F-Droid repository but it is not needed anymore.