### PR TITLE
Add PGN Sharing to the Openings Explorer

### DIFF
--- a/lib/src/view/explorer/opening_explorer_screen.dart
+++ b/lib/src/view/explorer/opening_explorer_screen.dart
@@ -52,7 +52,7 @@ class OpeningExplorerScreen extends ConsumerWidget {
           title: Text(context.l10n.openingExplorer),
           actions: [
             SemanticIconButton(
-              semanticsLabel: 'Share game',
+              semanticsLabel: context.l10n.studyShareAndExport,
               onPressed: () => _showShareMenu(context, ref),
               icon: const PlatformShareIcon(),
             ),


### PR DESCRIPTION
- This PR adds PGN sharing to the openings explorer
- Same functionality is already available in the analysis screen (and in the web version)
- Requested in https://github.com/lichess-org/mobile/pull/2632#issuecomment-3937798763

### Demo

![88](https://github.com/user-attachments/assets/11f40aa9-b48b-4b97-91db-59f9984ea439)
