### PR TITLE
Remove enableOnBackInvokedCallback from AndroidManifest

### DIFF
--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -5,7 +5,6 @@
         android:name="${applicationName}"
         android:icon="@mipmap/ic_launcher"
         android:roundIcon="@mipmap/ic_launcher_round"
-        android:enableOnBackInvokedCallback="true"
         android:fullBackupContent="@xml/backup_rules">
 
         <meta-data


### PR DESCRIPTION
## Summary

Remove this line so that `enableOnBackInvokedCallback` falls back to the platform default: `false` on Android 14/15 and `true` on Android 16.

## Motivation

This appears to be a Flutter issue rather than a Lichess-specific issue. See Flutter issue [#185257](https://github.com/flutter/flutter/issues/185257).

Related Lichess issues and discussion:
- [#3016](https://github.com/lichess-org/mobile/issues/3016)
- [#2790](https://github.com/lichess-org/mobile/issues/2790)

From current testing, the bug seems to occur only on the OPPO family of devices, including OnePlus and realme, running Android 14. Since the bug is highly disruptive in practice, it seems necessary to introduce a temporary workaround.

## Why this change

This approach disables predictive back on Android 14/15 while keeping it enabled on Android 16, following the platform default behavior. It is intended as the smallest possible change that avoids the issue without introducing a broader behavior change than necessary.