### PR TITLE
Add share button to tournament screen

### DIFF
--- a/lib/src/view/tournament/tournament_screen.dart
+++ b/lib/src/view/tournament/tournament_screen.dart
@@ -152,6 +152,12 @@ class _Body extends ConsumerWidget {
         appBar: PlatformAppBar(
           title: _Title(state: state),
           actions: [
+            SemanticIconButton(
+              icon: const PlatformShareIcon(),
+              semanticsLabel: 'Share tournament',
+              onPressed: () =>
+                  launchShareDialog(context, ShareParams(uri: lichessUri('/tournament/$id'))),
+            ),
             if (state.tournament.isFinished != true)
               SocketPingRatingIcon(socketUri: TournamentController.socketUri(id)),
             if (timeLeft != null)


### PR DESCRIPTION
Closes #2916

## Summary
- Adds a share button to the tournament screen app bar so users can share tournament links
- Uses the existing `launchShareDialog` + `lichessUri('/tournament/$id')` pattern, consistent with game, study, broadcast, and profile screens
- Button uses `PlatformShareIcon` for platform-appropriate icon (iOS/Android)

## Testing

| Before | After |
| --- | --- |
| <img src="https://github.com/user-attachments/assets/39ccb244-28b0-4b9b-9128-f02448024eff" /> | <img src="https://github.com/user-attachments/assets/2eb0af0c-4e38-4408-90a9-10bfbdbd6bbe" /> |

<video src="https://github.com/user-attachments/assets/ee577f41-eabc-49f0-be74-951fd00fcfd5" />
