### PR TITLE
Fix draft chat message cleared when user returns to board

### DIFF
--- a/lib/src/model/chat/chat_controller.dart
+++ b/lib/src/model/chat/chat_controller.dart
@@ -228,12 +228,19 @@ class ChatController extends AsyncNotifier<ChatState> {
       });
     }
   }
+
+  void setInputText(String text) {
+    state = state.whenData((s) => s.copyWith(inputText: text));
+  }
 }
 
 @freezed
 sealed class ChatState with _$ChatState {
   const ChatState._();
 
-  const factory ChatState({required IList<ChatMessage> messages, required int unreadMessages}) =
-      _ChatState;
+  const factory ChatState({
+    required IList<ChatMessage> messages,
+    required int unreadMessages,
+    @Default('') String inputText,
+  }) = _ChatState;
 }

--- a/lib/src/view/chat/chat_screen.dart
+++ b/lib/src/view/chat/chat_screen.dart
@@ -261,6 +261,16 @@ class _ChatBottomBarState extends ConsumerState<_ChatBottomBar> {
   final _textController = TextEditingController();
 
   @override
+  void initState() {
+    super.initState();
+    final draft = ref.read(chatControllerProvider(widget.options)).asData?.value.inputText ?? '';
+    _textController.text = draft;
+    _textController.addListener(() {
+      ref.read(chatControllerProvider(widget.options).notifier).setInputText(_textController.text);
+    });
+  }
+
+  @override
   void dispose() {
     _textController.dispose();
     super.dispose();
@@ -278,6 +288,7 @@ class _ChatBottomBarState extends ConsumerState<_ChatBottomBar> {
                     .read(chatControllerProvider(widget.options).notifier)
                     .postMessage(_textController.text);
                 _textController.clear();
+                ref.read(chatControllerProvider(widget.options).notifier).setInputText('');
               }
             : null,
         icon: const Icon(Icons.send),


### PR DESCRIPTION
When the user is playing a game and writes something in the chat but don't push the send button and goes back to the chessboard, the text in the chat inputfield won't be cleared anymore (see video).

Fixes #2269 

https://github.com/user-attachments/assets/0b9ca2d6-8c44-41bb-87b6-3363e1be022a

Enjoy!

Regards,

Maarten.