### PR TITLE
iOS Blog feed widget layout improvements

### DIFF
--- a/ios/LichessWidgets/Blog Feed Widget/Views/BlogFeedWidgetEntryView.swift
+++ b/ios/LichessWidgets/Blog Feed Widget/Views/BlogFeedWidgetEntryView.swift
@@ -8,9 +8,8 @@ struct BlogFeedWidgetEntryView: View {
     private var showDate: Bool { family == .systemLarge }
     private var lineLimit: Int {
         switch family {
-        case .systemSmall: 4
-        case .systemLarge: 2
-        default: 3
+        case .systemSmall: 3
+        default: 2
         }
     }
 

--- a/ios/LichessWidgets/Blog Feed Widget/Views/BlogFeedWidgetHeader.swift
+++ b/ios/LichessWidgets/Blog Feed Widget/Views/BlogFeedWidgetHeader.swift
@@ -10,15 +10,17 @@ struct BlogFeedWidgetHeader: View {
             Image("LichessLogo")
                 .resizable()
                 .frame(width: BlogFeedWidgetLayout.logoSize, height: BlogFeedWidgetLayout.logoSize)
-            Text(feedName)
-                .font(.system(size: BlogFeedWidgetLayout.titleFontSize, weight: .semibold))
-                .foregroundStyle(.primary)
-                .lineLimit(1)
-            if showTimestamp {
-                Spacer()
-                Text("Updated at \(updatedAt.shortTime)")
-                    .font(.system(size: BlogFeedWidgetLayout.secondaryFontSize))
-                    .foregroundStyle(.secondary)
+            HStack(alignment: .lastTextBaseline, spacing: 0) {
+                Text(feedName)
+                    .font(.system(size: BlogFeedWidgetLayout.titleFontSize, weight: .semibold))
+                    .foregroundStyle(.primary)
+                    .lineLimit(1)
+                if showTimestamp {
+                    Spacer()
+                    Text("Updated at \(updatedAt.shortTime)")
+                        .font(.system(size: BlogFeedWidgetLayout.secondaryFontSize))
+                        .foregroundStyle(.secondary)
+                }
             }
         }
     }

--- a/ios/LichessWidgets/Blog Feed Widget/Views/BlogFeedWidgetLayout.swift
+++ b/ios/LichessWidgets/Blog Feed Widget/Views/BlogFeedWidgetLayout.swift
@@ -3,9 +3,9 @@ import CoreGraphics
 /// Layout constants shared across blog feed widget views.
 enum BlogFeedWidgetLayout {
     // Typography
-    static let titleFontSize: CGFloat = 15
-    static let metaFontSize: CGFloat = 12
-    static let secondaryFontSize: CGFloat = 11
+    static let titleFontSize: CGFloat = 17
+    static let metaFontSize: CGFloat = 14
+    static let secondaryFontSize: CGFloat = 14
 
     // Header
     static let headerSpacing: CGFloat = 6
@@ -17,7 +17,7 @@ enum BlogFeedWidgetLayout {
 
     // Item list — these constants are used both in `spec(for:)` and the actual view layout,
     // keeping the geometry calculation in sync with what's rendered.
-    static let itemTopPadding: CGFloat = 8
+    static let itemTopPadding: CGFloat = 6
     /// Divider (~1pt) plus its 8pt top padding — total vertical space consumed between items.
     static let dividerTotalHeight: CGFloat = 9
 


### PR DESCRIPTION
- Improves iOS blog feed widget appearance
  - larger fonts
  - aligned title row baselines
  - fix problems with cut content (e.g. in the medium widget)

### Before & after

I added some dummy text. This is the busiest it could get:

<img width="3266" height="1322" alt="SCR-20260409-tmlc-tile" src="https://github.com/user-attachments/assets/79b4abbd-7d4b-4831-97bc-fb7a56a382cf" />
