### PR TITLE
Fix storm restart buttons

### DIFF
--- a/lib/src/view/puzzle/storm_screen.dart
+++ b/lib/src/view/puzzle/storm_screen.dart
@@ -696,10 +696,7 @@ class _BottomBar extends ConsumerWidget {
           icon: Icons.delete,
           label: context.l10n.stormNewRun.split('(').first.trimRight(),
           showLabel: true,
-          onTap: () {
-            stormState.clock.reset();
-            ref.invalidate(stormProvider);
-          },
+          onTap: () => ref.invalidate(stormProvider),
         ),
         if (stormState.mode == StormMode.running)
           BottomBarButton(
@@ -820,8 +817,10 @@ class _RunStatsPopupState extends ConsumerState<_RunStatsPopup> {
             padding: Styles.horizontalBodyPadding,
             child: FilledButton(
               onPressed: () {
-                ref.invalidate(stormProvider);
                 Navigator.of(context).pop();
+                WidgetsBinding.instance.addPostFrameCallback((_) {
+                  ref.invalidate(stormProvider);
+                });
               },
               child: Text(context.l10n.stormPlayAgain),
             ),

--- a/test/view/puzzle/storm_screen_test.dart
+++ b/test/view/puzzle/storm_screen_test.dart
@@ -154,10 +154,40 @@ void main() {
       await tester.pump(const Duration(milliseconds: 500));
       expect(find.byKey(const Key('h6-blackking')), findsOneWidget);
     });
+
+    testWidgets('play again starts new run', (tester) async {
+      final app = await makeTestProviderScopeApp(
+        tester,
+        home: const StormScreen(),
+        overrides: {
+          stormProvider: stormProvider.overrideWith((ref) => mockStromRun),
+          lichessClientProvider: lichessClientProvider.overrideWith(
+            (ref) => LichessClient(client, ref),
+          ),
+        },
+      );
+
+      await tester.pumpWidget(app);
+      await tester.pump(const Duration(seconds: 1));
+
+      await playMove(tester, 'h5', 'h7', orientation: Side.white);
+      await tester.pump(const Duration(milliseconds: 500));
+      await playMove(tester, 'e3', 'g1', orientation: Side.white);
+      await tester.pump(const Duration(milliseconds: 500));
+
+      await tester.tap(find.text('End run'));
+      await tester.pumpAndSettle();
+
+      await tester.tap(find.text('Play again'));
+      await tester.pumpAndSettle();
+
+      expect(find.byType(Chessboard), findsOneWidget);
+      expect(find.textContaining('You play the'), findsWidgets);
+    });
   });
 }
 
-final mockStromRun = PuzzleStormResponse(
+PuzzleStormResponse get mockStromRun => PuzzleStormResponse(
   puzzles: IList([
     LitePuzzle(
       id: const PuzzleId('5ech9'),


### PR DESCRIPTION
Fixes #2587

- Removed unnecessary clock reset from `New run` button
- Fixed `Play again` button to pop navigator before invalidating provider