### PR TITLE
Fix Layout Problem in the HTTP Logs Screen

### DIFF
--- a/lib/src/view/settings/http_log_screen.dart
+++ b/lib/src/view/settings/http_log_screen.dart
@@ -136,6 +136,13 @@ class _HttpLogListState extends ConsumerState<_HttpLogList> {
 
 final _logDateFormatter = DateFormat.yMd().add_Hms();
 
+String _formatElapsed(Duration elapsed) {
+  if (elapsed.inMilliseconds < 1000) {
+    return '${elapsed.inMilliseconds}ms';
+  }
+  return '${(elapsed.inMilliseconds / 1000).toStringAsFixed(1)}s';
+}
+
 class HttpLogTile extends StatelessWidget {
   const HttpLogTile({super.key, required this.httpLog});
 
@@ -167,7 +174,8 @@ class HttpLogTile extends StatelessWidget {
                   const SizedBox(height: 4),
                   if (httpLog.elapsed != null)
                     Text(
-                      '${httpLog.elapsed!.inMilliseconds}ms',
+                      _formatElapsed(httpLog.elapsed!),
+                      maxLines: 1,
                       style: TextStyle(
                         color: textShade(context, 0.7),
                         fontFeatures: const [FontFeature.tabularFigures()],


### PR DESCRIPTION
Two changes:

- maxLines: 1 — prevents the text from wrapping at all
- _formatElapsed() — formats durations ≥ 1000ms as "1.0s" instead of "1000ms", so longer values also stay short

#### Before & After

<img width="2350" height="2200" alt="SCR-20260319-tgqk-tile" src="https://github.com/user-attachments/assets/5a8df5a0-069b-4e45-abdd-fcd4cb0b5d0d" />

