### PR TITLE
Added android:autoVerify="true" to AndroidManifest.xml

### DIFF
--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -53,7 +53,7 @@
                 <data android:pathSuffix=".pgn" />
             </intent-filter>
 
-            <intent-filter>
+            <intent-filter android:autoVerify="true">
                 <action android:name="android.intent.action.VIEW" />
                 <category android:name="android.intent.category.DEFAULT" />
                 <category android:name="android.intent.category.BROWSABLE" />


### PR DESCRIPTION
The certificate digests are already set up at lichess.org/.well-known/assetlinks.json, but the new Lichess app is not enabling "open in" links by default, see this related issue:

https://github.com/lichess-org/mobile/issues/2734