### PR TITLE
Replace shouldExcludeGesturesOnFocusGained callaback by a boolean

### DIFF
--- a/lib/src/utils/gestures_exclusion.dart
+++ b/lib/src/utils/gestures_exclusion.dart
@@ -33,13 +33,10 @@ class AndroidGesturesExclusionWidget extends StatefulWidget {
   /// Global key of the board widget.
   final GlobalKey boardKey;
 
-  /// Optional callback called when focus is gained, to check whether
-  /// to exclude gestures or not.
+  /// Whether to exclude gestures when focus is gained.
   ///
-  /// If provided, the widget will call this callback when focus is gained,
-  /// and will not exclude gestures if the callback returns false.
-  /// If not provided, the widget will enable immersive mode by default.
-  final bool Function()? shouldExcludeGesturesOnFocusGained;
+  /// If null, gestures exclusion will be enabled by default.
+  final bool? shouldExcludeGesturesOnFocusGained;
 
   /// Whether to set immersive mode with the gestures exclusion.
   ///
@@ -63,7 +60,7 @@ class _AndroidGesturesExclusionWidgetState extends State<AndroidGesturesExclusio
       data: MediaQuery.of(context).copyWith(viewPadding: initialViewPadding),
       child: FocusDetector(
         onFocusGained: () {
-          if (widget.shouldExcludeGesturesOnFocusGained?.call() ?? true) {
+          if (widget.shouldExcludeGesturesOnFocusGained ?? true) {
             setAndroidBoardGesturesExclusion(
               widget.boardKey,
               withImmersiveMode: widget.shouldSetImmersiveMode,

--- a/lib/src/view/game/game_screen.dart
+++ b/lib/src/view/game/game_screen.dart
@@ -213,7 +213,7 @@ class _GameScreenState extends ConsumerState<GameScreen> {
           body: Theme.of(context).platform == TargetPlatform.android
               ? AndroidGesturesExclusionWidget(
                   boardKey: _boardKey,
-                  shouldExcludeGesturesOnFocusGained: () => isRealTimePlayingGame,
+                  shouldExcludeGesturesOnFocusGained: isRealTimePlayingGame,
                   shouldSetImmersiveMode: boardPreferences.immersiveModeWhilePlaying ?? false,
                   child: body,
                 )

--- a/lib/src/view/puzzle/puzzle_screen.dart
+++ b/lib/src/view/puzzle/puzzle_screen.dart
@@ -538,7 +538,7 @@ class _BodyState extends ConsumerState<_Body> {
     return Theme.of(context).platform == TargetPlatform.android
         ? AndroidGesturesExclusionWidget(
             boardKey: widget.boardKey,
-            shouldExcludeGesturesOnFocusGained: () => puzzleState.mode != PuzzleMode.view,
+            shouldExcludeGesturesOnFocusGained: puzzleState.mode != PuzzleMode.view,
             shouldSetImmersiveMode: boardPreferences.immersiveModeWhilePlaying ?? false,
             child: content,
           )

--- a/lib/src/view/puzzle/storm_screen.dart
+++ b/lib/src/view/puzzle/storm_screen.dart
@@ -346,7 +346,7 @@ class _BodyState extends ConsumerState<_Body> {
     return Theme.of(context).platform == TargetPlatform.android
         ? AndroidGesturesExclusionWidget(
             boardKey: _boardKey,
-            shouldExcludeGesturesOnFocusGained: () =>
+            shouldExcludeGesturesOnFocusGained:
                 stormState.mode == StormMode.initial || stormState.mode == StormMode.running,
             shouldSetImmersiveMode: boardPreferences.immersiveModeWhilePlaying ?? false,
             child: content,

--- a/lib/src/view/puzzle/streak_screen.dart
+++ b/lib/src/view/puzzle/streak_screen.dart
@@ -420,7 +420,7 @@ class _BodyState extends ConsumerState<_Body> {
     return Theme.of(context).platform == TargetPlatform.android
         ? AndroidGesturesExclusionWidget(
             boardKey: _boardKey,
-            shouldExcludeGesturesOnFocusGained: () => puzzleState.mode != PuzzleMode.view,
+            shouldExcludeGesturesOnFocusGained: puzzleState.mode != PuzzleMode.view,
             shouldSetImmersiveMode: boardPreferences.immersiveModeWhilePlaying ?? false,
             child: content,
           )


### PR DESCRIPTION
The goal is to simplify the code by replacing a callback by a boolean in the `AndroidGesturesExclusionWidget`.

This was part of the PR https://github.com/lichess-org/mobile/pull/1921. I only took this change for now because I am not sure about the rest.