### PR TITLE
Fix puzzle widget layout on iPad

### DIFF
--- a/ios/LichessWidgets/Daily Puzzle Widget/Views/DailyPuzzleWidgetLayout.swift
+++ b/ios/LichessWidgets/Daily Puzzle Widget/Views/DailyPuzzleWidgetLayout.swift
@@ -14,7 +14,7 @@ enum DailyPuzzleWidgetLayout {
     // Board
     static let boardBorderWidth: CGFloat = 1
     static let horizontalPadding: CGFloat = 16
-    static let topPadding: CGFloat = 11
+    static let verticalPadding: CGFloat = 10
 
     // Piece
     static let pieceSizeFactor: CGFloat = 0.9

--- a/ios/LichessWidgets/Daily Puzzle Widget/Views/DailyPuzzleWidgetView.swift
+++ b/ios/LichessWidgets/Daily Puzzle Widget/Views/DailyPuzzleWidgetView.swift
@@ -18,39 +18,37 @@ struct DailyPuzzleWidgetView: View {
 
     @ViewBuilder
     private var contentView: some View {
-        GeometryReader { geo in
-            VStack(spacing: 0) {
-                HStack(spacing: DailyPuzzleWidgetLayout.headerSpacing) {
-                    Image("LichessLogo")
-                        .resizable()
-                        .frame(
-                            width: DailyPuzzleWidgetLayout.logoSize,
-                            height: DailyPuzzleWidgetLayout.logoSize
-                        )
-                    Text("Daily Puzzle")
-                        .font(.system(size: DailyPuzzleWidgetLayout.titleFontSize, weight: .semibold))
-                        .foregroundStyle(.primary)
-                        .lineLimit(1)
-
-                    Spacer()
-
-                    Text(entry.date, format: entry.date.widgetDateFormat)
-                        .font(.system(size: DailyPuzzleWidgetLayout.metaFontSize))
-                        .foregroundStyle(.secondary)
-                }
-                .padding(.bottom, DailyPuzzleWidgetLayout.headerBottomPadding)
-
-                boardView
-                    .clipShape(ContainerRelativeShape())
-                    .overlay(
-                        ContainerRelativeShape()
-                            .stroke(.tertiary, lineWidth: DailyPuzzleWidgetLayout.boardBorderWidth)
+        VStack(spacing: 0) {
+            HStack(spacing: DailyPuzzleWidgetLayout.headerSpacing) {
+                Image("LichessLogo")
+                    .resizable()
+                    .frame(
+                        width: DailyPuzzleWidgetLayout.logoSize,
+                        height: DailyPuzzleWidgetLayout.logoSize
                     )
-                    .frame(width: geo.size.width, height: geo.size.width)
+                Text("Daily Puzzle")
+                    .font(.system(size: DailyPuzzleWidgetLayout.titleFontSize, weight: .semibold))
+                    .foregroundStyle(.primary)
+                    .lineLimit(1)
+
+                Spacer()
+
+                Text(entry.date, format: entry.date.widgetDateFormat)
+                    .font(.system(size: DailyPuzzleWidgetLayout.metaFontSize))
+                    .foregroundStyle(.secondary)
             }
+            .padding(.bottom, DailyPuzzleWidgetLayout.headerBottomPadding)
+
+            boardView
+                .clipShape(ContainerRelativeShape())
+                .overlay(
+                    ContainerRelativeShape()
+                        .stroke(.tertiary, lineWidth: DailyPuzzleWidgetLayout.boardBorderWidth)
+                )
         }
         .padding(.horizontal, DailyPuzzleWidgetLayout.horizontalPadding)
         .padding(.top, DailyPuzzleWidgetLayout.topPadding)
+        .padding(.bottom, DailyPuzzleWidgetLayout.bottomPadding)
     }
 
     @ViewBuilder

--- a/ios/LichessWidgets/Daily Puzzle Widget/Views/DailyPuzzleWidgetView.swift
+++ b/ios/LichessWidgets/Daily Puzzle Widget/Views/DailyPuzzleWidgetView.swift
@@ -84,3 +84,16 @@ struct DailyPuzzleWidgetView: View {
         .frame(maxWidth: .infinity, maxHeight: .infinity)
     }
 }
+
+#Preview("Puzzle – Brown", as: .systemLarge) {
+    DailyPuzzleWidget()
+} timeline: {
+    DailyPuzzleEntry(
+        date: .now,
+        puzzleId: "abcd1",
+        fen: "1n3rk1/4ppbp/rq1p2p1/3P4/2p1P3/2N2P1n/PPN3PP/R1BQ1R1K b - - 1 1",
+        lastMove: "g1h1",
+        boardStyle: .from(themeName: "brown"),
+        error: nil
+    )
+}


### PR DESCRIPTION
- Fixes problem with chessboard layout in widget puzzle on iPad and some iPhones (e.g. iPhone 14). Large widget size can vary depending on the device and this PR makes the layout fully adaptive

### Before

<img width="226" height="249" alt="SCR-20260414-qkaw" src="https://github.com/user-attachments/assets/3cc2f6bc-bf7f-4c4b-88ff-a61a7559d2da" />

### After

<img width="1956" height="1109" alt="SCR-20260414-qpga-tile" src="https://github.com/user-attachments/assets/925942c0-8815-4139-9d95-93e62829b6f1" />

iPhone screenshot for reference (no chance there)