### PR TITLE
Fix antichess stalemate variant outcome

### DIFF
--- a/lib/src/model/offline_computer/offline_computer_game_controller.dart
+++ b/lib/src/model/offline_computer/offline_computer_game_controller.dart
@@ -209,10 +209,6 @@ class OfflineComputerGameController extends Notifier<OfflineComputerGameState> {
       state = state.copyWith(
         game: state.game.copyWith(status: GameStatus.mate, winner: state.turn.opposite),
       );
-    } else if (state.currentPosition.isStalemate) {
-      state = state.copyWith(game: state.game.copyWith(status: GameStatus.stalemate));
-    } else if (state.currentPosition.isInsufficientMaterial) {
-      state = state.copyWith(game: state.game.copyWith(status: GameStatus.draw));
     } else if (state.currentPosition.isVariantEnd) {
       state = state.copyWith(
         game: state.game.copyWith(
@@ -220,6 +216,10 @@ class OfflineComputerGameController extends Notifier<OfflineComputerGameState> {
           winner: state.currentPosition.variantOutcome?.winner,
         ),
       );
+    } else if (state.currentPosition.isStalemate) {
+      state = state.copyWith(game: state.game.copyWith(status: GameStatus.stalemate));
+    } else if (state.currentPosition.isInsufficientMaterial) {
+      state = state.copyWith(game: state.game.copyWith(status: GameStatus.draw));
     }
 
     _moveFeedback(sanMove);

--- a/lib/src/model/over_the_board/over_the_board_game_controller.dart
+++ b/lib/src/model/over_the_board/over_the_board_game_controller.dart
@@ -100,8 +100,6 @@ class OverTheBoardGameController extends Notifier<OverTheBoardGameState> {
       state = state.copyWith(
         game: state.game.copyWith(status: GameStatus.mate, winner: state.turn.opposite),
       );
-    } else if (state.currentPosition.isStalemate) {
-      state = state.copyWith(game: state.game.copyWith(status: GameStatus.stalemate));
     } else if (state.currentPosition.variantOutcome != null) {
       switch (state.currentPosition.variantOutcome!.winner) {
         case Side.white:
@@ -115,6 +113,8 @@ class OverTheBoardGameController extends Notifier<OverTheBoardGameState> {
         case null:
           state = state.copyWith(game: state.game.copyWith(status: GameStatus.variantEnd));
       }
+    } else if (state.currentPosition.isStalemate) {
+      state = state.copyWith(game: state.game.copyWith(status: GameStatus.stalemate));
     }
 
     _moveFeedback(sanMove);

--- a/test/view/over_the_board/over_the_board_screen_test.dart
+++ b/test/view/over_the_board/over_the_board_screen_test.dart
@@ -29,6 +29,11 @@ import '../../test_provider_scope.dart';
 // A position after 1.e4 e5 — white to move
 const _customFen = 'rnbqkbnr/pppp1ppp/8/4p3/4P3/8/PPPP1PPP/RNBQKBNR w KQkq - 0 2';
 
+// Antichess position one move before stalemate:
+// White pawn on a5, black pawn on a7. White to move plays a6, blocking black's pawn.
+// Black has no legal moves = stalemate = black wins in antichess.
+const _antichessStalemateFen = '8/p7/8/P7/8/8/8/8 w - - 0 1';
+
 class MockOverTheBoardGameStorage extends Mock implements OverTheBoardGameStorage {}
 
 void main() {
@@ -542,6 +547,52 @@ void main() {
       expect(gameState.game.initialFen, isNull);
       expect(gameState.game.steps.length, 1);
       expect(gameState.game.steps.first.position, Chess.initial);
+    });
+
+    testWidgets('Antichess stalemate is a win, not a draw', (tester) async {
+      final gameStorage = MockOverTheBoardGameStorage();
+      when(() => gameStorage.fetchOngoingGame()).thenAnswer((_) async => null);
+      when(
+        () => gameStorage.save(
+          any(),
+          timeIncrement: any(named: 'timeIncrement'),
+          whiteTimeLeft: any(named: 'whiteTimeLeft'),
+          blackTimeLeft: any(named: 'blackTimeLeft'),
+        ),
+      ).thenAnswer((_) async {});
+
+      final app = await makeTestProviderScopeApp(
+        tester,
+        home: const OverTheBoardScreen(
+          initialVariant: Variant.antichess,
+          initialFen: _antichessStalemateFen,
+        ),
+        overrides: {
+          overTheBoardGameStorageProvider: overTheBoardGameStorageProvider.overrideWith(
+            (_) => gameStorage,
+          ),
+        },
+      );
+      await tester.pumpWidget(app);
+      await tester.pumpAndSettle();
+
+      await tester.tap(find.text('Play'));
+      await tester.pumpAndSettle();
+
+      // White plays a5-a6, blocking black's pawn. Black has no legal moves = stalemate.
+      // In antichess, the stalemated player (black) wins.
+      await playMove(tester, 'a5', 'a6');
+
+      await tester.pumpAndSettle(const Duration(milliseconds: 600));
+
+      // Verify it's a win for black (0-1), not a draw (½-½)
+      expect(find.text('0-1'), findsOneWidget);
+      expect(find.textContaining('Black is victorious'), findsOneWidget);
+
+      final container = ProviderScope.containerOf(tester.element(find.byType(Chessboard)));
+      final gameState = container.read(overTheBoardGameControllerProvider);
+      expect(gameState.game.status, GameStatus.variantEnd);
+      expect(gameState.game.winner, Side.black);
     });
 
     testWidgets('Rematch from custom position and variant restarts from same FEN and variant', (


### PR DESCRIPTION
# Fix antichess stalemate incorrectly shown as draw

Fixes #2814

## Summary

- In antichess, stalemate means the stalemated player **wins** — but the app was showing it as a draw (½-½)
- Root cause: the game-over logic in both OTB and offline computer controllers checked `isStalemate` before `variantOutcome`, so the variant-specific winner was never set
- Fix: reorder the conditionals to check `variantOutcome` first, allowing the dartchess library to correctly report the winner

## Changed files

- `lib/src/model/over_the_board/over_the_board_game_controller.dart` — reorder stalemate/variant checks
- `lib/src/model/offline_computer/offline_computer_game_controller.dart` — same reorder
- `test/view/over_the_board/over_the_board_screen_test.dart` — add regression test

## Test plan

- [x] New test: "Antichess stalemate is a win, not a draw" — starts an antichess OTB game from a position one move before stalemate, plays the move, and verifies the result is `0-1` / `GameStatus.variantEnd` / `winner: Side.black` (not `½-½`)
- [x] Verified the test **fails** with the old code and **passes** with the fix
- [x] All existing OTB tests pass (15/15)
- [x] Manual test: play an antichess game OTB to stalemate and confirm the result dialog shows the correct winner

| Before | After |
| --- | --- |
| <video src="https://github.com/user-attachments/assets/375eeeff-212c-4964-9e5b-041f11fc15b6"/> | <video src="https://github.com/user-attachments/assets/c93a1d2e-473b-49ef-a87a-860a6eb18a02"/> |