### PR TITLE
Fix bottom nav staying visible when opening deep links

### DIFF
--- a/lib/src/app_links_service.dart
+++ b/lib/src/app_links_service.dart
@@ -208,7 +208,7 @@ class AppLinksService {
 
     if (routes != null) {
       for (final route in routes) {
-        Navigator.of(context).push(route);
+        Navigator.of(context, rootNavigator: true).push(route);
       }
     } else {
       final isChallengeLink = await _tryResolveChallengeLink(context, uri);


### PR DESCRIPTION
# Fix bottom nav staying visible when opening deep links

## Summary

- Use `rootNavigator: true` when pushing deep link routes so they display above the tab scaffold instead of inside it, hiding the bottom navigation bar
- This is a one-line change in `handleAppLink()` in `app_links_service.dart`
- Fixes #2910

## Root Cause

`handleAppLink()` was calling `Navigator.of(context).push(route)` which pushed onto the **tab navigator** (since the context comes from `currentNavigatorKeyProvider`, a tab-specific key). This meant deep link screens were rendered *within* the tab, leaving the bottom navigation bar visible and shrinking the screen.

The fix changes this to `Navigator.of(context, rootNavigator: true).push(route)`, which pushes onto the **root navigator** above `MainTabScaffold` -- consistent with how every other full-screen navigation in the app works.

## Deep links tested

All deep link types go through `handleAppLink()` and are affected by this fix. Tested on Android emulator (API 36) against lichess.dev:

### Game (`/3K42eD3l`)

| Before | After |
|--------|-------|
| <img width="1080" height="2340" alt="1_game" src="https://github.com/user-attachments/assets/a024fdf7-c34d-46c0-a326-1de9eb646760" /> | <img width="1080" height="2340" alt="1_game" src="https://github.com/user-attachments/assets/78d6addc-89b7-461a-88e5-dd9261a422ad" /> |

### Study (`/study/9hdiWME4`)

| Before | After |
|--------|-------|
| <img width="1080" height="2340" alt="2_study" src="https://github.com/user-attachments/assets/b621d1ed-c0f8-4865-b3e8-d8335cddab6a" /> | <img width="1080" height="2340" alt="2_study" src="https://github.com/user-attachments/assets/44f45a01-791a-400b-a9bb-0babb44c4620" /> |

### Tournament (`/tournament/HWT5E5Ja`)

| Before | After |
|--------|-------|
| <img width="1080" height="2340" alt="3_tournament" src="https://github.com/user-attachments/assets/28a336a0-4fbe-4c4a-b379-ab11c7255c1b" /> | <img width="1080" height="2340" alt="3_tournament" src="https://github.com/user-attachments/assets/1bafc380-50e3-4f6c-bac4-8cae0b0c361d" /> |

### Broadcast (`/broadcast/.../BoiVuw5O`)

| Before | After |
|--------|-------|
| <img width="1080" height="2340" alt="4_broadcast" src="https://github.com/user-attachments/assets/72f5e729-cc50-4ac4-888e-03095cd0138a" /> | <img width="1080" height="2340" alt="4_broadcast" src="https://github.com/user-attachments/assets/ac797549-6350-43f7-a684-cdd8b2d75eb8" /> |