### PR TITLE
fix incorrect circle color in  Tournament Player Details

### DIFF
--- a/lib/src/view/broadcast/broadcast_player_results_screen.dart
+++ b/lib/src/view/broadcast/broadcast_player_results_screen.dart
@@ -17,6 +17,7 @@ import 'package:lichess_mobile/src/view/broadcast/broadcast_player_widget.dart';
 import 'package:lichess_mobile/src/widgets/network_image.dart';
 import 'package:lichess_mobile/src/widgets/platform.dart';
 import 'package:lichess_mobile/src/widgets/progression_widget.dart';
+import 'package:lichess_mobile/src/widgets/side_indicator.dart';
 import 'package:lichess_mobile/src/widgets/stat_card.dart';
 
 final broadcastTournamentIdProvider = FutureProvider.autoDispose
@@ -495,33 +496,16 @@ class _GameResultListTile extends StatelessWidget {
             )
           : null,
       trailing: SizedBox(
-        width: showTCIcon ? 72 : 60,
+        width: showTCIcon ? 75 : 60,
         child: Row(
           mainAxisSize: .min,
           mainAxisAlignment: .center,
           children: [
             SizedBox(
               width: 30,
-              child: Center(
-                child: Container(
-                  width: 15,
-                  height: 15,
-                  decoration: BoxDecoration(
-                    border:
-                        (Theme.of(context).brightness == .light && color == .white ||
-                            Theme.of(context).brightness == .dark && color == .black)
-                        ? Border.all(width: 2.0, color: ColorScheme.of(context).outline)
-                        : null,
-                    shape: .circle,
-                    color: switch (color) {
-                      .white => Colors.white.withValues(alpha: 0.9),
-                      .black => Colors.black.withValues(alpha: 0.9),
-                    },
-                  ),
-                ),
-              ),
+              child: Center(child: SideIndicator(side: color, size: 15)),
             ),
-            if (showTCIcon) SizedBox(width: 12, child: Icon(fideTC.icon, size: 15)),
+            if (showTCIcon) Icon(fideTC.icon, size: 15),
             SizedBox(
               width: 30,
               child: Column(

--- a/lib/src/view/tournament/tournament_screen.dart
+++ b/lib/src/view/tournament/tournament_screen.dart
@@ -44,6 +44,7 @@ import 'package:lichess_mobile/src/widgets/feedback.dart';
 import 'package:lichess_mobile/src/widgets/misc.dart';
 import 'package:lichess_mobile/src/widgets/network_image.dart';
 import 'package:lichess_mobile/src/widgets/platform.dart';
+import 'package:lichess_mobile/src/widgets/side_indicator.dart';
 import 'package:lichess_mobile/src/widgets/user.dart';
 import 'package:path_provider/path_provider.dart' show getTemporaryDirectory;
 import 'package:share_plus/share_plus.dart';
@@ -1492,7 +1493,7 @@ class _PairingTile extends ConsumerWidget {
               padding: EdgeInsets.only(right: 8.0),
               child: Icon(LichessIcons.body_cut, size: 20),
             ),
-          Icon(pairing.color == Side.white ? Icons.circle : Icons.circle_outlined, size: 20),
+          SideIndicator(side: pairing.color, size: 20),
           SizedBox(
             width: 24,
             height: 24,

--- a/lib/src/view/tournament/tournament_screen.dart
+++ b/lib/src/view/tournament/tournament_screen.dart
@@ -1492,7 +1492,7 @@ class _PairingTile extends ConsumerWidget {
               padding: EdgeInsets.only(right: 8.0),
               child: Icon(LichessIcons.body_cut, size: 20),
             ),
-          Icon(pairing.color == Side.white ? Icons.circle_outlined : Icons.circle, size: 20),
+          Icon(pairing.color == Side.white ? Icons.circle : Icons.circle_outlined, size: 20),
           SizedBox(
             width: 24,
             height: 24,

--- a/lib/src/widgets/side_indicator.dart
+++ b/lib/src/widgets/side_indicator.dart
@@ -1,0 +1,18 @@
+import 'package:dartchess/dartchess.dart';
+import 'package:flutter/material.dart';
+
+//Widget to indicate the side of the player based on the current theme.
+class SideIndicator extends StatelessWidget {
+  const SideIndicator({super.key, required this.side, required this.size});
+
+  final Side side;
+  final double size;
+
+  @override
+  Widget build(BuildContext context) {
+    final isLight = Theme.of(context).brightness == Brightness.light;
+    return isLight
+        ? Icon(side == .white ? Icons.circle_outlined : Icons.circle, size: size)
+        : Icon(side == .white ? Icons.circle : Icons.circle_outlined, size: size);
+  }
+}


### PR DESCRIPTION
The color of the circle indicating the color the player had in the game was swapped. Reported here: https://lichess.org/forum/community-blog-discussions/ublog-VGPcQtN3?page=5#DPksKbS9
Created a new side indicator widget and also used it in the `broadcast_player_results_screen.dart‎ `.

dark mode: 

<img width="1080" height="2400" alt="image" src="https://github.com/user-attachments/assets/433ccced-733f-4f52-a2c6-dcb3378e006a" />

light mode:

<img width="1080" height="2400" alt="image" src="https://github.com/user-attachments/assets/26cb581a-fe3e-45f4-bdd8-5c106e1bd640" />

