### PR TITLE
more robust draw detection logic in resultFromPgnResult

### DIFF
--- a/lib/src/model/analysis/analysis_controller.dart
+++ b/lib/src/model/analysis/analysis_controller.dart
@@ -99,6 +99,7 @@ enum AnalysisGameResult {
       '1-0' => AnalysisGameResult.whiteWins,
       '0-1' => AnalysisGameResult.blackWins,
       '½-½' => AnalysisGameResult.draw,
+      '1/2-1/2' => AnalysisGameResult.draw,
       _ => AnalysisGameResult.other,
     };
   }


### PR DESCRIPTION
Parses 1/2-1/2 as a draw too, as this is maybe the most common way to store draws in the Result Header.