### PR TITLE
Fix crashes on some old 32-bit devices.

### DIFF
--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -9,8 +9,11 @@
         android:fullBackupContent="@xml/backup_rules">
 
         <meta-data
-          android:name="com.google.firebase.messaging.default_notification_icon"
-          android:resource="@drawable/ic_stat_lichess_notification" />
+          android:name="io.flutter.embedding.android.EnableImpeller"
+          android:value="false" />
+        <meta-data
+            android:name="com.google.firebase.messaging.default_notification_icon"
+            android:resource="@drawable/ic_stat_lichess_notification" />
         <meta-data
             android:name="firebase_messaging_auto_init_enabled"
             android:value="false" />


### PR DESCRIPTION
We'll disable impeller engine globally as long as we can, and as long as we support 32-bit devices.

Fixes #2676