### PR TITLE
fix(play): prevent duplicate correspondence challenge submissions

### DIFF
--- a/lib/src/view/play/create_challenge_bottom_sheet.dart
+++ b/lib/src/view/play/create_challenge_bottom_sheet.dart
@@ -424,7 +424,8 @@ class _CreateChallengeBottomSheetState extends ConsumerState<CreateChallengeBott
                               }
                             : null,
                     },
-                    child: isWaitingForCorrespondenceChallenge &&
+                    child:
+                        isWaitingForCorrespondenceChallenge &&
                             (timeControl == ChallengeTimeControlType.correspondence ||
                                 timeControl == ChallengeTimeControlType.unlimited)
                         ? const ButtonLoadingIndicator()


### PR DESCRIPTION
Fixes #2815 

Improves correspondence challenge submission flow in create_challenge_bottom_sheet to make it safer and clearer for users.
- Adds explicit in-flight state to prevent duplicate correspondence/unlimited challenge submissions.
- Shows a loading indicator on the submit button while the challenge request is pending.
- Hardens async UI handling by capturing l10n/root context before await and using consistent success/error snackbars after the sheet closes.