### PR TITLE
fix: retry HTTP requests on transient network errors and 5xx

### DIFF
--- a/lib/src/network/http.dart
+++ b/lib/src/network/http.dart
@@ -149,12 +149,14 @@ final defaultClientProvider = Provider<DefaultClient>((Ref ref) {
 /// Only one instance of this client is created and kept alive for the whole app.
 final lichessClientProvider = Provider<LichessClient>((Ref ref) {
   final client = LichessClient(
-    // Retry just once, after 500ms, on 429 Too Many Requests.
+    // Retry once after 500ms on rate-limiting, server errors, or transient
+    // network failures (socket errors, timeouts).
     RetryClient(
       ref.read(httpClientFactoryProvider)(),
       retries: 1,
       delay: _defaultDelay,
-      when: (response) => response.statusCode == 429,
+      when: (response) => response.statusCode == 429 || response.statusCode >= 500,
+      whenError: (error, _) => error is SocketException || error is TimeoutException,
     ),
     ref,
   );

--- a/test/network/http_test.dart
+++ b/test/network/http_test.dart
@@ -210,6 +210,106 @@ void main() {
       );
     });
 
+    test('retries once on SocketException then succeeds', () async {
+      int callCount = 0;
+      final retryClient = MockClient((request) async {
+        callCount++;
+        if (callCount == 1) {
+          throw const SocketException('no internet');
+        }
+        return http.Response('{"ok": true}', 200);
+      });
+      final container = await makeContainer(
+        overrides: {
+          httpClientFactoryProvider: httpClientFactoryProvider.overrideWith((ref) {
+            return FakeHttpClientFactory(() => retryClient);
+          }),
+        },
+      );
+      final client = container.read(lichessClientProvider);
+      fakeAsync((async) {
+        late http.Response response;
+        client.get(Uri(path: '/test')).then((r) => response = r);
+        async.flushTimers();
+        expect(response.statusCode, 200);
+        expect(callCount, 2);
+      });
+    });
+
+    test('retries once on 500 then succeeds', () async {
+      int callCount = 0;
+      final retryClient = MockClient((request) async {
+        callCount++;
+        if (callCount == 1) {
+          return http.Response('error', 500);
+        }
+        return http.Response('{"ok": true}', 200);
+      });
+      final container = await makeContainer(
+        overrides: {
+          httpClientFactoryProvider: httpClientFactoryProvider.overrideWith((ref) {
+            return FakeHttpClientFactory(() => retryClient);
+          }),
+        },
+      );
+      final client = container.read(lichessClientProvider);
+      fakeAsync((async) {
+        late http.Response response;
+        client.get(Uri(path: '/test')).then((r) => response = r);
+        async.flushTimers();
+        expect(response.statusCode, 200);
+        expect(callCount, 2);
+      });
+    });
+
+    test('does not retry on 4xx errors', () async {
+      int callCount = 0;
+      final retryClient = MockClient((request) async {
+        callCount++;
+        return http.Response('not found', 404);
+      });
+      final container = await makeContainer(
+        overrides: {
+          httpClientFactoryProvider: httpClientFactoryProvider.overrideWith((ref) {
+            return FakeHttpClientFactory(() => retryClient);
+          }),
+        },
+      );
+      final client = container.read(lichessClientProvider);
+      fakeAsync((async) {
+        late http.Response response;
+        client.get(Uri(path: '/test')).then((r) => response = r);
+        async.flushTimers();
+        expect(response.statusCode, 404);
+        expect(callCount, 1);
+      });
+    });
+
+    test('propagates SocketException after retry exhausted', () async {
+      int callCount = 0;
+      final retryClient = MockClient((request) {
+        callCount++;
+        throw const SocketException('no internet');
+      });
+      final container = await makeContainer(
+        overrides: {
+          httpClientFactoryProvider: httpClientFactoryProvider.overrideWith((ref) {
+            return FakeHttpClientFactory(() => retryClient);
+          }),
+        },
+      );
+      final client = container.read(lichessClientProvider);
+      fakeAsync((async) {
+        Object? caughtError;
+        client.get(Uri(path: '/test')).then((_) {}).catchError((Object e) {
+          caughtError = e;
+        });
+        async.flushTimers();
+        expect(caughtError, isA<SocketException>());
+        expect(callCount, 2);
+      });
+    });
+
     test('failed JSON parsing will throw ClientException', () async {
       final container = await makeContainer(
         overrides: {

--- a/test/test_provider_scope.dart
+++ b/test/test_provider_scope.dart
@@ -113,6 +113,14 @@ Future<Widget> makeOfflineTestProviderScope(
     httpClientFactoryProvider: httpClientFactoryProvider.overrideWith((ref) {
       return FakeHttpClientFactory(() => offlineClient);
     }),
+    // Override lichessClientProvider to bypass RetryClient, which would
+    // otherwise retry on SocketException and create pending timers in
+    // FakeAsync-based tests.
+    lichessClientProvider: lichessClientProvider.overrideWith((ref) {
+      final client = LichessClient(offlineClient, ref);
+      ref.onDispose(() => client.close());
+      return client;
+    }),
     ...?overrides,
   },
   authUser: authUser,


### PR DESCRIPTION
> **Depends on #2777** — review that PR first; this one adds one commit on top.

## Summary
- Extend `RetryClient` to retry once (after 500ms) on `SocketException`, `TimeoutException`, and 5xx server errors, in addition to the existing 429 retry
- Override `lichessClientProvider` in `makeOfflineTestProviderScope` so the offline mock (which throws `SocketException`) bypasses `RetryClient` and doesn't create pending timers in `FakeAsync`-based tests
- Add 4 dedicated unit tests for retry behavior using `fakeAsync` for instant execution

## Context
The offline test mock (`offlineClient`) throws `SocketException` on every request. Without the test fix, `RetryClient` would catch and retry these, creating delay timers that outlive `FakeAsync` and fail the test. The fix is to bypass `RetryClient` in offline tests — those tests verify UI behavior when the network is down, not retry logic. Retry is now tested separately.

## Test plan
- [x] All 747 tests pass (743 existing + 4 new)
- [x] No test time regression (31s, same as main)
- [x] New tests verify: retry on `SocketException`, retry on 5xx, no retry on 4xx, error propagation after retries exhausted