### PR TITLE
fix variant support in OTB screen

### DIFF
--- a/lib/src/model/over_the_board/over_the_board_game_controller.dart
+++ b/lib/src/model/over_the_board/over_the_board_game_controller.dart
@@ -89,6 +89,19 @@ class OverTheBoardGameController extends Notifier<OverTheBoardGameState> {
       );
     } else if (state.currentPosition.isStalemate) {
       state = state.copyWith(game: state.game.copyWith(status: GameStatus.stalemate));
+    } else if (state.currentPosition.variantOutcome != null) {
+      switch (state.currentPosition.variantOutcome!.winner) {
+        case Side.white:
+          state = state.copyWith(
+            game: state.game.copyWith(status: GameStatus.variantEnd, winner: Side.white),
+          );
+        case Side.black:
+          state = state.copyWith(
+            game: state.game.copyWith(status: GameStatus.variantEnd, winner: Side.black),
+          );
+        case null:
+          state = state.copyWith(game: state.game.copyWith(status: GameStatus.variantEnd));
+      }
     }
 
     _moveFeedback(sanMove);
@@ -168,8 +181,8 @@ sealed class OverTheBoardGameState with _$OverTheBoardGameState {
   Position get currentPosition => game.stepAt(stepCursor).position;
   Side get turn => currentPosition.turn;
   bool get finished => game.finished;
-  NormalMove? get lastMove =>
-      stepCursor > 0 ? NormalMove.fromUci(game.steps[stepCursor].sanMove!.move.uci) : null;
+  Move? get lastMove =>
+      stepCursor > 0 ? Move.parse(game.steps[stepCursor].sanMove!.move.uci) : null;
 
   MaterialDiffSide? currentMaterialDiff(Side side) {
     return game.steps[stepCursor].diff?.bySide(side);

--- a/lib/src/view/game/status_l10n.dart
+++ b/lib/src/view/game/status_l10n.dart
@@ -59,6 +59,8 @@ String gameStatusL10n(
       switch (variant) {
         case Variant.kingOfTheHill:
           return context.l10n.kingInTheCenter;
+        case Variant.racingKings:
+          return context.l10n.raceFinished;
         case Variant.threeCheck:
           return context.l10n.threeChecks;
         default:


### PR DESCRIPTION
Can't really add widget tests for this right now, as long as `playSupportedVariants` only supports standard, but I did some manual testing with Racing kings (by temporarily modifying `playSupportedVariants`), and variant win/loss/draw is now detected correctly:

<img width="1080" height="2400" alt="Screenshot_1771578566" src="https://github.com/user-attachments/assets/503b3648-e0e0-4465-bdb8-fbf735a87b76" />

<img width="1080" height="2400" alt="Screenshot_1771578607" src="https://github.com/user-attachments/assets/2c594613-3d7a-4d66-bbd4-c54859f5034a" />
