### PR TITLE
Fix: save all PGN header fields before exporting

### DIFF
--- a/lib/src/view/analysis/analysis_share_screen.dart
+++ b/lib/src/view/analysis/analysis_share_screen.dart
@@ -166,9 +166,13 @@ class _EditPgnTagsFormState extends ConsumerState<_EditPgnTagsForm> {
                     return FilledButton(
                       onPressed: () {
                         for (final entry in pgnHeaders.entries) {
+                          final controller = _controllers[entry.key];
+                          if (controller == null) {
+                            throw StateError('Controller missing for key: ${entry.key}');
+                          }
                           ref
                               .read(ctrlProvider.notifier)
-                              .updatePgnHeader(entry.key, _controllers[entry.key]!.text);
+                              .updatePgnHeader(entry.key, controller.text);
                         }
                         launchShareDialog(
                           context,


### PR DESCRIPTION
When pressing the share button while still in the last PGN header field (BlackElo), 
the value was not saved. Fixed by reading all controllers before exporting.

Fixes #2850