### PR TITLE
Fix bottom overflow in the tournaments

### DIFF
--- a/lib/src/widgets/bottom_bar.dart
+++ b/lib/src/widgets/bottom_bar.dart
@@ -41,7 +41,7 @@ class BottomBar extends StatelessWidget {
             )
           : null,
       height: kBottomBarHeight,
-      padding: const EdgeInsets.symmetric(horizontal: 8.0, vertical: 6.0),
+      padding: const EdgeInsets.symmetric(horizontal: 8.0, vertical: 4.0),
       child: Row(
         mainAxisAlignment: mainAxisAlignment,
         children: expandChildren


### PR DESCRIPTION
- The overflow happened in `BottomBarButton` - its Column (icon + label text) at max text scale (`1.4×`) slightly exceeded the available height.
- I reduced vertical padding from `6.0` to `4.0`, giving `48px` of content height (which comfortably fits the icon + label).

#### Before & After

<img width="1222" height="1125" alt="SCR-20260320-qhon-tile" src="https://github.com/user-attachments/assets/a5a55deb-7b5b-4d54-9e5a-c4c406947314" />
