### PR TITLE
feat: add app version to About screen

### DIFF
--- a/lib/src/view/account/account_drawer.dart
+++ b/lib/src/view/account/account_drawer.dart
@@ -438,6 +438,10 @@ class AboutScreen extends ConsumerWidget {
               ),
             ],
           ),
+          Padding(
+            padding: Styles.bodySectionPadding,
+            child: Text('v${packageInfo.version}', style: TextTheme.of(context).bodySmall),
+          ),
         ],
       ),
     );


### PR DESCRIPTION
## Summary

- Display the app version at the bottom of the About screen, making it easier for users to find when reporting bugs
- Uses the same style as the existing version display in the Settings screen

Closes #2754

<img width="381" height="857" alt="image" src="https://github.com/user-attachments/assets/48762d02-7c89-41c2-bee2-f1c9f1e3d751" />

## Test plan

- [x] `flutter analyze` — no issues
- [x] `dart format` — properly formatted
- [x] Manual testing: open About screen → verify version is displayed at the bottom