### PR TITLE
Revert "[WIP] feat: enable Crashlytics NDK native symbol upload"

### DIFF
--- a/.github/workflows/deploy_play_store.yml
+++ b/.github/workflows/deploy_play_store.yml
@@ -69,5 +69,5 @@ jobs:
 
       - name: Install Firebase CLI
         run: curl -sL https://firebase.tools | bash
-      - name: Deploy debug symbols to Firebase Crashlytics
-        run: firebase --token="${{ secrets.FIREBASE_CI }}" crashlytics:symbols:upload --app="${{ secrets.FIREBASE_ANDROID_APP_ID }}" ./build/app/outputs/bundle/release/native-debug-symbols/native-debug-symbols.zip
+      - name: Deploy symbols to Firebase Crashlytics
+        run: firebase --token="${{ secrets.FIREBASE_CI }}" crashlytics:symbols:upload --app="${{ secrets.FIREBASE_ANDROID_APP_ID }}" ./build/app/outputs/bundle/release/symbols


### PR DESCRIPTION
Reverts lichess-org/mobile#2753

CI fails:
https://github.com/lichess-org/mobile/actions/runs/23187797048/job/67375651562

cc @lacostej 