### PR TITLE
Fix for android "Remove animations" system setting not reflected by board settings > piece animation

### DIFF
--- a/android/app/src/main/kotlin/org/lichess/mobileV2/MainActivity.kt
+++ b/android/app/src/main/kotlin/org/lichess/mobileV2/MainActivity.kt
@@ -4,6 +4,7 @@ import android.app.ActivityManager
 import android.content.Context
 import android.graphics.Rect
 import android.os.Bundle
+import android.provider.Settings
 import androidx.core.splashscreen.SplashScreen.Companion.installSplashScreen
 import androidx.core.view.ViewCompat
 import io.flutter.embedding.android.FlutterActivity
@@ -45,11 +46,10 @@ class MainActivity: FlutterActivity() {
             val totalMemInMb = memoryInfo.totalMem / 1048576L
             result.success(totalMemInMb.toInt())
           }
-          // "getAvailableRam" -> {
-          //   val memoryInfo = getAvailableMemory()
-          //   val availMemInMb = memoryInfo.availMem / 1048576L
-          //   result.success(availMemInMb.toInt())
-          // }
+          "areAnimationsEnabled" -> {
+            val animationsEnabled = areAnimationsEnabled()
+            result.success(animationsEnabled)
+          }
           else -> {
             result.notImplemented()
           }
@@ -71,6 +71,32 @@ class MainActivity: FlutterActivity() {
     val activityManager = getSystemService(Context.ACTIVITY_SERVICE) as ActivityManager
     return ActivityManager.MemoryInfo().also { memoryInfo ->
         activityManager.getMemoryInfo(memoryInfo)
+    }
+  }
+
+  private fun areAnimationsEnabled(): Boolean {
+    return try {
+      // Check both animator duration scale and transition animation scale
+      // TRANSITION_ANIMATION_SCALE controls "remove animations" setting
+      val animatorScale = Settings.Global.getFloat(
+        contentResolver,
+        Settings.Global.ANIMATOR_DURATION_SCALE,
+        1.0f
+      )
+      val transitionScale = Settings.Global.getFloat(
+        contentResolver,
+        Settings.Global.TRANSITION_ANIMATION_SCALE,
+        1.0f
+      )
+      val windowScale = Settings.Global.getFloat(
+        contentResolver,
+        Settings.Global.WINDOW_ANIMATION_SCALE,
+        1.0f
+      )
+      // If any of these are 0, animations are effectively disabled
+      animatorScale > 0.0f && transitionScale > 0.0f && windowScale > 0.0f
+    } catch (e: Settings.SettingNotFoundException) {
+      true
     }
   }
 }

--- a/lib/src/model/game/game_controller.dart
+++ b/lib/src/model/game/game_controller.dart
@@ -504,7 +504,7 @@ class GameController extends AsyncNotifier<GameState> {
 
   /// Move feedback while playing
   void _playMoveFeedback(SanMove sanMove, {bool skipAnimationDelay = false}) {
-    final animationDuration = ref.read(boardPreferencesProvider).pieceAnimationDuration;
+    final animationDuration = ref.read(effectivePieceAnimationDurationProvider);
 
     final delay = animationDuration ~/ 2;
 

--- a/lib/src/model/settings/board_preferences.dart
+++ b/lib/src/model/settings/board_preferences.dart
@@ -9,6 +9,7 @@ import 'package:lichess_mobile/src/model/common/chess.dart';
 import 'package:lichess_mobile/src/model/settings/preferences_storage.dart';
 import 'package:lichess_mobile/src/styles/styles.dart';
 import 'package:lichess_mobile/src/utils/color_palette.dart';
+import 'package:lichess_mobile/src/utils/system.dart';
 
 part 'board_preferences.freezed.dart';
 part 'board_preferences.g.dart';
@@ -20,6 +21,24 @@ final boardPreferencesProvider = NotifierProvider<BoardPreferences, BoardPrefs>(
   BoardPreferences.new,
   name: 'BoardPreferencesProvider',
 );
+
+/// A provider that returns the effective piece animation duration, considering Android system settings.
+final effectivePieceAnimationDurationProvider = Provider<Duration>((ref) {
+  final boardPrefs = ref.watch(boardPreferencesProvider);
+  final androidAnimationsAsync = ref.watch(androidAnimationsProvider);
+
+  final androidAnimationsEnabled = androidAnimationsAsync.maybeWhen(
+    data: (enabled) => enabled,
+    orElse: () => true, // Default to enabled if we can't determine
+  );
+
+  // If Android animations are disabled, always return Duration.zero regardless of app setting
+  if (!androidAnimationsEnabled) {
+    return Duration.zero;
+  }
+
+  return boardPrefs.pieceAnimationDuration;
+});
 
 class BoardPreferences extends Notifier<BoardPrefs> with PreferencesStorage<BoardPrefs> {
   @override

--- a/lib/src/utils/system.dart
+++ b/lib/src/utils/system.dart
@@ -41,6 +41,24 @@ class System {
 
     throw UnimplementedError('This method is only available on Android');
   }
+
+  /// Returns whether animations are enabled in Android system settings.
+  ///
+  /// Only available on Android. On other platforms, returns true (animations enabled).
+  Future<bool> areAnimationsEnabled() async {
+    if (Platform.isAndroid) {
+      try {
+        final result = await _channel.invokeMethod<bool>('areAnimationsEnabled');
+        return result ?? true;
+      } on PlatformException catch (e) {
+        debugPrint('Failed to get animation settings: ${e.message}');
+        return true;
+      } on MissingPluginException catch (_) {
+        return true;
+      }
+    }
+    return true;
+  }
 }
 
 /// A provider that returns OS version of an Android device.
@@ -50,4 +68,9 @@ final androidVersionProvider = FutureProvider<AndroidBuildVersion?>((ref) async 
   }
   final info = await DeviceInfoPlugin().androidInfo;
   return info.version;
+});
+
+/// A provider that returns whether animations are enabled in Android system settings.
+final androidAnimationsProvider = FutureProvider<bool>((ref) async {
+  return await System.instance.areAnimationsEnabled();
 });

--- a/lib/src/view/game/game_body.dart
+++ b/lib/src/view/game/game_body.dart
@@ -224,12 +224,12 @@ class GameBody extends ConsumerWidget {
             youAre == Side.white && !isBoardTurned || youAre == Side.black && isBoardTurned;
         final topPlayer = topPlayerIsBlack ? black : white;
         final bottomPlayer = topPlayerIsBlack ? white : black;
-
+        final pieceAnimationDuration = ref.read(effectivePieceAnimationDurationProvider);
         final animationDuration =
             gameState.game.meta.speed == Speed.ultraBullet ||
                 gameState.game.meta.speed == Speed.bullet
             ? Duration.zero
-            : boardPreferences.pieceAnimationDuration;
+            : pieceAnimationDuration;
 
         return FocusDetector(
           onFocusRegained: () {


### PR DESCRIPTION
_Fixes_ #2534 

**Fix description:**
The fix basically fetches current value of "Remove animations" in Android, and the board settings UI refreshes so that after fetching the value from system settings, the toggle option will be disabled if the system animation is disabled, and enabled when system animation is enabled.

Attaching a recording of how the fix works.

https://github.com/user-attachments/assets/0d319b1e-ac78-4f78-b571-5c1e19b1efa8

