### PR TITLE
fix: use auto-size text for conditional premove hint

### DIFF
--- a/lib/src/view/analysis/conditional_premoves.dart
+++ b/lib/src/view/analysis/conditional_premoves.dart
@@ -1,3 +1,4 @@
+import 'package:auto_size_text/auto_size_text.dart';
 import 'package:collection/collection.dart';
 import 'package:dartchess/dartchess.dart';
 import 'package:flutter/cupertino.dart';
@@ -96,9 +97,10 @@ class _AddVariationButton extends ConsumerWidget {
                     ],
                   )
                 : Center(
-                    child: Text(
+                    child: AutoSizeText(
                       context.l10n.playVariationToCreateConditionalPremoves,
                       maxLines: 1,
+                      minFontSize: 12,
                       overflow: TextOverflow.ellipsis,
                     ),
                   ),


### PR DESCRIPTION
German is a verbose language :D I think it's better to not cut off the text here

before:

<img width="1080" height="2400" alt="Screenshot_1769623628" src="https://github.com/user-attachments/assets/246ad969-31a8-4e20-841e-87205f22ffe6" />

after:

<img width="1080" height="2400" alt="Screenshot_1769623649" src="https://github.com/user-attachments/assets/346b733d-24bb-4ff0-9d6d-134e091303fb" />
