### PR TITLE
show tenths in analysis board if under 1 minute

### DIFF
--- a/lib/src/view/analysis/analysis_screen.dart
+++ b/lib/src/view/analysis/analysis_screen.dart
@@ -467,7 +467,7 @@ class _Clock extends StatelessWidget {
       color: isSideToMove ? colorScheme.secondaryContainer : null,
       child: Center(
         child: Text(
-          timeLeft.toHoursMinutesSeconds(),
+          timeLeft.toHoursMinutesSeconds(showTenths: timeLeft < const Duration(minutes: 1)),
           style: TextStyle(
             color: isSideToMove ? colorScheme.onSecondaryContainer : null,
             fontFeatures: const [FontFeature.tabularFigures()],


### PR DESCRIPTION
closes #2151 

Shows the tenths when below the clock is below 1 Minute in the Analysis Board. This is the same behavior as on the website.

<img width="609" height="1320" alt="grafik" src="https://github.com/user-attachments/assets/1e768991-9819-4931-8b72-621b931cbd2c" />
