### PR TITLE
Fix immersive mode and gesture exclusion for puzzle screen

### DIFF
--- a/lib/src/view/puzzle/puzzle_screen.dart
+++ b/lib/src/view/puzzle/puzzle_screen.dart
@@ -414,6 +414,7 @@ class _BodyState extends ConsumerState<_Body> {
                   mainAxisSize: MainAxisSize.max,
                   children: [
                     BoardWidget(
+                      boardKey: widget.boardKey,
                       size: boardSize,
                       fen: puzzleState.currentPosition.fen,
                       orientation: puzzleState.pov,
@@ -504,6 +505,7 @@ class _BodyState extends ConsumerState<_Body> {
                         ? const EdgeInsets.symmetric(horizontal: kTabletBoardTableSidePadding)
                         : EdgeInsets.zero,
                     child: BoardWidget(
+                      boardKey: widget.boardKey,
                       size: boardSize,
                       fen: puzzleState.currentPosition.fen,
                       orientation: puzzleState.pov,


### PR DESCRIPTION
The immersive mode and gesture exclusion don't work for the puzzle screen because the key was not added to the Chessboard widget.