### PR TITLE
Fix: invalidate ongoingGamesProvider so accepted challange visible in carousel

### DIFF
--- a/lib/src/model/challenge/challenge_service.dart
+++ b/lib/src/model/challenge/challenge_service.dart
@@ -6,6 +6,7 @@ import 'package:fast_immutable_collections/fast_immutable_collections.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_local_notifications/flutter_local_notifications.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:lichess_mobile/src/model/account/ongoing_game.dart';
 import 'package:lichess_mobile/src/model/challenge/challenge.dart';
 import 'package:lichess_mobile/src/model/challenge/challenge_repository.dart';
 import 'package:lichess_mobile/src/model/common/id.dart';
@@ -180,6 +181,8 @@ class ChallengeService {
     if (fullId == null) {
       return showSnackBar(context, 'Failed to accept challenge', type: SnackBarType.error);
     }
+
+    ref.invalidate(ongoingGamesProvider);
 
     _onChallengeAccepted(fullId);
   }


### PR DESCRIPTION
Add the import for ongoing_game.dart and a invalidate call on the ongoingGamesProvider.

https://github.com/user-attachments/assets/5a600fe9-ed36-49d2-8647-39795fd580aa

Fixes #2276 