### PR TITLE
Start from custom position (FEN) in over the board game

### DIFF
--- a/lib/src/view/offline_computer/offline_computer_game_screen.dart
+++ b/lib/src/view/offline_computer/offline_computer_game_screen.dart
@@ -6,7 +6,6 @@ import 'package:dartchess/dartchess.dart';
 import 'package:fast_immutable_collections/fast_immutable_collections.dart';
 import 'package:flutter/cupertino.dart';
 import 'package:flutter/material.dart';
-import 'package:flutter/services.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:lichess_mobile/src/model/analysis/analysis_controller.dart';
 import 'package:lichess_mobile/src/model/common/chess.dart';
@@ -31,7 +30,6 @@ import 'package:lichess_mobile/src/widgets/adaptive_bottom_sheet.dart';
 import 'package:lichess_mobile/src/widgets/adaptive_choice_picker.dart';
 import 'package:lichess_mobile/src/widgets/board_preview.dart';
 import 'package:lichess_mobile/src/widgets/bottom_bar.dart';
-import 'package:lichess_mobile/src/widgets/feedback.dart';
 import 'package:lichess_mobile/src/widgets/game_layout.dart';
 import 'package:lichess_mobile/src/widgets/list.dart';
 import 'package:lichess_mobile/src/widgets/material_diff.dart';
@@ -898,7 +896,7 @@ class _NewGameSheetState extends ConsumerState<_NewGameSheet> {
                           ),
                           controller: _fenController,
                           readOnly: true,
-                          onTap: _getClipboardData,
+                          onTap: () => pasteFenFromClipboard(context, _fenController),
                         ),
                       )
                     : const SizedBox.shrink(),
@@ -964,20 +962,6 @@ class _NewGameSheetState extends ConsumerState<_NewGameSheet> {
       _selectedVariant != Variant.fromPosition ||
       widget.initialFen != null ||
       (_fromPositionFen != null && _fromPositionFen!.isNotEmpty);
-
-  Future<void> _getClipboardData() async {
-    final data = await Clipboard.getData(Clipboard.kTextPlain);
-    if (data != null) {
-      try {
-        Chess.fromSetup(Setup.parseFen(data.text!.trim()));
-        _fenController.text = data.text!.trim();
-      } catch (_) {
-        if (mounted) {
-          showSnackBar(context, context.l10n.invalidFen, type: SnackBarType.error);
-        }
-      }
-    }
-  }
 }
 
 class _PracticeSettingsSheet extends ConsumerWidget {

--- a/lib/src/view/over_the_board/configure_over_the_board_game.dart
+++ b/lib/src/view/over_the_board/configure_over_the_board_game.dart
@@ -1,4 +1,3 @@
-import 'package:chessground/chessground.dart';
 import 'package:dartchess/dartchess.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
@@ -7,12 +6,12 @@ import 'package:lichess_mobile/src/model/common/time_increment.dart';
 import 'package:lichess_mobile/src/model/lobby/game_setup_preferences.dart';
 import 'package:lichess_mobile/src/model/over_the_board/over_the_board_clock.dart';
 import 'package:lichess_mobile/src/model/over_the_board/over_the_board_game_controller.dart';
-import 'package:lichess_mobile/src/model/settings/board_preferences.dart';
 import 'package:lichess_mobile/src/model/settings/over_the_board_preferences.dart';
 import 'package:lichess_mobile/src/styles/styles.dart';
 import 'package:lichess_mobile/src/utils/l10n_context.dart';
 import 'package:lichess_mobile/src/widgets/adaptive_bottom_sheet.dart';
 import 'package:lichess_mobile/src/widgets/adaptive_choice_picker.dart';
+import 'package:lichess_mobile/src/widgets/board_preview.dart';
 import 'package:lichess_mobile/src/widgets/list.dart';
 import 'package:lichess_mobile/src/widgets/non_linear_slider.dart';
 import 'package:lichess_mobile/src/widgets/settings.dart';
@@ -57,18 +56,30 @@ class _ConfigureOverTheBoardGameSheetState extends ConsumerState<_ConfigureOverT
 
   late TimeIncrement timeIncrement;
 
+  String? _fromPositionFen;
+  final _fenController = TextEditingController();
+
   @override
   void initState() {
-    chosenVariant = widget.initialVariant == Variant.fromPosition
-        ? Variant.standard
-        : widget.initialVariant;
+    chosenVariant = widget.initialVariant;
+    _fromPositionFen = widget.initialFen;
+    if (widget.initialFen != null) {
+      _fenController.text = widget.initialFen!;
+    }
+    _fenController.addListener(() {
+      setState(() => _fromPositionFen = _fenController.text.isEmpty ? null : _fenController.text);
+    });
     final clockProvider = ref.read(overTheBoardClockProvider);
     timeIncrement = clockProvider.timeIncrement;
     chosenTimeControlType = ref.read(overTheBoardPreferencesProvider).timeControlType;
     super.initState();
   }
 
-  bool get _hasInitialFen => widget.initialFen != null;
+  @override
+  void dispose() {
+    _fenController.dispose();
+    super.dispose();
+  }
 
   void _setTimeControlType(TimeControlType type) {
     ref.read(overTheBoardPreferencesProvider.notifier).setTimeControlType(type);
@@ -94,33 +105,14 @@ class _ConfigureOverTheBoardGameSheetState extends ConsumerState<_ConfigureOverT
     });
   }
 
+  bool get _isPlayEnabled =>
+      chosenVariant != Variant.fromPosition ||
+      (_fromPositionFen != null && _fromPositionFen!.isNotEmpty);
+
   @override
   Widget build(BuildContext context) {
-    final boardPrefs = ref.watch(boardPreferencesProvider);
-
     return BottomSheetScrollableContainer(
       children: [
-        if (_hasInitialFen)
-          Padding(
-            padding: const EdgeInsets.only(bottom: 16.0),
-            child: Center(
-              child: SizedBox(
-                width: 150,
-                height: 150,
-                child: StaticChessboard(
-                  size: 150,
-                  fen: widget.initialFen!,
-                  orientation: Side.white,
-                  pieceAssets: boardPrefs.pieceSet.assets,
-                  colorScheme: boardPrefs.boardTheme.colors,
-                  brightness: boardPrefs.brightness,
-                  hue: boardPrefs.hue,
-                  enableCoordinates: false,
-                  borderRadius: const BorderRadius.all(Radius.circular(4)),
-                ),
-              ),
-            ),
-          ),
         ListSection(
           materialFilledCard: true,
           children: [
@@ -130,9 +122,7 @@ class _ConfigureOverTheBoardGameSheetState extends ConsumerState<_ConfigureOverT
               onTap: () {
                 showChoicePicker<Variant>(
                   context,
-                  choices: playSupportedVariants
-                      .where((variant) => variant != Variant.fromPosition)
-                      .toList(),
+                  choices: playSupportedVariants.toList(),
                   selectedItem: chosenVariant,
                   labelBuilder: (variant) => VariantLabel(variant),
                   onSelectedItemChanged: (Variant variant) => setState(() {
@@ -140,6 +130,26 @@ class _ConfigureOverTheBoardGameSheetState extends ConsumerState<_ConfigureOverT
                   }),
                 );
               },
+            ),
+            AnimatedSize(
+              duration: const Duration(milliseconds: 300),
+              curve: Curves.fastOutSlowIn,
+              child: chosenVariant == Variant.fromPosition
+                  ? SmallBoardPreview(
+                      orientation: Side.white,
+                      fen: _fromPositionFen ?? kEmptyFEN,
+                      description: TextField(
+                        maxLines: 5,
+                        decoration: InputDecoration(
+                          labelText: context.l10n.pasteTheFenStringHere,
+                          suffixIcon: const Icon(Icons.paste),
+                        ),
+                        controller: _fenController,
+                        readOnly: true,
+                        onTap: () => pasteFenFromClipboard(context, _fenController),
+                      ),
+                    )
+                  : const SizedBox.shrink(),
             ),
             SettingsListTile(
               settingsLabel: Text(context.l10n.timeControl),
@@ -209,13 +219,21 @@ class _ConfigureOverTheBoardGameSheetState extends ConsumerState<_ConfigureOverT
         Padding(
           padding: Styles.horizontalBodyPadding,
           child: FilledButton(
-            onPressed: () {
-              ref.read(overTheBoardClockProvider.notifier).setupClock(timeIncrement);
-              ref
-                  .read(overTheBoardGameControllerProvider.notifier)
-                  .startNewGame(chosenVariant, timeIncrement, initialFen: widget.initialFen);
-              Navigator.pop(context);
-            },
+            onPressed: _isPlayEnabled
+                ? () {
+                    ref.read(overTheBoardClockProvider.notifier).setupClock(timeIncrement);
+                    ref
+                        .read(overTheBoardGameControllerProvider.notifier)
+                        .startNewGame(
+                          chosenVariant,
+                          timeIncrement,
+                          initialFen: chosenVariant == Variant.fromPosition
+                              ? _fromPositionFen
+                              : null,
+                        );
+                    Navigator.pop(context);
+                  }
+                : null,
             child: Text(context.l10n.play, style: Styles.bold),
           ),
         ),

--- a/lib/src/view/over_the_board/configure_over_the_board_game.dart
+++ b/lib/src/view/over_the_board/configure_over_the_board_game.dart
@@ -61,7 +61,17 @@ class _ConfigureOverTheBoardGameSheetState extends ConsumerState<_ConfigureOverT
 
   @override
   void initState() {
-    chosenVariant = widget.initialVariant;
+    // Auto-switch variant to fromPosition when an initialFen is given for a
+    // standard game (mirrors the controller's fromVariant logic), and fall back
+    // to standard when fromPosition arrives without a FEN (e.g. "New game"
+    // after a fromPosition game).
+    if (widget.initialFen != null && widget.initialVariant == Variant.standard) {
+      chosenVariant = Variant.fromPosition;
+    } else if (widget.initialFen == null && widget.initialVariant == Variant.fromPosition) {
+      chosenVariant = Variant.standard;
+    } else {
+      chosenVariant = widget.initialVariant;
+    }
     _fromPositionFen = widget.initialFen;
     if (widget.initialFen != null) {
       _fenController.text = widget.initialFen!;
@@ -224,13 +234,7 @@ class _ConfigureOverTheBoardGameSheetState extends ConsumerState<_ConfigureOverT
                     ref.read(overTheBoardClockProvider.notifier).setupClock(timeIncrement);
                     ref
                         .read(overTheBoardGameControllerProvider.notifier)
-                        .startNewGame(
-                          chosenVariant,
-                          timeIncrement,
-                          initialFen: chosenVariant == Variant.fromPosition
-                              ? _fromPositionFen
-                              : null,
-                        );
+                        .startNewGame(chosenVariant, timeIncrement, initialFen: _fromPositionFen);
                     Navigator.pop(context);
                   }
                 : null,

--- a/lib/src/view/play/create_challenge_bottom_sheet.dart
+++ b/lib/src/view/play/create_challenge_bottom_sheet.dart
@@ -2,7 +2,6 @@ import 'dart:async';
 
 import 'package:dartchess/dartchess.dart';
 import 'package:flutter/material.dart';
-import 'package:flutter/services.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:lichess_mobile/src/model/account/account_repository.dart';
 import 'package:lichess_mobile/src/model/challenge/challenge.dart';
@@ -263,7 +262,7 @@ class _CreateChallengeBottomSheetState extends ConsumerState<CreateChallengeBott
                   ),
                   controller: _controller,
                   readOnly: true,
-                  onTap: _getClipboardData,
+                  onTap: () => pasteFenFromClipboard(context, _controller),
                 ),
               ),
             ),
@@ -415,20 +414,6 @@ class _CreateChallengeBottomSheetState extends ConsumerState<CreateChallengeBott
         );
       case _:
         return const Center(child: CircularProgressIndicator.adaptive());
-    }
-  }
-
-  Future<void> _getClipboardData() async {
-    final ClipboardData? data = await Clipboard.getData(Clipboard.kTextPlain);
-    if (data != null) {
-      try {
-        Chess.fromSetup(Setup.parseFen(data.text!.trim()));
-        _controller.text = data.text!;
-      } catch (_) {
-        if (mounted) {
-          showSnackBar(context, context.l10n.invalidFen, type: SnackBarType.error);
-        }
-      }
     }
   }
 }

--- a/lib/src/widgets/board_preview.dart
+++ b/lib/src/widgets/board_preview.dart
@@ -1,10 +1,13 @@
 import 'package:chessground/chessground.dart';
 import 'package:dartchess/dartchess.dart';
 import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:lichess_mobile/src/constants.dart';
 import 'package:lichess_mobile/src/model/settings/board_preferences.dart';
 import 'package:lichess_mobile/src/styles/styles.dart';
+import 'package:lichess_mobile/src/utils/l10n_context.dart';
+import 'package:lichess_mobile/src/widgets/feedback.dart';
 
 /// A board preview with a description.
 class SmallBoardPreview extends ConsumerWidget {
@@ -140,5 +143,22 @@ class SmallBoardPreview extends ConsumerWidget {
     );
 
     return onTap != null ? InkWell(onTap: onTap, child: content) : content;
+  }
+}
+
+/// Reads a FEN from the clipboard, validates it, and sets it on [controller].
+///
+/// Shows a snackbar if the clipboard content is not a valid FEN.
+Future<void> pasteFenFromClipboard(BuildContext context, TextEditingController controller) async {
+  final data = await Clipboard.getData(Clipboard.kTextPlain);
+  if (data != null) {
+    try {
+      Chess.fromSetup(Setup.parseFen(data.text!.trim()));
+      controller.text = data.text!.trim();
+    } catch (_) {
+      if (context.mounted) {
+        showSnackBar(context, context.l10n.invalidFen, type: SnackBarType.error);
+      }
+    }
   }
 }

--- a/test/view/over_the_board/over_the_board_screen_test.dart
+++ b/test/view/over_the_board/over_the_board_screen_test.dart
@@ -460,6 +460,8 @@ void main() {
     );
 
     testWidgets('Game preserves non-standard variant when initialFen is provided', (tester) async {
+      // When the board editor sends a non-standard variant + custom FEN (e.g. Crazyhouse), the
+      // configure sheet must keep that variant and not auto-switch to fromPosition.
       final gameStorage = MockOverTheBoardGameStorage();
       when(() => gameStorage.fetchOngoingGame()).thenAnswer((_) async => null);
 
@@ -469,7 +471,10 @@ void main() {
         home: Consumer(
           builder: (context, r, _) {
             ref = r;
-            return const OverTheBoardScreen(initialFen: _customFen);
+            return const OverTheBoardScreen(
+              initialVariant: Variant.crazyhouse,
+              initialFen: _customFen,
+            );
           },
         ),
         overrides: {
@@ -479,12 +484,6 @@ void main() {
         },
       );
       await tester.pumpWidget(app);
-      await tester.pumpAndSettle();
-
-      // Change variant to Crazyhouse
-      await tester.tap(find.textContaining('Standard'));
-      await tester.pumpAndSettle();
-      await tester.tap(find.textContaining('Crazyhouse'));
       await tester.pumpAndSettle();
 
       await tester.tap(find.text('Play'));


### PR DESCRIPTION
- Adds _From position_ option to the game variants when starting an OTB game
- Resolves https://github.com/lichess-org/mobile/issues/2915
- Extracts clipboard FEN loading into a helper method

### Demo

FEN was `4kb1r/p4ppp/4q3/8/8/1B6/PPP2PPP/2KR4 w k - 2 15`

##### iOS

https://github.com/user-attachments/assets/e38009a4-e3b2-4507-8fdc-e2728807201c

##### Android

https://github.com/user-attachments/assets/7d12a169-9509-4f2d-a995-48d1a0668604
