### PR TITLE
allow split-screen on older android versions

### DIFF
--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -5,7 +5,6 @@
         android:name="${applicationName}"
         android:icon="@mipmap/ic_launcher"
         android:roundIcon="@mipmap/ic_launcher_round"
-        android:resizeableActivity="false"
         android:enableOnBackInvokedCallback="true"
         android:fullBackupContent="@xml/backup_rules">
 
@@ -26,7 +25,6 @@
             android:theme="@style/SplashTheme"
             android:configChanges="orientation|keyboardHidden|keyboard|screenSize|smallestScreenSize|locale|layoutDirection|fontScale|screenLayout|density|uiMode"
             android:hardwareAccelerated="true"
-            android:resizeableActivity="false"
             android:supportsPictureInPicture="false"
             android:windowSoftInputMode="adjustResize">
 


### PR DESCRIPTION
closes #1938 
Removes `android:resizeableActivity="false"` to re-enable split-screen (multi-window) support on older Android versions.

On newer android versions (Android 12L +), the system allows split-views anyways even with it set to false.

We support split screens on iPadOs and newer android versions so I don't see why we would disallow it on older android versions.

The issues that lead to `android:resizeableActivity="false"` are fixed now: https://github.com/lichess-org/mobile/issues/914

Tested on multiple older android versions and could not find any issues. Screenshot on Android 8: 
<img width="1909" height="1125" alt="grafik" src="https://github.com/user-attachments/assets/6e8f724d-b67e-428b-a587-5b2d11adea76" />


Note: This also enaboles split screen on phones, but some non stock Android version enabled that anyways.