### PR TITLE
fix acpl touch

### DIFF
--- a/lib/src/widgets/acpl_chart.dart
+++ b/lib/src/widgets/acpl_chart.dart
@@ -64,7 +64,8 @@ class AcplChart extends StatelessWidget {
           child: LineChart(
             LineChartData(
               lineTouchData: LineTouchData(
-                enabled: false,
+                enabled: true,
+                handleBuiltInTouches: false,
                 touchCallback: (FlTouchEvent event, LineTouchResponse? touchResponse) {
                   if (event is FlTapUpEvent ||
                       event is FlPanUpdateEvent ||


### PR DESCRIPTION
closes #2793 

Was caused by a bug fix in the `fl_chart` package https://github.com/imaNNeo/fl_chart/issues/1676

Tested successfully on the broadcast and game analysis graph