### PR TITLE
add more Annotations Symbols

### DIFF
--- a/lib/src/widgets/pgn.dart
+++ b/lib/src/widgets/pgn.dart
@@ -44,6 +44,8 @@ Color? _nagColor(BuildContext context, int nag) {
 String moveAnnotationChar(Iterable<int> nags) {
   return nags
       .map(
+        //sources: https://github.com/lichess-org/scalachess/blob/3f96a2935ee2ee670def67632171ffcea7c96b6d/core/src/main/scala/format/pgn/Glyph.scala
+        //https://en.wikipedia.org/wiki/Portable_Game_Notation
         (nag) => switch (nag) {
           1 => '!',
           2 => '?',
@@ -51,6 +53,24 @@ String moveAnnotationChar(Iterable<int> nags) {
           4 => '??',
           5 => '!?',
           6 => '?!',
+          8 => '□',
+          10 => '=',
+          11 => '=',
+          13 => '∞',
+          14 => '⩲',
+          15 => '⩱',
+          16 => '±',
+          17 => '∓',
+          18 => '+-',
+          19 => '-+',
+          22 => '⨀',
+          32 => '⟳',
+          36 => '↑',
+          44 => '=∞',
+          132 => '⇆',
+          138 => '⊕',
+          140 => '∆',
+          146 => 'N',
           int() => '',
         },
       )
@@ -69,6 +89,24 @@ Annotation? makeAnnotation(Iterable<int>? nags) {
     6 => const Annotation(symbol: '?!', color: LichessColors.cyan),
     2 => const Annotation(symbol: '?', color: mistakeColor),
     4 => const Annotation(symbol: '??', color: blunderColor),
+    8 => const Annotation(symbol: '□', color: Colors.grey),
+    10 => const Annotation(symbol: '=', color: Colors.grey),
+    11 => const Annotation(symbol: '=', color: Colors.grey),
+    13 => const Annotation(symbol: '∞', color: Colors.grey),
+    14 => const Annotation(symbol: '⩲', color: Colors.grey),
+    15 => const Annotation(symbol: '⩱', color: Colors.grey),
+    16 => const Annotation(symbol: '±', color: Colors.grey),
+    17 => const Annotation(symbol: '∓', color: Colors.grey),
+    18 => const Annotation(symbol: '+-', color: Colors.grey),
+    19 => const Annotation(symbol: '-+', color: Colors.grey),
+    22 => const Annotation(symbol: '⨀', color: Colors.grey),
+    32 => const Annotation(symbol: '⟳', color: Colors.grey),
+    36 => const Annotation(symbol: '↑', color: Colors.grey),
+    44 => const Annotation(symbol: '=∞', color: Colors.grey),
+    132 => const Annotation(symbol: '⇆', color: Colors.grey),
+    138 => const Annotation(symbol: '⊕', color: Colors.grey),
+    140 => const Annotation(symbol: '∆', color: Colors.grey),
+    146 => const Annotation(symbol: 'N', color: Colors.grey),
     int() => null,
   };
 }


### PR DESCRIPTION
Adds more annotation symbols.
Useful for studies or imported PGN games.  Especially when sharing opening preperation via pgn this is essential.
I choose to keep the annotation all grey (on the website they have colors, but just kind of random https://github.com/lichess-org/lila/blob/feb34f75f9e29ba295b32ed54740471da0382444/ui/lib/src/game/glyphs.ts)  and not color the notation (same as website)
Preview: 

https://github.com/user-attachments/assets/95f9fda9-b03f-46aa-8c5a-2ef5a2cd3061

Supports all glyphs that are present on the website: https://github.com/lichess-org/scalachess/blob/3f96a2935ee2ee670def67632171ffcea7c96b6d/core/src/main/scala/format/pgn/Glyph.scala
Plus also some more that Chessbase uses.

Example pgn to test: 
`1. e4 $3 e6 $1 2. d4 $5 d5 $6 3. e5 $2 $18 c5 $4 4. c3 $18 Nc6 $16 5. Nf3 $14 Bd7 $11 6. Be2 $13 Nge7 $44 7. Na3 $15 cxd4 $17 8. cxd4 $19 Nf5 $132 9. O-O Qb6 $32 10. Kh1 $8 h5 $138 11. h4 $36 *`
