### PR TITLE
fix: show puzzle storm-only days in user activity

### DIFF
--- a/lib/src/model/user/user.dart
+++ b/lib/src/model/user/user.dart
@@ -345,6 +345,7 @@ sealed class UserActivity with _$UserActivity {
       bestTournament == null &&
       puzzles == null &&
       streak == null &&
+      storm == null &&
       correspondenceEnds == null &&
       correspondenceMovesNb == null &&
       correspondenceGamesNb == null;


### PR DESCRIPTION
Fixes the mobile activity feed so days with only Puzzle Storm are no longer treated as empty.

The issue was that `storm` was rendered in the UI, but not included in `UserActivity.isEmpty`, so those days were filtered out before rendering.