### PR TITLE
Show Broadcast Tiebreaks in Bottom Sheet

### DIFF
--- a/lib/src/view/broadcast/broadcast_player_results_screen.dart
+++ b/lib/src/view/broadcast/broadcast_player_results_screen.dart
@@ -3,6 +3,7 @@ import 'dart:math';
 import 'package:fast_immutable_collections/fast_immutable_collections.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:intl/intl.dart';
 import 'package:lichess_mobile/src/model/broadcast/broadcast.dart';
 import 'package:lichess_mobile/src/model/broadcast/broadcast_federation.dart';
 import 'package:lichess_mobile/src/model/broadcast/broadcast_providers.dart';
@@ -331,8 +332,7 @@ class _OverallStatPlayer extends StatelessWidget {
                     width: statWidth,
                     child: _StatCard(
                       context.l10n.broadcastScore,
-                      value:
-                          '${score.toStringAsFixed((score == score.roundToDouble()) ? 0 : 1)} / $played',
+                      value: '${NumberFormat('0.#').format(score)} / $played',
                     ),
                   ),
                 if (performance != null)
@@ -385,9 +385,7 @@ class _TieBreaksSection extends StatelessWidget {
                   dense: true,
                   title: Text(tieBreak.description),
                   trailing: Text(
-                    tieBreak.points.toStringAsFixed(
-                      (tieBreak.points == tieBreak.points.roundToDouble()) ? 0 : 1,
-                    ),
+                    NumberFormat('0.##').format(tieBreak.points),
                     style: Theme.of(context).textTheme.bodyMedium,
                   ),
                 ),


### PR DESCRIPTION
On long press on a player, in a tournament where tiebreaks are enabled, show the tiebreaks in a bottom sheet.
IMO this is an UX improvement because it quickly allows to compare the tiebreaks between players.
Also improves number formating of the tiebreaks.
Video:

https://github.com/user-attachments/assets/af18ee56-1a0e-4aa2-9624-8f8d4608a614
