### PR TITLE
Update guidance on version numbers in bug.yml

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug.yml
+++ b/.github/ISSUE_TEMPLATE/bug.yml
@@ -28,7 +28,7 @@ body:
   - type: input
     attributes:
       label: App version
-      description: Specify the application version (e.g. 0.7.8). If your version is 8.0.0 it means you are using the old application. You should [download the new one](https://lichess.org/mobile).
+      description: Specify the application version (e.g. 0.22.7). If your version is 8.0.0 it means you are using [the old application](https://github.com/lichess-org/lichobile). You should [download the new one](https://lichess.org/mobile).
     validations:
       required: true
   - type: input


### PR DESCRIPTION
Minor update to the issue template, adding an example of the current version number format, and linking to the repo for the old version. 