### PR TITLE
Fix deep link route transition

### DIFF
--- a/lib/src/app_links_service.dart
+++ b/lib/src/app_links_service.dart
@@ -19,6 +19,7 @@ import 'package:lichess_mobile/src/model/puzzle/puzzle_providers.dart';
 import 'package:lichess_mobile/src/model/puzzle/puzzle_theme.dart';
 import 'package:lichess_mobile/src/model/user/user.dart';
 import 'package:lichess_mobile/src/tab_scaffold.dart';
+import 'package:lichess_mobile/src/utils/navigation.dart';
 import 'package:lichess_mobile/src/view/analysis/analysis_screen.dart';
 import 'package:lichess_mobile/src/view/broadcast/broadcast_game_screen.dart';
 import 'package:lichess_mobile/src/view/broadcast/broadcast_player_results_screen.dart';
@@ -54,36 +55,59 @@ class AppLinksService {
   StreamSubscription<Uri>? _linkSubscription;
 
   Future<void> start() async {
+    // Handle the link that cold-started the app (if any) after the first frame
+    // so the navigator is ready. Push without animation — the user launched the
+    // app via this link so the target screen should just be there.
+    WidgetsBinding.instance.addPostFrameCallback((_) async {
+      try {
+        final initialUri = await _appLinks.getInitialLink();
+        if (initialUri != null) {
+          await _handleUri(initialUri, animated: false);
+        }
+      } catch (e, st) {
+        _logger.severe('Error handling initial app link: $e\n$st');
+      }
+    });
+
+    // Links received while the app is already running get a normal transition.
     _linkSubscription = _appLinks.uriLinkStream.listen((uri) async {
       try {
-        // File links are handled by the sharing intent logic, so we can ignore them here.
-        if (uri.scheme == 'file' || uri.scheme == 'content') {
-          return;
-        }
-        if (uri.scheme == kLichessUriScheme && uri.host == kOAuthRedirectUriHost) {
-          ref.read(oauthCallbackProvider).add(uri);
-          return;
-        }
-        if (uri.scheme == kLichessUriScheme && uri.host == 'open-web') {
-          _handleOpenWebLink(uri);
-          return;
-        }
-        final context = ref.read(currentNavigatorKeyProvider).currentContext;
-        if (uri.scheme == kLichessUriScheme &&
-            uri.host == _kDailyPuzzleDeeplinkHost &&
-            uri.pathSegments.firstOrNull == _kDailyPuzzleDeeplinkPath) {
-          if (context != null && context.mounted) {
-            await handleDailyPuzzleLink(context, uri.pathSegments.elementAtOrNull(1));
-          }
-          return;
-        }
-        if (context != null && context.mounted) {
-          await handleAppLink(context, uri);
-        }
+        await _handleUri(uri, animated: true);
       } catch (e, st) {
         _logger.severe('Error handling app link: $e\n$st');
       }
     });
+  }
+
+  Future<void> _handleUri(Uri uri, {required bool animated}) async {
+    // File links are handled by the sharing intent logic, so we can ignore them here.
+    if (uri.scheme == 'file' || uri.scheme == 'content') {
+      return;
+    }
+    if (uri.scheme == kLichessUriScheme && uri.host == kOAuthRedirectUriHost) {
+      ref.read(oauthCallbackProvider).add(uri);
+      return;
+    }
+    if (uri.scheme == kLichessUriScheme && uri.host == 'open-web') {
+      _handleOpenWebLink(uri);
+      return;
+    }
+    final context = ref.read(currentNavigatorKeyProvider).currentContext;
+    if (uri.scheme == kLichessUriScheme &&
+        uri.host == _kDailyPuzzleDeeplinkHost &&
+        uri.pathSegments.firstOrNull == _kDailyPuzzleDeeplinkPath) {
+      if (context != null && context.mounted) {
+        await handleDailyPuzzleLink(
+          context,
+          uri.pathSegments.elementAtOrNull(1),
+          animated: animated,
+        );
+      }
+      return;
+    }
+    if (context != null && context.mounted) {
+      await handleAppLink(context, uri, animated: animated);
+    }
   }
 
   void dispose() {
@@ -177,7 +201,11 @@ class AppLinksService {
   /// is fetched but NOT flagged as the daily so the user isn't confused when
   /// navigating back to the puzzle tab.
   @visibleForTesting
-  Future<void> handleDailyPuzzleLink(BuildContext context, String? puzzleId) async {
+  Future<void> handleDailyPuzzleLink(
+    BuildContext context,
+    String? puzzleId, {
+    bool animated = true,
+  }) async {
     try {
       Puzzle puzzle;
       final dailyPuzzle = await ref.read(dailyPuzzleProvider.future);
@@ -196,13 +224,15 @@ class AppLinksService {
         }
       }
       if (!context.mounted) return;
-      await Navigator.of(context, rootNavigator: true).push(
-        PuzzleScreen.buildRoute(
-          context,
-          angle: const PuzzleTheme(PuzzleThemeKey.mix),
-          puzzle: puzzle,
-        ),
+      final route = PuzzleScreen.buildRoute(
+        context,
+        angle: const PuzzleTheme(PuzzleThemeKey.mix),
+        puzzle: puzzle,
       );
+      await Navigator.of(
+        context,
+        rootNavigator: true,
+      ).push(animated ? route : _withNoTransition(route));
     } catch (e, st) {
       _logger.severe('Failed to open daily puzzle from widget: $e\n$st');
     }
@@ -260,13 +290,14 @@ class AppLinksService {
   }
 
   /// Handles an app link [Uri] by navigating to the corresponding screen(s).
-  Future<void> handleAppLink(BuildContext context, Uri uri) async {
+  Future<void> handleAppLink(BuildContext context, Uri uri, {bool animated = true}) async {
     final routes = await resolveAppLinkUri(context, uri);
     if (!context.mounted) return;
 
     if (routes != null) {
+      final navigator = Navigator.of(context, rootNavigator: true);
       for (final route in routes) {
-        Navigator.of(context, rootNavigator: true).push(route);
+        navigator.push(animated ? route : _withNoTransition(route));
       }
     } else {
       final isChallengeLink = await _tryResolveChallengeLink(context, uri);
@@ -274,6 +305,21 @@ class AppLinksService {
 
       launchUrl(uri);
     }
+  }
+
+  /// Returns a copy of [route] with [Duration.zero] transition so the screen
+  /// appears instantly — used when the app is opened via a deep link and a
+  /// transition would be jarring.
+  static Route<dynamic> _withNoTransition(Route<dynamic> route) {
+    if (route is ScreenRoute) {
+      return MaterialScreenRoute(
+        screen: route.screen,
+        settings: route.settings,
+        fullscreenDialog: route.fullscreenDialog,
+        overrideTransitionDuration: Duration.zero,
+      );
+    }
+    return route;
   }
 
   static const kLichessLinkifiers = [UrlLinkifier(), EmailLinkifier(), UserTagLinkifier()];

--- a/lib/src/app_links_service.dart
+++ b/lib/src/app_links_service.dart
@@ -341,6 +341,8 @@ class AppLinksService {
         screen: route.screen,
         settings: route.settings,
         fullscreenDialog: route.fullscreenDialog,
+        maintainState: route.maintainState,
+        allowSnapshotting: route.allowSnapshotting,
         overrideTransitionDuration: Duration.zero,
       );
     }

--- a/lib/src/app_links_service.dart
+++ b/lib/src/app_links_service.dart
@@ -229,10 +229,11 @@ class AppLinksService {
         angle: const PuzzleTheme(PuzzleThemeKey.mix),
         puzzle: puzzle,
       );
-      await Navigator.of(
-        context,
-        rootNavigator: true,
-      ).push(animated ? route : _withNoTransition(route));
+      await _pushDeepLinkRoute(
+        Navigator.of(context, rootNavigator: true),
+        route,
+        animated: animated,
+      );
     } catch (e, st) {
       _logger.severe('Failed to open daily puzzle from widget: $e\n$st');
     }
@@ -297,7 +298,7 @@ class AppLinksService {
     if (routes != null) {
       final navigator = Navigator.of(context, rootNavigator: true);
       for (final route in routes) {
-        navigator.push(animated ? route : _withNoTransition(route));
+        _pushDeepLinkRoute(navigator, route, animated: animated);
       }
     } else {
       final isChallengeLink = await _tryResolveChallengeLink(context, uri);
@@ -305,6 +306,30 @@ class AppLinksService {
 
       launchUrl(uri);
     }
+  }
+
+  /// Pushes [route] onto [navigator], replacing the top route instead of
+  /// stacking when the top is already the same screen type — preventing
+  /// duplicates when the user taps a deep link while already on that screen.
+  /// Also applies [_withNoTransition] when [animated] is `false`.
+  static Future<void> _pushDeepLinkRoute(
+    NavigatorState navigator,
+    Route<dynamic> route, {
+    required bool animated,
+  }) {
+    final pushed = animated ? route : _withNoTransition(route);
+    Route<dynamic>? top;
+    navigator.popUntil((r) {
+      top = r;
+      return true;
+    });
+    final topRoute = top;
+    if (topRoute is ScreenRoute &&
+        pushed is ScreenRoute &&
+        topRoute.screen.runtimeType == pushed.screen.runtimeType) {
+      return navigator.pushReplacement(pushed);
+    }
+    return navigator.push(pushed);
   }
 
   /// Returns a copy of [route] with [Duration.zero] transition so the screen

--- a/test/app_links_service_test.dart
+++ b/test/app_links_service_test.dart
@@ -1,3 +1,5 @@
+import 'dart:async';
+
 import 'package:dartchess/dartchess.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
@@ -205,8 +207,8 @@ void main() {
             capturedService = ref.read(appLinksServiceProvider);
             capturedContext = context;
             return ElevatedButton(
-              onPressed: () {
-                ref.read(appLinksServiceProvider).handleDailyPuzzleLink(context, null);
+              onPressed: () async {
+                await ref.read(appLinksServiceProvider).handleDailyPuzzleLink(context, null);
               },
               child: const Text('go to puzzle'),
             );
@@ -221,8 +223,9 @@ void main() {
       expect(find.byType(PuzzleScreen), findsOneWidget);
 
       // Second call from the home context (still mounted below PuzzleScreen):
-      // should replace rather than push.
-      capturedService!.handleDailyPuzzleLink(capturedContext!, null);
+      // should replace rather than push. Fire-and-forget: the push future only
+      // resolves when the route is popped, so we drive it via pumpAndSettle.
+      unawaited(capturedService!.handleDailyPuzzleLink(capturedContext!, null));
       await tester.pumpAndSettle();
 
       // Pressing back must return to the home widget — no extra PuzzleScreen in the stack.
@@ -515,8 +518,8 @@ void main() {
             capturedService = ref.read(appLinksServiceProvider);
             capturedContext = context;
             return ElevatedButton(
-              onPressed: () {
-                ref.read(appLinksServiceProvider).handleAppLink(context, uri);
+              onPressed: () async {
+                await ref.read(appLinksServiceProvider).handleAppLink(context, uri);
               },
               child: const Text('go to puzzle'),
             );
@@ -531,8 +534,9 @@ void main() {
       expect(find.byType(PuzzleScreen), findsOneWidget);
 
       // Second call from the home context (still mounted below PuzzleScreen):
-      // should replace rather than push.
-      capturedService!.handleAppLink(capturedContext!, uri);
+      // should replace rather than push. Fire-and-forget: the push future only
+      // resolves when the route is popped, so we drive it via pumpAndSettle.
+      unawaited(capturedService!.handleAppLink(capturedContext!, uri));
       await tester.pumpAndSettle();
 
       // Pressing back must return to the home widget — no extra PuzzleScreen in the stack.

--- a/test/app_links_service_test.dart
+++ b/test/app_links_service_test.dart
@@ -192,6 +192,46 @@ void main() {
             .having((s) => s.puzzle?.isDailyPuzzle, 'is daily', true),
       );
     });
+
+    testWidgets('replaces existing PuzzleScreen instead of stacking a duplicate', (tester) async {
+      AppLinksService? capturedService;
+      BuildContext? capturedContext;
+
+      final app = await makeTestProviderScopeApp(
+        tester,
+        overrides: {httpClientFactoryProvider: puzzleHttpOverride()},
+        home: Consumer(
+          builder: (context, ref, _) {
+            capturedService = ref.read(appLinksServiceProvider);
+            capturedContext = context;
+            return ElevatedButton(
+              onPressed: () {
+                ref.read(appLinksServiceProvider).handleDailyPuzzleLink(context, null);
+              },
+              child: const Text('go to puzzle'),
+            );
+          },
+        ),
+      );
+      await tester.pumpWidget(app);
+
+      // First tap: pushes PuzzleScreen.
+      await tester.tap(find.text('go to puzzle'));
+      await tester.pumpAndSettle();
+      expect(find.byType(PuzzleScreen), findsOneWidget);
+
+      // Second call from the home context (still mounted below PuzzleScreen):
+      // should replace rather than push.
+      capturedService!.handleDailyPuzzleLink(capturedContext!, null);
+      await tester.pumpAndSettle();
+
+      // Pressing back must return to the home widget — no extra PuzzleScreen in the stack.
+      await tester.pageBack();
+      await tester.pumpAndSettle();
+
+      expect(find.text('go to puzzle'), findsOneWidget);
+      expect(find.byType(PuzzleScreen), findsNothing);
+    });
   });
 
   group('resolveAppLinkUri', () {

--- a/test/app_links_service_test.dart
+++ b/test/app_links_service_test.dart
@@ -502,6 +502,47 @@ void main() {
       );
     });
 
+    testWidgets('replaces existing screen instead of stacking a duplicate', (tester) async {
+      AppLinksService? capturedService;
+      BuildContext? capturedContext;
+
+      final uri = Uri.parse('https://lichess.org/training/61044');
+
+      final app = await makeTestProviderScopeApp(
+        tester,
+        home: Consumer(
+          builder: (context, ref, _) {
+            capturedService = ref.read(appLinksServiceProvider);
+            capturedContext = context;
+            return ElevatedButton(
+              onPressed: () {
+                ref.read(appLinksServiceProvider).handleAppLink(context, uri);
+              },
+              child: const Text('go to puzzle'),
+            );
+          },
+        ),
+      );
+      await tester.pumpWidget(app);
+
+      // First tap: pushes PuzzleScreen.
+      await tester.tap(find.text('go to puzzle'));
+      await tester.pumpAndSettle();
+      expect(find.byType(PuzzleScreen), findsOneWidget);
+
+      // Second call from the home context (still mounted below PuzzleScreen):
+      // should replace rather than push.
+      capturedService!.handleAppLink(capturedContext!, uri);
+      await tester.pumpAndSettle();
+
+      // Pressing back must return to the home widget — no extra PuzzleScreen in the stack.
+      await tester.pageBack();
+      await tester.pumpAndSettle();
+
+      expect(find.text('go to puzzle'), findsOneWidget);
+      expect(find.byType(PuzzleScreen), findsNothing);
+    });
+
     testWidgets('resolves /challengeId link for open challenge', (WidgetTester tester) async {
       const challenge = Challenge(
         id: ChallengeId('abcdefgh'),


### PR DESCRIPTION
This pull request improves deep link handling in the app, ensuring that navigation is smoother and more predictable when opening the app via a link or when tapping links while the app is already running.

**Deep link navigation improvements:**

* Added logic to replace the top screen with the target screen (instead of stacking duplicates) when handling deep links, preventing multiple instances of the same screen (e.g., `PuzzleScreen`) from piling up.
* Introduced the `_pushDeepLinkRoute` method to centralize navigation logic for deep links, including support for instant (no-animation) transitions when the app is cold-started from a link.
* Updated `handleDailyPuzzleLink` and `handleAppLink` to use the new navigation logic and accept an `animated` parameter, allowing for instant transitions when appropriate. 

**App startup and link handling:**

* Modified the `start` method to handle the initial app link after the first frame, ensuring the navigator is ready and using an instant transition for a smoother user experience.