### PR TITLE
Show full-screen retry on friends load error

### DIFF
--- a/lib/src/view/relation/friend_screen.dart
+++ b/lib/src/view/relation/friend_screen.dart
@@ -30,15 +30,11 @@ final followingStatusesProvider = FutureProvider.autoDispose<(IList<User>, IList
     return (IList<User>(), IList<UserStatus>());
   }
 
-  final ids = following.map((user) => user.id).toIList();
-  final statuses = <UserStatus>[];
   // The /api/users/status endpoint accepts at most 100 IDs per request.
-  for (var i = 0; i < ids.length; i += 100) {
-    final chunk = ids.sublist(i, i + 100 < ids.length ? i + 100 : ids.length);
-    final result = await ref.read(userRepositoryProvider).getUsersStatuses(chunk.toISet());
-    statuses.addAll(result);
-  }
-  return (following, IList(statuses));
+  final statuses = await ref
+      .read(userRepositoryProvider)
+      .getUsersStatuses(following.take(100).map((user) => user.id).toISet());
+  return (following, statuses);
 });
 
 class FriendScreen extends ConsumerStatefulWidget {


### PR DESCRIPTION
Maybe a partial fix for https://github.com/lichess-org/mobile/issues/2724 and related issues?

**Changes**
 1. ~~Add a timeout on `Response.fromStream()` in `LichessClient._sendUnstreamed`. That way in case `Response.fromStream()` reads the body and hangs, we can just timeout instead. I think this can fix the infinite loading potentially? But then what if the user is following so many people that they always trigger the `Response.fromStream()` timeout?~~
 2. Call `getUsersStatuses` with only the first 100 user IDs, since the Lichess API silently truncates to 100 IDs (`.take(100)` in [Api.scala](https://github.com/lichess-org/lila/blob/21aec830ca771c12ee9a31416214c7a09472a043/app/controllers/Api.scala#L82)).
 3. Replace `firstWhere` with `firstWhereOrNull` so a missing status defaults to offline instead of throwing.
 4. Don't show the loading spinner forever for the `AsyncError` case at least. 

**Investigation**

I see that we call `/api/users/status` right after the call to `/api/rel/following`. Based on the [API documenation](https://lichess.org/api#tag/users/GET/api/users/status), looks like we limit the URL to have 100 user IDs in the query. Based on what I'm seeing in [Api.scala](https://github.com/lichess-org/lila/blob/21aec830ca771c12ee9a31416214c7a09472a043/app/controllers/Api.scala#L82), this limit is done by taking the first 100 user IDs. 

That means when `_isOnline` is called, the `statuses.firstWhere` call will fail for everyone besides the first 100 user IDs and throw a `StateError`. I think that might be causing an issue as well so I've added chunking for the `/api/users/status` call and replaced `firstWhere` with `firstWhereOrNull` so that a missing status defaults to offline instead of throwing an error.

Let me know if I should continue using `firstWhere` so that we fail instead of showing potentially wrong information and hiding a bug!