### PR TITLE
Fix/retro reuse existing analysis

### DIFF
--- a/lib/src/model/analysis/retro_controller.dart
+++ b/lib/src/model/analysis/retro_controller.dart
@@ -79,7 +79,8 @@ final retroControllerProvider = AsyncNotifierProvider.autoDispose
       name: 'RetroControllerProvider',
     );
 
-class RetroController extends AsyncNotifier<RetroState> with EngineEvaluationMixin {
+class RetroController extends AsyncNotifier<RetroState>
+    with EngineEvaluationMixin {
   RetroController(this.options);
 
   final RetroOptions options;
@@ -103,10 +104,14 @@ class RetroController extends AsyncNotifier<RetroState> with EngineEvaluationMix
     final serverAnalysisService = ref.watch(serverAnalysisServiceProvider);
 
     ref.onDispose(() {
-      serverAnalysisService.lastAnalysisEvent.removeListener(_listenToServerAnalysisEvents);
+      serverAnalysisService.lastAnalysisEvent.removeListener(
+        _listenToServerAnalysisEvents,
+      );
     });
 
-    socketClient = ref.watch(socketPoolProvider).open(AnalysisController.socketUri);
+    socketClient = ref
+        .watch(socketPoolProvider)
+        .open(AnalysisController.socketUri);
 
     _game = await ref.watch(archivedGameProvider(options.id).future);
 
@@ -135,15 +140,21 @@ class RetroController extends AsyncNotifier<RetroState> with EngineEvaluationMix
 
       // Attach listener BEFORE possibly requesting analysis,
       // so we don't miss the first progress event.
-      serverAnalysisService.lastAnalysisEvent.addListener(_listenToServerAnalysisEvents);
+      serverAnalysisService.lastAnalysisEvent.addListener(
+        _listenToServerAnalysisEvents,
+      );
 
       // Reuse an already available event immediately if it belongs to this game.
       final existingEvent = serverAnalysisService.lastAnalysisEvent.value;
       if (existingEvent != null && existingEvent.$1 == options.id) {
-        ServerAnalysisService.mergeOngoingAnalysis(_root, existingEvent.$2.tree);
+        ServerAnalysisService.mergeOngoingAnalysis(
+          _root,
+          existingEvent.$2.tree,
+        );
 
         final progress =
-            existingEvent.$2.evals.where((e) => e.hasEval).length / _root.mainline.length;
+            existingEvent.$2.evals.where((e) => e.hasEval).length /
+            _root.mainline.length;
 
         state = AsyncValue.data(
           state.requireValue.copyWith(serverAnalysisProgress: progress),
@@ -177,7 +188,9 @@ class RetroController extends AsyncNotifier<RetroState> with EngineEvaluationMix
               'Server analysis did not finish within $kMaxWaitForServerAnalysis for game ${options.id}',
             );
             state = AsyncError(
-              Exception('Server analysis did not finish within $kMaxWaitForServerAnalysis'),
+              Exception(
+                'Server analysis did not finish within $kMaxWaitForServerAnalysis',
+              ),
               StackTrace.current,
             );
           },
@@ -211,9 +224,11 @@ class RetroController extends AsyncNotifier<RetroState> with EngineEvaluationMix
         }
 
         final bigEvalSwing =
-            Eval.winningChancesPovDiff(side, eval, newEval).abs() > _kEvalSwingThreshold;
+            Eval.winningChancesPovDiff(side, eval, newEval).abs() >
+            _kEvalSwingThreshold;
 
-        final lostEasyMate = eval.mate != null && newEval.mate == null && eval.mate!.abs() <= 3;
+        final lostEasyMate =
+            eval.mate != null && newEval.mate == null && eval.mate!.abs() <= 3;
 
         final hasSolution = branch.children.length > 1;
 
@@ -226,7 +241,10 @@ class RetroController extends AsyncNotifier<RetroState> with EngineEvaluationMix
           try {
             final entry = await ref
                 .read(openingExplorerRepositoryProvider)
-                .getMasterDatabase(branch.position.fen, since: MasterDb.kEarliestYear);
+                .getMasterDatabase(
+                  branch.position.fen,
+                  since: MasterDb.kEarliestYear,
+                );
 
             final masterMovesPlayedMoreThanOnce = entry.moves.where(
               (move) => move.white + move.draws + move.black > 1,
@@ -250,7 +268,10 @@ class RetroController extends AsyncNotifier<RetroState> with EngineEvaluationMix
           }
         }
 
-        return Mistake(branch: branch.view, openingExplorerSolutions: openingExplorerSolutions);
+        return Mistake(
+          branch: branch.view,
+          openingExplorerSolutions: openingExplorerSolutions,
+        );
       }),
     )).nonNulls.toIList();
 
@@ -258,10 +279,14 @@ class RetroController extends AsyncNotifier<RetroState> with EngineEvaluationMix
       serverAnalysisAvailable: true,
       mistakes: mistakes.toIList(),
       currentMistakeIndex: 0,
-      feedback: mistakes.isNotEmpty ? RetroFeedback.findMove : RetroFeedback.done,
+      feedback: mistakes.isNotEmpty
+          ? RetroFeedback.findMove
+          : RetroFeedback.done,
       mainlinePath: _root.mainlinePath,
       pov: side,
-      currentNode: RetroCurrentNode.fromNode(mistakes.firstOrNull?.branch.branch ?? _root),
+      currentNode: RetroCurrentNode.fromNode(
+        mistakes.firstOrNull?.branch.branch ?? _root,
+      ),
       lastMove: mistakes.firstOrNull?.branch.sanMove.move,
       variant: _game.meta.variant,
       root: _root.view,
@@ -279,12 +304,16 @@ class RetroController extends AsyncNotifier<RetroState> with EngineEvaluationMix
   void onUserMove(Move move) {
     if (!state.requireValue.currentPosition.isLegal(move)) return;
 
-    if (move case NormalMove() when isPromotionPawnMove(state.requireValue.currentPosition, move)) {
+    if (move case NormalMove()
+        when isPromotionPawnMove(state.requireValue.currentPosition, move)) {
       state = AsyncValue.data(state.requireValue.copyWith(promotionMove: move));
       return;
     }
 
-    final (newPath, isNewNode) = _root.addMoveAt(state.requireValue.currentPath, move);
+    final (newPath, isNewNode) = _root.addMoveAt(
+      state.requireValue.currentPath,
+      move,
+    );
     if (newPath != null) {
       _setPath(newPath);
     }
@@ -321,12 +350,16 @@ class RetroController extends AsyncNotifier<RetroState> with EngineEvaluationMix
     final currentMistake = state.value?.currentMistake;
     if (currentMistake != null) {
       onUserMove(currentMistake.serverMove);
-      state = AsyncValue.data(state.requireValue.copyWith(feedback: RetroFeedback.viewingSolution));
+      state = AsyncValue.data(
+        state.requireValue.copyWith(feedback: RetroFeedback.viewingSolution),
+      );
     }
   }
 
   Future<void> flipSide() async {
-    state = AsyncValue.data(await _computeMistakes(state.requireValue.pov.opposite));
+    state = AsyncValue.data(
+      await _computeMistakes(state.requireValue.pov.opposite),
+    );
   }
 
   void restart() {
@@ -343,7 +376,9 @@ class RetroController extends AsyncNotifier<RetroState> with EngineEvaluationMix
 
     _setPath(
       _root.mainlinePath.truncate(
-        mistake?.branch.position.ply ?? lastMistake?.branch.position.ply ?? _root.mainlinePath.size,
+        mistake?.branch.position.ply ??
+            lastMistake?.branch.position.ply ??
+            _root.mainlinePath.size,
       ),
     );
 
@@ -376,7 +411,9 @@ class RetroController extends AsyncNotifier<RetroState> with EngineEvaluationMix
       if (!isNavigating && isForward) {
         final isCheck = currentNode.sanMove.isCheck;
         if (currentNode.sanMove.isCapture) {
-          ref.read(moveFeedbackServiceProvider).captureFeedback(state.variant, check: isCheck);
+          ref
+              .read(moveFeedbackServiceProvider)
+              .captureFeedback(state.variant, check: isCheck);
         } else {
           ref.read(moveFeedbackServiceProvider).moveFeedback(check: isCheck);
         }
@@ -413,7 +450,9 @@ class RetroController extends AsyncNotifier<RetroState> with EngineEvaluationMix
     }
 
     if (pathChange) {
-      this.state = AsyncValue.data(this.state.requireValue.copyWith(engineInThreatMode: false));
+      this.state = AsyncValue.data(
+        this.state.requireValue.copyWith(engineInThreatMode: false),
+      );
       requestEval();
     }
 
@@ -421,12 +460,16 @@ class RetroController extends AsyncNotifier<RetroState> with EngineEvaluationMix
   }
 
   void _onIncorrectMove() {
-    state = AsyncValue.data(state.requireValue.copyWith(feedback: RetroFeedback.incorrect));
+    state = AsyncValue.data(
+      state.requireValue.copyWith(feedback: RetroFeedback.incorrect),
+    );
     userPrevious();
   }
 
   void _onCorrectMove() {
-    state = AsyncValue.data(state.requireValue.copyWith(feedback: RetroFeedback.correct));
+    state = AsyncValue.data(
+      state.requireValue.copyWith(feedback: RetroFeedback.correct),
+    );
   }
 
   @override
@@ -462,7 +505,9 @@ class RetroController extends AsyncNotifier<RetroState> with EngineEvaluationMix
   void _refreshCurrentNode({bool recomputeRootView = false}) {
     state = AsyncData(
       state.requireValue.copyWith(
-        currentNode: RetroCurrentNode.fromNode(_root.nodeAt(state.requireValue.currentPath)),
+        currentNode: RetroCurrentNode.fromNode(
+          _root.nodeAt(state.requireValue.currentPath),
+        ),
       ),
     );
   }
@@ -472,16 +517,21 @@ class RetroController extends AsyncNotifier<RetroState> with EngineEvaluationMix
     switch (state.feedback) {
       case RetroFeedback.incorrect:
       case RetroFeedback.findMove:
-        if (state.currentPosition.ply == state.currentMistake!.serverBranch.position.ply) {
+        if (state.currentPosition.ply ==
+            state.currentMistake!.serverBranch.position.ply) {
           if (state.currentMistake!.isSolution(state.currentNode)) {
             _onCorrectMove();
-          } else if (state.currentPosition == state.currentMistake!.userBranch.position) {
+          } else if (state.currentPosition ==
+              state.currentMistake!.userBranch.position) {
             Timer(const Duration(milliseconds: 500), () {
               _onIncorrectMove();
             });
           } else {
             this.state = AsyncValue.data(
-              state.copyWith(feedback: RetroFeedback.evalMove, evalRequestedAt: DateTime.now()),
+              state.copyWith(
+                feedback: RetroFeedback.evalMove,
+                evalRequestedAt: DateTime.now(),
+              ),
             );
             // Be sure to get enough depth to evaluate the move properly
             requestEval(goDeeper: true);
@@ -494,11 +544,17 @@ class RetroController extends AsyncNotifier<RetroState> with EngineEvaluationMix
   Future<void> _listenToServerAnalysisEvents() async {
     if (!state.hasValue) return;
 
-    final event = ref.read(serverAnalysisServiceProvider).lastAnalysisEvent.value;
+    final event = ref
+        .read(serverAnalysisServiceProvider)
+        .lastAnalysisEvent
+        .value;
     if (event != null && event.$1 == options.id) {
       ServerAnalysisService.mergeOngoingAnalysis(_root, event.$2.tree);
-      final progress = event.$2.evals.where((e) => e.hasEval).length / _root.mainline.length;
-      state = AsyncValue.data(state.requireValue.copyWith(serverAnalysisProgress: progress));
+      final progress =
+          event.$2.evals.where((e) => e.hasEval).length / _root.mainline.length;
+      state = AsyncValue.data(
+        state.requireValue.copyWith(serverAnalysisProgress: progress),
+      );
 
       if (event.$2.isAnalysisComplete) {
         if (_serverAnalysisCompleter.isCompleted == false) {
@@ -511,7 +567,14 @@ class RetroController extends AsyncNotifier<RetroState> with EngineEvaluationMix
   }
 }
 
-enum RetroFeedback { findMove, evalMove, correct, incorrect, viewingSolution, done }
+enum RetroFeedback {
+  findMove,
+  evalMove,
+  correct,
+  incorrect,
+  viewingSolution,
+  done,
+}
 
 @freezed
 sealed class RetroState
@@ -552,10 +615,12 @@ sealed class RetroState
       feedback == RetroFeedback.incorrect ||
       feedback == RetroFeedback.evalMove;
 
-  Duration? get evalTime =>
-      evalRequestedAt != null ? DateTime.now().difference(evalRequestedAt!) : null;
+  Duration? get evalTime => evalRequestedAt != null
+      ? DateTime.now().difference(evalRequestedAt!)
+      : null;
 
-  double get evalProgress => feedback == RetroFeedback.evalMove && currentNode.eval != null
+  double get evalProgress =>
+      feedback == RetroFeedback.evalMove && currentNode.eval != null
       ? min(1.0, currentNode.eval!.depth / _kEvalDepthThreshold)
       : 0.0;
 
@@ -586,7 +651,9 @@ sealed class RetroState
 }
 
 @freezed
-sealed class RetroCurrentNode with _$RetroCurrentNode implements AnalysisCurrentNodeInterface {
+sealed class RetroCurrentNode
+    with _$RetroCurrentNode
+    implements AnalysisCurrentNodeInterface {
   const RetroCurrentNode._();
 
   const factory RetroCurrentNode({

--- a/lib/src/model/analysis/retro_controller.dart
+++ b/lib/src/model/analysis/retro_controller.dart
@@ -113,21 +113,6 @@ class RetroController extends AsyncNotifier<RetroState> with EngineEvaluationMix
     _root = _game.makeTree();
 
     if (_game.serverAnalysis == null) {
-      await serverAnalysisService.requestAnalysis(options.id);
-
-      _serverAnalysisCompleter.future.timeout(
-        kMaxWaitForServerAnalysis,
-        onTimeout: () {
-          _logger.warning(
-            'Server analysis did not finish within $kMaxWaitForServerAnalysis for game ${options.id}',
-          );
-          state = AsyncError(
-            Exception('Server analysis did not finish within $kMaxWaitForServerAnalysis'),
-            StackTrace.current,
-          );
-        },
-      );
-
       final retroState = RetroState(
         serverAnalysisAvailable: false,
         mistakes: const IList.empty(),
@@ -148,9 +133,58 @@ class RetroController extends AsyncNotifier<RetroState> with EngineEvaluationMix
 
       state = AsyncValue.data(retroState);
 
+      // Attach listener BEFORE possibly requesting analysis,
+      // so we don't miss the first progress event.
       serverAnalysisService.lastAnalysisEvent.addListener(_listenToServerAnalysisEvents);
 
-      return retroState;
+      // Reuse an already available event immediately if it belongs to this game.
+      final existingEvent = serverAnalysisService.lastAnalysisEvent.value;
+      if (existingEvent != null && existingEvent.$1 == options.id) {
+        ServerAnalysisService.mergeOngoingAnalysis(_root, existingEvent.$2.tree);
+
+        final progress =
+            existingEvent.$2.evals.where((e) => e.hasEval).length / _root.mainline.length;
+
+        state = AsyncValue.data(
+          state.requireValue.copyWith(serverAnalysisProgress: progress),
+        );
+
+        if (existingEvent.$2.isAnalysisComplete) {
+          if (!_serverAnalysisCompleter.isCompleted) {
+            _serverAnalysisCompleter.complete();
+          }
+
+          state = AsyncData(await _computeMistakes(options.initialSide));
+
+          socketClient.firstConnection.then((_) {
+            requestEval();
+          });
+
+          return state.requireValue;
+        }
+      }
+
+      // Only request analysis if this exact game is not already being analyzed.
+      if (serverAnalysisService.currentAnalysis.value != options.id) {
+        await serverAnalysisService.requestAnalysis(options.id);
+      }
+
+      unawaited(
+        _serverAnalysisCompleter.future.timeout(
+          kMaxWaitForServerAnalysis,
+          onTimeout: () {
+            _logger.warning(
+              'Server analysis did not finish within $kMaxWaitForServerAnalysis for game ${options.id}',
+            );
+            state = AsyncError(
+              Exception('Server analysis did not finish within $kMaxWaitForServerAnalysis'),
+              StackTrace.current,
+            );
+          },
+        ),
+      );
+
+      return state.requireValue;
     }
 
     state = AsyncData(await _computeMistakes(options.initialSide));

--- a/lib/src/model/analysis/server_analysis_service.dart
+++ b/lib/src/model/analysis/server_analysis_service.dart
@@ -19,7 +19,9 @@ import 'package:lichess_mobile/src/network/socket.dart';
 const Duration kMaxWaitForServerAnalysis = Duration(minutes: 1);
 
 /// A provider for [ServerAnalysisService].
-final serverAnalysisServiceProvider = Provider<ServerAnalysisService>((Ref ref) {
+final serverAnalysisServiceProvider = Provider<ServerAnalysisService>((
+  Ref ref,
+) {
   return ServerAnalysisService(ref);
 }, name: 'ServerAnalysisServiceProvider');
 
@@ -40,7 +42,8 @@ class ServerAnalysisService {
   ValueListenable<GameId?> get currentAnalysis => _currentAnalysis;
 
   /// The last analysis progress event received from the server.
-  ValueListenable<(GameAnyId, ServerEvalEvent)?> get lastAnalysisEvent => _analysisProgress;
+  ValueListenable<(GameAnyId, ServerEvalEvent)?> get lastAnalysisEvent =>
+      _analysisProgress;
 
   SocketClient? _socketClient;
 
@@ -75,12 +78,15 @@ class ServerAnalysisService {
       _socketClient!.stream.listen(
         (event) {
           if (event.topic == 'analysisProgress') {
-            final data = ServerEvalEvent.fromJson(event.data as Map<String, dynamic>);
+            final data = ServerEvalEvent.fromJson(
+              event.data as Map<String, dynamic>,
+            );
 
             _analysisProgress.value = (id, data);
 
             if (data.isAnalysisComplete) {
-              if (_analysisCompleter != null && !_analysisCompleter!.isCompleted) {
+              if (_analysisCompleter != null &&
+                  !_analysisCompleter!.isCompleted) {
                 _analysisCompleter?.complete();
               }
             }
@@ -115,9 +121,11 @@ class ServerAnalysisService {
       rethrow;
     }
 
-    _analysisCompleter?.future.timeout(kMaxWaitForServerAnalysis).whenComplete(() {
-      _cancelAnalysis();
-    });
+    _analysisCompleter?.future.timeout(kMaxWaitForServerAnalysis).whenComplete(
+      () {
+        _cancelAnalysis();
+      },
+    );
   }
 
   /// Cancel the ongoing server analysis, if any.
@@ -145,9 +153,12 @@ class ServerAnalysisService {
     final glyphs = n2['glyphs'] as List<dynamic>?;
     final glyph = glyphs?.first as Map<String, dynamic>?;
     final comments = n2['comments'] as List<dynamic>?;
-    final comment = (comments?.first as Map<String, dynamic>?)?['text'] as String?;
+    final comment =
+        (comments?.first as Map<String, dynamic>?)?['text'] as String?;
     final children = n2['children'] as List<dynamic>? ?? [];
-    final pgnComment = pgnEval != null ? PgnComment(eval: pgnEval, text: comment) : null;
+    final pgnComment = pgnEval != null
+        ? PgnComment(eval: pgnEval, text: comment)
+        : null;
     if (n1 is Branch) {
       if (pgnComment != null) {
         if (n1.lichessAnalysisComments == null) {
@@ -183,10 +194,11 @@ class ServerAnalysisService {
 }
 
 /// A provider that exposes the current game being analyzed by the server.
-final currentAnalysisProvider = NotifierProvider.autoDispose<CurrentAnalysis, GameId?>(
-  CurrentAnalysis.new,
-  name: 'CurrentAnalysisProvider',
-);
+final currentAnalysisProvider =
+    NotifierProvider.autoDispose<CurrentAnalysis, GameId?>(
+      CurrentAnalysis.new,
+      name: 'CurrentAnalysisProvider',
+    );
 
 class CurrentAnalysis extends Notifier<GameId?> {
   @override
@@ -203,7 +215,10 @@ class CurrentAnalysis extends Notifier<GameId?> {
   }
 
   void _listener() {
-    final gameId = ref.read(serverAnalysisServiceProvider).currentAnalysis.value;
+    final gameId = ref
+        .read(serverAnalysisServiceProvider)
+        .currentAnalysis
+        .value;
     if (state != gameId) {
       state = gameId;
     }

--- a/lib/src/model/analysis/server_analysis_service.dart
+++ b/lib/src/model/analysis/server_analysis_service.dart
@@ -49,6 +49,14 @@ class ServerAnalysisService {
   /// This will return a future that completes when the server analysis is
   /// launched (but not when it is finished).
   Future<void> requestAnalysis(GameId id, [Side? side]) async {
+    // If we are already listening for analysis updates of this exact game,
+    // don't tear everything down and reconnect.
+    if (_currentAnalysis.value == id &&
+        _socketSubscription != null &&
+        _analysisCompleter != null) {
+      return;
+    }
+
     _cancelAnalysis();
 
     final uri = Uri(path: '/watch/$id/${side?.name ?? Side.white}/v6');
@@ -95,6 +103,7 @@ class ServerAnalysisService {
       // of analyses is reached.
       if (e.statusCode == 400) {
         debugPrint('Analysis already requested for game $id');
+        _currentAnalysis.value = id.gameId;
       } else {
         debugPrint('ServerException requesting server analysis: $e');
         _cancelAnalysis();


### PR DESCRIPTION
## What this changes

This PR tries to fix the case where **Learn from your mistakes** can get stuck / keep loading after a computer analysis was already requested first.

The issue seems to come from the retro flow attaching too late to analysis progress and potentially trying to request / restart analysis again for the same game.

## Changes

- avoid restarting server analysis if the same game is already being analyzed
- attach the retro listener earlier
- reuse an already available analysis progress event for the same game
- keep tracking the current game even when the server responds with `400 already requested`