### PR TITLE
only display * for ongoing games

### DIFF
--- a/lib/src/model/broadcast/broadcast.dart
+++ b/lib/src/model/broadcast/broadcast.dart
@@ -323,6 +323,7 @@ sealed class BroadcastPlayerGameResult with _$BroadcastPlayerGameResult {
     required double? customPoints,
     required int? ratingDiff,
     required BroadcastPlayer opponent,
+    required bool ongoing,
   }) = _BroadcastPlayerGameResult;
 }
 

--- a/lib/src/model/broadcast/broadcast_repository.dart
+++ b/lib/src/model/broadcast/broadcast_repository.dart
@@ -411,6 +411,7 @@ BroadcastPlayerGameResult _playerGameResultFromPick(RequiredPick pick) {
     points: points,
     customPoints: pick('customPoints').asDoubleOrNull(),
     opponent: _playerFromPick(pick('opponent').required()),
+    ongoing: pick('ongoing').asBoolOrNull() ?? false,
   );
 }
 

--- a/lib/src/view/broadcast/broadcast_player_results_screen.dart
+++ b/lib/src/view/broadcast/broadcast_player_results_screen.dart
@@ -469,6 +469,7 @@ class _GameResultListTile extends StatelessWidget {
       :ratingDiff,
       :opponent,
       :fideTC,
+      :ongoing,
     ) = playerGameResult;
     final BroadcastPlayer(:federation, :rating) = opponent;
     final pic = opponent.fideId != null ? tournament.photos?.get(opponent.fideId!) : null;
@@ -527,7 +528,8 @@ class _GameResultListTile extends StatelessWidget {
                       Text(
                         customPoints != null && customPoints != 0.5
                             ? NumberFormat('0.##').format(customPoints)
-                            : points?.resultFor(color).resultToString(color) ?? '*',
+                            : points?.resultFor(color).resultToString(color) ??
+                                  (ongoing ? '*' : ''),
                         style: Theme.of(context).textTheme.bodyMedium?.copyWith(
                           fontWeight: .bold,
                           color: points?.resultFor(color).colorFor(color, context),


### PR DESCRIPTION
fix #2939

Couldn't test it because there is no tournament currently that provides pairings in advance. But * is still displayed for ongoing games, so I am close to certain it will work.