### PR TITLE
Clock low time warning animation

### DIFF
--- a/lib/src/view/clock/clock_tool_screen.dart
+++ b/lib/src/view/clock/clock_tool_screen.dart
@@ -183,7 +183,7 @@ class _ClockTileState extends ConsumerState<ClockTile> with SingleTickerProvider
     final clockStyle = ClockStyle(
       textColor: textColor,
       activeTextColor: Colors.white,
-      emergencyTextColor: Colors.white,
+      emergencyTextColor: Colors.white70,
       backgroundColor: Colors.transparent,
       activeBackgroundColor: Colors.transparent,
       emergencyBackgroundColor: Colors.transparent,


### PR DESCRIPTION
- Adds an animation when the clock reaches emergency threshold (already defined 10% of the time set)
- Already discussed in https://github.com/lichess-org/mobile/pull/2771
- Resolves https://github.com/lichess-org/mobile/issues/2738


#### Demo

##### Android

https://github.com/user-attachments/assets/47bf5508-41fb-4f45-9169-0d4fc5fd1ec5

##### iOS

https://github.com/user-attachments/assets/82a0dd6c-967d-45b4-98e1-d91647ff135a

