### PR TITLE
Fix retro reuse existing analysis

### DIFF
--- a/lib/src/model/analysis/retro_controller.dart
+++ b/lib/src/model/analysis/retro_controller.dart
@@ -145,9 +145,7 @@ class RetroController extends AsyncNotifier<RetroState> with EngineEvaluationMix
         final progress =
             existingEvent.$2.evals.where((e) => e.hasEval).length / _root.mainline.length;
 
-        state = AsyncValue.data(
-          state.requireValue.copyWith(serverAnalysisProgress: progress),
-        );
+        state = AsyncValue.data(state.requireValue.copyWith(serverAnalysisProgress: progress));
 
         if (existingEvent.$2.isAnalysisComplete) {
           if (!_serverAnalysisCompleter.isCompleted) {

--- a/lib/src/model/analysis/server_analysis_service.dart
+++ b/lib/src/model/analysis/server_analysis_service.dart
@@ -51,9 +51,7 @@ class ServerAnalysisService {
   Future<void> requestAnalysis(GameId id, [Side? side]) async {
     // If we are already listening for analysis updates of this exact game,
     // don't tear everything down and reconnect.
-    if (_currentAnalysis.value == id &&
-        _socketSubscription != null &&
-        _analysisCompleter != null) {
+    if (_currentAnalysis.value == id && _socketSubscription != null && _analysisCompleter != null) {
       return;
     }
 


### PR DESCRIPTION
Related to #2564 and #2750

## What this changes

This PR tries to fix the case where **Learn from your mistakes** can get stuck / keep loading after a computer analysis was already requested first.

The issue seems to come from the retro flow attaching too late to analysis progress and potentially trying to request / restart analysis again for the same game.

## Changes

- avoid restarting server analysis if the same game is already being analyzed
- attach the retro listener earlier
- reuse an already available analysis progress event for the same game
- keep tracking the current game even when the server responds with `400 already requested`

## Why

This should help with the cases described in:

- #2564 — `Learn from your misstake "something went wrong"`
- #2750 — `"Learn from your mistakes" sometimes remains stuck loading`