### PR TITLE
crazyhouse: fix premoves

### DIFF
--- a/lib/src/widgets/game_layout.dart
+++ b/lib/src/widgets/game_layout.dart
@@ -205,6 +205,10 @@ class _GameLayoutState extends ConsumerState<GameLayout> {
         };
 
         final pockets = widget.boardParams.pockets;
+        final premoveDropRole = switch (gameData?.premovable?.premove) {
+          DropMove(:final role) => role,
+          _ => null,
+        };
 
         Widget topTable({required double boardSize}) => RotatedBox(
           quarterTurns: widget.topTableUpsideDown ? 2 : 0,
@@ -222,6 +226,7 @@ class _GameLayoutState extends ConsumerState<GameLayout> {
                   pockets: pockets,
                   squareSize: pocketSquareSize(boardSize: boardSize, isTablet: isTablet),
                   isUpsideDown: widget.topTableUpsideDown,
+                  premoveDropRole: premoveDropRole,
                 ),
               widget.topTable,
             ],
@@ -245,6 +250,7 @@ class _GameLayoutState extends ConsumerState<GameLayout> {
                   pockets: pockets,
                   squareSize: pocketSquareSize(boardSize: boardSize, isTablet: isTablet),
                   isUpsideDown: widget.bottomTableUpsideDown,
+                  premoveDropRole: premoveDropRole,
                 ),
             ],
           ),

--- a/lib/src/widgets/pockets.dart
+++ b/lib/src/widgets/pockets.dart
@@ -14,6 +14,7 @@ class PocketsMenu extends ConsumerWidget {
     required this.playerSide,
     required this.squareSize,
     this.isUpsideDown = false,
+    this.premoveDropRole,
     this.pieceAssets,
   });
 
@@ -37,6 +38,9 @@ class PocketsMenu extends ConsumerWidget {
   /// This is used to also flip the drag feedback widget when dragging a piece onto the board.
   final bool isUpsideDown;
 
+  /// If non-null and [side] is the opposite of [sideToMove], the pocket with this role will be highlighted.
+  final Role? premoveDropRole;
+
   /// Optionally overrides pieces assets used to render the pieces in the pockets.
   ///
   /// If null, the piece assets from the current board preferences are used.
@@ -59,18 +63,31 @@ class PocketsMenu extends ConsumerWidget {
             children: Role.values
                 .where((role) => role != Role.king)
                 .map(
-                  (role) => _Pocket(
-                    count: pockets.of(side, role),
-                    role: role,
-                    interactive:
-                        side == sideToMove &&
-                        (playerSide == PlayerSide.both ||
-                            (playerSide == PlayerSide.white && side == Side.white) ||
-                            (playerSide == PlayerSide.black && side == Side.black)),
-                    side: side,
-                    squareSize: squareSize,
-                    pieceAssets: pieceAssets ?? boardPrefs.pieceSet.assets,
-                    isUpsideDown: isUpsideDown,
+                  (role) => Container(
+                    color: side == sideToMove?.opposite && premoveDropRole == role
+                        ? ref.watch(
+                            boardPreferencesProvider.select(
+                              (prefs) => prefs.boardTheme.colors.validPremoves,
+                            ),
+                          )
+                        : null,
+                    child: _Pocket(
+                      count: pockets.of(side, role),
+                      role: role,
+                      interactive: switch (playerSide) {
+                        PlayerSide.none => false,
+                        // If these are the pockets of the user, they are always interactive to allow premoves.
+                        PlayerSide.white => side == Side.white,
+                        PlayerSide.black => side == Side.black,
+                        // In OTB games, premoves are not possible, so pockets are only interactive if it's this player's turn.
+                        PlayerSide.both => side == sideToMove,
+                      },
+
+                      side: side,
+                      squareSize: squareSize,
+                      pieceAssets: pieceAssets ?? boardPrefs.pieceSet.assets,
+                      isUpsideDown: isUpsideDown,
+                    ),
                   ),
                 )
                 .toList(growable: false),

--- a/test/view/game/game_screen_test.dart
+++ b/test/view/game/game_screen_test.dart
@@ -340,6 +340,51 @@ void main() {
       expect(find.byKey(const Key('d4-whitepawn')), findsOneWidget);
     });
 
+    testWidgets('can premove drop moves in Crazyhouse', (WidgetTester tester) async {
+      const gameFullId = GameFullId('qVChCOTcHSeW');
+      final gameSocketUri = GameController.socketUri(gameFullId);
+
+      await createTestGame(
+        tester,
+        pgn: 'e4 d5 exd5',
+        variant: Variant.crazyhouse,
+        clock: const (
+          running: true,
+          initial: Duration(minutes: 1),
+          increment: Duration.zero,
+          white: Duration(seconds: 58),
+          black: Duration(seconds: 54),
+          emerg: Duration(seconds: 10),
+        ),
+        serverPrefs: const ServerGamePrefs(
+          showRatings: true,
+          enablePremove: true,
+          autoQueen: .always,
+          confirmResign: true,
+          submitMove: false,
+          zenMode: .no,
+        ),
+      );
+
+      await playDropMove(tester, Side.white, Role.pawn, 'a4');
+
+      // premove indicator should be visible
+      expect(find.byKey(const ValueKey('a4-premove')), findsOneWidget);
+
+      // opponent plays Qxd5
+      sendServerSocketMessages(gameSocketUri, [
+        '{"t": "move", "v": 1, "d": {"ply": 4, "uci": "d8d5", "san": "Qxd5", "clock": {"white": 57, "black": 52}}}',
+      ]);
+      await tester.pump();
+
+      // let the premove microtask run
+      await tester.pump(const Duration(milliseconds: 1));
+
+      // premove should have been played
+      expect(find.byKey(const ValueKey('a4-premove')), findsNothing);
+      expect(find.byKey(const Key('a4-whitepawn')), findsOneWidget);
+    });
+
     testWidgets('takeback', (WidgetTester tester) async {
       await createTestGame(
         tester,


### PR DESCRIPTION
Also, highlight the premoved piece in the pockets menu:

<img width="1080" height="2424" alt="Screenshot_1774005183" src="https://github.com/user-attachments/assets/d82016df-fe5e-43c9-bda8-96a6b2ec169d" />
