### PR TITLE
Fix puzzle text label overflow problem

### DIFF
--- a/lib/src/view/puzzle/puzzle_tab_screen.dart
+++ b/lib/src/view/puzzle/puzzle_tab_screen.dart
@@ -448,11 +448,20 @@ class DailyPuzzle extends ConsumerWidget {
                   ),
                 ],
               ),
-              Icon(Icons.today, size: 32, color: context.lichessColors.brag.withValues(alpha: 0.7)),
-              Text(
-                data.puzzle.sideToMove == Side.white
-                    ? context.l10n.whitePlays
-                    : context.l10n.blackPlays,
+              Row(
+                children: [
+                  Icon(
+                    Icons.today,
+                    size: 32,
+                    color: context.lichessColors.brag.withValues(alpha: 0.7),
+                  ),
+                  const SizedBox(width: 8),
+                  Text(
+                    data.puzzle.sideToMove == Side.white
+                        ? context.l10n.whitePlays
+                        : context.l10n.blackPlays,
+                  ),
+                ],
               ),
             ],
           ),
@@ -581,22 +590,29 @@ class PuzzleAnglePreview extends ConsumerWidget {
                         ],
                       },
                     ),
-                    Icon(
-                      switch (angle) {
-                        PuzzleTheme(themeKey: final themeKey) => themeKey.icon,
-                        PuzzleOpening() => PuzzleIcons.opening,
-                      },
-                      size: 32,
-                      color: DefaultTextStyle.of(context).style.color?.withValues(alpha: 0.6),
+                    Row(
+                      children: [
+                        Icon(
+                          switch (angle) {
+                            PuzzleTheme(themeKey: final themeKey) => themeKey.icon,
+                            PuzzleOpening() => PuzzleIcons.opening,
+                          },
+                          size: 32,
+                          color: DefaultTextStyle.of(context).style.color?.withValues(alpha: 0.6),
+                        ),
+                        const SizedBox(width: 8),
+                        if (puzzle != null)
+                          Text(
+                            puzzle.puzzle.sideToMove == Side.white
+                                ? context.l10n.whitePlays
+                                : context.l10n.blackPlays,
+                          )
+                        else
+                          const Flexible(
+                            child: Text('No puzzles available, please go online to fetch them.'),
+                          ),
+                      ],
                     ),
-                    if (puzzle != null)
-                      Text(
-                        puzzle.puzzle.sideToMove == Side.white
-                            ? context.l10n.whitePlays
-                            : context.l10n.blackPlays,
-                      )
-                    else
-                      const Text('No puzzles available, please go online to fetch them.'),
                   ],
                 ),
                 onTap: puzzle != null ? onTap : null,


### PR DESCRIPTION
- Resolves https://github.com/lichess-org/mobile/issues/2707
- This PR slightly changes the current design by putting the _White/Black to play_ label on the same line as the icon. I think it looks better that way.

#### Before and after

<img width="2350" height="2200" alt="SCR-20260313-trzw-tile" src="https://github.com/user-attachments/assets/95772f82-26db-4584-9a65-a574aed5fe38" />
