### PR TITLE
Fix gesture exclusion for game screen

### DIFF
--- a/lib/src/view/game/game_body.dart
+++ b/lib/src/view/game/game_body.dart
@@ -245,7 +245,7 @@ class GameBody extends ConsumerWidget {
           child: WakelockWidget(
             shouldEnableOnFocusGained: () => gameState.game.playable,
             child: GameLayout(
-              key: boardKey,
+              boardKey: boardKey,
               boardSettingsOverrides: BoardSettingsOverrides(
                 animationDuration: animationDuration,
                 autoQueenPromotion: gameState.canAutoQueen,


### PR DESCRIPTION
When `findRenderObject` is used it find the render object of `GameLayout` I think when it should be the board widget.