### PR TITLE
Grey logo  + increase animation duration

### DIFF
--- a/android/app/src/main/res/drawable/animated_logo.xml
+++ b/android/app/src/main/res/drawable/animated_logo.xml
@@ -19,6 +19,24 @@
                     android:pathData="M 45.507 2.778 C 41.584 3.242 38.338 3.78 35.189 6.093 C 8.371 4.207 1.453 22.814 2.978 34.849 C 6.103 58.016 37.687 64.206 48.143 48.556 C 39.872 57.107 26.726 58.28 16.673 51.982 C 6.621 45.684 1.66 32.658 7.426 21.741 C 13.192 10.824 23.329 7.261 34.478 9.339 C 37.178 7.763 40.283 5.761 42.983 5.798 L 41.101 11.198 L 55.27 34.942 C 54.782 41.224 49.204 41.733 49.204 41.733 C 48.567 40.1 47.389 38.464 43.824 35.027 C 40.261 31.589 24.419 23.719 26.282 17.019 C 24.059 24.76 37.739 32.743 41.882 36.644 C 46.027 40.544 47.911 43.356 48.321 44.151 C 48.321 44.151 58.757 41.369 57.03 34.232 L 43.778 10.19 Z"/>
                 
                 <path
+                    android:name="path_1_grey"
+                    android:pathData="M 26.422 16.267 C 24.996 25.64 36.359 30.378 42.578 35.833 C 45.911 38.758 47.48 40.769 48.893 44.644"
+                    android:strokeColor="@color/ic_splash_grey"
+                    android:strokeWidth="4.198888888888889"
+                    android:trimPathEnd="1"/>
+                <path
+                    android:name="path_2_grey"
+                    android:pathData="M 50.211 42.578 C 53.341 41.241 57.61 36.487 56.257 34.108 C 53.756 29.711 46.387 17.786 43.046 12.186 C 42.577 11.399 42.776 10.147 43.704 8.519 C 45.213 5.874 45.878 2.266 45.878 2.266"
+                    android:strokeColor="@color/ic_splash_grey"
+                    android:strokeWidth="4.618888888888889"
+                    android:trimPathEnd="1"/>
+                <path
+                    android:name="path_3_grey"
+                    android:pathData="M 43.833 4.642 C 43.833 4.642 39.449 5.36 36.903 7.124 C 36.237 7.587 33.908 8.011 32.574 7.834 C 12.974 5.229 -0.326 23.479 4.541 38.212 C 9.404 52.946 29.586 66.39 48.697 47.841"
+                    android:strokeColor="@color/ic_splash_grey"
+                    android:strokeWidth="5.03888888888889"
+                    android:trimPathEnd="1"/>
+                <path
                     android:name="path_1"
                     android:pathData="M 26.422 16.267 C 24.996 25.64 36.359 30.378 42.578 35.833 C 45.911 38.758 47.48 40.769 48.893 44.644"
                     android:strokeColor="@color/ic_splash"
@@ -40,6 +58,7 @@
         <aapt:attr name="android:animation">
             <objectAnimator
                 android:propertyName="trimPathEnd"
+                android:startOffset="100"
                 android:duration="250"
                 android:valueFrom="0"
                 android:valueTo="1"
@@ -52,14 +71,14 @@
             <set>
                 <objectAnimator
                     android:propertyName="trimPathEnd"
-                    android:duration="250"
+                    android:duration="350"
                     android:valueFrom="0"
                     android:valueTo="0"
                     android:valueType="floatType"
                     android:interpolator="@android:interpolator/fast_out_slow_in"/>
                 <objectAnimator
                     android:propertyName="trimPathEnd"
-                    android:startOffset="250"
+                    android:startOffset="350"
                     android:duration="250"
                     android:valueFrom="0"
                     android:valueTo="1"
@@ -73,15 +92,15 @@
             <set>
                 <objectAnimator
                     android:propertyName="trimPathEnd"
-                    android:duration="500"
+                    android:duration="600"
                     android:valueFrom="0"
                     android:valueTo="0"
                     android:valueType="floatType"
                     android:interpolator="@android:interpolator/fast_out_slow_in"/>
                 <objectAnimator
                     android:propertyName="trimPathEnd"
-                    android:startOffset="500"
-                    android:duration="250"
+                    android:startOffset="600"
+                    android:duration="400"
                     android:valueFrom="0"
                     android:valueTo="1"
                     android:valueType="floatType"

--- a/android/app/src/main/res/values-night/colors.xml
+++ b/android/app/src/main/res/values-night/colors.xml
@@ -2,4 +2,5 @@
 <resources>
     <color name="bg_splash">#000000</color>
     <color name="ic_splash">#FFFFFF</color>
+    <color name="ic_splash_grey">#565656</color>
 </resources>

--- a/android/app/src/main/res/values-v31/styles.xml
+++ b/android/app/src/main/res/values-v31/styles.xml
@@ -2,7 +2,7 @@
     <style name="SplashTheme" parent="SplashTheme.NightAdjusted">
         <item name="windowSplashScreenBackground">@color/bg_splash</item>
         <item name="windowSplashScreenAnimatedIcon">@drawable/animated_logo</item>
-        <item name="windowSplashScreenAnimationDuration">750</item>
+        <item name="windowSplashScreenAnimationDuration">1000</item>
         <item name="postSplashScreenTheme">@style/NormalTheme</item>
     </style>
 

--- a/android/app/src/main/res/values/colors.xml
+++ b/android/app/src/main/res/values/colors.xml
@@ -3,4 +3,5 @@
     <color name="ic_launcher_background">#131416</color>
     <color name="bg_splash">#FFFFFF</color>
     <color name="ic_splash">#000000</color>
+    <color name="ic_splash_grey">#AAAAAA</color>
 </resources>


### PR DESCRIPTION
- Adds a grey logo below the animation, to improve the way it looks if the app loads too quickly
- Increases the animation duration slightly to 0.9s (longer is not recommeded by android docs)
- slight delay before the animation plays of 0.1s (longer is not recommeded by android docs)


Light mode:

https://github.com/user-attachments/assets/61debda0-0e0f-43f7-8006-b5189edf823d

Dark mode:

https://github.com/user-attachments/assets/ba663051-b11d-4bf6-9914-23274b80bd9f



