### PR TITLE
add color back to broadcast player results

### DIFF
--- a/lib/src/view/broadcast/broadcast_player_results_screen.dart
+++ b/lib/src/view/broadcast/broadcast_player_results_screen.dart
@@ -467,31 +467,59 @@ class _GameResultListTile extends StatelessWidget {
             )
           : null,
       trailing: SizedBox(
-        width: 40,
-        child: Column(
+        width: 60,
+        child: Row(
           mainAxisSize: .min,
-          crossAxisAlignment: .end,
+          mainAxisAlignment: .center,
           children: [
-            Row(
-              mainAxisSize: .min,
-              children: [
-                Text(
-                  switch (points) {
-                    BroadcastPoints.one => '1',
-                    BroadcastPoints.half => '½',
-                    BroadcastPoints.zero => '0',
-                    _ => '*',
-                  },
-                  style: Theme.of(
-                    context,
-                  ).textTheme.bodyMedium?.copyWith(fontWeight: FontWeight.bold),
+            SizedBox(
+              width: 30,
+              child: Center(
+                child: Container(
+                  width: 15,
+                  height: 15,
+                  decoration: BoxDecoration(
+                    border:
+                        (Theme.of(context).brightness == .light && color == .white ||
+                            Theme.of(context).brightness == .dark && color == .black)
+                        ? Border.all(width: 2.0, color: ColorScheme.of(context).outline)
+                        : null,
+                    shape: .circle,
+                    color: switch (color) {
+                      .white => Colors.white.withValues(alpha: 0.9),
+                      .black => Colors.black.withValues(alpha: 0.9),
+                    },
+                  ),
                 ),
-              ],
+              ),
             ),
-            if (showRatingDiff &&
-                playerGameResult.ratingDiff != null &&
-                playerGameResult.ratingDiff != 0)
-              ProgressionWidget(playerGameResult.ratingDiff!, fontSize: 12),
+            SizedBox(
+              width: 30,
+              child: Column(
+                mainAxisSize: .min,
+                crossAxisAlignment: .end,
+                children: [
+                  Row(
+                    mainAxisSize: .min,
+                    children: [
+                      Text(
+                        switch (points) {
+                          .one => '1',
+                          .half => '½',
+                          .zero => '0',
+                          _ => '*',
+                        },
+                        style: Theme.of(context).textTheme.bodyMedium?.copyWith(fontWeight: .bold),
+                      ),
+                    ],
+                  ),
+                  if (showRatingDiff &&
+                      playerGameResult.ratingDiff != null &&
+                      playerGameResult.ratingDiff != 0)
+                    ProgressionWidget(playerGameResult.ratingDiff!, fontSize: 12),
+                ],
+              ),
+            ),
           ],
         ),
       ),


### PR DESCRIPTION
closes #2528 

Adds back the color indicator to the player results screen. It is useful for example while playing otb tournaments to see the games that the player played with that color.

<img width="1195" height="1825" alt="grafik" src="https://github.com/user-attachments/assets/3feb2691-5cdc-4942-8ba6-928472351b52" />
