### PR TITLE
feat: add "Next to play" side choice for games from position

### DIFF
--- a/lib/src/model/offline_computer/offline_computer_game_preferences.dart
+++ b/lib/src/model/offline_computer/offline_computer_game_preferences.dart
@@ -65,12 +65,18 @@ class OfflineComputerGamePreferences extends Notifier<OfflineComputerGamePrefs>
 enum SideChoice {
   white,
   random,
-  black;
+  black,
+  nextToPlay;
 
-  Side? toSide() => switch (this) {
+  /// Resolves the side choice to a [Side].
+  ///
+  /// When [fen] is provided and this is [nextToPlay], returns the side to move
+  /// from the FEN. Returns `null` for [random] (caller should pick randomly).
+  Side? toSide({String? fen}) => switch (this) {
     SideChoice.white => Side.white,
     SideChoice.random => null,
     SideChoice.black => Side.black,
+    SideChoice.nextToPlay => fen != null ? Setup.parseFen(fen).turn : null,
   };
 
   static SideChoice fromSide(Side? side) => switch (side) {

--- a/lib/src/view/offline_computer/offline_computer_game_screen.dart
+++ b/lib/src/view/offline_computer/offline_computer_game_screen.dart
@@ -738,6 +738,8 @@ class _NewGameSheetState extends ConsumerState<_NewGameSheet> {
     SideChoice.white => context.l10n.white,
     SideChoice.random => context.l10n.randomColor,
     SideChoice.black => context.l10n.black,
+    // TODO: replace with a translated string once the feature is stable
+    SideChoice.nextToPlay => 'Next to play',
   };
 
   @override
@@ -745,7 +747,7 @@ class _NewGameSheetState extends ConsumerState<_NewGameSheet> {
     super.initState();
     final prefs = ref.read(offlineComputerGamePreferencesProvider);
     _selectedLevel = prefs.stockfishLevel;
-    _selectedSideChoice = prefs.sideChoice;
+    _selectedSideChoice = widget.initialFen != null ? SideChoice.nextToPlay : prefs.sideChoice;
     _selectedVariant = widget.initialVariant ?? prefs.variant;
     _casual = prefs.casual;
     _practiceMode = prefs.practiceMode;
@@ -761,20 +763,31 @@ class _NewGameSheetState extends ConsumerState<_NewGameSheet> {
           Padding(
             padding: const EdgeInsets.only(bottom: 16.0),
             child: Center(
-              child: SizedBox(
-                width: 150,
-                height: 150,
-                child: StaticChessboard(
-                  size: 150,
-                  fen: widget.initialFen!,
-                  orientation: _selectedSideChoice.toSide() ?? Side.white,
-                  pieceAssets: boardPrefs.pieceSet.assets,
-                  colorScheme: boardPrefs.boardTheme.colors,
-                  brightness: boardPrefs.brightness,
-                  hue: boardPrefs.hue,
-                  enableCoordinates: false,
-                  borderRadius: const BorderRadius.all(Radius.circular(4)),
-                ),
+              child: Column(
+                children: [
+                  SizedBox(
+                    width: 150,
+                    height: 150,
+                    child: StaticChessboard(
+                      size: 150,
+                      fen: widget.initialFen!,
+                      orientation: _selectedSideChoice.toSide(fen: widget.initialFen) ?? Side.white,
+                      pieceAssets: boardPrefs.pieceSet.assets,
+                      colorScheme: boardPrefs.boardTheme.colors,
+                      brightness: boardPrefs.brightness,
+                      hue: boardPrefs.hue,
+                      enableCoordinates: false,
+                      borderRadius: const BorderRadius.all(Radius.circular(4)),
+                    ),
+                  ),
+                  const SizedBox(height: 8),
+                  Text(
+                    Setup.parseFen(widget.initialFen!).turn == Side.white
+                        ? context.l10n.whitePlays
+                        : context.l10n.blackPlays,
+                    style: TextStyle(fontStyle: FontStyle.italic, color: textShade(context, 0.7)),
+                  ),
+                ],
               ),
             ),
           ),
@@ -817,7 +830,9 @@ class _NewGameSheetState extends ConsumerState<_NewGameSheet> {
               onTap: () {
                 showChoicePicker(
                   context,
-                  choices: SideChoice.values,
+                  choices: widget.initialFen != null
+                      ? SideChoice.values
+                      : SideChoice.values.where((c) => c != SideChoice.nextToPlay).toList(),
                   selectedItem: _selectedSideChoice,
                   labelBuilder: (SideChoice choice) => Text(_sideChoiceLabel(context, choice)),
                   onSelectedItemChanged: (SideChoice choice) {
@@ -878,7 +893,9 @@ class _NewGameSheetState extends ConsumerState<_NewGameSheet> {
           padding: Styles.horizontalBodyPadding,
           child: FilledButton(
             onPressed: () {
-              final side = _selectedSideChoice.toSide() ?? Side.values[Random().nextInt(2)];
+              final side =
+                  _selectedSideChoice.toSide(fen: widget.initialFen) ??
+                  Side.values[Random().nextInt(2)];
               ref
                   .read(offlineComputerGameControllerProvider.notifier)
                   .startNewGame(

--- a/test/view/offline_computer/offline_computer_game_screen_test.dart
+++ b/test/view/offline_computer/offline_computer_game_screen_test.dart
@@ -1164,6 +1164,123 @@ void main() {
       expect(gameState.game.meta.variant, Variant.atomic);
       expect(gameState.game.initialFen, null);
     });
+
+    testWidgets('Side defaults to "Next to play" when initialFen is provided', (tester) async {
+      final gameStorage = MockOfflineComputerGameStorage();
+      when(() => gameStorage.fetchGame()).thenAnswer((_) async => null);
+
+      const customFen = 'rnbqkbnr/pppp1ppp/8/4p3/4P3/8/PPPP1PPP/RNBQKBNR w KQkq - 0 2';
+
+      final app = await makeTestProviderScopeApp(
+        tester,
+        home: const OfflineComputerGameScreen(initialFen: customFen),
+        overrides: {
+          offlineComputerGameStorageProvider: offlineComputerGameStorageProvider.overrideWith(
+            (_) => gameStorage,
+          ),
+        },
+      );
+      await tester.pumpWidget(app);
+      await tester.pumpAndSettle();
+
+      // Verify the side selection defaults to "Next to play"
+      expect(find.text('Next to play'), findsOneWidget);
+    });
+
+    testWidgets('"Next to play" resolves to white when FEN has white to move', (tester) async {
+      final gameStorage = MockOfflineComputerGameStorage();
+      when(() => gameStorage.fetchGame()).thenAnswer((_) async => null);
+
+      late WidgetRef ref;
+      // White to move
+      const customFen = 'rnbqkbnr/pppp1ppp/8/4p3/4P3/8/PPPP1PPP/RNBQKBNR w KQkq - 0 2';
+
+      final app = await makeTestProviderScopeApp(
+        tester,
+        home: Consumer(
+          builder: (context, r, _) {
+            ref = r;
+            return const OfflineComputerGameScreen(initialFen: customFen);
+          },
+        ),
+        overrides: {
+          offlineComputerGameStorageProvider: offlineComputerGameStorageProvider.overrideWith(
+            (_) => gameStorage,
+          ),
+        },
+      );
+      await tester.pumpWidget(app);
+      await tester.pumpAndSettle();
+
+      // Default is "Next to play", just tap Play
+      await tester.tap(find.text('Play'));
+      await tester.pumpAndSettle();
+
+      final gameState = ref.read(offlineComputerGameControllerProvider);
+      expect(gameState.game.playerSide, Side.white);
+      expect(gameState.turn, Side.white);
+    });
+
+    testWidgets('"Next to play" resolves to black when FEN has black to move', (tester) async {
+      final gameStorage = MockOfflineComputerGameStorage();
+      when(() => gameStorage.fetchGame()).thenAnswer((_) async => null);
+
+      late WidgetRef ref;
+      // Black to move
+      const customFen = 'rnbqkbnr/pppp1ppp/8/4p3/4P3/5N2/PPPP1PPP/RNBQKB1R b KQkq - 1 2';
+
+      final app = await makeTestProviderScopeApp(
+        tester,
+        home: Consumer(
+          builder: (context, r, _) {
+            ref = r;
+            return const OfflineComputerGameScreen(initialFen: customFen);
+          },
+        ),
+        overrides: {
+          offlineComputerGameStorageProvider: offlineComputerGameStorageProvider.overrideWith(
+            (_) => gameStorage,
+          ),
+        },
+      );
+      await tester.pumpWidget(app);
+      await tester.pumpAndSettle();
+
+      // Default is "Next to play", just tap Play
+      await tester.tap(find.text('Play'));
+      await tester.pumpAndSettle();
+
+      final gameState = ref.read(offlineComputerGameControllerProvider);
+      expect(gameState.game.playerSide, Side.black);
+    });
+
+    testWidgets('"Next to play" is not shown in side picker without initialFen', (tester) async {
+      final gameStorage = MockOfflineComputerGameStorage();
+      when(() => gameStorage.fetchGame()).thenAnswer((_) async => null);
+
+      final app = await makeTestProviderScopeApp(
+        tester,
+        home: const OfflineComputerGameScreen(),
+        overrides: {
+          offlineComputerGameStorageProvider: offlineComputerGameStorageProvider.overrideWith(
+            (_) => gameStorage,
+          ),
+        },
+      );
+      await tester.pumpWidget(app);
+      await tester.pumpAndSettle();
+
+      // Default should be "Random side", not "Next to play"
+      expect(find.text('Random side'), findsOneWidget);
+      expect(find.text('Next to play'), findsNothing);
+
+      // Open side picker
+      await tester.tap(find.byType(SettingsListTile).first);
+      await tester.pumpAndSettle();
+
+      // "Next to play" should not be in the picker
+      expect(find.text('Next to play'), findsNothing);
+    });
   });
 
   group('Practice comment card', () {


### PR DESCRIPTION
## Summary

- Adds a **"Next to play"** option to the side picker when starting an offline computer game from a custom position (via "Continue from here")
- Automatically selects the side that has the move in the FEN, removing the need to manually toggle White/Black each time
- Shows **"White to play"** or **"Black to play"** below the mini board preview so the user knows which side moves first
- Only shown when `initialFen` is provided; defaults to "Next to play" in that context
- Adds 4 widget tests covering the new behavior
- "Next to play" label is hardcoded in English for now, following the project convention of adding translations after the feature is stable

Closes #2714

## Screenshot

<img width="300" height="640" alt="next-to-play-1" src="https://github.com/user-attachments/assets/b2dfa1f0-908f-4cc3-9f64-358809769adb" />

## Video demo

https://github.com/user-attachments/assets/ce5695f2-3895-4ee2-9885-102970b74161


## Test plan

- [x] `flutter analyze` — no issues
- [x] `dart format` — properly formatted
- [x] `flutter test` — all tests pass (4 new tests added)
- [x] Manual testing on Android emulator (Pixel, API 35):
  - Solve a puzzle → Continue from here → Play against computer
  - Side defaults to "Next to play"
  - "White to play" / "Black to play" shown below mini board
  - Correctly resolves to white/black based on position's side to move
  - "Next to play" does not appear when starting a standard game (no initialFen)