### PR TITLE
fix: use buildScreenRoute when replacing AnalysisScreen

### DIFF
--- a/lib/src/utils/navigation.dart
+++ b/lib/src/utils/navigation.dart
@@ -21,10 +21,16 @@ class MaterialScreenRoute<T extends Object?> extends MaterialPageRoute<T>
     super.maintainState,
     super.fullscreenDialog,
     super.allowSnapshotting,
+    this.overrideTransitionDuration,
   }) : super(builder: (_) => FullScreenBackground(child: screen));
 
   @override
   final Widget screen;
+
+  final Duration? overrideTransitionDuration;
+
+  @override
+  Duration get transitionDuration => overrideTransitionDuration ?? super.transitionDuration;
 }
 
 /// Builds a new route for the [screen] based on the platform.
@@ -38,10 +44,12 @@ Route<T> buildScreenRoute<T>(
   required Widget screen,
   bool fullscreenDialog = false,
   RouteSettings? settings,
+  Duration? transitionDuration,
 }) {
   return MaterialScreenRoute<T>(
     screen: screen,
     fullscreenDialog: fullscreenDialog,
     settings: settings,
+    overrideTransitionDuration: transitionDuration,
   );
 }

--- a/lib/src/view/analysis/analysis_screen.dart
+++ b/lib/src/view/analysis/analysis_screen.dart
@@ -602,8 +602,9 @@ class _BottomBar extends ConsumerWidget {
                           .read(analysisControllerProvider(options).notifier)
                           .clearSavedStandaloneAnalysis();
                       Navigator.of(context, rootNavigator: true).pushReplacement(
-                        PageRouteBuilder<dynamic>(
-                          pageBuilder: (context, animation, secondaryAnimation) => AnalysisScreen(
+                        buildScreenRoute<dynamic>(
+                          context,
+                          screen: AnalysisScreen(
                             options: (options as Standalone).copyWith(variant: variant),
                           ),
                           transitionDuration: Duration.zero,


### PR DESCRIPTION
closes #2682