### PR TITLE
Change the order of resign and undo move buttons

### DIFF
--- a/lib/src/view/offline_computer/offline_computer_game_screen.dart
+++ b/lib/src/view/offline_computer/offline_computer_game_screen.dart
@@ -360,16 +360,16 @@ class _BottomBar extends ConsumerWidget {
           icon: Icons.menu,
         ),
         BottomBarButton(
+          label: context.l10n.resign,
+          onTap: gameState.game.resignable ? () => _showResignDialog(context, ref) : null,
+          icon: CupertinoIcons.flag,
+        ),
+        BottomBarButton(
           label: context.l10n.takeback,
           onTap: gameState.canTakeback && (gameState.game.casual || gameState.game.practiceMode)
               ? () => ref.read(offlineComputerGameControllerProvider.notifier).takeback()
               : null,
           icon: CupertinoIcons.arrow_uturn_left,
-        ),
-        BottomBarButton(
-          label: context.l10n.resign,
-          onTap: gameState.game.resignable ? () => _showResignDialog(context, ref) : null,
-          icon: CupertinoIcons.flag,
         ),
         BottomBarButton(
           label: context.l10n.getAHint,


### PR DESCRIPTION
- Changes the order of buttons when playing against the computer - _resign_ before _undo move_
- Requested in https://github.com/lichess-org/mobile/issues/2686

#### Before and after

<img width="2102" height="1954" alt="SCR-20260410-pmsa-tile" src="https://github.com/user-attachments/assets/b4f41c80-fb76-4e33-9bee-85ffedc04ec0" />
