### PR TITLE
Internationalise iOS widgets

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -100,11 +100,12 @@ The formatter is configured via `analysis_options.yaml` (`formatter: page_width:
 
 ### Adding New Translations
 1. Edit `translation/source/mobile.xml` for mobile-specific strings
-2. Generate ARB files and Dart code:
+2. Regenerate everything:
 ```bash
-./scripts/gen-arb.mjs
-flutter gen-l10n
+./scripts/gen-translations.sh
 ```
+
+This runs `gen-arb.mjs`, `flutter gen-l10n`, and `gen-widget-strings.mjs` in order.
 
 Mobile-specific translations get a `mobile` prefix (e.g., "foo" becomes `mobileFoo` in Dart).
 
@@ -373,6 +374,8 @@ The Flutter app (via `home_widget` package) writes to the shared App Group from 
 - `isKidMode` — hides blog widgets when active (triggers blog widget reload)
 
 When modifying widget-related settings or board theme/piece set preferences in Dart, ensure the corresponding `HomeWidget.saveWidgetData` call and `HomeWidget.updateWidget` are kept in sync in `lib/src/app.dart`.
+
+Widget UI strings are translated via `ios/LichessWidgets/Localizable.xcstrings` (a String Catalog). To add a new translatable string, register it under `WIDGET_KEYS` in `scripts/gen-widget-strings.mjs` and run `./scripts/gen-translations.sh`.
 
 ### Code Signing
 

--- a/docs/internationalisation.md
+++ b/docs/internationalisation.md
@@ -14,11 +14,14 @@ ARB files are generated with a script that processes these translations: `script
 
 Then a flutter command is used to generate the dart files from the ARB files.
 
-So, in order to update the dart files we need to run:
+A third script, `scripts/gen-widget-strings.mjs`, generates `ios/LichessWidgets/Localizable.xcstrings`
+— a String Catalog used by the native iOS widget extension to translate its UI strings. See
+[ios/EXTENSIONS.md](../ios/EXTENSIONS.md#internationalisation) for details on adding new widget strings.
+
+All three steps are combined in a single script:
 
 ```bash
-./scripts/gen-arb.mjs
-flutter gen-l10n
+./scripts/gen-translations.sh
 ```
 
 ## How to add new translations
@@ -42,8 +45,7 @@ Note that a module can contain a lot of translations that we don't need in the a
 Once you've added the module to the script, you can run the script to update the translations.
 
 ```bash
-./scripts/gen-arb.mjs
-flutter gen-l10n
+./scripts/gen-translations.sh
 ```
 
 You should see the new strings in the `lib/l10n/app_*.arb` and `lib/l10n/app_*.dart` files.

--- a/ios/EXTENSIONS.md
+++ b/ios/EXTENSIONS.md
@@ -51,6 +51,26 @@ This will generate the profile, push it to the certificates repo, and set the co
 
 Also add the new bundle ID to both `app_identifier` arrays in `fastlane/Matchfile` and the `sync_code_signing` call in `fastlane/Fastfile`.
 
+## Internationalisation
+
+Widget UI strings are translated using a String Catalog at `ios/LichessWidgets/Localizable.xcstrings`. This file is generated from the app's ARB translation files and must not be edited by hand.
+
+### How it works
+
+`scripts/gen-widget-strings.mjs` reads every `lib/l10n/app_*.arb` file and extracts the keys listed in its `WIDGET_KEYS` map, then writes them into `Localizable.xcstrings` with all available translations. The String Catalog is picked up automatically by Xcode via the `fileSystemSynchronizedRootGroup` — no project file changes needed.
+
+SwiftUI `Text("Daily Puzzle")` resolves the string at runtime against the catalog using the device locale, so no code changes are needed on the Swift side for existing strings.
+
+### Adding a new translatable string
+
+1. Make sure the string exists in the ARB files (either from Crowdin or from `translation/source/mobile.xml` — see [docs/internationalisation.md](../docs/internationalisation.md)).
+2. Add an entry to `WIDGET_KEYS` in `scripts/gen-widget-strings.mjs`:
+   ```js
+   'English UI string': { arbKey: 'theArbKey', fallback: 'English UI string' },
+   ```
+3. Run `./scripts/gen-translations.sh` to regenerate the catalog.
+4. Use the exact same English string as a `LocalizedStringKey` in SwiftUI (`Text("English UI string")`).
+
 ## Chessboard assets
 
 Board textures, piece images, and theme colour data used by the widgets are

--- a/ios/LichessWidgets/Extensions/Date+Formatting.swift
+++ b/ios/LichessWidgets/Extensions/Date+Formatting.swift
@@ -4,9 +4,11 @@ extension Date {
     /// "14:53" — used for "Updated at" timestamps.
     var shortTime: String { formatted(.dateTime.hour().minute()) }
 
-    /// "Mar 19" for the current year, "Mar 19, 2025" for a past/future year.
-    var widgetDateFormat: FormatStyle {
+    /// "14 avr." / "Apr 14" — abbreviated day+month in the device locale.
+    /// Includes the year when the date falls outside the current year.
+    var widgetDateFormat: Date.FormatStyle {
         let sameYear = Calendar.current.isDate(self, equalTo: .now, toGranularity: .year)
-        return sameYear ? .dateTime.month(.abbreviated).day() : .dateTime.month(.abbreviated).day().year()
+        let base = Date.FormatStyle(locale: .current).month(.abbreviated).day()
+        return sameYear ? base : base.year()
     }
 }

--- a/ios/LichessWidgets/Localizable.xcstrings
+++ b/ios/LichessWidgets/Localizable.xcstrings
@@ -1,0 +1,305 @@
+{
+  "sourceLanguage": "en",
+  "strings": {
+    "Daily Puzzle": {
+      "extractionState": "manual",
+      "localizations": {
+        "af": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Daaglikse Raaisel"
+          }
+        },
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "اللغز اليومي"
+          }
+        },
+        "be": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Штодзённыя задачы"
+          }
+        },
+        "bg": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Задача на деня"
+          }
+        },
+        "bn": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "দৈনিক ধাঁধা"
+          }
+        },
+        "bs": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Problem dana"
+          }
+        },
+        "ca": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Problema del dia"
+          }
+        },
+        "cs": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Denní úloha"
+          }
+        },
+        "da": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Daglig taktikopgave"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Taktikaufgabe des Tages"
+          }
+        },
+        "el": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Τακτικό της ημέρας"
+          }
+        },
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Daily Puzzle"
+          }
+        },
+        "eo": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Taga puzlo"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ejercicio del día"
+          }
+        },
+        "et": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Päeva pusle"
+          }
+        },
+        "eu": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Eguneroko ariketa"
+          }
+        },
+        "fa": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "معمای روزانه"
+          }
+        },
+        "fi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Päivän tehtävä"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Problème du jour"
+          }
+        },
+        "gl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Crebacabezas do día"
+          }
+        },
+        "gsw": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Täglichi Ufgab"
+          }
+        },
+        "he": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "החידה היומית"
+          }
+        },
+        "hi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "दैनिक पहेली"
+          }
+        },
+        "hr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Dnevna zagonetka"
+          }
+        },
+        "hu": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Napi feladvány"
+          }
+        },
+        "hy": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ամենօրյա Խնդիր"
+          }
+        },
+        "id": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Teka-teki harian"
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Tattica di oggi"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "本日の問題"
+          }
+        },
+        "kk": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Күнделікті жұмбақ"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "일일 퍼즐"
+          }
+        },
+        "lt": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Dienos Galvosūkis"
+          }
+        },
+        "lv": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Šodienas uzdevums"
+          }
+        },
+        "nb": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Dagens nøtt"
+          }
+        },
+        "nl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Dagelijkse Puzzel"
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Zadanie dnia"
+          }
+        },
+        "pt": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Problema diário"
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Problema diário"
+          }
+        },
+        "ro": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Puzzle Zilnic"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Задача дня"
+          }
+        },
+        "sk": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Úloha na tento deň"
+          }
+        },
+        "sl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Uganka dneva"
+          }
+        },
+        "sv": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Dagens problem"
+          }
+        },
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Günlük Bulmaca"
+          }
+        },
+        "uk": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Щоденна задача"
+          }
+        },
+        "uz": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Kun masalasi"
+          }
+        },
+        "vi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Câu đố Hàng ngày"
+          }
+        },
+        "zh": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "每日棋谜"
+          }
+        },
+        "zh-TW": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "每日謎題"
+          }
+        }
+      }
+    }
+  },
+  "version": "1.0"
+}

--- a/scripts/gen-translations.sh
+++ b/scripts/gen-translations.sh
@@ -1,0 +1,8 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPTS_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+"$SCRIPTS_DIR/gen-arb.mjs"
+flutter gen-l10n
+node "$SCRIPTS_DIR/gen-widget-strings.mjs"

--- a/scripts/gen-widget-strings.mjs
+++ b/scripts/gen-widget-strings.mjs
@@ -1,0 +1,75 @@
+#!/usr/bin/env node
+/**
+ * Generates ios/LichessWidgets/Localizable.xcstrings from the app's ARB translation files.
+ *
+ * Run from the repo root:
+ *   node scripts/gen-widget-strings.mjs
+ *
+ * The output is a String Catalog (Xcode 15+) containing all widget UI strings.
+ * Xcode picks it up automatically via the fileSystemSynchronizedRootGroup.
+ *
+ * To add a new string:
+ *   1. Add the ARB key to WIDGET_KEYS below with its default English value.
+ *   2. Re-run this script.
+ */
+
+import fs from 'fs';
+import path from 'path';
+import { fileURLToPath } from 'url';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const ROOT = path.resolve(__dirname, '..');
+const L10N_DIR = path.join(ROOT, 'lib', 'l10n');
+const OUT_FILE = path.join(ROOT, 'ios', 'LichessWidgets', 'Localizable.xcstrings');
+
+// Map each widget UI string to its ARB key and English fallback.
+const WIDGET_KEYS = {
+  'Daily Puzzle': { arbKey: 'puzzleDailyPuzzle', fallback: 'Daily Puzzle' },
+};
+
+// ARB locale codes use '_', iOS uses '-' for subtags.
+function arbToIosLocale(arb) {
+  return arb.replace(/_/g, '-');
+}
+
+// Collect all ARB files (skip en_US which duplicates en).
+const arbFiles = fs
+  .readdirSync(L10N_DIR)
+  .filter((f) => f.startsWith('app_') && f.endsWith('.arb') && f !== 'app_en_US.arb')
+  .map((f) => ({ file: f, locale: arbToIosLocale(f.replace(/^app_/, '').replace(/\.arb$/, '')) }));
+
+// Build the strings dictionary.
+const strings = {};
+
+for (const [uiString, { arbKey, fallback }] of Object.entries(WIDGET_KEYS)) {
+  const localizations = {};
+
+  for (const { file, locale } of arbFiles) {
+    const arb = JSON.parse(fs.readFileSync(path.join(L10N_DIR, file), 'utf8'));
+    const value = arb[arbKey];
+    if (value && value !== fallback || locale === 'en') {
+      localizations[locale] = {
+        stringUnit: {
+          state: 'translated',
+          value: value ?? fallback,
+        },
+      };
+    }
+  }
+
+  strings[uiString] = {
+    extractionState: 'manual',
+    localizations,
+  };
+}
+
+const catalog = {
+  sourceLanguage: 'en',
+  strings,
+  version: '1.0',
+};
+
+fs.writeFileSync(OUT_FILE, JSON.stringify(catalog, null, 2) + '\n');
+console.log(`Written: ${path.relative(ROOT, OUT_FILE)}`);
+console.log(`  Strings: ${Object.keys(strings).length}`);
+console.log(`  Locales: ${arbFiles.length}`);


### PR DESCRIPTION
This PR adds the basic setup to internationalise iOS widgets based on existing translations in dart (from crowdin).

For now only the Daily Puzzle widget is translated. Other widgets can be updated later in other PRs.