### PR TITLE
change upload to import

### DIFF
--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -115,6 +115,7 @@
   "mobileOpeningExplorerNotAvailableOffline": "Opening Explorer is not available offline.",
   "mobileChallengeCreated": "Challenge created: You will be notified when the game starts.\\nYou can access it from the home tab.",
   "mobilePreviousPage": "Previous",
+  "mobileOrImportPgnFile": "Or import a PGN file",
   "activityActivity": "Activity",
   "activityHostedALiveStream": "Hosted a live stream",
   "activityRankedInSwissTournament": "Ranked #{param1} in {param2}",

--- a/lib/l10n/l10n.dart
+++ b/lib/l10n/l10n.dart
@@ -722,6 +722,12 @@ abstract class AppLocalizations {
   /// **'Previous'**
   String get mobilePreviousPage;
 
+  /// No description provided for @mobileOrImportPgnFile.
+  ///
+  /// In en, this message translates to:
+  /// **'Or import a PGN file'**
+  String get mobileOrImportPgnFile;
+
   /// No description provided for @activityActivity.
   ///
   /// In en, this message translates to:

--- a/lib/l10n/l10n_af.dart
+++ b/lib/l10n/l10n_af.dart
@@ -281,6 +281,9 @@ class AppLocalizationsAf extends AppLocalizations {
   String get mobilePreviousPage => 'Previous';
 
   @override
+  String get mobileOrImportPgnFile => 'Or import a PGN file';
+
+  @override
   String get activityActivity => 'Aktiwiteite';
 
   @override

--- a/lib/l10n/l10n_ar.dart
+++ b/lib/l10n/l10n_ar.dart
@@ -281,6 +281,9 @@ class AppLocalizationsAr extends AppLocalizations {
   String get mobilePreviousPage => 'Previous';
 
   @override
+  String get mobileOrImportPgnFile => 'Or import a PGN file';
+
+  @override
   String get activityActivity => 'الأنشطة';
 
   @override

--- a/lib/l10n/l10n_az.dart
+++ b/lib/l10n/l10n_az.dart
@@ -281,6 +281,9 @@ class AppLocalizationsAz extends AppLocalizations {
   String get mobilePreviousPage => 'Previous';
 
   @override
+  String get mobileOrImportPgnFile => 'Or import a PGN file';
+
+  @override
   String get activityActivity => 'Aktivlik';
 
   @override

--- a/lib/l10n/l10n_be.dart
+++ b/lib/l10n/l10n_be.dart
@@ -281,6 +281,9 @@ class AppLocalizationsBe extends AppLocalizations {
   String get mobilePreviousPage => 'Previous';
 
   @override
+  String get mobileOrImportPgnFile => 'Or import a PGN file';
+
+  @override
   String get activityActivity => 'Актыўнасць';
 
   @override

--- a/lib/l10n/l10n_bg.dart
+++ b/lib/l10n/l10n_bg.dart
@@ -281,6 +281,9 @@ class AppLocalizationsBg extends AppLocalizations {
   String get mobilePreviousPage => 'Previous';
 
   @override
+  String get mobileOrImportPgnFile => 'Or import a PGN file';
+
+  @override
   String get activityActivity => 'Дейност';
 
   @override

--- a/lib/l10n/l10n_bn.dart
+++ b/lib/l10n/l10n_bn.dart
@@ -281,6 +281,9 @@ class AppLocalizationsBn extends AppLocalizations {
   String get mobilePreviousPage => 'Previous';
 
   @override
+  String get mobileOrImportPgnFile => 'Or import a PGN file';
+
+  @override
   String get activityActivity => 'কার্যকলাপ';
 
   @override

--- a/lib/l10n/l10n_bs.dart
+++ b/lib/l10n/l10n_bs.dart
@@ -281,6 +281,9 @@ class AppLocalizationsBs extends AppLocalizations {
   String get mobilePreviousPage => 'Previous';
 
   @override
+  String get mobileOrImportPgnFile => 'Or import a PGN file';
+
+  @override
   String get activityActivity => 'Aktivnost';
 
   @override

--- a/lib/l10n/l10n_ca.dart
+++ b/lib/l10n/l10n_ca.dart
@@ -281,6 +281,9 @@ class AppLocalizationsCa extends AppLocalizations {
   String get mobilePreviousPage => 'Anterior';
 
   @override
+  String get mobileOrImportPgnFile => 'Or import a PGN file';
+
+  @override
   String get activityActivity => 'Activitat';
 
   @override

--- a/lib/l10n/l10n_cs.dart
+++ b/lib/l10n/l10n_cs.dart
@@ -281,6 +281,9 @@ class AppLocalizationsCs extends AppLocalizations {
   String get mobilePreviousPage => 'Předchozí';
 
   @override
+  String get mobileOrImportPgnFile => 'Or import a PGN file';
+
+  @override
   String get activityActivity => 'Aktivita';
 
   @override

--- a/lib/l10n/l10n_da.dart
+++ b/lib/l10n/l10n_da.dart
@@ -281,6 +281,9 @@ class AppLocalizationsDa extends AppLocalizations {
   String get mobilePreviousPage => 'Forrige';
 
   @override
+  String get mobileOrImportPgnFile => 'Or import a PGN file';
+
+  @override
   String get activityActivity => 'Aktivitet';
 
   @override

--- a/lib/l10n/l10n_de.dart
+++ b/lib/l10n/l10n_de.dart
@@ -281,6 +281,9 @@ class AppLocalizationsDe extends AppLocalizations {
   String get mobilePreviousPage => 'Zurück';
 
   @override
+  String get mobileOrImportPgnFile => 'Or import a PGN file';
+
+  @override
   String get activityActivity => 'Verlauf';
 
   @override

--- a/lib/l10n/l10n_el.dart
+++ b/lib/l10n/l10n_el.dart
@@ -281,6 +281,9 @@ class AppLocalizationsEl extends AppLocalizations {
   String get mobilePreviousPage => 'Προηγούμενη';
 
   @override
+  String get mobileOrImportPgnFile => 'Or import a PGN file';
+
+  @override
   String get activityActivity => 'Δραστηριότητα';
 
   @override

--- a/lib/l10n/l10n_en.dart
+++ b/lib/l10n/l10n_en.dart
@@ -281,6 +281,9 @@ class AppLocalizationsEn extends AppLocalizations {
   String get mobilePreviousPage => 'Previous';
 
   @override
+  String get mobileOrImportPgnFile => 'Or import a PGN file';
+
+  @override
   String get activityActivity => 'Activity';
 
   @override

--- a/lib/l10n/l10n_eo.dart
+++ b/lib/l10n/l10n_eo.dart
@@ -281,6 +281,9 @@ class AppLocalizationsEo extends AppLocalizations {
   String get mobilePreviousPage => 'Previous';
 
   @override
+  String get mobileOrImportPgnFile => 'Or import a PGN file';
+
+  @override
   String get activityActivity => 'Aktiveco';
 
   @override

--- a/lib/l10n/l10n_es.dart
+++ b/lib/l10n/l10n_es.dart
@@ -281,6 +281,9 @@ class AppLocalizationsEs extends AppLocalizations {
   String get mobilePreviousPage => 'Anterior';
 
   @override
+  String get mobileOrImportPgnFile => 'Or import a PGN file';
+
+  @override
   String get activityActivity => 'Actividad';
 
   @override

--- a/lib/l10n/l10n_et.dart
+++ b/lib/l10n/l10n_et.dart
@@ -281,6 +281,9 @@ class AppLocalizationsEt extends AppLocalizations {
   String get mobilePreviousPage => 'Previous';
 
   @override
+  String get mobileOrImportPgnFile => 'Or import a PGN file';
+
+  @override
   String get activityActivity => 'Aktiivsus';
 
   @override

--- a/lib/l10n/l10n_eu.dart
+++ b/lib/l10n/l10n_eu.dart
@@ -281,6 +281,9 @@ class AppLocalizationsEu extends AppLocalizations {
   String get mobilePreviousPage => 'Aurrekoa';
 
   @override
+  String get mobileOrImportPgnFile => 'Or import a PGN file';
+
+  @override
   String get activityActivity => 'Jarduera';
 
   @override

--- a/lib/l10n/l10n_fa.dart
+++ b/lib/l10n/l10n_fa.dart
@@ -281,6 +281,9 @@ class AppLocalizationsFa extends AppLocalizations {
   String get mobilePreviousPage => 'پیشین';
 
   @override
+  String get mobileOrImportPgnFile => 'Or import a PGN file';
+
+  @override
   String get activityActivity => 'فعالیت';
 
   @override

--- a/lib/l10n/l10n_fi.dart
+++ b/lib/l10n/l10n_fi.dart
@@ -281,6 +281,9 @@ class AppLocalizationsFi extends AppLocalizations {
   String get mobilePreviousPage => 'Edellinen';
 
   @override
+  String get mobileOrImportPgnFile => 'Or import a PGN file';
+
+  @override
   String get activityActivity => 'Toiminta';
 
   @override

--- a/lib/l10n/l10n_fr.dart
+++ b/lib/l10n/l10n_fr.dart
@@ -281,6 +281,9 @@ class AppLocalizationsFr extends AppLocalizations {
   String get mobilePreviousPage => 'Précédent';
 
   @override
+  String get mobileOrImportPgnFile => 'Or import a PGN file';
+
+  @override
   String get activityActivity => 'Activité';
 
   @override

--- a/lib/l10n/l10n_gl.dart
+++ b/lib/l10n/l10n_gl.dart
@@ -281,6 +281,9 @@ class AppLocalizationsGl extends AppLocalizations {
   String get mobilePreviousPage => 'Anterior';
 
   @override
+  String get mobileOrImportPgnFile => 'Or import a PGN file';
+
+  @override
   String get activityActivity => 'Actividade';
 
   @override

--- a/lib/l10n/l10n_gsw.dart
+++ b/lib/l10n/l10n_gsw.dart
@@ -281,6 +281,9 @@ class AppLocalizationsGsw extends AppLocalizations {
   String get mobilePreviousPage => 'Vorher';
 
   @override
+  String get mobileOrImportPgnFile => 'Or import a PGN file';
+
+  @override
   String get activityActivity => 'Aktivitäte';
 
   @override

--- a/lib/l10n/l10n_he.dart
+++ b/lib/l10n/l10n_he.dart
@@ -281,6 +281,9 @@ class AppLocalizationsHe extends AppLocalizations {
   String get mobilePreviousPage => 'Previous';
 
   @override
+  String get mobileOrImportPgnFile => 'Or import a PGN file';
+
+  @override
   String get activityActivity => 'פעילות';
 
   @override

--- a/lib/l10n/l10n_hi.dart
+++ b/lib/l10n/l10n_hi.dart
@@ -281,6 +281,9 @@ class AppLocalizationsHi extends AppLocalizations {
   String get mobilePreviousPage => 'Previous';
 
   @override
+  String get mobileOrImportPgnFile => 'Or import a PGN file';
+
+  @override
   String get activityActivity => 'कार्यकलाप';
 
   @override

--- a/lib/l10n/l10n_hr.dart
+++ b/lib/l10n/l10n_hr.dart
@@ -281,6 +281,9 @@ class AppLocalizationsHr extends AppLocalizations {
   String get mobilePreviousPage => 'Previous';
 
   @override
+  String get mobileOrImportPgnFile => 'Or import a PGN file';
+
+  @override
   String get activityActivity => 'Aktivnost';
 
   @override

--- a/lib/l10n/l10n_hu.dart
+++ b/lib/l10n/l10n_hu.dart
@@ -281,6 +281,9 @@ class AppLocalizationsHu extends AppLocalizations {
   String get mobilePreviousPage => 'Previous';
 
   @override
+  String get mobileOrImportPgnFile => 'Or import a PGN file';
+
+  @override
   String get activityActivity => 'Aktivitás';
 
   @override

--- a/lib/l10n/l10n_hy.dart
+++ b/lib/l10n/l10n_hy.dart
@@ -281,6 +281,9 @@ class AppLocalizationsHy extends AppLocalizations {
   String get mobilePreviousPage => 'Previous';
 
   @override
+  String get mobileOrImportPgnFile => 'Or import a PGN file';
+
+  @override
   String get activityActivity => 'Գործունեություն';
 
   @override

--- a/lib/l10n/l10n_id.dart
+++ b/lib/l10n/l10n_id.dart
@@ -281,6 +281,9 @@ class AppLocalizationsId extends AppLocalizations {
   String get mobilePreviousPage => 'Previous';
 
   @override
+  String get mobileOrImportPgnFile => 'Or import a PGN file';
+
+  @override
   String get activityActivity => 'Aktivitas';
 
   @override

--- a/lib/l10n/l10n_it.dart
+++ b/lib/l10n/l10n_it.dart
@@ -281,6 +281,9 @@ class AppLocalizationsIt extends AppLocalizations {
   String get mobilePreviousPage => 'Previous';
 
   @override
+  String get mobileOrImportPgnFile => 'Or import a PGN file';
+
+  @override
   String get activityActivity => 'Attività';
 
   @override

--- a/lib/l10n/l10n_ja.dart
+++ b/lib/l10n/l10n_ja.dart
@@ -281,6 +281,9 @@ class AppLocalizationsJa extends AppLocalizations {
   String get mobilePreviousPage => '前';
 
   @override
+  String get mobileOrImportPgnFile => 'Or import a PGN file';
+
+  @override
   String get activityActivity => '活動';
 
   @override

--- a/lib/l10n/l10n_kk.dart
+++ b/lib/l10n/l10n_kk.dart
@@ -281,6 +281,9 @@ class AppLocalizationsKk extends AppLocalizations {
   String get mobilePreviousPage => 'Previous';
 
   @override
+  String get mobileOrImportPgnFile => 'Or import a PGN file';
+
+  @override
   String get activityActivity => 'Белсенділігі';
 
   @override

--- a/lib/l10n/l10n_ko.dart
+++ b/lib/l10n/l10n_ko.dart
@@ -281,6 +281,9 @@ class AppLocalizationsKo extends AppLocalizations {
   String get mobilePreviousPage => '이전';
 
   @override
+  String get mobileOrImportPgnFile => 'Or import a PGN file';
+
+  @override
   String get activityActivity => '활동';
 
   @override

--- a/lib/l10n/l10n_lt.dart
+++ b/lib/l10n/l10n_lt.dart
@@ -281,6 +281,9 @@ class AppLocalizationsLt extends AppLocalizations {
   String get mobilePreviousPage => 'Previous';
 
   @override
+  String get mobileOrImportPgnFile => 'Or import a PGN file';
+
+  @override
   String get activityActivity => 'Veikla';
 
   @override

--- a/lib/l10n/l10n_lv.dart
+++ b/lib/l10n/l10n_lv.dart
@@ -281,6 +281,9 @@ class AppLocalizationsLv extends AppLocalizations {
   String get mobilePreviousPage => 'Previous';
 
   @override
+  String get mobileOrImportPgnFile => 'Or import a PGN file';
+
+  @override
   String get activityActivity => 'Aktivitāte';
 
   @override

--- a/lib/l10n/l10n_mk.dart
+++ b/lib/l10n/l10n_mk.dart
@@ -281,6 +281,9 @@ class AppLocalizationsMk extends AppLocalizations {
   String get mobilePreviousPage => 'Previous';
 
   @override
+  String get mobileOrImportPgnFile => 'Or import a PGN file';
+
+  @override
   String get activityActivity => 'Активност';
 
   @override

--- a/lib/l10n/l10n_nb.dart
+++ b/lib/l10n/l10n_nb.dart
@@ -281,6 +281,9 @@ class AppLocalizationsNb extends AppLocalizations {
   String get mobilePreviousPage => 'Forrige';
 
   @override
+  String get mobileOrImportPgnFile => 'Or import a PGN file';
+
+  @override
   String get activityActivity => 'Aktivitet';
 
   @override

--- a/lib/l10n/l10n_nl.dart
+++ b/lib/l10n/l10n_nl.dart
@@ -281,6 +281,9 @@ class AppLocalizationsNl extends AppLocalizations {
   String get mobilePreviousPage => 'Vorige';
 
   @override
+  String get mobileOrImportPgnFile => 'Or import a PGN file';
+
+  @override
   String get activityActivity => 'Activiteit';
 
   @override

--- a/lib/l10n/l10n_pl.dart
+++ b/lib/l10n/l10n_pl.dart
@@ -281,6 +281,9 @@ class AppLocalizationsPl extends AppLocalizations {
   String get mobilePreviousPage => 'Wróć';
 
   @override
+  String get mobileOrImportPgnFile => 'Or import a PGN file';
+
+  @override
   String get activityActivity => 'Aktywność';
 
   @override

--- a/lib/l10n/l10n_pt.dart
+++ b/lib/l10n/l10n_pt.dart
@@ -281,6 +281,9 @@ class AppLocalizationsPt extends AppLocalizations {
   String get mobilePreviousPage => 'Previous';
 
   @override
+  String get mobileOrImportPgnFile => 'Or import a PGN file';
+
+  @override
   String get activityActivity => 'Atividade';
 
   @override

--- a/lib/l10n/l10n_ro.dart
+++ b/lib/l10n/l10n_ro.dart
@@ -281,6 +281,9 @@ class AppLocalizationsRo extends AppLocalizations {
   String get mobilePreviousPage => 'Înapoi';
 
   @override
+  String get mobileOrImportPgnFile => 'Or import a PGN file';
+
+  @override
   String get activityActivity => 'Activitate';
 
   @override

--- a/lib/l10n/l10n_ru.dart
+++ b/lib/l10n/l10n_ru.dart
@@ -281,6 +281,9 @@ class AppLocalizationsRu extends AppLocalizations {
   String get mobilePreviousPage => 'Предыдущие';
 
   @override
+  String get mobileOrImportPgnFile => 'Or import a PGN file';
+
+  @override
   String get activityActivity => 'Активность';
 
   @override

--- a/lib/l10n/l10n_sk.dart
+++ b/lib/l10n/l10n_sk.dart
@@ -281,6 +281,9 @@ class AppLocalizationsSk extends AppLocalizations {
   String get mobilePreviousPage => 'Previous';
 
   @override
+  String get mobileOrImportPgnFile => 'Or import a PGN file';
+
+  @override
   String get activityActivity => 'Aktivita';
 
   @override

--- a/lib/l10n/l10n_sl.dart
+++ b/lib/l10n/l10n_sl.dart
@@ -281,6 +281,9 @@ class AppLocalizationsSl extends AppLocalizations {
   String get mobilePreviousPage => 'Prejšnji';
 
   @override
+  String get mobileOrImportPgnFile => 'Or import a PGN file';
+
+  @override
   String get activityActivity => 'Aktivnost';
 
   @override

--- a/lib/l10n/l10n_sq.dart
+++ b/lib/l10n/l10n_sq.dart
@@ -281,6 +281,9 @@ class AppLocalizationsSq extends AppLocalizations {
   String get mobilePreviousPage => 'E mëparshmja';
 
   @override
+  String get mobileOrImportPgnFile => 'Or import a PGN file';
+
+  @override
   String get activityActivity => 'Aktiviteti';
 
   @override

--- a/lib/l10n/l10n_sr.dart
+++ b/lib/l10n/l10n_sr.dart
@@ -281,6 +281,9 @@ class AppLocalizationsSr extends AppLocalizations {
   String get mobilePreviousPage => 'Previous';
 
   @override
+  String get mobileOrImportPgnFile => 'Or import a PGN file';
+
+  @override
   String get activityActivity => 'Активност';
 
   @override

--- a/lib/l10n/l10n_sv.dart
+++ b/lib/l10n/l10n_sv.dart
@@ -281,6 +281,9 @@ class AppLocalizationsSv extends AppLocalizations {
   String get mobilePreviousPage => 'Previous';
 
   @override
+  String get mobileOrImportPgnFile => 'Or import a PGN file';
+
+  @override
   String get activityActivity => 'Aktivitet';
 
   @override

--- a/lib/l10n/l10n_tr.dart
+++ b/lib/l10n/l10n_tr.dart
@@ -281,6 +281,9 @@ class AppLocalizationsTr extends AppLocalizations {
   String get mobilePreviousPage => 'Önceki';
 
   @override
+  String get mobileOrImportPgnFile => 'Or import a PGN file';
+
+  @override
   String get activityActivity => 'Son Etkinlikler';
 
   @override

--- a/lib/l10n/l10n_uk.dart
+++ b/lib/l10n/l10n_uk.dart
@@ -281,6 +281,9 @@ class AppLocalizationsUk extends AppLocalizations {
   String get mobilePreviousPage => 'Попередня';
 
   @override
+  String get mobileOrImportPgnFile => 'Or import a PGN file';
+
+  @override
   String get activityActivity => 'Активність';
 
   @override

--- a/lib/l10n/l10n_vi.dart
+++ b/lib/l10n/l10n_vi.dart
@@ -281,6 +281,9 @@ class AppLocalizationsVi extends AppLocalizations {
   String get mobilePreviousPage => 'Trang trước';
 
   @override
+  String get mobileOrImportPgnFile => 'Or import a PGN file';
+
+  @override
   String get activityActivity => 'Hoạt động';
 
   @override

--- a/lib/l10n/l10n_zh.dart
+++ b/lib/l10n/l10n_zh.dart
@@ -281,6 +281,9 @@ class AppLocalizationsZh extends AppLocalizations {
   String get mobilePreviousPage => '上一页';
 
   @override
+  String get mobileOrImportPgnFile => 'Or import a PGN file';
+
+  @override
   String get activityActivity => '动态';
 
   @override

--- a/lib/src/view/more/import_pgn_screen.dart
+++ b/lib/src/view/more/import_pgn_screen.dart
@@ -66,7 +66,10 @@ class _BodyState extends State<_Body> {
           ),
           Padding(
             padding: Styles.bodySectionBottomPadding,
-            child: FilledButton(onPressed: _pickPgnFile, child: Text(context.l10n.orUploadPgnFile)),
+            child: FilledButton(
+              onPressed: _pickPgnFile,
+              child: Text(context.l10n.mobileOrImportPgnFile),
+            ),
           ),
         ],
       ),

--- a/test/view/more/import_pgn_screen_test.dart
+++ b/test/view/more/import_pgn_screen_test.dart
@@ -203,7 +203,7 @@ void main() {
       final app = await _makeApp(tester);
       await tester.pumpWidget(app);
 
-      await tester.tap(find.widgetWithText(FilledButton, 'Or upload a PGN file'));
+      await tester.tap(find.widgetWithText(FilledButton, 'Or import a PGN file'));
       await tester.pumpAndSettle();
 
       expect(find.textContaining('e5'), findsOneWidget);
@@ -239,7 +239,7 @@ void main() {
       final app = await _makeApp(tester);
       await tester.pumpWidget(app);
 
-      await tester.tap(find.widgetWithText(FilledButton, 'Or upload a PGN file'));
+      await tester.tap(find.widgetWithText(FilledButton, 'Or import a PGN file'));
       await tester.pumpAndSettle();
 
       expect(find.text('2 games'), findsOneWidget);

--- a/translation/source/mobile.xml
+++ b/translation/source/mobile.xml
@@ -88,4 +88,5 @@
   <string name="openingExplorerNotAvailableOffline" comment="">Opening Explorer is not available offline.</string>
   <string name="challengeCreated" comment="Shown as a bottom banner when another player has been challenged.">Challenge created: You will be notified when the game starts.\nYou can access it from the home tab.</string>
   <string name="previousPage" comment="Shows the previous page, e.g. in tournament standings">Previous</string>
+  <string name="orImportPgnFile" comment="Button text to import a PGN file from the device">Or import a PGN file</string>
 </resources>


### PR DESCRIPTION
I prefer “Import” to “Upload,” because “Upload” might imply that the file is sent to the server. This PR also adds a new translation for “Or Import a PGN file.”
<img width="605" height="1362" alt="grafik" src="https://github.com/user-attachments/assets/c2566bc5-e526-4049-a703-dc30f5b79579" />
