### PR TITLE
fix: delay clock switch during OTB pawn promotion

### DIFF
--- a/lib/src/view/over_the_board/over_the_board_screen.dart
+++ b/lib/src/view/over_the_board/over_the_board_screen.dart
@@ -270,14 +270,25 @@ class _BodyState extends ConsumerState<_Body> {
                           : gameState.turn == Side.white
                           ? PlayerSide.white
                           : PlayerSide.black,
-                      onPromotionSelection: ref
-                          .read(overTheBoardGameControllerProvider.notifier)
-                          .onPromotionSelection,
+                      onPromotionSelection: (role) {
+                        ref
+                            .read(overTheBoardGameControllerProvider.notifier)
+                            .onPromotionSelection(role);
+                        if (role != null) {
+                          ref
+                              .read(overTheBoardClockProvider.notifier)
+                              .onMove(newSideToMove: gameState.turn.opposite);
+                        }
+                      },
                       promotionMove: gameState.promotionMove,
                       onMove: (move, {viaDragAndDrop}) {
-                        ref
-                            .read(overTheBoardClockProvider.notifier)
-                            .onMove(newSideToMove: gameState.turn.opposite);
+                        final isPromotion = move is NormalMove &&
+                            isPromotionPawnMove(gameState.currentPosition, move);
+                        if (!isPromotion) {
+                          ref
+                              .read(overTheBoardClockProvider.notifier)
+                              .onMove(newSideToMove: gameState.turn.opposite);
+                        }
                         ref.read(overTheBoardGameControllerProvider.notifier).makeMove(move);
                       },
                       premovable: null,


### PR DESCRIPTION
## Summary

Fixes the OTB clock switching to the opponent immediately when a pawn reaches the promotion square, before the player selects a piece.

## Why this matters

In timed OTB games, the opponent's clock runs while the promoting player is choosing a piece. This is unfair - the promoting player should keep their clock running until they complete the promotion selection.

## Changes

`lib/src/view/over_the_board/over_the_board_screen.dart`:

- `onMove`: Check `isPromotionPawnMove()` before switching the clock. Skip the clock switch for promotion moves so the promoting player's clock keeps running.
- `onPromotionSelection`: Switch the clock after the player selects a promotion piece. Only switches when `role != null` (player made a selection, not cancelled).

The controller's `makeMove` already handles promotion detection correctly (returning early at line 67-70 of `over_the_board_game_controller.dart`) - the bug was that the view layer switched the clock unconditionally before checking if the move was complete.

## Testing

Reproduced the bug using the steps from the issue: start an OTB game with clock, push a pawn to the last rank, observe that the clock now stays on the promoting player until they select a piece.

Fixes #2819

This contribution was developed with AI assistance (Claude Code).