### PR TITLE
[WIP] feat: enable Crashlytics NDK native symbol upload

### DIFF
--- a/.github/workflows/deploy_play_store.yml
+++ b/.github/workflows/deploy_play_store.yml
@@ -69,5 +69,5 @@ jobs:
 
       - name: Install Firebase CLI
         run: curl -sL https://firebase.tools | bash
-      - name: Deploy symbols to Firebase Crashlytics
-        run: firebase --token="${{ secrets.FIREBASE_CI }}" crashlytics:symbols:upload --app="${{ secrets.FIREBASE_ANDROID_APP_ID }}" ./build/app/outputs/bundle/release/symbols
+      - name: Deploy debug symbols to Firebase Crashlytics
+        run: firebase --token="${{ secrets.FIREBASE_CI }}" crashlytics:symbols:upload --app="${{ secrets.FIREBASE_ANDROID_APP_ID }}" ./build/app/outputs/bundle/release/native-debug-symbols/native-debug-symbols.zip


### PR DESCRIPTION
## Summary

- Upload the `native-debug-symbols.zip` (which includes both native `.so` symbols and Dart `libapp.so` symbols) to Firebase Crashlytics, replacing the previous Dart-only symbols upload
- Enables symbolicated native crash reports for bundled libraries like `libflutter.so` and Stockfish
- The zip is already built by `add-debug-symbols.sh` and uploaded to Google Play Console, but was not being sent to Crashlytics

Closes #2752

## Test plan

- [ ] Verify the deploy workflow succeeds on next Play Store deployment
- [ ] Verify native crash symbols appear in the Firebase Crashlytics console