### PR TITLE
Prevent http requests we know will fail

### DIFF
--- a/lib/src/model/offline_computer/offline_computer_game_controller.dart
+++ b/lib/src/model/offline_computer/offline_computer_game_controller.dart
@@ -9,6 +9,7 @@ import 'package:flutter/foundation.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:freezed_annotation/freezed_annotation.dart';
 import 'package:lichess_mobile/src/model/analysis/analysis_controller.dart';
+import 'package:lichess_mobile/src/model/auth/auth_controller.dart';
 import 'package:lichess_mobile/src/model/common/chess.dart';
 import 'package:lichess_mobile/src/model/common/chess960.dart';
 import 'package:lichess_mobile/src/model/common/eval.dart';
@@ -307,7 +308,10 @@ class OfflineComputerGameController extends Notifier<OfflineComputerGameState> {
     );
 
     // Makes or updates the comment verdict to goodMove if the move is a known book move.
-    if (state.game.meta.variant == Variant.standard && plyBeforeMove < _kOpeningPlyThreshold) {
+    // The server will reject us unless we are logged in. Only ask then.
+    if (ref.read(isLoggedInProvider) &&
+        state.game.meta.variant == Variant.standard &&
+        plyBeforeMove < _kOpeningPlyThreshold) {
       _makeCommentFromOpeningDb(
         sanMove,
         stepCursor: stepCursorAfterMove,


### PR DESCRIPTION
If the user is not logged in the Lichess server will deny requests to access the master game database.
I would like to prevent requests to the master database when we are not logged in.
I noticed this when I tried Practice Mode on my phone.
![logscreenshot](https://github.com/user-attachments/assets/4cf6c3e1-d192-44ff-926e-539d29ff8f67)
