### PR TITLE
feat: color game results in analysis board

### DIFF
--- a/lib/src/view/analysis/analysis_screen.dart
+++ b/lib/src/view/analysis/analysis_screen.dart
@@ -47,6 +47,16 @@ import 'package:lichess_mobile/src/widgets/variant_app_bar_title.dart';
 import 'package:logging/logging.dart';
 import 'package:share_plus/share_plus.dart';
 
+extension _AnalysisGameResultColor on AnalysisGameResult {
+  Color? colorFor(Side side, BuildContext context) => switch (this) {
+    AnalysisGameResult.whiteWins =>
+      side == Side.white ? context.lichessColors.good : context.lichessColors.error,
+    AnalysisGameResult.blackWins =>
+      side == Side.white ? context.lichessColors.error : context.lichessColors.good,
+    _ => null,
+  };
+}
+
 final _logger = Logger('AnalysisScreen');
 
 class AnalysisScreen extends StatelessWidget {
@@ -245,12 +255,14 @@ class _Body extends ConsumerWidget {
         clock: footerClock,
         isSideToMove: analysisState.currentPosition.turn == pov,
         result: result?.resultToString(pov),
+        resultColor: result?.colorFor(pov, context),
       );
       boardHeader = _PlayerWidget(
         player: headerPlayer,
         clock: headerClock,
         isSideToMove: analysisState.currentPosition.turn == pov.opposite,
         result: result?.resultToString(pov.opposite),
+        resultColor: result?.colorFor(pov.opposite, context),
       );
     } else if (options case Pgn()) {
       // PGN analysis - try to get player info from PGN headers
@@ -264,12 +276,17 @@ class _Body extends ConsumerWidget {
             : null;
 
         boardFooter = footerPlayer != null
-            ? _AnalysisPlayerWidget(player: footerPlayer, result: result?.resultToString(pov))
+            ? _AnalysisPlayerWidget(
+                player: footerPlayer,
+                result: result?.resultToString(pov),
+                resultColor: result?.colorFor(pov, context),
+              )
             : null;
         boardHeader = headerPlayer != null
             ? _AnalysisPlayerWidget(
                 player: headerPlayer,
                 result: result?.resultToString(pov.opposite),
+                resultColor: result?.colorFor(pov.opposite, context),
               )
             : null;
       }
@@ -334,11 +351,13 @@ class _PlayerWidget extends StatelessWidget {
     required this.clock,
     required this.isSideToMove,
     this.result,
+    this.resultColor,
   });
 
   final Player player;
   final Duration? clock;
   final String? result;
+  final Color? resultColor;
   final bool isSideToMove;
 
   @override
@@ -349,7 +368,10 @@ class _PlayerWidget extends StatelessWidget {
       child: Row(
         children: [
           if (result != null) ...[
-            Text(result!, style: const TextStyle(fontWeight: FontWeight.bold)),
+            Text(
+              result!,
+              style: TextStyle(fontWeight: FontWeight.bold, color: resultColor),
+            ),
             const SizedBox(width: 16.0),
           ],
           if (player.user != null)
@@ -664,10 +686,11 @@ class _BottomBar extends ConsumerWidget {
 
 /// Player widget for PGN imports, displaying analysis player info
 class _AnalysisPlayerWidget extends StatelessWidget {
-  const _AnalysisPlayerWidget({required this.player, this.result});
+  const _AnalysisPlayerWidget({required this.player, this.result, this.resultColor});
 
   final AnalysisPlayer player;
   final String? result;
+  final Color? resultColor;
 
   @override
   Widget build(BuildContext context) {
@@ -677,7 +700,10 @@ class _AnalysisPlayerWidget extends StatelessWidget {
       child: Row(
         children: [
           if (result != null) ...[
-            Text(result!, style: const TextStyle(fontWeight: .bold)),
+            Text(
+              result!,
+              style: TextStyle(fontWeight: .bold, color: resultColor),
+            ),
             const SizedBox(width: 16.0),
           ],
           if (player.title != null) ...[


### PR DESCRIPTION
## Summary

- Adds green/red coloring to win/loss results (1/0) next to player names in the analysis board, matching the broadcast style
- Wins show in green, losses in red, draws remain in the default color
- Applies to both archived game analysis and PGN import analysis

Closes #2745

<img width="386" height="781" alt="Screenshot 2026-03-12 at 08 28 59" src="https://github.com/user-attachments/assets/773304f3-0509-4c51-b66e-1bf88f50395b" />


## Test plan

- [x] `flutter analyze` — no issues
- [x] `dart format` — properly formatted
- [x] `flutter test test/view/analysis/analysis_screen_test.dart` — all 58 tests pass
- [x] Manual testing: open a completed game → analysis board → verify colored results next to player names