### PR TITLE
fix/correspondence-clock-reset-issue

### DIFF
--- a/lib/src/view/game/correspondence_clock_widget.dart
+++ b/lib/src/view/game/correspondence_clock_widget.dart
@@ -65,7 +65,7 @@ class _CorrespondenceClockState extends State<CorrespondenceClock> {
   @override
   void didUpdateWidget(CorrespondenceClock oldClock) {
     super.didUpdateWidget(oldClock);
-    if (widget.duration != oldClock.duration) {
+    if (widget.duration != oldClock.duration || (widget.active != oldClock.active)) {
       timeLeft = widget.duration;
     }
     if (widget.active) {

--- a/test/view/game/correspondence_clock_widget_test.dart
+++ b/test/view/game/correspondence_clock_widget_test.dart
@@ -1,0 +1,73 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:lichess_mobile/l10n/l10n.dart';
+import 'package:lichess_mobile/src/view/game/correspondence_clock_widget.dart';
+
+Widget _buildClock({required Duration duration, required bool active, VoidCallback? onFlag}) {
+  return MaterialApp(
+    localizationsDelegates: AppLocalizations.localizationsDelegates,
+    home: Scaffold(
+      body: CorrespondenceClock(duration: duration, active: active, onFlag: onFlag),
+    ),
+  );
+}
+
+void main() {
+  group('CorrespondenceClock', () {
+    testWidgets('displays the initial time correctly', (tester) async {
+      await tester.pumpWidget(_buildClock(duration: const Duration(minutes: 5), active: false));
+      await tester.pump();
+      expect(find.text('00:05:00', findRichText: true), findsOneWidget);
+    });
+
+    testWidgets('does not tick when inactive', (tester) async {
+      await tester.pumpWidget(_buildClock(duration: const Duration(minutes: 5), active: false));
+      await tester.pump();
+      expect(find.text('00:05:00', findRichText: true), findsOneWidget);
+
+      await tester.pump(const Duration(seconds: 10));
+      expect(find.text('00:05:00', findRichText: true), findsOneWidget);
+    });
+
+    testWidgets('resets timeLeft to new duration when active changes from true to false', (
+      tester,
+    ) async {
+      await tester.pumpWidget(_buildClock(duration: const Duration(minutes: 5), active: true));
+      await tester.pump();
+      expect(find.text('00:05:00', findRichText: true), findsOneWidget);
+
+      // Simulate server sending corrected time when it becomes our turn:
+      // active changes (true -> false) and a new duration is provided.
+      await tester.pumpWidget(_buildClock(duration: const Duration(minutes: 3), active: false));
+      await tester.pump();
+
+      // timeLeft must be reset to the new server duration, not the locally ticked value.
+      expect(find.text('00:03:00', findRichText: true), findsOneWidget);
+    });
+
+    testWidgets('resets timeLeft to new duration when active changes from false to true', (
+      tester,
+    ) async {
+      await tester.pumpWidget(_buildClock(duration: const Duration(minutes: 3), active: false));
+      await tester.pump();
+      expect(find.text('00:03:00', findRichText: true), findsOneWidget);
+
+      // Simulate becoming our turn: active changes (false -> true) with updated duration.
+      await tester.pumpWidget(_buildClock(duration: const Duration(minutes: 5), active: true));
+      await tester.pump();
+
+      expect(find.text('00:05:00', findRichText: true), findsOneWidget);
+    });
+
+    testWidgets('resets timeLeft when duration changes without active changing', (tester) async {
+      await tester.pumpWidget(_buildClock(duration: const Duration(minutes: 5), active: false));
+      await tester.pump();
+      expect(find.text('00:05:00', findRichText: true), findsOneWidget);
+
+      await tester.pumpWidget(_buildClock(duration: const Duration(minutes: 7), active: false));
+      await tester.pump();
+
+      expect(find.text('00:07:00', findRichText: true), findsOneWidget);
+    });
+  });
+}


### PR DESCRIPTION
The root course of this problem was the method **didUpdateWidget**
```dart 
void didUpdateWidget(CorrespondenceClock oldClock) {
    super.didUpdateWidget(oldClock);
    if (widget.duration != oldClock.duration || (widget.active != oldClock.active)) {
      timeLeft = widget.duration;
    }
    if (widget.active) {
      startClock();
    } else {
      stopClock();
    }
  }
```
The if statement was

```dart
if (widget.duration != oldClock.duration)
```
I played a 1 day correspondece game. The variable timeLeft is only reset when widget.duration changes. But after every move, the server always sends 24:00:00 — so widget.duration stays the same. Meanwhile, the internal timeLeft has already counted down during your turn.

See video how it works now.

https://github.com/user-attachments/assets/ed45eabf-1818-44e3-a6be-986b01fa5fef

Fixes #1955 

