### PR TITLE
fix: include variant in `evalGet` event

### DIFF
--- a/lib/src/model/engine/evaluation_mixin.dart
+++ b/lib/src/model/engine/evaluation_mixin.dart
@@ -267,6 +267,7 @@ mixin EngineEvaluationMixin<T extends EvaluationMixinState> on AnyNotifier<Async
       'fen': curPosition.fen,
       'path': state.requireValue.currentPath.value,
       'mpv': numEvalLines,
+      if (curPosition.rule != Rule.chess) 'variant': Variant.fromRule(curPosition.rule).name,
       'up': true,
     });
   }

--- a/lib/src/model/offline_computer/offline_computer_game_controller.dart
+++ b/lib/src/model/offline_computer/offline_computer_game_controller.dart
@@ -469,6 +469,7 @@ class OfflineComputerGameController extends Notifier<OfflineComputerGameState> {
       socketClient.send('evalGet', {
         'fen': work.position.fen,
         'path': uciPath.value,
+        if (work.position.rule != Rule.chess) 'variant': Variant.fromRule(work.position.rule).name,
         'mpv': numEvalLines,
       });
       await for (final event


### PR DESCRIPTION
Before:

<img width="270" height="600" alt="Screenshot_1772281804" src="https://github.com/user-attachments/assets/2ec58637-2263-44d4-87e8-468a374a221c" />

After: (you check with https://lichess.org/analysis/racingKings so verify that the cloud moves match now)

<img width="270" height="600" alt="Screenshot_1772281824" src="https://github.com/user-attachments/assets/6f6ff75b-af5b-45ac-ad2a-6382aa339221" />
