### PR TITLE
feat: support clockTenths pref from the website

### DIFF
--- a/lib/src/model/account/account_preferences.dart
+++ b/lib/src/model/account/account_preferences.dart
@@ -19,6 +19,7 @@ typedef AccountPrefState = ({
   SubmitMove submitMove,
   // clock
   Moretime moretime,
+  ClockTenths clockTenths,
   BooleanPref clockSound,
   // privacy
   BooleanPref follow,
@@ -53,6 +54,7 @@ final defaultAccountPreferences = (
   autoThreefold: AutoThreefold.always,
   takeback: Takeback.always,
   moretime: Moretime.always,
+  clockTenths: ClockTenths.lessThan10s,
   clockSound: const BooleanPref(true),
   confirmResign: const BooleanPref(true),
   submitMove: SubmitMove({SubmitMoveChoice.correspondence}),
@@ -97,6 +99,7 @@ class AccountPreferences extends AsyncNotifier<AccountPrefState?> {
   Future<void> setAutoQueen(AutoQueen value) => _setPref('autoQueen', value);
   Future<void> setAutoThreefold(AutoThreefold value) => _setPref('autoThreefold', value);
   Future<void> setMoretime(Moretime value) => _setPref('moretime', value);
+  Future<void> setClockTenths(ClockTenths value) => _setPref('clockTenths', value);
   Future<void> setClockSound(BooleanPref value) => _setPref('clockSound', value);
   Future<void> setConfirmResign(BooleanPref value) => _setPref('confirmResign', value);
   Future<void> setSubmitMove(SubmitMove value) => _setPref('submitMove', value);
@@ -394,6 +397,44 @@ enum Moretime implements AccountPref<int> {
         return Moretime.always;
       default:
         throw Exception('Invalid value for Moretime');
+    }
+  }
+}
+
+enum ClockTenths implements AccountPref<int> {
+  never(0),
+  lessThan10s(1),
+  always(2);
+
+  const ClockTenths(this.value);
+
+  @override
+  final int value;
+
+  @override
+  String get toFormData => value.toString();
+
+  String label(AppLocalizations l10n) {
+    switch (this) {
+      case ClockTenths.never:
+        return l10n.never;
+      case ClockTenths.lessThan10s:
+        return l10n.preferencesWhenTimeRemainingLessThanTenSeconds;
+      case ClockTenths.always:
+        return l10n.always;
+    }
+  }
+
+  static ClockTenths fromInt(int value) {
+    switch (value) {
+      case 0:
+        return ClockTenths.never;
+      case 1:
+        return ClockTenths.lessThan10s;
+      case 2:
+        return ClockTenths.always;
+      default:
+        throw Exception('Invalid value for ClockTenths: $value');
     }
   }
 }

--- a/lib/src/model/account/account_repository.dart
+++ b/lib/src/model/account/account_repository.dart
@@ -96,6 +96,7 @@ AccountPrefState _accountPreferencesFromPick(RequiredPick pick) {
     autoThreefold: AutoThreefold.fromInt(pick('autoThreefold').asIntOrThrow()),
     takeback: Takeback.fromInt(pick('takeback').asIntOrThrow()),
     moretime: Moretime.fromInt(pick('moretime').asIntOrThrow()),
+    clockTenths: ClockTenths.fromInt(pick('clockTenths').asIntOrThrow()),
     clockSound: BooleanPref(pick('clockSound').asBoolOrThrow()),
     confirmResign: BooleanPref.fromInt(pick('confirmResign').asIntOrThrow()),
     submitMove: SubmitMove.fromInt(pick('submitMove').asIntOrThrow()),

--- a/lib/src/view/game/game_body.dart
+++ b/lib/src/view/game/game_body.dart
@@ -6,6 +6,7 @@ import 'package:dartchess/dartchess.dart';
 import 'package:flutter/cupertino.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:lichess_mobile/src/model/account/account_preferences.dart';
 import 'package:lichess_mobile/src/model/account/account_repository.dart';
 import 'package:lichess_mobile/src/model/account/ongoing_game.dart';
 import 'package:lichess_mobile/src/model/common/id.dart';
@@ -102,6 +103,9 @@ class GameBody extends ConsumerWidget {
     final boardPreferences = ref.watch(boardPreferencesProvider);
     final gamePrefs = ref.watch(gamePreferencesProvider);
     final blindfoldMode = gamePrefs.blindfoldMode ?? false;
+    final clockTenths = ref.watch(
+      accountPreferencesProvider.select((prefs) => prefs.value?.clockTenths),
+    );
 
     switch (ref.watch(ctrlProvider)) {
       case AsyncError(error: final e, stackTrace: final s):
@@ -159,6 +163,7 @@ class GameBody extends ConsumerWidget {
                         emergencyThreshold: youAre == Side.black
                             ? gameState.game.meta.clock?.emergency
                             : null,
+                        clockTenths: clockTenths,
                       );
                     },
                   ),
@@ -207,6 +212,7 @@ class GameBody extends ConsumerWidget {
                         emergencyThreshold: youAre == Side.white
                             ? gameState.game.meta.clock?.emergency
                             : null,
+                        clockTenths: clockTenths,
                       );
                     },
                   ),

--- a/lib/src/view/over_the_board/over_the_board_screen.dart
+++ b/lib/src/view/over_the_board/over_the_board_screen.dart
@@ -6,6 +6,7 @@ import 'package:dartchess/dartchess.dart';
 import 'package:flutter/cupertino.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:lichess_mobile/src/model/account/account_preferences.dart';
 import 'package:lichess_mobile/src/model/analysis/analysis_controller.dart';
 import 'package:lichess_mobile/src/model/common/chess.dart';
 import 'package:lichess_mobile/src/model/common/id.dart';
@@ -476,6 +477,9 @@ class _Player extends ConsumerWidget {
     final gameState = ref.watch(overTheBoardGameControllerProvider);
     final boardPreferences = ref.watch(boardPreferencesProvider);
     final clock = ref.watch(overTheBoardClockProvider);
+    final clockTenths = ref.watch(
+      accountPreferencesProvider.select((prefs) => prefs.value?.clockTenths),
+    );
 
     return GamePlayer(
       game: gameState.game,
@@ -494,6 +498,7 @@ class _Player extends ConsumerWidget {
               emergencyThreshold: Duration(
                 seconds: (clock.timeIncrement.time * 0.125).clamp(10, 60).toInt(),
               ),
+              clockTenths: clockTenths,
             ),
     );
   }

--- a/lib/src/view/settings/account_preferences_screen.dart
+++ b/lib/src/view/settings/account_preferences_screen.dart
@@ -260,6 +260,27 @@ class _AccountPreferencesScreenState extends ConsumerState<AccountPreferencesScr
                           );
                         },
                 ),
+                SettingsListTile(
+                  settingsLabel: Text(context.l10n.preferencesTenthsOfSeconds),
+                  settingsValue: data.clockTenths.label(context.l10n),
+                  onTap: () {
+                    showChoicePicker(
+                      context,
+                      choices: ClockTenths.values,
+                      selectedItem: data.clockTenths,
+                      labelBuilder: (t) => Text(t.label(context.l10n)),
+                      onSelectedItemChanged: isLoading
+                          ? null
+                          : (ClockTenths? value) {
+                              _setPref(
+                                () => ref
+                                    .read(accountPreferencesProvider.notifier)
+                                    .setClockTenths(value ?? data.clockTenths),
+                              );
+                            },
+                    );
+                  },
+                ),
               ],
             ),
             ListSection(

--- a/lib/src/view/watch/tv_screen.dart
+++ b/lib/src/view/watch/tv_screen.dart
@@ -2,6 +2,7 @@ import 'package:dartchess/dartchess.dart';
 import 'package:flutter/cupertino.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:lichess_mobile/src/model/account/account_preferences.dart';
 import 'package:lichess_mobile/src/model/common/id.dart';
 import 'package:lichess_mobile/src/model/game/game_board_params.dart';
 import 'package:lichess_mobile/src/model/tv/tv_channel.dart';
@@ -96,6 +97,9 @@ class _TvScreenState extends ConsumerState<TvScreen> {
                   data: (gameState) {
                     final game = gameState.game;
                     final position = gameState.game.positionAt(gameState.stepCursor);
+                    final clockTenths = ref.watch(
+                      accountPreferencesProvider.select((prefs) => prefs.value?.clockTenths),
+                    );
 
                     // If Stockfish is playing, user is null
                     final crosstable = game.white.user != null && game.black.user != null
@@ -125,6 +129,7 @@ class _TvScreenState extends ConsumerState<TvScreen> {
                                 return Clock(
                                   timeLeft: timeLeft,
                                   active: gameState.activeClockSide == Side.black,
+                                  clockTenths: clockTenths,
                                 );
                               },
                             )
@@ -146,6 +151,7 @@ class _TvScreenState extends ConsumerState<TvScreen> {
                                 return Clock(
                                   timeLeft: timeLeft,
                                   active: gameState.activeClockSide == Side.white,
+                                  clockTenths: clockTenths,
                                 );
                               },
                             )

--- a/lib/src/widgets/clock.dart
+++ b/lib/src/widgets/clock.dart
@@ -3,14 +3,13 @@ import 'dart:async';
 import 'package:clock/clock.dart';
 import 'package:flutter/material.dart';
 import 'package:lichess_mobile/src/constants.dart';
+import 'package:lichess_mobile/src/model/account/account_preferences.dart';
 import 'package:lichess_mobile/src/styles/styles.dart';
 import 'package:lichess_mobile/src/utils/screen.dart';
 
 const _kClockFontSize = 26.0;
 const _kClockTenthFontSize = 20.0;
 const _kClockHundredsFontSize = 18.0;
-
-const _showTenthsThreshold = Duration(seconds: 10);
 
 /// A stateless widget that displays the time left on the clock.
 ///
@@ -21,6 +20,7 @@ class Clock extends StatelessWidget {
     this.active = false,
     this.clockStyle,
     this.emergencyThreshold,
+    this.clockTenths,
     this.padLeft = false,
     this.padding = const EdgeInsets.symmetric(vertical: 3.0, horizontal: 5.0),
     super.key,
@@ -39,6 +39,8 @@ class Clock extends StatelessWidget {
   /// Clock style to use.
   final ClockStyle? clockStyle;
 
+  final ClockTenths? clockTenths;
+
   /// Whether to pad with a leading zero (default is `false`).
   final bool padLeft;
 
@@ -50,8 +52,13 @@ class Clock extends StatelessWidget {
     final hours = timeLeft.inHours;
     final mins = timeLeft.inMinutes.remainder(60);
     final secs = timeLeft.inSeconds.remainder(60).toString().padLeft(2, '0');
-    final showTenths = timeLeft < _showTenthsThreshold;
     final isEmergency = emergencyThreshold != null && timeLeft <= emergencyThreshold!;
+
+    final showTenths = switch (clockTenths) {
+      ClockTenths.never => false,
+      ClockTenths.lessThan10s || null => timeLeft < const Duration(seconds: 10),
+      ClockTenths.always => true,
+    };
 
     final hoursDisplay = padLeft ? hours.toString().padLeft(2, '0') : hours.toString();
     final minsDisplay = padLeft ? mins.toString().padLeft(2, '0') : mins.toString();

--- a/test/widgets/clock_test.dart
+++ b/test/widgets/clock_test.dart
@@ -1,6 +1,7 @@
 import 'package:clock/clock.dart' as clock;
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
+import 'package:lichess_mobile/src/model/account/account_preferences.dart';
 import 'package:lichess_mobile/src/widgets/clock.dart';
 
 void main() {
@@ -20,6 +21,42 @@ void main() {
       );
 
       expect(find.text('0:00.98', findRichText: true), findsOneWidget);
+    });
+
+    testWidgets('Show tenths according to pref', (WidgetTester tester) async {
+      await tester.pumpWidget(const MaterialApp(home: Clock(timeLeft: Duration(seconds: 11))));
+      expect(find.text('0:11', findRichText: true), findsOneWidget);
+
+      await tester.pumpWidget(const MaterialApp(home: Clock(timeLeft: Duration(seconds: 1))));
+      expect(find.text('0:01.0', findRichText: true), findsOneWidget);
+
+      await tester.pumpWidget(
+        const MaterialApp(
+          home: Clock(timeLeft: Duration(seconds: 11), clockTenths: ClockTenths.never),
+        ),
+      );
+      expect(find.text('0:11', findRichText: true), findsOneWidget);
+
+      await tester.pumpWidget(
+        const MaterialApp(
+          home: Clock(timeLeft: Duration(seconds: 1), clockTenths: ClockTenths.never),
+        ),
+      );
+      expect(find.text('0:01', findRichText: true), findsOneWidget);
+
+      await tester.pumpWidget(
+        const MaterialApp(
+          home: Clock(timeLeft: Duration(seconds: 11), clockTenths: ClockTenths.always),
+        ),
+      );
+      expect(find.text('0:11.0', findRichText: true), findsOneWidget);
+
+      await tester.pumpWidget(
+        const MaterialApp(
+          home: Clock(timeLeft: Duration(seconds: 1), clockTenths: ClockTenths.always),
+        ),
+      );
+      expect(find.text('0:01.0', findRichText: true), findsOneWidget);
     });
   });
 


### PR DESCRIPTION
The current behavior is to always show tenths below 10s, this PR uses the existing preference from account settings to also support "never" and "always".

Needs https://github.com/lichess-org/lila/pull/19799