### PR TITLE
fix: preselect analysis/boardEditor variant in OTB and offline computer

### DIFF
--- a/lib/src/view/analysis/analysis_screen.dart
+++ b/lib/src/view/analysis/analysis_screen.dart
@@ -718,15 +718,23 @@ class _BottomBar extends ConsumerWidget {
       actions: [
         BottomSheetAction(
           makeLabel: (context) => Text(context.l10n.playAgainstComputer),
-          onPressed: () => Navigator.of(
-            context,
-          ).push(OfflineComputerGameScreen.buildRoute(context, initialFen: boardFen)),
+          onPressed: () => Navigator.of(context).push(
+            OfflineComputerGameScreen.buildRoute(
+              context,
+              initialVariant: analysisState.variant,
+              initialFen: boardFen,
+            ),
+          ),
         ),
         BottomSheetAction(
           makeLabel: (context) => Text(context.l10n.mobileOverTheBoard),
-          onPressed: () => Navigator.of(
-            context,
-          ).push(OverTheBoardScreen.buildRoute(context, initialFen: boardFen)),
+          onPressed: () => Navigator.of(context).push(
+            OverTheBoardScreen.buildRoute(
+              context,
+              initialVariant: analysisState.variant,
+              initialFen: boardFen,
+            ),
+          ),
         ),
       ],
     );

--- a/lib/src/view/board_editor/board_editor_screen.dart
+++ b/lib/src/view/board_editor/board_editor_screen.dart
@@ -390,7 +390,8 @@ class _BottomBar extends ConsumerWidget {
               if (editorState.pgn != null && pieceCount > 0 && pieceCount <= 32)
                 BottomSheetAction(
                   makeLabel: (context) => Text(context.l10n.continueFromHere),
-                  onPressed: () => _showContinueFromHereMenu(context, editorState.fen),
+                  onPressed: () =>
+                      _showContinueFromHereMenu(context, editorState.variant, editorState.fen),
                 ),
               BottomSheetAction(
                 makeLabel: (context) => Text(context.l10n.clearBoard),
@@ -447,20 +448,21 @@ class _BottomBar extends ConsumerWidget {
     );
   }
 
-  Future<void> _showContinueFromHereMenu(BuildContext context, String fen) {
+  Future<void> _showContinueFromHereMenu(BuildContext context, Variant variant, String fen) {
     return showAdaptiveActionSheet(
       context: context,
       actions: [
         BottomSheetAction(
           makeLabel: (context) => Text(context.l10n.playAgainstComputer),
-          onPressed: () => Navigator.of(
-            context,
-          ).push(OfflineComputerGameScreen.buildRoute(context, initialFen: fen)),
+          onPressed: () => Navigator.of(context).push(
+            OfflineComputerGameScreen.buildRoute(context, initialVariant: variant, initialFen: fen),
+          ),
         ),
         BottomSheetAction(
           makeLabel: (context) => Text(context.l10n.mobileOverTheBoard),
-          onPressed: () =>
-              Navigator.of(context).push(OverTheBoardScreen.buildRoute(context, initialFen: fen)),
+          onPressed: () => Navigator.of(
+            context,
+          ).push(OverTheBoardScreen.buildRoute(context, initialVariant: variant, initialFen: fen)),
         ),
       ],
     );

--- a/lib/src/view/offline_computer/offline_computer_game_screen.dart
+++ b/lib/src/view/offline_computer/offline_computer_game_screen.dart
@@ -61,13 +61,25 @@ extension _PracticeCommentDisplay on PracticeComment {
 }
 
 class OfflineComputerGameScreen extends ConsumerWidget {
-  const OfflineComputerGameScreen({this.initialFen, super.key});
+  const OfflineComputerGameScreen({this.initialVariant, this.initialFen, super.key});
+
+  /// Optional initial variant to be preselected in the "New Game" dialog.
+  ///
+  /// If null, the variant from the last game against the computer will be used.
+  final Variant? initialVariant;
 
   /// Optional initial FEN to start the game from a custom position.
   final String? initialFen;
 
-  static Route<void> buildRoute(BuildContext context, {String? initialFen}) {
-    return buildScreenRoute(context, screen: OfflineComputerGameScreen(initialFen: initialFen));
+  static Route<void> buildRoute(
+    BuildContext context, {
+    Variant? initialVariant,
+    String? initialFen,
+  }) {
+    return buildScreenRoute(
+      context,
+      screen: OfflineComputerGameScreen(initialVariant: initialVariant, initialFen: initialFen),
+    );
   }
 
   @override
@@ -96,13 +108,15 @@ class OfflineComputerGameScreen extends ConsumerWidget {
             ),
         ],
       ),
-      body: _Body(initialFen: initialFen),
+      body: _Body(initialVariant: initialVariant, initialFen: initialFen),
     );
   }
 }
 
 class _Body extends ConsumerStatefulWidget {
-  const _Body({this.initialFen});
+  const _Body({required this.initialVariant, this.initialFen});
+
+  final Variant? initialVariant;
 
   final String? initialFen;
 
@@ -121,7 +135,7 @@ class _BodyState extends ConsumerState<_Body> {
       // If we have an initial FEN, always show the new game dialog
       if (widget.initialFen != null) {
         if (!mounted) return;
-        _showNewGameDialog();
+        _showNewGameDialog(initialVariant: widget.initialVariant);
         return;
       }
 
@@ -130,7 +144,7 @@ class _BodyState extends ConsumerState<_Body> {
         ref.read(offlineComputerGameControllerProvider.notifier).loadGame(savedGame);
       } else {
         if (!mounted) return;
-        _showNewGameDialog();
+        _showNewGameDialog(initialVariant: widget.initialVariant);
       }
     });
   }
@@ -158,7 +172,7 @@ class _BodyState extends ConsumerState<_Body> {
                 game: newGameState.game,
                 onNewGame: () {
                   Navigator.pop(context);
-                  _showNewGameDialog();
+                  _showNewGameDialog(initialVariant: gameState.game.meta.variant);
                 },
               ),
               barrierDismissible: true,
@@ -269,7 +283,10 @@ class _BodyState extends ConsumerState<_Body> {
                     ),
                     moves: gameState.moves,
                     currentMoveIndex: gameState.stepCursor,
-                    userActionsBar: _BottomBar(onNewGame: _showNewGameDialog),
+                    userActionsBar: _BottomBar(
+                      onNewGame: () =>
+                          _showNewGameDialog(initialVariant: gameState.game.meta.variant),
+                    ),
                   ),
                 ),
               ),
@@ -280,13 +297,14 @@ class _BodyState extends ConsumerState<_Body> {
     );
   }
 
-  void _showNewGameDialog() {
+  void _showNewGameDialog({required Variant? initialVariant}) {
     final double screenHeight = MediaQuery.sizeOf(context).height;
     showModalBottomSheet<void>(
       context: context,
       isScrollControlled: true,
       constraints: BoxConstraints(maxHeight: screenHeight - (screenHeight / 10)),
-      builder: (context) => _NewGameSheet(initialFen: widget.initialFen),
+      builder: (context) =>
+          _NewGameSheet(initialVariant: initialVariant, initialFen: widget.initialFen),
     );
   }
 
@@ -699,7 +717,9 @@ class _PracticeCommentCardState extends ConsumerState<_PracticeCommentCard> {
 }
 
 class _NewGameSheet extends ConsumerStatefulWidget {
-  const _NewGameSheet({this.initialFen});
+  const _NewGameSheet({required this.initialVariant, this.initialFen});
+
+  final Variant? initialVariant;
 
   final String? initialFen;
 
@@ -726,7 +746,7 @@ class _NewGameSheetState extends ConsumerState<_NewGameSheet> {
     final prefs = ref.read(offlineComputerGamePreferencesProvider);
     _selectedLevel = prefs.stockfishLevel;
     _selectedSideChoice = prefs.sideChoice;
-    _selectedVariant = prefs.variant;
+    _selectedVariant = widget.initialVariant ?? prefs.variant;
     _casual = prefs.casual;
     _practiceMode = prefs.practiceMode;
   }
@@ -807,28 +827,27 @@ class _NewGameSheetState extends ConsumerState<_NewGameSheet> {
                 );
               },
             ),
-            if (widget.initialFen == null)
-              SettingsListTile(
-                settingsLabel: Text(context.l10n.variant),
-                settingsValue: _selectedVariant.label,
-                onTap: () {
-                  showChoicePicker(
-                    context,
-                    choices: playSupportedVariants.where((v) => v != Variant.fromPosition).toList(),
-                    selectedItem: _selectedVariant,
-                    labelBuilder: (Variant variant) => Text(variant.label),
-                    onSelectedItemChanged: (Variant variant) {
-                      setState(() {
-                        _selectedVariant = variant;
-                        if (variant == Variant.crazyhouse) {
-                          _practiceMode = false;
-                        }
-                      });
-                      ref.read(offlineComputerGamePreferencesProvider.notifier).setVariant(variant);
-                    },
-                  );
-                },
-              ),
+            SettingsListTile(
+              settingsLabel: Text(context.l10n.variant),
+              settingsValue: _selectedVariant.label,
+              onTap: () {
+                showChoicePicker(
+                  context,
+                  choices: playSupportedVariants.where((v) => v != Variant.fromPosition).toList(),
+                  selectedItem: _selectedVariant,
+                  labelBuilder: (Variant variant) => Text(variant.label),
+                  onSelectedItemChanged: (Variant variant) {
+                    setState(() {
+                      _selectedVariant = variant;
+                      if (variant == Variant.crazyhouse) {
+                        _practiceMode = false;
+                      }
+                    });
+                    ref.read(offlineComputerGamePreferencesProvider.notifier).setVariant(variant);
+                  },
+                );
+              },
+            ),
             SwitchSettingTile(
               title: const Text('Practice mode'),
               subtitle: const Text('Get feedback on your moves'),

--- a/lib/src/view/over_the_board/configure_over_the_board_game.dart
+++ b/lib/src/view/over_the_board/configure_over_the_board_game.dart
@@ -20,6 +20,7 @@ import 'package:lichess_mobile/src/widgets/settings.dart';
 void showConfigureGameSheet(
   BuildContext context, {
   required bool isDismissible,
+  required Variant initialVariant,
   String? initialFen,
 }) {
   final double screenHeight = MediaQuery.sizeOf(context).height;
@@ -29,13 +30,18 @@ void showConfigureGameSheet(
     isDismissible: isDismissible,
     constraints: BoxConstraints(maxHeight: screenHeight - (screenHeight / 10)),
     builder: (BuildContext context) {
-      return _ConfigureOverTheBoardGameSheet(initialFen: initialFen);
+      return _ConfigureOverTheBoardGameSheet(
+        initialVariant: initialVariant,
+        initialFen: initialFen,
+      );
     },
   );
 }
 
 class _ConfigureOverTheBoardGameSheet extends ConsumerStatefulWidget {
-  const _ConfigureOverTheBoardGameSheet({this.initialFen});
+  const _ConfigureOverTheBoardGameSheet({required this.initialVariant, this.initialFen});
+
+  final Variant initialVariant;
 
   final String? initialFen;
 
@@ -52,9 +58,9 @@ class _ConfigureOverTheBoardGameSheetState extends ConsumerState<_ConfigureOverT
 
   @override
   void initState() {
-    final gameState = ref.read(overTheBoardGameControllerProvider);
-    final savedVariant = gameState.game.meta.variant;
-    chosenVariant = savedVariant == Variant.fromPosition ? Variant.standard : savedVariant;
+    chosenVariant = widget.initialVariant == Variant.fromPosition
+        ? Variant.standard
+        : widget.initialVariant;
     final clockProvider = ref.read(overTheBoardClockProvider);
     timeIncrement = clockProvider.timeIncrement;
     chosenTimeControlType = ref.read(overTheBoardPreferencesProvider).timeControlType;

--- a/lib/src/view/over_the_board/over_the_board_screen.dart
+++ b/lib/src/view/over_the_board/over_the_board_screen.dart
@@ -7,6 +7,7 @@ import 'package:flutter/cupertino.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:lichess_mobile/src/model/analysis/analysis_controller.dart';
+import 'package:lichess_mobile/src/model/common/chess.dart';
 import 'package:lichess_mobile/src/model/common/id.dart';
 import 'package:lichess_mobile/src/model/game/game_board_params.dart';
 import 'package:lichess_mobile/src/model/over_the_board/over_the_board_clock.dart';
@@ -32,13 +33,23 @@ import 'package:lichess_mobile/src/widgets/game_layout.dart';
 import 'package:lichess_mobile/src/widgets/yes_no_dialog.dart';
 
 class OverTheBoardScreen extends StatelessWidget {
-  const OverTheBoardScreen({this.initialFen, super.key});
+  const OverTheBoardScreen({this.initialFen, this.initialVariant, super.key});
 
   /// Optional initial FEN to start the game from a custom position.
   final String? initialFen;
 
-  static Route<void> buildRoute(BuildContext context, {String? initialFen}) {
-    return buildScreenRoute(context, screen: OverTheBoardScreen(initialFen: initialFen));
+  /// Initial variant to be preselected in the "New Game" dialog.
+  final Variant? initialVariant;
+
+  static Route<void> buildRoute(
+    BuildContext context, {
+    Variant? initialVariant,
+    String? initialFen,
+  }) {
+    return buildScreenRoute(
+      context,
+      screen: OverTheBoardScreen(initialVariant: initialVariant, initialFen: initialFen),
+    );
   }
 
   @override
@@ -54,13 +65,15 @@ class OverTheBoardScreen extends StatelessWidget {
           ),
         ],
       ),
-      body: _Body(initialFen: initialFen),
+      body: _Body(initialVariant: initialVariant ?? Variant.standard, initialFen: initialFen),
     );
   }
 }
 
 class _Body extends ConsumerStatefulWidget {
-  const _Body({this.initialFen});
+  const _Body({required this.initialVariant, this.initialFen});
+
+  final Variant initialVariant;
 
   final String? initialFen;
 
@@ -81,7 +94,12 @@ class _BodyState extends ConsumerState<_Body> {
       // If we have an initial FEN, always show the new game dialog
       if (widget.initialFen != null) {
         if (!mounted) return;
-        showConfigureGameSheet(context, isDismissible: true, initialFen: widget.initialFen);
+        showConfigureGameSheet(
+          context,
+          isDismissible: true,
+          initialVariant: widget.initialVariant,
+          initialFen: widget.initialFen,
+        );
         return;
       }
 
@@ -98,7 +116,7 @@ class _BodyState extends ConsumerState<_Body> {
             );
       } else {
         if (!mounted) return;
-        showConfigureGameSheet(context, isDismissible: true);
+        showConfigureGameSheet(context, initialVariant: widget.initialVariant, isDismissible: true);
       }
     });
   }
@@ -378,7 +396,11 @@ class _BottomBar extends ConsumerWidget {
       actions: [
         BottomSheetAction(
           makeLabel: (context) => Text(context.l10n.mobileNewGame),
-          onPressed: () => showConfigureGameSheet(context, isDismissible: true),
+          onPressed: () => showConfigureGameSheet(
+            context,
+            initialVariant: gameState.game.meta.variant,
+            isDismissible: true,
+          ),
         ),
         if (gameState.game.finished)
           BottomSheetAction(

--- a/test/view/analysis/analysis_screen_test.dart
+++ b/test/view/analysis/analysis_screen_test.dart
@@ -205,6 +205,60 @@ void main() {
       await playDropMove(tester, Side.black, Role.pawn, 'h5');
       expect(find.byKey(const ValueKey('h5-blackpawn')), findsOneWidget);
     });
+
+    testWidgets('Continue against computer', (tester) async {
+      final app = await makeTestProviderScopeApp(
+        tester,
+        home: const AnalysisScreen(
+          options: AnalysisOptions.pgn(
+            id: StringId('standalone'),
+            orientation: Side.white,
+            pgn: '',
+            isComputerAnalysisAllowed: true,
+            variant: Variant.atomic,
+          ),
+        ),
+      );
+
+      await tester.pumpWidget(app);
+
+      await tester.tap(find.bySemanticsLabel('Menu'));
+      await tester.pumpAndSettle(); // wait for menu to open
+      await tester.tap(find.text('Continue from here'));
+      await tester.pumpAndSettle(); // wait for dialog to open
+
+      await tester.tap(find.text('Play against computer'));
+      await tester.pumpAndSettle(); // wait for play menu to open
+      // Variant we set previously should be preselected
+      expect(find.text('Atomic'), findsOneWidget);
+    });
+
+    testWidgets('Continue OTB', (tester) async {
+      final app = await makeTestProviderScopeApp(
+        tester,
+        home: const AnalysisScreen(
+          options: AnalysisOptions.pgn(
+            id: StringId('standalone'),
+            orientation: Side.white,
+            pgn: '',
+            isComputerAnalysisAllowed: true,
+            variant: Variant.atomic,
+          ),
+        ),
+      );
+
+      await tester.pumpWidget(app);
+
+      await tester.tap(find.bySemanticsLabel('Menu'));
+      await tester.pumpAndSettle(); // wait for menu to open
+      await tester.tap(find.text('Continue from here'));
+      await tester.pumpAndSettle(); // wait for dialog to open
+
+      await tester.tap(find.text('Over the board'));
+      await tester.pumpAndSettle(); // wait for play menu to open
+      // Variant we set previously should be preselected
+      expect(find.text('Atomic'), findsOneWidget);
+    });
   });
 
   group('Analysis Tree View', () {

--- a/test/view/board_editor/board_editor_screen_test.dart
+++ b/test/view/board_editor/board_editor_screen_test.dart
@@ -428,6 +428,50 @@ void main() {
         'rnbqkbnr/pppppppp/8/8/8/3P4/PPPPPPPP/RNBPKBNR w KQkq - 0 1',
       );
     });
+
+    testWidgets('Continue against computer', (tester) async {
+      final app = await makeTestProviderScopeApp(tester, home: const BoardEditorScreen());
+      await tester.pumpWidget(app);
+
+      await tester.tap(find.bySemanticsLabel('Menu'));
+      await tester.pumpAndSettle(); // wait for menu to open
+      await tester.tap(find.text('Variant'));
+      await tester.pumpAndSettle(); // wait for variant selection dialog to open
+      await tester.tap(find.textContaining('Atomic'));
+      await tester.pumpAndSettle(); // wait for variant to change
+
+      await tester.tap(find.bySemanticsLabel('Menu'));
+      await tester.pumpAndSettle(); // wait for menu to open
+      await tester.tap(find.text('Continue from here'));
+      await tester.pumpAndSettle(); // wait for dialog to open
+
+      await tester.tap(find.text('Play against computer'));
+      await tester.pumpAndSettle(); // wait for play menu to open
+      // Variant we set previously should be preselected
+      expect(find.text('Atomic'), findsOneWidget);
+    });
+
+    testWidgets('Continue OTB', (tester) async {
+      final app = await makeTestProviderScopeApp(tester, home: const BoardEditorScreen());
+      await tester.pumpWidget(app);
+
+      await tester.tap(find.bySemanticsLabel('Menu'));
+      await tester.pumpAndSettle(); // wait for menu to open
+      await tester.tap(find.text('Variant'));
+      await tester.pumpAndSettle(); // wait for variant selection dialog to open
+      await tester.tap(find.textContaining('Atomic'));
+      await tester.pumpAndSettle(); // wait for variant to change
+
+      await tester.tap(find.bySemanticsLabel('Menu'));
+      await tester.pumpAndSettle(); // wait for menu to open
+      await tester.tap(find.text('Continue from here'));
+      await tester.pumpAndSettle(); // wait for dialog to open
+
+      await tester.tap(find.text('Over the board'));
+      await tester.pumpAndSettle(); // wait for over the board menu to open
+      // Variant we set previously should be preselected
+      expect(find.text('Atomic'), findsOneWidget);
+    });
   });
 }
 

--- a/test/view/offline_computer/offline_computer_game_screen_test.dart
+++ b/test/view/offline_computer/offline_computer_game_screen_test.dart
@@ -1132,6 +1132,38 @@ void main() {
       expect(gameState.game.meta.variant, Variant.standard);
       expect(gameState.game.initialFen, null);
     });
+
+    testWidgets('A given initial variant is selected by default', (tester) async {
+      final gameStorage = MockOfflineComputerGameStorage();
+      when(() => gameStorage.fetchGame()).thenAnswer((_) async => null);
+
+      late WidgetRef ref;
+
+      final app = await makeTestProviderScopeApp(
+        tester,
+        home: Consumer(
+          builder: (context, r, _) {
+            ref = r;
+            return const OfflineComputerGameScreen(initialVariant: Variant.atomic);
+          },
+        ),
+        overrides: {
+          offlineComputerGameStorageProvider: offlineComputerGameStorageProvider.overrideWith(
+            (_) => gameStorage,
+          ),
+        },
+      );
+      await tester.pumpWidget(app);
+      await tester.pumpAndSettle();
+
+      await selectSide(tester, Side.white);
+      await tester.tap(find.text('Play'));
+      await tester.pumpAndSettle();
+
+      final gameState = ref.read(offlineComputerGameControllerProvider);
+      expect(gameState.game.meta.variant, Variant.atomic);
+      expect(gameState.game.initialFen, null);
+    });
   });
 
   group('Practice comment card', () {

--- a/test/view/over_the_board/over_the_board_screen_test.dart
+++ b/test/view/over_the_board/over_the_board_screen_test.dart
@@ -543,7 +543,9 @@ void main() {
       expect(gameState.game.steps.first.position, Chess.initial);
     });
 
-    testWidgets('Rematch from custom position restarts from same FEN', (tester) async {
+    testWidgets('Rematch from custom position and variant restarts from same FEN and variant', (
+      tester,
+    ) async {
       final gameStorage = MockOverTheBoardGameStorage();
       when(() => gameStorage.fetchOngoingGame()).thenAnswer((_) async => null);
       when(
@@ -557,7 +559,7 @@ void main() {
 
       final app = await makeTestProviderScopeApp(
         tester,
-        home: const OverTheBoardScreen(initialFen: _customFen),
+        home: const OverTheBoardScreen(initialVariant: Variant.atomic, initialFen: _customFen),
         overrides: {
           overTheBoardGameStorageProvider: overTheBoardGameStorageProvider.overrideWith(
             (_) => gameStorage,
@@ -588,7 +590,7 @@ void main() {
 
       // Rematch should restart from the same custom FEN
       expect(gameState.game.initialFen, _customFen);
-      expect(gameState.game.meta.variant, Variant.fromPosition);
+      expect(gameState.game.meta.variant, Variant.atomic);
       expect(gameState.game.steps.length, 1);
       expect(find.byKey(const ValueKey('e4-whitepawn')), findsOneWidget);
       expect(find.byKey(const ValueKey('e5-blackpawn')), findsOneWidget);


### PR DESCRIPTION
When entering OTB or "play against computer" from the board editor or analysis board, preselect the variant that was set in board editor / analysis board

Before:

[before.webm](https://github.com/user-attachments/assets/1ec23798-a780-4efa-a9ac-a2c447d88b96)

After:

[after.webm](https://github.com/user-attachments/assets/62f4b93d-6023-4b3d-9b93-f668ea5f1c65)
