### PR TITLE
fix: align Flutter version config and document requirements

### DIFF
--- a/.fvmrc
+++ b/.fvmrc
@@ -1,4 +1,4 @@
 {
-  "flutter": "beta",
+  "flutter": "stable",
   "flavors": {}
 }

--- a/docs/setting_dev_env.md
+++ b/docs/setting_dev_env.md
@@ -6,11 +6,12 @@ If you get stuck during the installation process the most suitable place to seek
 
 ## Installing Flutter
 
-This project uses Flutter.
+This project uses the latest **Flutter stable** release. The minimum required version is defined in `pubspec.yaml`.
 
 1. Follow [the flutter install guide](https://docs.flutter.dev/get-started/install).
    This project is meant to run on iOS and Android, so you need to follow the "Platform setup" section of that guide to
    install the iOS and/or Android platform.
+   Make sure to install the latest Flutter stable release.
 
 > [!WARNING]
 > Installing on Linux using `snapd` might cause some [problems](https://github.com/lichess-org/mobile/issues/123) building stockfish.

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -7,7 +7,7 @@ version: 0.22.0+002200 # See README.md for details about versioning
 environment:
   # this should be updated with every new flutter stable release
   sdk: ^3.10.0
-  flutter: ^3.38.0
+  flutter: ^3.41.0
 
 dependencies:
   app_links: ^7.0.0


### PR DESCRIPTION
## Summary

- `.fvmrc`: change from `"beta"` to `"stable"` to match CI (which uses `subosito/flutter-action@v2` defaulting to latest stable)
- `pubspec.yaml`: update Flutter constraint from `^3.38.0` to `^3.41.0` — the old constraint was misleading since `pubspec.lock` pins `material_color_utilities: 0.13.0` which requires Flutter 3.41+
- `docs/setting_dev_env.md`: document that the project uses latest Flutter stable, with minimum version defined in `pubspec.yaml`

Pinning a specific Flutter version in CI was considered but not implemented, as the current behavior (using latest stable) serves as an early warning when a new Flutter release introduces breaking changes. If stricter version pinning is needed in the future, [subosito/flutter-action#296](https://github.com/subosito/flutter-action/issues/296) would allow using `.fvmrc` as the single source of truth for both local dev and CI.

Closes #2716

## Test plan

- No code changes, only config and documentation
- CI should continue to work as before (already uses latest stable)
- Contributors using FVM will now get stable instead of beta