### PR TITLE
Enable access to analysis board during casual and practice games against computer #2823

### DIFF
--- a/lib/src/view/offline_computer/offline_computer_game_screen.dart
+++ b/lib/src/view/offline_computer/offline_computer_game_screen.dart
@@ -394,7 +394,7 @@ class _BottomBar extends ConsumerWidget {
             ref.read(_isBoardFlippedProvider.notifier).toggle();
           },
         ),
-        if (gameState.game.finished)
+        if (gameState.game.finished || gameState.game.casual || gameState.game.practiceMode)
           BottomSheetAction(
             makeLabel: (context) => Text(context.l10n.analysis),
             onPressed: () => Navigator.of(context).push(


### PR DESCRIPTION
user can now access the analysis board during game in casual and practice mode against stockfish.