### PR TITLE
Use default Xcode indentation in iOS folder

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -6,3 +6,6 @@ end_of_line = lf
 insert_final_newline = true
 indent_style = space
 indent_size = 2
+
+[ios/**.{swift,m,mm,h}]
+indent_size = 4


### PR DESCRIPTION
- Updates the `.editorconfig` file to set `indent_size` to `4` for native iOS Xcode project files (default for Swift, Objective-C, etc.) while keeping it at `2` for the Flutter/Dart files.

- In practice it means that Xcode built-in formatting is now the same as the `.editorconfig` setting (`indent_size = 4`)