### PR TITLE
Highlight current user row in tournament standings

### DIFF
--- a/lib/src/view/tournament/tournament_screen.dart
+++ b/lib/src/view/tournament/tournament_screen.dart
@@ -603,9 +603,11 @@ class _StandingPlayer extends ConsumerWidget {
   @override
   Widget build(BuildContext context, WidgetRef ref) {
     final tournamentId = state.id;
+    final isMe = ref.watch(authControllerProvider)?.user.id == player.user.id;
     return ListTile(
       contentPadding: const EdgeInsetsDirectional.only(start: 16.0, end: 16.0),
       visualDensity: VisualDensity.compact,
+      selected: isMe,
       tileColor: player.rank.isEven ? context.lichessTheme.rowEven : context.lichessTheme.rowOdd,
       leading: player.withdraw
           ? Icon(Icons.pause, color: textShade(context, 0.3), size: 20)


### PR DESCRIPTION
Closes https://github.com/lichess-org/mobile/issues/2923

## Summary
- Highlights the logged-in user's row in tournament standings using `ListTile`'s `selected` property
- Uses the same selection styling as broadcast round selection for consistency
- Makes it easier to find your own position when browsing standings

## Implementation
Compares the current `authControllerProvider` user ID against each `StandingPlayer.user.id` and sets `selected: true` on the matching row. This is a 2-line change in `_StandingPlayer`.

## Test plan

| Before | After |
| --- | --- |
| <img width="1080" height="2340" alt="image" src="https://github.com/user-attachments/assets/58f0f0f8-0474-4b3a-a6b3-85f355052707" /> | <img width="1080" height="2340" alt="image" src="https://github.com/user-attachments/assets/96c4b897-a8b1-4210-a8ad-d63c4a243d45" /> |