### PR TITLE
Fix puzzle widget theme sync

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -361,7 +361,7 @@ The app includes a native iOS WidgetKit extension (`ios/LichessWidgets/`) provid
 ### Architecture
 
 - **`LichessWidgetsBundle.swift`** — `@main` entry point registering all 4 widgets.
-- **`LichessAppGroup.swift`** — Reads shared `UserDefaults` from App Group `group.org.lichess.mobileV2`:
+- **`LichessAppGroup.swift`** — Reads shared `UserDefaults` from App Group `group.org.lichess.mobileV2.LichessWidgets`:
   - `lichessHost`, `boardTheme`, `pieceSet`, `isKidMode`
 - **`Deeplinks.swift`** — Custom URI scheme encoding for opening URLs in the in-app browser.
 - **Dependencies**: WidgetKit, ChessgroundAssets (Swift Package, shared with Dart), FeedKit, XMLKit.

--- a/ios/LichessWidgets/LichessAppGroup.swift
+++ b/ios/LichessWidgets/LichessAppGroup.swift
@@ -1,7 +1,7 @@
 import Foundation
 
 enum LichessAppGroup {
-    static let id = "group.org.lichess.mobileV2"
+    static let id = "group.org.lichess.mobileV2.LichessWidgets"
 
     // Keys must match the strings passed to HomeWidget.saveWidgetData in lib/src/app.dart.
     static let kidModeKey = "isKidMode"

--- a/lib/src/app.dart
+++ b/lib/src/app.dart
@@ -106,10 +106,9 @@ class _AppState extends ConsumerState<Application> {
         }
       }, fireImmediately: true);
       ref.listenManual(boardPreferencesProvider, (prev, state) {
-        // Guard with prev != null (same pattern as kidMode's state.hasValue) so we
-        // don't write + reload the widget on every cold start when nothing changed.
-        if (prev != null &&
-            (prev.boardTheme != state.boardTheme || prev.pieceSet != state.pieceSet)) {
+        if (prev == null ||
+            prev.boardTheme != state.boardTheme ||
+            prev.pieceSet != state.pieceSet) {
           Future.wait([
             HomeWidget.saveWidgetData<String>('boardTheme', state.boardTheme.name),
             HomeWidget.saveWidgetData<String>('pieceSet', state.pieceSet.name),

--- a/lib/src/app.dart
+++ b/lib/src/app.dart
@@ -30,7 +30,7 @@ import 'package:lichess_mobile/src/utils/screen.dart';
 import 'package:lichess_mobile/src/view/more/import_pgn_screen.dart';
 import 'package:receive_sharing_intent/receive_sharing_intent.dart';
 
-const String _kIosAppGroupId = 'group.org.lichess.mobileV2';
+const String _kIosAppGroupId = 'group.org.lichess.mobileV2.LichessWidgets';
 const List<String> _kIosBlogWidgetKinds = [
   'OfficialBlogWidget',
   'CommunityBlogWidget',


### PR DESCRIPTION
Fixes two bugs related to the puzzle widget (one of them probably also affecting kid mode in blog feed widgets).

#### Bug 1

We have recently changed the entitlements files from `group.org.lichess.mobileV2` to `group.org.lichess.mobileV2.LichessWidgets`, but both the Dart (`_kIosAppGroupId` in `lib/src/app.dart`) and Swift (`LichessAppGroup.id` in `ios/LichessWidgets/LichessAppGroup.swift`) code still referenced the old ID. So the app wrote into one suite and the widget read from another (which fell back to defaults)

Fix: Simple app group name fix

#### Bug 2

An updated would not have `boardTheme`/`pieceSet` written, and the widget would use its Swift-side fallback defaults (`defaultThemeName`/`defaultPieceSet`) instead of the app's actual preferences

Fix: Sync at app start

### Demo


https://github.com/user-attachments/assets/7428f70a-f653-4abe-a0c8-408be220f584

