### PR TITLE
Fix last edited PGN header not saved on share (#2850)

### DIFF
--- a/lib/src/view/analysis/analysis_share_screen.dart
+++ b/lib/src/view/analysis/analysis_share_screen.dart
@@ -162,6 +162,18 @@ class _EditPgnTagsFormState extends ConsumerState<_EditPgnTagsForm> {
                   builder: (context) {
                     return FilledButton(
                       onPressed: () {
+                        // Flush all text field values into state before
+                        // generating the PGN. We can't rely on unfocus
+                        // alone because the focus listener may not fire
+                        // synchronously or may not fire at all if focus
+                        // was already lost.
+                        final notifier = ref.read(
+                          analysisControllerProvider(widget.options).notifier,
+                        );
+                        for (final entry in _controllers.entries) {
+                          notifier.updatePgnHeader(entry.key, entry.value.text);
+                        }
+                        FocusScope.of(context).unfocus();
                         launchShareDialog(
                           context,
                           ShareParams(

--- a/test/view/analysis/analysis_share_screen_test.dart
+++ b/test/view/analysis/analysis_share_screen_test.dart
@@ -1,0 +1,84 @@
+import 'package:dartchess/dartchess.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:lichess_mobile/src/model/analysis/analysis_controller.dart';
+import 'package:lichess_mobile/src/model/common/chess.dart';
+import 'package:lichess_mobile/src/model/common/id.dart';
+import 'package:lichess_mobile/src/view/analysis/analysis_share_screen.dart';
+
+import '../../test_provider_scope.dart';
+
+void main() {
+  const options = AnalysisOptions.pgn(
+    id: StringId('test_share'),
+    orientation: Side.white,
+    pgn: '1. e4 *',
+    isComputerAnalysisAllowed: false,
+    variant: Variant.standard,
+  );
+
+  tearDown(() {
+    clearSavedStandaloneAnalysis();
+  });
+
+  group('AnalysisShareScreen', () {
+    testWidgets('last edited PGN header is saved on share', (tester) async {
+      final app = await makeTestProviderScopeApp(
+        tester,
+        home: const AnalysisShareScreen(options: options),
+      );
+
+      await tester.pumpWidget(app);
+      await tester.pumpAndSettle();
+
+      // Find the BlackElo text field by its label
+      final blackEloLabel = find.text('BlackElo');
+      expect(blackEloLabel, findsOneWidget);
+
+      // The TextField is a sibling of the label inside a Row
+      final blackEloRow = find.ancestor(of: blackEloLabel, matching: find.byType(Row));
+      final blackEloField = find.descendant(of: blackEloRow, matching: find.byType(TextField));
+      expect(blackEloField, findsOneWidget);
+
+      // Enter a value without leaving the field
+      await tester.tap(blackEloField);
+      await tester.enterText(blackEloField, '2400');
+      await tester.pump();
+
+      // Tap the Share button while BlackElo still has focus
+      await tester.tap(find.text('Share PGN'));
+      await tester.pump();
+
+      // Verify the state has the updated BlackElo (not "?")
+      final container = ProviderScope.containerOf(tester.element(find.byType(AnalysisShareScreen)));
+      final headers = container.read(analysisControllerProvider(options)).requireValue.pgnHeaders;
+      expect(headers['BlackElo'], '2400');
+    });
+
+    testWidgets('WhiteElo is also saved when it is the last edited field', (tester) async {
+      final app = await makeTestProviderScopeApp(
+        tester,
+        home: const AnalysisShareScreen(options: options),
+      );
+
+      await tester.pumpWidget(app);
+      await tester.pumpAndSettle();
+
+      final whiteEloLabel = find.text('WhiteElo');
+      final whiteEloRow = find.ancestor(of: whiteEloLabel, matching: find.byType(Row));
+      final whiteEloField = find.descendant(of: whiteEloRow, matching: find.byType(TextField));
+
+      await tester.tap(whiteEloField);
+      await tester.enterText(whiteEloField, '1800');
+      await tester.pump();
+
+      await tester.tap(find.text('Share PGN'));
+      await tester.pump();
+
+      final container = ProviderScope.containerOf(tester.element(find.byType(AnalysisShareScreen)));
+      final headers = container.read(analysisControllerProvider(options)).requireValue.pgnHeaders;
+      expect(headers['WhiteElo'], '1800');
+    });
+  });
+}


### PR DESCRIPTION
Fixes #2850

## Summary

- When exporting PGN from the analysis board's Share & Export screen, whichever text field was still focused when tapping "Share PGN" would retain its default `?` value in the exported PGN. This most commonly affected BlackElo since it's the last rating field.
- We now explicitly flush all text controller values into state before generating the PGN, making it independent of focus timing.

## Changes

- `analysis_share_screen.dart`: Iterate through all text controllers and call `updatePgnHeader` for each before calling `makeExportPgn()`
- New test file `analysis_share_screen_test.dart`: Verifies that the last edited field (BlackElo, WhiteElo) is correctly persisted when sharing without first unfocusing

## Test plan

- [x] Run `flutter test test/view/analysis/analysis_share_screen_test.dart`
- [x] Tested manually with different fields to confirm that the fix works.
