### PR TITLE
fix crash when playing illegal drop move while in check

### DIFF
--- a/lib/src/model/settings/board_preferences.dart
+++ b/lib/src/model/settings/board_preferences.dart
@@ -237,6 +237,7 @@ sealed class BoardPrefs with _$BoardPrefs implements Serializable {
       promotionMove: promotionMove,
       sideToMove: position.turn,
       validMoves: _makeLegalMoves(position, variant: variant, castlingMethod: castlingMethod),
+      validDropSquares: position.legalDrops.squares.toISet(),
       isCheck: boardHighlights && position.isCheck,
       canPromoteToKing: variant == Variant.antichess,
     );

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -14,7 +14,7 @@ dependencies:
   app_settings: ^7.0.0
   async: ^2.10.0
   auto_size_text: ^3.0.0
-  chessground: ^8.0.1
+  chessground: ^8.3.0
   clock: ^1.1.1
   collection: ^1.17.0
   connectivity_plus: ^7.0.0


### PR DESCRIPTION
needs https://github.com/lichess-org/flutter-chessground/pull/90

This would previously crash:

[drop.webm](https://github.com/user-attachments/assets/95bd6646-02d5-4325-bdb8-011fafacd0af)
