### PR TITLE
Puzzle Dashboard Improvements

### DIFF
--- a/lib/src/view/puzzle/dashboard_screen.dart
+++ b/lib/src/view/puzzle/dashboard_screen.dart
@@ -303,14 +303,14 @@ enum Metric {
     final all = themes.where((e) => e.nb > minNb).sortedByCompare((e) => e.performance, (a, b) {
       final perfCmp = a.compareTo(b);
       return perfCmp;
-    }).toList(); // now it's a List, so .reversed works
+    }).toList();
 
     return switch (this) {
       strength =>
         all
             .where((e) => e.firstWins >= 3 && e.performance > dashboard.global.performance)
             .toList()
-            .reversed // .reversed on List returns Iterable, so chain .toList()
+            .reversed
             .take(_itemsToShow)
             .toList(),
       improvementArea =>


### PR DESCRIPTION
- Aligns the logic of showing _strengths_ and _areas of improvement_ with the web behaviour (based on [`lila/../PuzzleDashboard.scala`](https://github.com/lichess-org/lila/blob/master/modules/puzzle/src/main/PuzzleDashboard.scala). The problem was discovered by @ijm8710 in https://github.com/lichess-org/mobile/pull/2651#issuecomment-3970833343
- Changes the order of stats to align with the spider chart
- Hides performance section title when there is nothing to show (no items)


<img width="3540" height="2212" alt="SCR-20260228-schi-tile" src="https://github.com/user-attachments/assets/6e892f8d-5629-4c8d-a047-9a0114dc6ea6" />
