### PR TITLE
fix: register socket listeners before awaiting first connection

### DIFF
--- a/lib/src/model/broadcast/broadcast_analysis_controller.dart
+++ b/lib/src/model/broadcast/broadcast_analysis_controller.dart
@@ -87,8 +87,6 @@ class BroadcastAnalysisController extends AsyncNotifier<BroadcastAnalysisState>
 
     _subscription = _socketClient.stream.listen(_handleSocketEvent);
 
-    await _socketClient.firstConnection;
-
     _socketOpenSubscription = _socketClient.connectedStream.listen((_) {
       if (state.value?.isNewOrOngoing == true) {
         _syncDebouncer(() {
@@ -96,6 +94,8 @@ class BroadcastAnalysisController extends AsyncNotifier<BroadcastAnalysisState>
         });
       }
     });
+
+    await _socketClient.firstConnection;
 
     _appLifecycleListener = AppLifecycleListener(
       onResume: () {

--- a/lib/src/model/broadcast/broadcast_round_controller.dart
+++ b/lib/src/model/broadcast/broadcast_round_controller.dart
@@ -62,8 +62,6 @@ class BroadcastRoundController extends AsyncNotifier<BroadcastRoundState> {
 
     _subscription = _socketClient.stream.listen(_handleSocketEvent);
 
-    await _socketClient.firstConnection;
-
     _socketOpenSubscription = _socketClient.connectedStream.listen((_) {
       if (ref.mounted && state.value?.round.status == RoundStatus.live) {
         _syncRoundDebouncer(() {
@@ -71,6 +69,8 @@ class BroadcastRoundController extends AsyncNotifier<BroadcastRoundState> {
         });
       }
     });
+
+    await _socketClient.firstConnection;
 
     _appLifecycleListener = AppLifecycleListener(
       onResume: () {

--- a/lib/src/model/tv/live_tv_channels.dart
+++ b/lib/src/model/tv/live_tv_channels.dart
@@ -53,9 +53,6 @@ class LiveTvChannels extends AsyncNotifier<LiveTvChannelsState> {
 
     _socketClient = ref.read(socketPoolProvider).open(Uri(path: kDefaultSocketRoute));
 
-    await _socketClient.firstConnection;
-    _socketWatch(repoGames);
-
     _socketReadySubscription?.cancel();
     _socketReadySubscription = _socketClient.connectedStream.listen((_) async {
       final repoGames = await ref.read(tvRepositoryProvider).channels();
@@ -64,6 +61,9 @@ class LiveTvChannels extends AsyncNotifier<LiveTvChannelsState> {
 
     _socketSubscription?.cancel();
     _socketSubscription = _socketClient.stream.listen(_handleSocketEvent);
+
+    await _socketClient.firstConnection;
+    _socketWatch(repoGames);
 
     return repoGames.map((channel, game) {
       return MapEntry(


### PR DESCRIPTION
## Summary

While investigating #2750 (fixed in #2756), we found the same race condition pattern in three other places: socket event listeners registered **after** `await _socketClient.firstConnection`, meaning reconnection events firing during the initial connection gap could be missed.

Affected controllers:
- `BroadcastRoundController` — `connectedStream.listen()` moved before `await firstConnection`
- `BroadcastAnalysisController` — same pattern
- `LiveTvChannels` — both `connectedStream.listen()` and `stream.listen()` moved before `await firstConnection`

The fix is the same in all cases: register listeners before awaiting, so no events are lost.

## Test plan

- [x] Open a broadcast round — should load and update normally
- [x] Open broadcast analysis — should load and update normally
- [x] Open TV channels — should load and update normally
- [ ] Verify reconnection after brief connectivity loss still triggers sync in all three views