### PR TITLE
Remove padding in analysis board for phones that are not too small

### DIFF
--- a/lib/src/constants.dart
+++ b/lib/src/constants.dart
@@ -63,7 +63,6 @@ const kMaxClockTextScaleFactor = 1.94;
 const kEmptyWidget = SizedBox.shrink();
 const kEmptyFen = '8/8/8/8/8/8/8/8 w - - 0 1';
 const kTabletBoardTableSidePadding = 16.0;
-const kAnalysisPortraitBoardSidePadding = 8.0;
 const kBottomBarHeight = 56.0;
 const kMaterialPopupMenuMaxWidth = 500.0;
 

--- a/lib/src/view/analysis/analysis_layout.dart
+++ b/lib/src/view/analysis/analysis_layout.dart
@@ -290,7 +290,7 @@ class AnalysisLayout extends StatelessWidget {
                   final evalGaugeSize = engineGaugeBuilder != null ? evalGaugeWidth : 0.0;
                   final boardSize = isTablet || isSmallScreen
                       ? defaultBoardSize - evalGaugeSize - kTabletBoardTableSidePadding * 2
-                      : defaultBoardSize - evalGaugeSize - kAnalysisPortraitBoardSidePadding * 2;
+                      : defaultBoardSize - evalGaugeSize;
 
                   return Column(
                     mainAxisAlignment: MainAxisAlignment.center,
@@ -301,9 +301,7 @@ class AnalysisLayout extends StatelessWidget {
                       Padding(
                         padding: isTablet
                             ? const EdgeInsets.all(kTabletBoardTableSidePadding)
-                            : const EdgeInsets.symmetric(
-                                horizontal: kAnalysisPortraitBoardSidePadding,
-                              ),
+                            : EdgeInsets.zero,
                         child: Column(
                           children: [
                             if (boardHeader != null)

--- a/test/view/analysis/analysis_layout_test.dart
+++ b/test/view/analysis/analysis_layout_test.dart
@@ -92,7 +92,7 @@ void main() {
       final boardSize = tester.getSize(find.byType(Chessboard));
 
       if (isPortrait) {
-        final expectedBoardSize = isTablet ? surface.width - 32.0 : surface.width - 16.0;
+        final expectedBoardSize = isTablet ? surface.width - 32.0 : surface.width;
         expect(
           boardSize,
           Size(expectedBoardSize, expectedBoardSize),


### PR DESCRIPTION
The image on the left is with padding and on the right without padding.

I think it looks nicer without padding and the vertical space gained by using the padding isn't that important.

<img width="40%" alt="with_padding" src="https://github.com/user-attachments/assets/0db99ea1-2830-48e7-8b4f-b77e6cb2cc8f" />&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;<img width="40%" alt="without_padding" src="https://github.com/user-attachments/assets/a6caf69d-b1e7-4f2f-8a2a-c932a0aba4ea" />
