### PR TITLE
fix: support drop moves in learn from your mistakes

### DIFF
--- a/lib/src/model/analysis/retro_controller.dart
+++ b/lib/src/model/analysis/retro_controller.dart
@@ -43,10 +43,10 @@ sealed class Mistake with _$Mistake {
   }) = _Mistake;
 
   ViewBranch get userBranch => branch.children[0];
-  NormalMove get userMove => userBranch.sanMove.move as NormalMove;
+  Move get userMove => userBranch.sanMove.move;
 
   ViewBranch get serverBranch => branch.children[1];
-  NormalMove get serverMove => serverBranch.sanMove.move as NormalMove;
+  Move get serverMove => serverBranch.sanMove.move;
 
   bool isSolution(RetroCurrentNode node) =>
       node.position == serverBranch.position ||

--- a/lib/src/view/analysis/retro_screen.dart
+++ b/lib/src/view/analysis/retro_screen.dart
@@ -9,6 +9,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:lichess_mobile/src/model/analysis/analysis_preferences.dart';
 import 'package:lichess_mobile/src/model/analysis/retro_controller.dart';
+import 'package:lichess_mobile/src/model/common/eval.dart';
 import 'package:lichess_mobile/src/model/common/node.dart';
 import 'package:lichess_mobile/src/model/engine/evaluation_preferences.dart';
 import 'package:lichess_mobile/src/model/engine/evaluation_service.dart';
@@ -201,14 +202,14 @@ class _RetroAnalysisBoardState
   ISet<Shape> get extraShapes {
     final state = ref.watch(retroControllerProvider(widget.options)).requireValue;
     if (state.isSolving && state.currentMistake != null) {
+      final boardPrefs = ref.watch(boardPreferencesProvider);
       final mistake = state.currentMistake!.userMove;
-      return ISet<Shape>([
-        Arrow(
-          color: ShapeColor.red.color.withValues(alpha: 0.4),
-          orig: mistake.from,
-          dest: mistake.to,
-        ),
-      ]);
+      return moveShapes(
+        move: mistake,
+        color: ShapeColor.red.color.withValues(alpha: 0.4),
+        sideToMove: state.currentPosition.turn,
+        pieceAssets: boardPrefs.pieceSet.assets,
+      );
     }
     return ISet();
   }


### PR DESCRIPTION
I think when I wrote this, I thought that server analysis did not support variants, that's why the cast to `NormalMove` was there. But it's not actually neccessary. Also adjusted the move shape so that we display a red circle when a mistake is a `DropMove` (by using the existing `moveShapes` helper function