### PR TITLE
fix: add request timeout to prevent indefinite loading

### DIFF
--- a/lib/src/network/http.dart
+++ b/lib/src/network/http.dart
@@ -332,6 +332,8 @@ class _RegisterCallbackClient extends BaseClient {
 class LichessClient implements Client {
   LichessClient(this._inner, this._ref);
 
+  static const defaultRequestTimeout = Duration(seconds: 15);
+
   final Ref _ref;
   final Client _inner;
 
@@ -353,7 +355,7 @@ class LichessClient implements Client {
     _logger.info('${request.method} ${request.url} ${request.headers['User-Agent']}');
 
     try {
-      final response = await _inner.send(request);
+      final response = await _inner.send(request).timeout(defaultRequestTimeout);
 
       _logIfError(response);
 


### PR DESCRIPTION
## Summary
- Adds a 15-second default timeout to all HTTP requests in `LichessClient.send()`
- Prevents screens from getting stuck in loading state when requests hang indefinitely (e.g. friends screen)

The timeout is applied at the `LichessClient` layer, so it covers all API requests without needing per-call configuration. The timeout is a `static const` that can be referenced if specific calls need to document why they override it.

## Test plan
- [x] All existing tests pass (743/743)
- [ ] Verify friends screen loads or shows error within 15 seconds on poor network
- [ ] Verify normal API calls are unaffected by the timeout

EDIT: (maintainer)
I removed the issue marked as fixed.