### PR TITLE
fix: avoid race condition in retro controller analysis loading

### DIFF
--- a/lib/src/model/analysis/retro_controller.dart
+++ b/lib/src/model/analysis/retro_controller.dart
@@ -113,7 +113,23 @@ class RetroController extends AsyncNotifier<RetroState> with EngineEvaluationMix
     _root = _game.makeTree();
 
     if (_game.serverAnalysis == null) {
+      // Add listener before requesting analysis to avoid missing events
+      // that arrive between the request and listener registration.
+      serverAnalysisService.lastAnalysisEvent.addListener(_listenToServerAnalysisEvents);
+
       await serverAnalysisService.requestAnalysis(options.id);
+
+      // Check if analysis already completed (e.g. was requested from the
+      // analysis screen and finished before we started listening).
+      final existingEvent = serverAnalysisService.lastAnalysisEvent.value;
+      if (existingEvent != null &&
+          existingEvent.$1 == options.id &&
+          existingEvent.$2.isAnalysisComplete) {
+        ServerAnalysisService.mergeOngoingAnalysis(_root, existingEvent.$2.tree);
+        state = AsyncData(await _computeMistakes(options.initialSide));
+        requestEval();
+        return state.requireValue;
+      }
 
       _serverAnalysisCompleter.future.timeout(
         kMaxWaitForServerAnalysis,
@@ -147,8 +163,6 @@ class RetroController extends AsyncNotifier<RetroState> with EngineEvaluationMix
       );
 
       state = AsyncValue.data(retroState);
-
-      serverAnalysisService.lastAnalysisEvent.addListener(_listenToServerAnalysisEvents);
 
       return retroState;
     }


### PR DESCRIPTION
## Summary

Fixes #2750

"Learn from your mistakes" can get stuck loading due to a race condition in `RetroController.build()`:

1. The `lastAnalysisEvent` listener was registered **after** `requestAnalysis()` returned
2. If analysis completed quickly (e.g. already requested from the analysis screen), the completion event was missed
3. The controller would wait until the 1-minute timeout before showing an error

The fix:
- Register the listener **before** calling `requestAnalysis()` so no events are missed
- After the request, check if the analysis already completed (via the `ValueNotifier`'s current value) and process it immediately

## Test plan

- [ ] Open a finished game's analysis screen
- [ ] Request server analysis (if not already available)
- [ ] Tap "Learn from your mistakes" — should load without getting stuck
- [ ] Repeat several times rapidly switching between analysis and retro screens