### PR TITLE
Fix: Challenge opponent again via clicking on name after game finished

### DIFF
--- a/lib/src/model/lobby/create_game_service.dart
+++ b/lib/src/model/lobby/create_game_service.dart
@@ -138,8 +138,14 @@ class CreateGameService {
       throw StateError('Already creating a challenge.');
     }
 
+    final keepAlive = ref.keepAlive();
+
     // ensure the pending connection is closed in any case
-    final completer = Completer<ChallengeResponse>()..future.whenComplete(dispose);
+    final completer = Completer<ChallengeResponse>()
+      ..future.whenComplete(() {
+        keepAlive.close();
+        dispose();
+      });
 
     try {
       final socketPool = ref.read(socketPoolProvider);
@@ -184,7 +190,7 @@ class CreateGameService {
         completer,
       );
     } catch (e) {
-      _log.warning('Failed to create challenge', e);
+      _log.warning('Failed to create challenge socket, completing with error', e);
       // if the completer is not yet completed, complete it with an error
       if (!completer.isCompleted) {
         completer.completeError(e);

--- a/lib/src/view/game/game_loading_board.dart
+++ b/lib/src/view/game/game_loading_board.dart
@@ -314,25 +314,44 @@ class _OpenChallengeLoadingContentState extends ConsumerState<OpenChallengeLoadi
                             context,
                             title: Text(context.l10n.challengeAFriend),
                             onUserTap: (user) async {
+                              // Capture everything that needs BuildContext before the async
+                              // gap: after cancelChallenge() completes, the GameScreen
+                              // rebuilds to ChallengeCancelledState, which removes this
+                              // widget from the tree and makes context.mounted false.
+                              final rootNav = Navigator.of(context, rootNavigator: true);
+                              final directedChallengeReq = widget.challengeRequest.copyWith(
+                                destUser: user,
+                              );
+                              final directedChallengeRoute =
+                                  widget.challengeRequest.timeControl ==
+                                      ChallengeTimeControlType.clock
+                                  ? GameScreen.buildRoute(
+                                      context,
+                                      source: UserChallengeSource(directedChallengeReq),
+                                    )
+                                  : null;
+
                               try {
                                 await widget.cancelChallenge();
                               } catch (e) {
                                 debugPrint('Error cancelling open challenge: $e');
                               }
 
-                              final directedChallengeReq = widget.challengeRequest.copyWith(
-                                destUser: user,
-                              );
-                              if (!context.mounted) return;
-
-                              if (widget.challengeRequest.timeControl ==
-                                  ChallengeTimeControlType.clock) {
-                                Navigator.of(context).pop();
-                                Navigator.of(context, rootNavigator: true).pushReplacement(
-                                  GameScreen.buildRoute(
-                                    context,
-                                    source: UserChallengeSource(directedChallengeReq),
+                              if (directedChallengeRoute != null) {
+                                // Invalidate the provider so the new GameScreen creates a
+                                // fresh challenge even if the same UserChallengeSource was
+                                // used in a previous game (Freezed equality shares providers).
+                                ref.invalidate(
+                                  gameScreenLoaderProvider(
+                                    UserChallengeSource(directedChallengeReq),
                                   ),
+                                );
+                                // Use pushAndRemoveUntil to clear any old GameScreen with
+                                // the same source from the stack so they don't share the
+                                // provider and interfere with the new challenge.
+                                rootNav.pushAndRemoveUntil(
+                                  directedChallengeRoute,
+                                  (route) => route.isFirst,
                                 );
                               } else {
                                 await ref

--- a/lib/src/view/game/game_loading_board.dart
+++ b/lib/src/view/game/game_loading_board.dart
@@ -14,6 +14,7 @@ import 'package:lichess_mobile/src/model/lobby/game_seek.dart';
 import 'package:lichess_mobile/src/model/lobby/lobby_numbers.dart';
 import 'package:lichess_mobile/src/model/settings/brightness.dart';
 import 'package:lichess_mobile/src/utils/l10n_context.dart';
+import 'package:lichess_mobile/src/utils/navigation.dart';
 import 'package:lichess_mobile/src/utils/share.dart';
 import 'package:lichess_mobile/src/utils/string.dart';
 import 'package:lichess_mobile/src/view/account/rating_pref_aware.dart';
@@ -314,10 +315,7 @@ class _OpenChallengeLoadingContentState extends ConsumerState<OpenChallengeLoadi
                             context,
                             title: Text(context.l10n.challengeAFriend),
                             onUserTap: (user) async {
-                              // Capture everything that needs BuildContext before the async
-                              // gap: after cancelChallenge() completes, the GameScreen
-                              // rebuilds to ChallengeCancelledState, which removes this
-                              // widget from the tree and makes context.mounted false.
+                              // Capture everything that needs BuildContext before the async gap.
                               final rootNav = Navigator.of(context, rootNavigator: true);
                               final directedChallengeReq = widget.challengeRequest.copyWith(
                                 destUser: user,
@@ -337,6 +335,8 @@ class _OpenChallengeLoadingContentState extends ConsumerState<OpenChallengeLoadi
                                 debugPrint('Error cancelling open challenge: $e');
                               }
 
+                              if (!context.mounted) return;
+
                               if (directedChallengeRoute != null) {
                                 // Invalidate the provider so the new GameScreen creates a
                                 // fresh challenge even if the same UserChallengeSource was
@@ -346,12 +346,11 @@ class _OpenChallengeLoadingContentState extends ConsumerState<OpenChallengeLoadi
                                     UserChallengeSource(directedChallengeReq),
                                   ),
                                 );
-                                // Use pushAndRemoveUntil to clear any old GameScreen with
-                                // the same source from the stack so they don't share the
-                                // provider and interfere with the new challenge.
+                                // Use pushAndRemoveUntil to clear any old GameScreen from
+                                // the stack without removing unrelated routes.
                                 rootNav.pushAndRemoveUntil(
                                   directedChallengeRoute,
-                                  (route) => route.isFirst,
+                                  (route) => route is! ScreenRoute || route.screen is! GameScreen,
                                 );
                               } else {
                                 await ref

--- a/lib/src/view/play/create_challenge_bottom_sheet.dart
+++ b/lib/src/view/play/create_challenge_bottom_sheet.dart
@@ -306,22 +306,28 @@ class _CreateChallengeBottomSheetState extends ConsumerState<CreateChallengeBott
                     onPressed: timeControl == ChallengeTimeControlType.clock || widget.user == null
                         ? isValidTimeControl && isValidPosition
                               ? () {
+                                  final source = UserChallengeSource(
+                                    preferences.makeRequest(
+                                      account,
+                                      widget.user,
+                                      preferences.variant != Variant.fromPosition
+                                          ? null
+                                          : fromPositionFenInput,
+                                    ),
+                                  );
+                                  // Invalidate any stale provider state from a previous game
+                                  // with the same source (same opponent + settings), so the
+                                  // new GameScreen always runs build() and creates a fresh
+                                  // challenge instead of showing the old GameCreatedState.
+                                  ref.invalidate(gameScreenLoaderProvider(source));
                                   Navigator.of(
                                     context,
                                   ).popUntil((route) => route is! ModalBottomSheetRoute);
-                                  Navigator.of(context, rootNavigator: true).push(
-                                    GameScreen.buildRoute(
-                                      context,
-                                      source: UserChallengeSource(
-                                        preferences.makeRequest(
-                                          account,
-                                          widget.user,
-                                          preferences.variant != Variant.fromPosition
-                                              ? null
-                                              : fromPositionFenInput,
-                                        ),
-                                      ),
-                                    ),
+                                  // Use pushAndRemoveUntil to clear any old GameScreen with
+                                  // the same source from the navigation stack.
+                                  Navigator.of(context, rootNavigator: true).pushAndRemoveUntil(
+                                    GameScreen.buildRoute(context, source: source),
+                                    (route) => route.isFirst,
                                   );
                                 }
                               : null

--- a/lib/src/view/play/create_challenge_bottom_sheet.dart
+++ b/lib/src/view/play/create_challenge_bottom_sheet.dart
@@ -15,6 +15,7 @@ import 'package:lichess_mobile/src/model/lobby/game_setup_preferences.dart';
 import 'package:lichess_mobile/src/model/user/user.dart';
 import 'package:lichess_mobile/src/styles/styles.dart';
 import 'package:lichess_mobile/src/utils/l10n_context.dart';
+import 'package:lichess_mobile/src/utils/navigation.dart';
 import 'package:lichess_mobile/src/view/game/game_screen.dart';
 import 'package:lichess_mobile/src/view/game/game_screen_providers.dart';
 import 'package:lichess_mobile/src/widgets/adaptive_bottom_sheet.dart';
@@ -323,11 +324,11 @@ class _CreateChallengeBottomSheetState extends ConsumerState<CreateChallengeBott
                                   Navigator.of(
                                     context,
                                   ).popUntil((route) => route is! ModalBottomSheetRoute);
-                                  // Use pushAndRemoveUntil to clear any old GameScreen with
-                                  // the same source from the navigation stack.
+                                  // Use pushAndRemoveUntil to clear any old GameScreen from
+                                  // the navigation stack without removing unrelated routes.
                                   Navigator.of(context, rootNavigator: true).pushAndRemoveUntil(
                                     GameScreen.buildRoute(context, source: source),
-                                    (route) => route.isFirst,
+                                    (route) => route is! ScreenRoute || route.screen is! GameScreen,
                                   );
                                 }
                               : null


### PR DESCRIPTION
Bug: Challenging the same friend again after a game didn't send the challenge

This was a complex issue, so i needed some assistance. Glaude Code assisted me with solving this bug. Below the causes and the fixes which are made. I also provide a movie to show that it works now.

Root cause (two related issues):

context.mounted false after cancel — When picking a friend from an open challenge screen, cancelling the open challenge caused the screen to rebuild immediately and remove itself from the widget tree. The code then checked if (!context.mounted) return and bailed out before ever sending the directed challenge to the friend.

Stale provider reuse — Riverpod's gameScreenLoaderProvider is keyed by the challenge source. When challenging the same friend with the same settings a second time, the new game screen found the old provider still alive with the finished game's state (GameCreatedState), and showed that old game instead of creating a new challenge.

Fixes:

In game_loading_board.dart — Capture all navigator references and build the route before the async cancelChallenge() call, so navigation works regardless of what happens to the widget tree afterwards.

In create_challenge_bottom_sheet.dart — Call ref.invalidate(gameScreenLoaderProvider(source)) before navigating to force a fresh challenge creation, and use pushAndRemoveUntil instead of push to clear old game screens from the navigation stack so they can't interfere.

Fixex #1625 

https://github.com/user-attachments/assets/a0d184f8-49d3-4218-ba40-bf4175f3cb8f

