### PR TITLE
add arrows to imported pgn analysis board

### DIFF
--- a/lib/src/model/analysis/analysis_controller.dart
+++ b/lib/src/model/analysis/analysis_controller.dart
@@ -994,6 +994,12 @@ sealed class AnalysisState
     return forecast!.isCandidate(candidate) ? candidate : null;
   }
 
+  IList<PgnCommentShape> get pgnShapes => IList(
+    (currentNode.isRoot ? pgnRootComments : currentNode.comments)
+        ?.map((comment) => comment.shapes)
+        .flattened,
+  );
+
   /// If it's our turn and we have branched off from the main line, this is the move we would play
   /// if we to save the entire current path as a premove line.
   SanMove? get pendingMove => forecast?.onMyTurn == true && branchedOffFromLiveMove

--- a/lib/src/view/analysis/game_analysis_board.dart
+++ b/lib/src/view/analysis/game_analysis_board.dart
@@ -1,8 +1,11 @@
+import 'package:chessground/chessground.dart';
 import 'package:dartchess/dartchess.dart';
+import 'package:fast_immutable_collections/fast_immutable_collections.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:lichess_mobile/src/model/analysis/analysis_controller.dart';
 import 'package:lichess_mobile/src/model/analysis/analysis_preferences.dart';
 import 'package:lichess_mobile/src/model/engine/evaluation_service.dart';
+import 'package:lichess_mobile/src/model/settings/board_preferences.dart';
 import 'package:lichess_mobile/src/view/analysis/analysis_board.dart';
 
 class GameAnalysisBoard extends AnalysisBoard {
@@ -48,4 +51,25 @@ class _GameAnalysisBoardState
   @override
   void onPromotionSelection(Role? role) =>
       ref.read(analysisControllerProvider(widget.options).notifier).onPromotionSelection(role);
+
+  @override
+  ISet<Shape> get extraShapes {
+    final analysisState = ref.watch(analysisControllerProvider(widget.options)).requireValue;
+    final pgnShapes = ISet(analysisState.pgnShapes.map((shape) => shape.chessground));
+    return pgnShapes;
+  }
+}
+
+extension on PgnCommentShape {
+  Shape get chessground {
+    final shapeColor = switch (color) {
+      CommentShapeColor.green => ShapeColor.green,
+      CommentShapeColor.red => ShapeColor.red,
+      CommentShapeColor.blue => ShapeColor.blue,
+      CommentShapeColor.yellow => ShapeColor.yellow,
+    };
+    return from != to
+        ? Arrow(color: shapeColor.color, orig: from, dest: to)
+        : Circle(color: shapeColor.color, orig: from);
+  }
 }


### PR DESCRIPTION
Displays arrows in the analysis board, the same way it is done in the study screen: 

<img width="609" height="1366" alt="grafik" src="https://github.com/user-attachments/assets/5bb5abe1-8cbd-4694-9d50-01b2812af1d2" />

Useful for opening PGNs shared by coaches.

pgn for testing:
`1. d4 {[%csl Gd4,Re1,Bf4,Gf6,Yf7,Bg6][%cal Gd4e5,Rd4c5,Rc2c4,Bf4f5,Bh5g6,Yc5d6]} e6 {[%csl Ye5,Be6,Rf5,Gf6]} *`

