### PR TITLE
fix: do not use saved standalone analysis in opening explorer

### DIFF
--- a/lib/src/model/analysis/analysis_controller.dart
+++ b/lib/src/model/analysis/analysis_controller.dart
@@ -44,6 +44,12 @@ final _dateFormat = DateFormat('yyyy.MM.dd');
 sealed class AnalysisOptions with _$AnalysisOptions {
   const AnalysisOptions._();
 
+  const factory AnalysisOptions.standalone({
+    required Variant variant,
+    @Default(null) int? initialMoveCursor,
+    @Default(Side.white) Side orientation,
+  }) = Standalone;
+
   const factory AnalysisOptions.pgn({
     required StringId id,
     required Side orientation,
@@ -51,7 +57,7 @@ sealed class AnalysisOptions with _$AnalysisOptions {
     required String pgn,
     required Variant variant,
     required bool isComputerAnalysisAllowed,
-  }) = Standalone;
+  }) = Pgn;
 
   const factory AnalysisOptions.archivedGame({
     required Side orientation,
@@ -69,13 +75,14 @@ sealed class AnalysisOptions with _$AnalysisOptions {
 
   GameId? get gameId => switch (this) {
     ArchivedGame(:final gameId) => gameId,
-    Standalone() => null,
+    Pgn() || Standalone() => null,
     ActiveCorrespondenceGame(:final gameFullId) => gameFullId.gameId,
   };
 
   StringId get contextId => switch (this) {
     ArchivedGame(:final gameId) => gameId,
-    Standalone(:final id) => id,
+    Pgn(:final id) => id,
+    Standalone() => const StringId('standalone'),
     ActiveCorrespondenceGame(:final gameFullId) => gameFullId.gameId,
   };
 }
@@ -118,7 +125,7 @@ final analysisControllerProvider = AsyncNotifierProvider.autoDispose
       name: 'AnalysisControllerProvider',
     );
 
-({StringId id, Root root, UciPath path, Variant variant})? _savedStandalone;
+({Root root, UciPath path, Variant variant})? _savedStandalone;
 
 void clearSavedStandaloneAnalysis() {
   _savedStandalone = null;
@@ -190,12 +197,19 @@ class AnalysisController extends AsyncNotifier<AnalysisState>
           division = archivedGame.meta.division;
           activeCorrespondenceGame = null;
         }
-      case Standalone(:final id, :final variant, pgn: final gamePgn):
+      case Pgn(:final variant, pgn: final gamePgn):
         {
-          _variant = gamePgn.isEmpty && _savedStandalone != null
-              ? _savedStandalone!.variant
-              : variant;
+          _variant = variant;
           pgn = gamePgn;
+          opening = null;
+          serverAnalysis = null;
+          division = null;
+          activeCorrespondenceGame = null;
+        }
+      case Standalone(:final variant):
+        {
+          _variant = _savedStandalone != null ? _savedStandalone!.variant : variant;
+          pgn = '';
           opening = null;
           serverAnalysis = null;
           division = null;
@@ -203,8 +217,8 @@ class AnalysisController extends AsyncNotifier<AnalysisState>
 
           // We want to keep the standalone analysis session alive even if the user navigates away
           ref.onCancel(() {
-            if (_root.mainline.isNotEmpty && id == const StringId('standalone')) {
-              _savedStandalone = (id: id, root: _root, path: _currentPath, variant: _variant);
+            if (_root.mainline.isNotEmpty) {
+              _savedStandalone = (root: _root, path: _currentPath, variant: _variant);
             }
           });
         }
@@ -247,17 +261,16 @@ class AnalysisController extends AsyncNotifier<AnalysisState>
     final isGameFinished = pgnHeaders['Result'] != '*';
 
     final isComputerAnalysisAllowed = switch (options) {
-      Standalone(:final isComputerAnalysisAllowed) => isComputerAnalysisAllowed,
+      Pgn(:final isComputerAnalysisAllowed) => isComputerAnalysisAllowed,
       ArchivedGame() => isGameFinished,
+      Standalone() => true,
       ActiveCorrespondenceGame() => false,
     };
 
     final List<Future<(UciPath, FullOpening)?>> openingFutures = [];
 
     _root = switch (options) {
-      Standalone(:final pgn, :final id)
-          when _savedStandalone != null && id == _savedStandalone!.id && pgn.isEmpty =>
-        _savedStandalone!.root,
+      Standalone() when _savedStandalone != null => _savedStandalone!.root,
       _ => Root.fromPgnGame(
         game,
         isLichessAnalysis: options.isLichessGameAnalysis,
@@ -297,7 +310,7 @@ class AnalysisController extends AsyncNotifier<AnalysisState>
         });
 
     final currentPath = switch (options) {
-      Standalone(:final pgn) when _savedStandalone != null && pgn.isEmpty => _savedStandalone!.path,
+      Standalone() when _savedStandalone != null => _savedStandalone!.path,
       _ => options.initialMoveCursor == null ? _root.mainlinePath : path,
     };
     final currentNode = _root.nodeAt(currentPath);
@@ -342,7 +355,9 @@ class AnalysisController extends AsyncNotifier<AnalysisState>
       gameId: options.gameId,
       archivedGame: archivedGame,
       currentPath: currentPath,
-      pathToLiveMove: isGameFinished || options is Standalone ? null : currentPath,
+      pathToLiveMove: isGameFinished || options is Standalone || options is Pgn
+          ? null
+          : currentPath,
       forecast: forecast,
       isOnMainline: _root.isOnMainline(currentPath),
       root: _root.view,
@@ -1023,7 +1038,7 @@ sealed class AnalysisState
 
   /// Creates an AnalysisPlayer from PGN headers for the given side.
   ///
-  /// Used for standalone analysis to display player names and ratings if provided in the PGN.
+  /// Used for pgn analysis to display player names and ratings if provided in the PGN.
   AnalysisPlayer? playerFromPgnHeaders(Side side) {
     if (archivedGame != null) return null;
     return AnalysisPlayer.fromPgnHeaders(pgnHeaders, side);

--- a/lib/src/view/analysis/analysis_screen.dart
+++ b/lib/src/view/analysis/analysis_screen.dart
@@ -329,8 +329,8 @@ class _Body extends ConsumerWidget {
         isSideToMove: analysisState.currentPosition.turn == pov.opposite,
         result: result?.resultToString(pov.opposite),
       );
-    } else if (options case Standalone()) {
-      // Standalone analysis - try to get player info from PGN headers
+    } else if (options case Pgn()) {
+      // PGN analysis - try to get player info from PGN headers
       final footerPlayer = analysisState.playerFromPgnHeaders(pov);
       final headerPlayer = analysisState.playerFromPgnHeaders(pov.opposite);
 
@@ -569,7 +569,7 @@ class _BottomBar extends ConsumerWidget {
     return showAdaptiveActionSheet(
       context: context,
       actions: [
-        if (options case Standalone(:final pgn)) ...[
+        if (options case Standalone()) ...[
           BottomSheetAction(
             makeLabel: (context) => Text(context.l10n.clearSavedMoves),
             onPressed: () => ref
@@ -578,43 +578,42 @@ class _BottomBar extends ConsumerWidget {
           ),
           // Only allow changing the variant if this is standalone analysis entered from the home screen,
           // but not for any other case like puzzle analysis or an active correspondence game.
-          if (pgn.isEmpty)
-            BottomSheetAction(
-              makeLabel: (context) => Text(context.l10n.variant),
-              onPressed: () => showChoicePicker<Variant>(
-                context,
-                choices: readSupportedVariants
-                    .where(
-                      (variant) => variant != Variant.fromPosition && variant != Variant.chess960,
-                    )
-                    .toList(),
-                selectedItem: analysisState.variant,
-                labelBuilder: (Variant variant) => Text.rich(
-                  TextSpan(
-                    children: [
-                      WidgetSpan(child: Icon(variant.icon), alignment: PlaceholderAlignment.middle),
-                      const WidgetSpan(child: SizedBox(width: 8)),
-                      TextSpan(text: variant.label),
-                    ],
-                  ),
+          BottomSheetAction(
+            makeLabel: (context) => Text(context.l10n.variant),
+            onPressed: () => showChoicePicker<Variant>(
+              context,
+              choices: readSupportedVariants
+                  .where(
+                    (variant) => variant != Variant.fromPosition && variant != Variant.chess960,
+                  )
+                  .toList(),
+              selectedItem: analysisState.variant,
+              labelBuilder: (Variant variant) => Text.rich(
+                TextSpan(
+                  children: [
+                    WidgetSpan(child: Icon(variant.icon), alignment: PlaceholderAlignment.middle),
+                    const WidgetSpan(child: SizedBox(width: 8)),
+                    TextSpan(text: variant.label),
+                  ],
                 ),
-                onSelectedItemChanged: (Variant variant) =>
-                    WidgetsBinding.instance.addPostFrameCallback((_) {
-                      ref
-                          .read(analysisControllerProvider(options).notifier)
-                          .clearSavedStandaloneAnalysis();
-                      Navigator.of(context, rootNavigator: true).pushReplacement(
-                        buildScreenRoute<dynamic>(
-                          context,
-                          screen: AnalysisScreen(
-                            options: (options as Standalone).copyWith(variant: variant),
-                          ),
-                          transitionDuration: Duration.zero,
-                        ),
-                      );
-                    }),
               ),
+              onSelectedItemChanged: (Variant variant) =>
+                  WidgetsBinding.instance.addPostFrameCallback((_) {
+                    ref
+                        .read(analysisControllerProvider(options).notifier)
+                        .clearSavedStandaloneAnalysis();
+                    Navigator.of(context, rootNavigator: true).pushReplacement(
+                      buildScreenRoute<dynamic>(
+                        context,
+                        screen: AnalysisScreen(
+                          options: (options as Standalone).copyWith(variant: variant),
+                        ),
+                        transitionDuration: Duration.zero,
+                      ),
+                    );
+                  }),
             ),
+          ),
         ],
         if (analysisState.isEngineAvailable(evalPrefs))
           BottomSheetAction(

--- a/lib/src/view/more/more_tab_screen.dart
+++ b/lib/src/view/more/more_tab_screen.dart
@@ -84,13 +84,7 @@ class _Body extends ConsumerWidget {
                 onTap: () => Navigator.of(context, rootNavigator: true).push(
                   AnalysisScreen.buildRoute(
                     context,
-                    const AnalysisOptions.pgn(
-                      id: StringId('standalone'),
-                      orientation: Side.white,
-                      pgn: '',
-                      isComputerAnalysisAllowed: true,
-                      variant: Variant.standard,
-                    ),
+                    const AnalysisOptions.standalone(variant: Variant.standard),
                   ),
                 ),
               ),

--- a/test/model/engine/fake_stockfish.dart
+++ b/test/model/engine/fake_stockfish.dart
@@ -10,6 +10,18 @@ String _engineName(StockfishFlavor flavor) => switch (flavor) {
   StockfishFlavor.variant => 'Fairy-Stockfish',
 };
 
+Rule ruleFromUciVariant(String uciVariant) => switch (uciVariant) {
+  'chess' => Rule.chess,
+  'antichess' => Rule.antichess,
+  'kingofthehill' => Rule.kingofthehill,
+  '3check' => Rule.threecheck,
+  'atomic' => Rule.atomic,
+  'horde' => Rule.horde,
+  'racingkings' => Rule.racingKings,
+  'crazyhouse' => Rule.crazyhouse,
+  _ => throw ArgumentError('Unexpected uci variant: $uciVariant'),
+};
+
 /// A fake implementation of [Stockfish] for testing.
 class FakeStockfish implements Stockfish {
   FakeStockfish();
@@ -79,7 +91,7 @@ class FakeStockfish implements Stockfish {
           final movesPartIndex = parts.indexWhere((p) => p == 'moves');
           if (parts.length > 2) {
             _position = Position.setupPosition(
-              Rule.chess,
+              _variant != null ? ruleFromUciVariant(_variant!) : Rule.chess,
               Setup.parseFen(
                 parts.sublist(2, movesPartIndex != -1 ? movesPartIndex : null).join(' '),
               ),

--- a/test/view/analysis/analysis_screen_test.dart
+++ b/test/view/analysis/analysis_screen_test.dart
@@ -111,67 +111,78 @@ void main() {
       );
     });
 
-    for (final pgn in ['', sanMoves]) {
-      testWidgets('change variant if PGN is empty, pgn: $pgn', (tester) async {
-        final app = await makeTestProviderScopeApp(
-          tester,
-          home: AnalysisScreen(
-            options: AnalysisOptions.pgn(
-              id: const StringId('standalone'),
-              orientation: Side.white,
-              pgn: pgn,
-              isComputerAnalysisAllowed: false,
-              variant: Variant.standard,
-            ),
+    testWidgets('change variant in standalone analysis', (tester) async {
+      final app = await makeTestProviderScopeApp(
+        tester,
+        home: const AnalysisScreen(options: AnalysisOptions.standalone(variant: Variant.standard)),
+      );
+
+      await tester.pumpWidget(app);
+
+      expect(find.byType(PocketsMenu), findsNothing);
+
+      await tester.tap(find.bySemanticsLabel('Menu'));
+      await tester.pumpAndSettle(); // wait for menu to open
+
+      expect(find.text('Variant'), findsOneWidget);
+
+      await tester.tap(find.text('Variant'));
+      await tester.pumpAndSettle(); // wait for dialog to open
+
+      expect(find.textContaining('Standard'), findsOneWidget);
+      expect(find.textContaining('Chess960'), findsNothing);
+      expect(find.textContaining('From Position'), findsNothing);
+      expect(find.textContaining('Antichess'), findsOneWidget);
+      expect(find.textContaining('King of the Hill'), findsOneWidget);
+      expect(find.textContaining('Three Check'), findsOneWidget);
+      expect(find.textContaining('Atomic'), findsOneWidget);
+      expect(find.textContaining('Horde'), findsOneWidget);
+      expect(find.textContaining('Racing Kings'), findsOneWidget);
+      expect(find.textContaining('Crazyhouse'), findsOneWidget);
+
+      await tester.tap(find.textContaining('Horde'));
+      await tester.pumpAndSettle(); // wait for dialog to close and new variant to be loaded
+
+      expect(find.byType(PocketsMenu), findsNothing);
+
+      // Horde starting position should be loaded:
+      expect(find.byKey(const ValueKey('b5-whitepawn')), findsOneWidget);
+
+      // Change to crazhouse, pockets should be displayed:
+      await tester.tap(find.bySemanticsLabel('Menu'));
+      await tester.pumpAndSettle(); // wait for menu to open
+      await tester.tap(find.text('Variant'));
+      await tester.pumpAndSettle(); // wait for dialog to open
+      await tester.tap(find.textContaining('Crazyhouse'));
+      await tester.pumpAndSettle(); // wait for dialog to close and new variant to be loaded
+
+      // One for white, one for black
+      expect(find.byType(PocketsMenu), findsNWidgets(2));
+    });
+
+    testWidgets('Cannot change variant in PGN analysis', (tester) async {
+      final app = await makeTestProviderScopeApp(
+        tester,
+        home: const AnalysisScreen(
+          options: AnalysisOptions.pgn(
+            id: StringId('standalone'),
+            pgn: '',
+            isComputerAnalysisAllowed: false,
+            orientation: Side.white,
+            variant: Variant.standard,
           ),
-        );
+        ),
+      );
 
-        await tester.pumpWidget(app);
+      await tester.pumpWidget(app);
 
-        expect(find.byType(PocketsMenu), findsNothing);
+      expect(find.byType(PocketsMenu), findsNothing);
 
-        await tester.tap(find.bySemanticsLabel('Menu'));
-        await tester.pumpAndSettle(); // wait for menu to open
+      await tester.tap(find.bySemanticsLabel('Menu'));
+      await tester.pumpAndSettle(); // wait for menu to open
 
-        final canChangeVariant = pgn.isEmpty;
-        expect(find.text('Variant'), canChangeVariant ? findsOneWidget : findsNothing);
-
-        if (canChangeVariant) {
-          await tester.tap(find.text('Variant'));
-          await tester.pumpAndSettle(); // wait for dialog to open
-
-          expect(find.textContaining('Standard'), findsOneWidget);
-          expect(find.textContaining('Chess960'), findsNothing);
-          expect(find.textContaining('From Position'), findsNothing);
-          expect(find.textContaining('Antichess'), findsOneWidget);
-          expect(find.textContaining('King of the Hill'), findsOneWidget);
-          expect(find.textContaining('Three Check'), findsOneWidget);
-          expect(find.textContaining('Atomic'), findsOneWidget);
-          expect(find.textContaining('Horde'), findsOneWidget);
-          expect(find.textContaining('Racing Kings'), findsOneWidget);
-          expect(find.textContaining('Crazyhouse'), findsOneWidget);
-
-          await tester.tap(find.textContaining('Horde'));
-          await tester.pumpAndSettle(); // wait for dialog to close and new variant to be loaded
-
-          expect(find.byType(PocketsMenu), findsNothing);
-
-          // Horde starting position should be loaded:
-          expect(find.byKey(const ValueKey('b5-whitepawn')), findsOneWidget);
-
-          // Change to crazhouse, pockets should be displayed:
-          await tester.tap(find.bySemanticsLabel('Menu'));
-          await tester.pumpAndSettle(); // wait for menu to open
-          await tester.tap(find.text('Variant'));
-          await tester.pumpAndSettle(); // wait for dialog to open
-          await tester.tap(find.textContaining('Crazyhouse'));
-          await tester.pumpAndSettle(); // wait for dialog to close and new variant to be loaded
-
-          // One for white, one for black
-          expect(find.byType(PocketsMenu), findsNWidgets(2));
-        }
-      });
-    }
+      expect(find.text('Variant'), findsNothing);
+    });
 
     testWidgets('Crazyhouse support DropMoves for both sides', (tester) async {
       final app = await makeTestProviderScopeApp(

--- a/test/view/explorer/opening_explorer_screen_test.dart
+++ b/test/view/explorer/opening_explorer_screen_test.dart
@@ -15,6 +15,7 @@ import 'package:lichess_mobile/src/model/settings/preferences_storage.dart';
 import 'package:lichess_mobile/src/model/user/user.dart';
 import 'package:lichess_mobile/src/network/http.dart';
 import 'package:lichess_mobile/src/view/explorer/opening_explorer_screen.dart';
+import 'package:lichess_mobile/src/view/more/more_tab_screen.dart';
 
 import '../../network/fake_http_client_factory.dart';
 import '../../test_helpers.dart';
@@ -185,6 +186,42 @@ void main() {
       //   findsOneWidget,
       // );
     }, variant: kPlatformVariant);
+
+    // regression test for #2726
+    testWidgets('opening explorer does not use standalone analysis', (WidgetTester tester) async {
+      final app = await makeTestProviderScopeApp(
+        tester,
+        home: const MoreTabScreen(),
+        overrides: {
+          httpClientFactoryProvider: httpClientFactoryProvider.overrideWith((ref) {
+            return FakeHttpClientFactory(() => mockClient);
+          }),
+        },
+        authUser: authUser,
+      );
+      await tester.pumpWidget(app);
+
+      await tester.tap(find.text('Analysis board'));
+      await tester.pumpAndSettle(); // wait for analysis screen to open
+
+      await playMove(tester, 'e2', 'e4');
+      expect(find.byKey(const ValueKey('e4-whitepawn')), findsOneWidget);
+
+      // Go back to "more" screen and open opening explorer
+      await tester.pageBack();
+      await tester.pump();
+
+      await tester.tap(find.text('Opening explorer'));
+      await tester.pumpAndSettle(); // wait for opening explorer screen to open
+
+      // Should not use saved standalone analysis here
+      expect(find.byKey(const ValueKey('e2-whitepawn')), findsOneWidget);
+
+      // There was a bug where the opening explorer would partially load saved analysis,
+      // leading to not being to move any pieces.
+      await playMove(tester, 'd2', 'd4');
+      expect(find.byKey(const ValueKey('d4-whitepawn')), findsOneWidget);
+    });
   });
 }
 


### PR DESCRIPTION
Instead of checking if the pgn is empty to check if we can save/restore saved standalone analysis (which is also true for opening explorer), introducea dedicated `AnalysisOptions` variant for standalone analysis. I think this makes the rest of the code more readable as well.

Closes #2726