### PR TITLE
Fix the F-Droid workflow

### DIFF
--- a/.github/workflows/upload_fdroid_github.yml
+++ b/.github/workflows/upload_fdroid_github.yml
@@ -8,7 +8,7 @@ permissions: read-all
 jobs:
   github-upload:
     runs-on: ubuntu-latest
-    if: github.ref == 'refs/heads/fdroid'  # only runs if on the 'fdroid' branch
+    if: endsWith(github.event.inputs.tag, 'fdroid') # only runs if on a fdroid tag
     steps:
       - name: Set up JDK 17
         uses: actions/setup-java@v5


### PR DESCRIPTION
The workflow needs to run on the fdroid tags and it seems to [skip the job](https://github.com/lichess-org/mobile/actions/runs/21171226648/job/60888211731) with the current condition on the branch. I think this is due to the fact that there are commits after the tag on the fdroid branch.

I have changed the condition so that it works with fdroid tags.