### PR TITLE
Fix app logs preference

### DIFF
--- a/lib/src/model/settings/log_preferences.dart
+++ b/lib/src/model/settings/log_preferences.dart
@@ -15,7 +15,7 @@ final logPreferencesProvider = NotifierProvider<LogPreferencesNotifier, LogPrefs
 class LogPreferencesNotifier extends Notifier<LogPrefs> with PreferencesStorage<LogPrefs> {
   @override
   @protected
-  PrefCategory get prefCategory => PrefCategory.overTheBoard;
+  PrefCategory get prefCategory => PrefCategory.log;
 
   @override
   @protected

--- a/lib/src/model/settings/preferences_storage.dart
+++ b/lib/src/model/settings/preferences_storage.dart
@@ -30,7 +30,8 @@ enum PrefCategory {
   puzzle('preferences.puzzle'),
   broadcast('preferences.broadcast'),
   engineEvaluation('preferences.engineEvaluation'),
-  offlineComputerGame('preferences.offlineComputerGame');
+  offlineComputerGame('preferences.offlineComputerGame'),
+  log('preferences.log');
 
   const PrefCategory(this.storageKey);
 


### PR DESCRIPTION
App logs preference uses the same key as over the board. Fixes it by creating a new one.