### PR TITLE
Disable blog feed widget content when kid mode is active

### DIFF
--- a/ios/EXTENSIONS.md
+++ b/ios/EXTENSIONS.md
@@ -13,7 +13,8 @@ You can still build and test extensions using your own Apple Developer account a
 1. Open `ios/Runner.xcworkspace` in Xcode.
 2. Select the **Runner** target → **Signing & Capabilities** → set **Team** to your account and change the bundle ID to something you own (e.g. `com.yourname.lichess`).
 3. Do the same for the extension target (e.g. **LichessWidgetsExtension**), using a matching sub-ID (e.g. `com.yourname.lichess.widget`).
-4. Build and run from Xcode — the extension will be signed with your profile and work on your device.
+4. For both targets, go to **Signing & Capabilities** → **+ Capability** → **App Groups**, and add an app group matching your bundle ID (e.g. `group.com.yourname.lichess`). The group ID must match across both targets and must also match what the Flutter app passes to `HomeWidget.setAppGroupId(...)` in `lib/src/app.dart`.
+5. Build and run from Xcode — the extension will be signed with your profile and work on your device.
 
 These changes are local only and should not be committed.
 
@@ -23,6 +24,15 @@ When a PR that adds a new extension is ready to merge, a Lichess org member with
 
 1. Register the new App ID (for the extension's bundle ID) in the Apple Developer portal.
 2. Create a provisioning profile for it.
+
+### Registering a new App Group
+
+When a PR introduces a new App Group (shared `UserDefaults` between the main app and an extension), a Lichess org member needs to do this once:
+
+1. In the [Apple Developer portal](https://developer.apple.com/account/resources/identifiers/list/applicationGroup), go to **Identifiers** → **App Groups** → **+** and register the new group ID (e.g. `group.org.lichess.mobileV2`).
+2. Edit the **main app** identifier (`org.lichess.mobileV2`) → **App Groups** → enable the new group.
+3. Edit the **extension** identifier (e.g. `org.lichess.mobileV2.LichessWidgets`) → **App Groups** → enable the same group.
+4. Regenerate and re-download any affected provisioning profiles, or let `match` handle it (see below).
 
 ## Deploying extensions via fastlane
 

--- a/ios/LichessWidgets/Blog Feed Widget/BlogFeedFetcher.swift
+++ b/ios/LichessWidgets/Blog Feed Widget/BlogFeedFetcher.swift
@@ -20,7 +20,7 @@ struct BlogFeedFetcher {
 
     func fetchEntry(feed: BlogFeedChoice, username: String?, family: WidgetFamily) async -> BlogFeedEntry {
         let (items, error) = await fetchFeed(feed: feed, username: username, family: family)
-        return BlogFeedEntry(date: .now, feed: feed, username: username, items: items, error: error)
+        return BlogFeedEntry(date: .now, feed: feed, username: username, items: items, error: error, isKidMode: false)
     }
 
     private func fetchFeed(feed: BlogFeedChoice,

--- a/ios/LichessWidgets/Blog Feed Widget/BlogFeedPlaceholder.swift
+++ b/ios/LichessWidgets/Blog Feed Widget/BlogFeedPlaceholder.swift
@@ -9,7 +9,8 @@ enum BlogFeedPlaceholder {
             feed: feed,
             username: username,
             items: Array(items(for: feed).prefix(family.maxItems)),
-            error: nil
+            error: nil,
+            isKidMode: false
         )
     }
 

--- a/ios/LichessWidgets/Blog Feed Widget/GenericBlogFeedProvider.swift
+++ b/ios/LichessWidgets/Blog Feed Widget/GenericBlogFeedProvider.swift
@@ -11,6 +11,10 @@ struct GenericBlogFeedProvider: TimelineProvider {
 
     func getSnapshot(in context: Context, completion: @escaping (BlogFeedEntry) -> Void) {
         if context.isPreview { completion(placeholder(in: context)); return }
+        if LichessAppGroup.isKidModeActive {
+            completion(kidModeEntry())
+            return
+        }
         Task {
             completion(await fetcher.fetchEntry(feed: feed,
                                                 username: nil,
@@ -19,6 +23,10 @@ struct GenericBlogFeedProvider: TimelineProvider {
     }
 
     func getTimeline(in context: Context, completion: @escaping (Timeline<BlogFeedEntry>) -> Void) {
+        if LichessAppGroup.isKidModeActive {
+            completion(Timeline(entries: [kidModeEntry()], policy: .never))
+            return
+        }
         Task {
             let entry = await fetcher.fetchEntry(feed: feed,
                                                  username: nil,
@@ -26,5 +34,9 @@ struct GenericBlogFeedProvider: TimelineProvider {
             let nextUpdate = BlogFeedFetcher.nextUpdateDate
             completion(Timeline(entries: [entry], policy: .after(nextUpdate)))
         }
+    }
+
+    private func kidModeEntry() -> BlogFeedEntry {
+        BlogFeedEntry(date: .now, feed: feed, username: nil, items: [], error: nil, isKidMode: true)
     }
 }

--- a/ios/LichessWidgets/Blog Feed Widget/GenericBlogFeedProvider.swift
+++ b/ios/LichessWidgets/Blog Feed Widget/GenericBlogFeedProvider.swift
@@ -12,7 +12,7 @@ struct GenericBlogFeedProvider: TimelineProvider {
     func getSnapshot(in context: Context, completion: @escaping (BlogFeedEntry) -> Void) {
         if context.isPreview { completion(placeholder(in: context)); return }
         if LichessAppGroup.isKidModeActive {
-            completion(kidModeEntry())
+            completion(.kidMode(feed: feed))
             return
         }
         Task {
@@ -24,7 +24,7 @@ struct GenericBlogFeedProvider: TimelineProvider {
 
     func getTimeline(in context: Context, completion: @escaping (Timeline<BlogFeedEntry>) -> Void) {
         if LichessAppGroup.isKidModeActive {
-            completion(Timeline(entries: [kidModeEntry()], policy: .never))
+            completion(Timeline(entries: [.kidMode(feed: feed)], policy: .never))
             return
         }
         Task {
@@ -36,7 +36,4 @@ struct GenericBlogFeedProvider: TimelineProvider {
         }
     }
 
-    private func kidModeEntry() -> BlogFeedEntry {
-        BlogFeedEntry(date: .now, feed: feed, username: nil, items: [], error: nil, isKidMode: true)
-    }
 }

--- a/ios/LichessWidgets/Blog Feed Widget/Model/BlogFeedEntry.swift
+++ b/ios/LichessWidgets/Blog Feed Widget/Model/BlogFeedEntry.swift
@@ -8,6 +8,10 @@ struct BlogFeedEntry: TimelineEntry {
     let error: String?
     let isKidMode: Bool
 
+    static func kidMode(feed: BlogFeedChoice, username: String? = nil) -> BlogFeedEntry {
+        BlogFeedEntry(date: .now, feed: feed, username: username, items: [], error: nil, isKidMode: true)
+    }
+
     /// Display name for the widget header.
     var headerTitle: String {
         if feed == .userBlog, let username, !username.isEmpty {

--- a/ios/LichessWidgets/Blog Feed Widget/Model/BlogFeedEntry.swift
+++ b/ios/LichessWidgets/Blog Feed Widget/Model/BlogFeedEntry.swift
@@ -6,6 +6,7 @@ struct BlogFeedEntry: TimelineEntry {
     let username: String?
     let items: [BlogFeedItem]
     let error: String?
+    let isKidMode: Bool
 
     /// Display name for the widget header.
     var headerTitle: String {

--- a/ios/LichessWidgets/Blog Feed Widget/UserBlogFeedProvider.swift
+++ b/ios/LichessWidgets/Blog Feed Widget/UserBlogFeedProvider.swift
@@ -9,16 +9,26 @@ struct UserBlogFeedProvider: AppIntentTimelineProvider {
 
     func snapshot(for configuration: UserBlogFeedIntent, in context: Context) async -> BlogFeedEntry {
         if context.isPreview { return placeholder(in: context) }
+        if LichessAppGroup.isKidModeActive {
+            return kidModeEntry(username: configuration.username)
+        }
         return await fetcher.fetchEntry(feed: .userBlog,
                                         username: configuration.username,
                                         family: context.family)
     }
 
     func timeline(for configuration: UserBlogFeedIntent, in context: Context) async -> Timeline<BlogFeedEntry> {
+        if LichessAppGroup.isKidModeActive {
+            return Timeline(entries: [kidModeEntry(username: configuration.username)], policy: .never)
+        }
         let entry = await fetcher.fetchEntry(feed: .userBlog,
                                              username: configuration.username,
                                              family: context.family)
         let nextUpdate = BlogFeedFetcher.nextUpdateDate
         return Timeline(entries: [entry], policy: .after(nextUpdate))
+    }
+
+    private func kidModeEntry(username: String?) -> BlogFeedEntry {
+        BlogFeedEntry(date: .now, feed: .userBlog, username: username, items: [], error: nil, isKidMode: true)
     }
 }

--- a/ios/LichessWidgets/Blog Feed Widget/UserBlogFeedProvider.swift
+++ b/ios/LichessWidgets/Blog Feed Widget/UserBlogFeedProvider.swift
@@ -10,7 +10,7 @@ struct UserBlogFeedProvider: AppIntentTimelineProvider {
     func snapshot(for configuration: UserBlogFeedIntent, in context: Context) async -> BlogFeedEntry {
         if context.isPreview { return placeholder(in: context) }
         if LichessAppGroup.isKidModeActive {
-            return kidModeEntry(username: configuration.username)
+            return .kidMode(feed: .userBlog, username: configuration.username)
         }
         return await fetcher.fetchEntry(feed: .userBlog,
                                         username: configuration.username,
@@ -19,7 +19,7 @@ struct UserBlogFeedProvider: AppIntentTimelineProvider {
 
     func timeline(for configuration: UserBlogFeedIntent, in context: Context) async -> Timeline<BlogFeedEntry> {
         if LichessAppGroup.isKidModeActive {
-            return Timeline(entries: [kidModeEntry(username: configuration.username)], policy: .never)
+            return Timeline(entries: [.kidMode(feed: .userBlog, username: configuration.username)], policy: .never)
         }
         let entry = await fetcher.fetchEntry(feed: .userBlog,
                                              username: configuration.username,
@@ -28,7 +28,4 @@ struct UserBlogFeedProvider: AppIntentTimelineProvider {
         return Timeline(entries: [entry], policy: .after(nextUpdate))
     }
 
-    private func kidModeEntry(username: String?) -> BlogFeedEntry {
-        BlogFeedEntry(date: .now, feed: .userBlog, username: username, items: [], error: nil, isKidMode: true)
-    }
 }

--- a/ios/LichessWidgets/Blog Feed Widget/Views/BlogFeedWidgetEntryView.swift
+++ b/ios/LichessWidgets/Blog Feed Widget/Views/BlogFeedWidgetEntryView.swift
@@ -76,7 +76,18 @@ struct BlogFeedWidgetEntryView: View {
             Divider()
                 .padding(.top, BlogFeedWidgetLayout.itemTopPadding)
 
-            if family == .systemSmall {
+            if entry.isKidMode {
+                VStack(spacing: BlogFeedWidgetLayout.errorStackSpacing) {
+                    Image(systemName: "lock.fill")
+                        .font(.system(size: BlogFeedWidgetLayout.errorIconSize))
+                        .foregroundStyle(.secondary)
+                    Text("Not available in Kid Mode")
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
+                        .multilineTextAlignment(.center)
+                }
+                .frame(maxWidth: .infinity, maxHeight: .infinity)
+            } else if family == .systemSmall {
                 itemsContent(spec: nil)
                     .frame(maxWidth: .infinity, alignment: .leading)
                 Spacer()

--- a/ios/LichessWidgets/LichessAppGroup.swift
+++ b/ios/LichessWidgets/LichessAppGroup.swift
@@ -3,7 +3,10 @@ import Foundation
 enum LichessAppGroup {
     static let id = "group.org.lichess.mobileV2"
 
+    // Key must match the string passed to HomeWidget.saveWidgetData in lib/src/app.dart.
+    static let kidModeKey = "isKidMode"
+
     static var isKidModeActive: Bool {
-        UserDefaults(suiteName: id)?.bool(forKey: "isKidMode") ?? false
+        UserDefaults(suiteName: id)?.bool(forKey: kidModeKey) ?? false
     }
 }

--- a/ios/LichessWidgets/LichessAppGroup.swift
+++ b/ios/LichessWidgets/LichessAppGroup.swift
@@ -1,0 +1,9 @@
+import Foundation
+
+enum LichessAppGroup {
+    static let id = "group.org.lichess.mobileV2"
+
+    static var isKidModeActive: Bool {
+        UserDefaults(suiteName: id)?.bool(forKey: "isKidMode") ?? false
+    }
+}

--- a/ios/LichessWidgets/LichessWidgets.entitlements
+++ b/ios/LichessWidgets/LichessWidgets.entitlements
@@ -2,12 +2,6 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
-	<key>aps-environment</key>
-	<string>development</string>
-	<key>com.apple.developer.associated-domains</key>
-	<array>
-		<string>applinks:lichess.org</string>
-	</array>
 	<key>com.apple.security.application-groups</key>
 	<array>
 		<string>group.org.lichess.mobileV2</string>

--- a/ios/Podfile.lock
+++ b/ios/Podfile.lock
@@ -139,6 +139,8 @@ PODS:
   - GoogleUtilities/UserDefaults (8.1.0):
     - GoogleUtilities/Logger
     - GoogleUtilities/Privacy
+  - home_widget (0.0.1):
+    - Flutter
   - image_picker_ios (0.0.1):
     - Flutter
   - multistockfish_chess (0.3.0):
@@ -194,6 +196,7 @@ DEPENDENCIES:
   - flutter_local_notifications (from `.symlinks/plugins/flutter_local_notifications/ios`)
   - flutter_native_splash (from `.symlinks/plugins/flutter_native_splash/ios`)
   - flutter_secure_storage_darwin (from `.symlinks/plugins/flutter_secure_storage_darwin/darwin`)
+  - home_widget (from `.symlinks/plugins/home_widget/ios`)
   - image_picker_ios (from `.symlinks/plugins/image_picker_ios/ios`)
   - multistockfish_chess (from `.symlinks/plugins/multistockfish_chess/ios`)
   - multistockfish_sf16 (from `.symlinks/plugins/multistockfish_sf16/ios`)
@@ -256,6 +259,8 @@ EXTERNAL SOURCES:
     :path: ".symlinks/plugins/flutter_native_splash/ios"
   flutter_secure_storage_darwin:
     :path: ".symlinks/plugins/flutter_secure_storage_darwin/darwin"
+  home_widget:
+    :path: ".symlinks/plugins/home_widget/ios"
   image_picker_ios:
     :path: ".symlinks/plugins/image_picker_ios/ios"
   multistockfish_chess:
@@ -310,6 +315,7 @@ SPEC CHECKSUMS:
   flutter_secure_storage_darwin: acdb3f316ed05a3e68f856e0353b133eec373a23
   GoogleDataTransport: aae35b7ea0c09004c3797d53c8c41f66f219d6a7
   GoogleUtilities: 00c88b9a86066ef77f0da2fab05f65d7768ed8e1
+  home_widget: 54b4f6b36ed8d64cfee594a476225c35c3e45091
   image_picker_ios: e0ece4aa2a75771a7de3fa735d26d90817041326
   multistockfish_chess: 826a3fb3746cbf66496bb1388eb664084fac393c
   multistockfish_sf16: dfd62eb23f5caaad596fa61e88624ead35f0a5e8

--- a/ios/Runner.xcodeproj/project.pbxproj
+++ b/ios/Runner.xcodeproj/project.pbxproj
@@ -3,7 +3,7 @@
 	archiveVersion = 1;
 	classes = {
 	};
-	objectVersion = 54;
+	objectVersion = 70;
 	objects = {
 
 /* Begin PBXBuildFile section */
@@ -83,7 +83,7 @@
 /* End PBXFileReference section */
 
 /* Begin PBXFileSystemSynchronizedBuildFileExceptionSet section */
-		2F2A90F02F6DF5F4008DA3C7 /* Exceptions for "LichessWidgets" folder in "LichessWidgetsExtension" target */ = {
+		2F2A90F02F6DF5F4008DA3C7 /* PBXFileSystemSynchronizedBuildFileExceptionSet */ = {
 			isa = PBXFileSystemSynchronizedBuildFileExceptionSet;
 			membershipExceptions = (
 				Resources/Info.plist,
@@ -93,18 +93,7 @@
 /* End PBXFileSystemSynchronizedBuildFileExceptionSet section */
 
 /* Begin PBXFileSystemSynchronizedRootGroup section */
-		2F2A90E12F6DF5F3008DA3C7 /* LichessWidgets */ = {
-			isa = PBXFileSystemSynchronizedRootGroup;
-			exceptions = (
-				2F2A90F02F6DF5F4008DA3C7 /* Exceptions for "LichessWidgets" folder in "LichessWidgetsExtension" target */,
-			);
-			explicitFileTypes = {
-			};
-			explicitFolders = (
-			);
-			path = LichessWidgets;
-			sourceTree = "<group>";
-		};
+		2F2A90E12F6DF5F3008DA3C7 /* LichessWidgets */ = {isa = PBXFileSystemSynchronizedRootGroup; exceptions = (2F2A90F02F6DF5F4008DA3C7 /* PBXFileSystemSynchronizedBuildFileExceptionSet */, ); explicitFileTypes = {}; explicitFolders = (); path = LichessWidgets; sourceTree = "<group>"; };
 /* End PBXFileSystemSynchronizedRootGroup section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -326,9 +315,13 @@
 			inputFileListPaths = (
 				"${PODS_ROOT}/Target Support Files/Pods-Runner/Pods-Runner-frameworks-${CONFIGURATION}-input-files.xcfilelist",
 			);
+			inputPaths = (
+			);
 			name = "[CP] Embed Pods Frameworks";
 			outputFileListPaths = (
 				"${PODS_ROOT}/Target Support Files/Pods-Runner/Pods-Runner-frameworks-${CONFIGURATION}-output-files.xcfilelist",
+			);
+			outputPaths = (
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
@@ -416,9 +409,13 @@
 			inputFileListPaths = (
 				"${PODS_ROOT}/Target Support Files/Pods-Runner/Pods-Runner-resources-${CONFIGURATION}-input-files.xcfilelist",
 			);
+			inputPaths = (
+			);
 			name = "[CP] Copy Pods Resources";
 			outputFileListPaths = (
 				"${PODS_ROOT}/Target Support Files/Pods-Runner/Pods-Runner-resources-${CONFIGURATION}-output-files.xcfilelist",
+			);
+			outputPaths = (
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;

--- a/ios/Runner.xcodeproj/project.pbxproj
+++ b/ios/Runner.xcodeproj/project.pbxproj
@@ -3,7 +3,7 @@
 	archiveVersion = 1;
 	classes = {
 	};
-	objectVersion = 70;
+	objectVersion = 54;
 	objects = {
 
 /* Begin PBXBuildFile section */
@@ -83,7 +83,7 @@
 /* End PBXFileReference section */
 
 /* Begin PBXFileSystemSynchronizedBuildFileExceptionSet section */
-		2F2A90F02F6DF5F4008DA3C7 /* PBXFileSystemSynchronizedBuildFileExceptionSet */ = {
+		2F2A90F02F6DF5F4008DA3C7 /* Exceptions for "LichessWidgets" folder in "LichessWidgetsExtension" target */ = {
 			isa = PBXFileSystemSynchronizedBuildFileExceptionSet;
 			membershipExceptions = (
 				Resources/Info.plist,
@@ -93,7 +93,18 @@
 /* End PBXFileSystemSynchronizedBuildFileExceptionSet section */
 
 /* Begin PBXFileSystemSynchronizedRootGroup section */
-		2F2A90E12F6DF5F3008DA3C7 /* LichessWidgets */ = {isa = PBXFileSystemSynchronizedRootGroup; exceptions = (2F2A90F02F6DF5F4008DA3C7 /* PBXFileSystemSynchronizedBuildFileExceptionSet */, ); explicitFileTypes = {}; explicitFolders = (); path = LichessWidgets; sourceTree = "<group>"; };
+		2F2A90E12F6DF5F3008DA3C7 /* LichessWidgets */ = {
+			isa = PBXFileSystemSynchronizedRootGroup;
+			exceptions = (
+				2F2A90F02F6DF5F4008DA3C7 /* Exceptions for "LichessWidgets" folder in "LichessWidgetsExtension" target */,
+			);
+			explicitFileTypes = {
+			};
+			explicitFolders = (
+			);
+			path = LichessWidgets;
+			sourceTree = "<group>";
+		};
 /* End PBXFileSystemSynchronizedRootGroup section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -315,13 +326,9 @@
 			inputFileListPaths = (
 				"${PODS_ROOT}/Target Support Files/Pods-Runner/Pods-Runner-frameworks-${CONFIGURATION}-input-files.xcfilelist",
 			);
-			inputPaths = (
-			);
 			name = "[CP] Embed Pods Frameworks";
 			outputFileListPaths = (
 				"${PODS_ROOT}/Target Support Files/Pods-Runner/Pods-Runner-frameworks-${CONFIGURATION}-output-files.xcfilelist",
-			);
-			outputPaths = (
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
@@ -409,13 +416,9 @@
 			inputFileListPaths = (
 				"${PODS_ROOT}/Target Support Files/Pods-Runner/Pods-Runner-resources-${CONFIGURATION}-input-files.xcfilelist",
 			);
-			inputPaths = (
-			);
 			name = "[CP] Copy Pods Resources";
 			outputFileListPaths = (
 				"${PODS_ROOT}/Target Support Files/Pods-Runner/Pods-Runner-resources-${CONFIGURATION}-output-files.xcfilelist",
-			);
-			outputPaths = (
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
@@ -567,6 +570,7 @@
 				CLANG_ENABLE_OBJC_WEAK = YES;
 				CLANG_WARN_DOCUMENTATION_COMMENTS = YES;
 				CLANG_WARN_UNGUARDED_AVAILABILITY = YES_AGGRESSIVE;
+				CODE_SIGN_ENTITLEMENTS = LichessWidgets/LichessWidgets.entitlements;
 				CODE_SIGN_IDENTITY = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 1;
@@ -612,6 +616,7 @@
 				CLANG_ENABLE_OBJC_WEAK = YES;
 				CLANG_WARN_DOCUMENTATION_COMMENTS = YES;
 				CLANG_WARN_UNGUARDED_AVAILABILITY = YES_AGGRESSIVE;
+				CODE_SIGN_ENTITLEMENTS = LichessWidgets/LichessWidgets.entitlements;
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Distribution";
 				CODE_SIGN_STYLE = Manual;
 				CURRENT_PROJECT_VERSION = 1;
@@ -657,6 +662,7 @@
 				CLANG_ENABLE_OBJC_WEAK = YES;
 				CLANG_WARN_DOCUMENTATION_COMMENTS = YES;
 				CLANG_WARN_UNGUARDED_AVAILABILITY = YES_AGGRESSIVE;
+				CODE_SIGN_ENTITLEMENTS = LichessWidgets/LichessWidgets.entitlements;
 				CODE_SIGN_IDENTITY = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 1;

--- a/lib/src/app.dart
+++ b/lib/src/app.dart
@@ -94,12 +94,12 @@ class _AppState extends ConsumerState<Application> {
 
     if (Platform.isIOS) {
       HomeWidget.setAppGroupId(_kIosAppGroupId);
-      ref.listenManual(kidModeProvider, (_, state) {
-        if (state.hasValue) {
+      ref.listenManual(kidModeProvider, (prev, state) {
+        if (state.hasValue && prev?.value != state.value) {
           HomeWidget.saveWidgetData<bool>('isKidMode', state.value).then((_) {
-            for (final kind in _kIosBlogWidgetKinds) {
-              HomeWidget.updateWidget(iOSName: kind);
-            }
+            Future.wait([
+              for (final kind in _kIosBlogWidgetKinds) HomeWidget.updateWidget(iOSName: kind),
+            ]);
           });
         }
       }, fireImmediately: true);

--- a/lib/src/app.dart
+++ b/lib/src/app.dart
@@ -4,9 +4,11 @@ import 'dart:io';
 import 'package:flutter/material.dart';
 import 'package:flutter_native_splash/flutter_native_splash.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:home_widget/home_widget.dart';
 import 'package:l10n_esperanto/l10n_esperanto.dart';
 import 'package:lichess_mobile/l10n/l10n.dart';
 import 'package:lichess_mobile/src/app_links_service.dart';
+import 'package:lichess_mobile/src/model/account/account_repository.dart';
 import 'package:lichess_mobile/src/model/account/account_service.dart';
 import 'package:lichess_mobile/src/model/account/ongoing_game.dart';
 import 'package:lichess_mobile/src/model/announce/announce_service.dart';
@@ -26,6 +28,13 @@ import 'package:lichess_mobile/src/theme.dart';
 import 'package:lichess_mobile/src/utils/screen.dart';
 import 'package:lichess_mobile/src/view/more/import_pgn_screen.dart';
 import 'package:receive_sharing_intent/receive_sharing_intent.dart';
+
+const String _kIosAppGroupId = 'group.org.lichess.mobileV2';
+const List<String> _kIosBlogWidgetKinds = [
+  'OfficialBlogWidget',
+  'CommunityBlogWidget',
+  'UserBlogFeedWidget',
+];
 
 /// Application initialization and main entry point.
 class AppInitializationScreen extends ConsumerWidget {
@@ -82,6 +91,19 @@ class _AppState extends ConsumerState<Application> {
     ref.read(quickActionServiceProvider).start();
     ref.read(announceServiceProvider).start();
     ref.read(appLinksServiceProvider).start();
+
+    if (Platform.isIOS) {
+      HomeWidget.setAppGroupId(_kIosAppGroupId);
+      ref.listenManual(kidModeProvider, (_, state) {
+        if (state.hasValue) {
+          HomeWidget.saveWidgetData<bool>('isKidMode', state.value).then((_) {
+            for (final kind in _kIosBlogWidgetKinds) {
+              HomeWidget.updateWidget(iOSName: kind);
+            }
+          });
+        }
+      }, fireImmediately: true);
+    }
 
     // Listen for connectivity changes and perform actions accordingly.
     ref.listenManual(connectivityChangesProvider, (prev, current) async {

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -743,6 +743,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "2.1.0"
+  home_widget:
+    dependency: "direct main"
+    description:
+      name: home_widget
+      sha256: d794a73894012459a4c63b94a6dc2cb3ccaa6eb08fb15b974aa7ac642594aed5
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.9.0"
   hooks:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -50,6 +50,7 @@ dependencies:
   flutter_slidable: ^4.0.0
   flutter_spinkit: ^5.2.0
   freezed_annotation: ^3.0.0
+  home_widget: ^0.9.0
   http: ^1.1.0
   image_picker: ^1.1.2
   intl: ^0.20.2
@@ -83,7 +84,6 @@ dependencies:
   stream_transform: ^2.1.0
   url_launcher: ^6.1.9
   visibility_detector: ^0.4.0
-  home_widget: ^0.9.0
   wakelock_plus: ^1.1.1
   web_socket_channel: ^3.0.0
 

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -83,6 +83,7 @@ dependencies:
   stream_transform: ^2.1.0
   url_launcher: ^6.1.9
   visibility_detector: ^0.4.0
+  home_widget: ^0.9.0
   wakelock_plus: ^1.1.1
   web_socket_channel: ^3.0.0
 


### PR DESCRIPTION
- Disables (or enables) blog feed widgets in kid mode by bridging the kid mode state from Flutter to the iOS widget extension via a shared App Group.

- All three blog widgets (OfficialBlogWidget, CommunityBlogWidget, UserBlogFeedWidget) skip the network fetch and return a "Not available in Kid Mode" placeholder when the `isKidModeActive` flag is set. The flag is bridged from the Flutter app using [home_widget](https://docs.page/abausg/home_widget) package

- Updates `ios/EXTENSIONS.md` with App Group setup steps for contributors testing locally and for org members registering the group in the Apple Developer portal (@veloce 🙂)

### Demo

#### Activating kid mode

https://github.com/user-attachments/assets/30e37a8e-4c00-4a35-9626-8e4777770258

#### Deactivating kid mode

https://github.com/user-attachments/assets/0e186ed1-725b-4a54-bc2c-6c58322c5209

