### PR TITLE
Fix the over the board clock switching before promotion piece is selected

### DIFF
--- a/lib/src/view/over_the_board/over_the_board_screen.dart
+++ b/lib/src/view/over_the_board/over_the_board_screen.dart
@@ -270,14 +270,24 @@ class _BodyState extends ConsumerState<_Body> {
                           : gameState.turn == Side.white
                           ? PlayerSide.white
                           : PlayerSide.black,
-                      onPromotionSelection: ref
-                          .read(overTheBoardGameControllerProvider.notifier)
-                          .onPromotionSelection,
+                      onPromotionSelection: (role) {
+                        ref
+                            .read(overTheBoardGameControllerProvider.notifier)
+                            .onPromotionSelection(role);
+                        if (role != null) {
+                          ref
+                              .read(overTheBoardClockProvider.notifier)
+                              .onMove(newSideToMove: gameState.turn.opposite);
+                        }
+                      },
                       promotionMove: gameState.promotionMove,
                       onMove: (move, {viaDragAndDrop}) {
-                        ref
-                            .read(overTheBoardClockProvider.notifier)
-                            .onMove(newSideToMove: gameState.turn.opposite);
+                        if (move is! NormalMove ||
+                            !isPromotionPawnMove(gameState.currentPosition, move)) {
+                          ref
+                              .read(overTheBoardClockProvider.notifier)
+                              .onMove(newSideToMove: gameState.turn.opposite);
+                        }
                         ref.read(overTheBoardGameControllerProvider.notifier).makeMove(move);
                       },
                       premovable: null,


### PR DESCRIPTION
When a pawn reaches the last rank the clock was immediately switching to the opponent before the player chose a promotion piece. Now the clock only switches after the promotion selection is confirmed.

The onMove callback fires as soon as the pawn lands on the last rank before the promotion dialog even shows up just moved the clock switch behind a condition of if the move is a promotion skip switching in onMove and do it in onPromotionSelection instead

Fixes #2819 - "bug in "over the board" mode"