### PR TITLE
Allow to share games opened from player results or app links

### DIFF
--- a/lib/src/view/broadcast/broadcast_game_screen.dart
+++ b/lib/src/view/broadcast/broadcast_game_screen.dart
@@ -177,21 +177,22 @@ class _BroadcastGameMenu extends ConsumerWidget {
             ref.read(broadcastPreferencesProvider.notifier).toggleShowEngineLines();
           },
         ),
-        if (tournamentSlug != null && roundSlug != null)
-          ContextMenuAction(
-            icon: Theme.of(context).platform == TargetPlatform.iOS
-                ? Icons.ios_share_outlined
-                : Icons.share_outlined,
-            label: context.l10n.mobileShareGameURL,
-            onPressed: () {
-              launchShareDialog(
-                context,
-                ShareParams(
-                  uri: lichessUri('/broadcast/$tournamentSlug/$roundSlug/$roundId/$gameId'),
+        ContextMenuAction(
+          icon: Theme.of(context).platform == TargetPlatform.iOS
+              ? Icons.ios_share_outlined
+              : Icons.share_outlined,
+          label: context.l10n.mobileShareGameURL,
+          onPressed: () {
+            launchShareDialog(
+              context,
+              ShareParams(
+                uri: lichessUri(
+                  '/broadcast/${tournamentSlug ?? '-'}/${roundSlug ?? '-'}/$roundId/$gameId',
                 ),
-              );
-            },
-          ),
+              ),
+            );
+          },
+        ),
         ContextMenuAction(
           icon: Icons.description_outlined,
           label: context.l10n.mobileShareGamePGN,


### PR DESCRIPTION
closes #1546 
Add a fallback for the slugs that is simply  - . Slugs are only used for SEO anyways. This allows to share the game link even if the game was launched from the player results screen or a app link.