### PR TITLE
Do not refresh providers unnecessarily when app state changes

### DIFF
--- a/lib/src/model/game/game_history.dart
+++ b/lib/src/model/game/game_history.dart
@@ -33,7 +33,7 @@ const _nbPerPage = 20;
 final myRecentGamesProvider = FutureProvider.autoDispose<IList<LightExportedGameWithPov>>((
   Ref ref,
 ) async {
-  final online = (await ref.watch(connectivityChangesProvider.future)).isOnline;
+  final online = await ref.watch(onlineStatusProvider.future);
   final authUser = ref.watch(authControllerProvider);
   if (authUser != null && online) {
     return ref
@@ -71,7 +71,7 @@ final userNumberOfGamesProvider = FutureProvider.autoDispose.family<int, LightUs
   LightUser? user,
 ) async {
   final authUser = ref.watch(authControllerProvider);
-  final online = (await ref.watch(connectivityChangesProvider.future)).isOnline;
+  final online = await ref.watch(onlineStatusProvider.future);
   return user != null
       ? (await ref.watch(userProvider(user.id).future)).count?.all ?? 0
       : authUser != null && online
@@ -120,7 +120,7 @@ class UserGameHistoryNotifier extends AsyncNotifier<UserGameHistoryState> {
 
     final authUser = ref.watch(authControllerProvider);
     final prefs = ref.watch(gameHistoryPreferencesProvider);
-    final online = (await ref.watch(connectivityChangesProvider.future)).isOnline;
+    final online = await ref.watch(onlineStatusProvider.future);
     final storage = await ref.watch(gameStorageProvider.future);
 
     final id = params.userId ?? authUser?.user.id;

--- a/lib/src/network/connectivity.dart
+++ b/lib/src/network/connectivity.dart
@@ -19,7 +19,7 @@ final connectivityPluginProvider = Provider<Connectivity>((Ref _) => Connectivit
 /// This provider is derived from [connectivityChangesProvider] and only exposes the `isOnline ` field of the connectivity status.
 final onlineStatusProvider = FutureProvider.autoDispose<bool>((ref) {
   return ref.watch(connectivityChangesProvider.selectAsync((status) => status.isOnline));
-}, name: 'OnlineChangesProvider');
+}, name: 'OnlineStatusProvider');
 
 /// This provider is used to check the device's connectivity status, reacting to
 /// changes in connectivity and app lifecycle events.

--- a/lib/src/network/connectivity.dart
+++ b/lib/src/network/connectivity.dart
@@ -14,8 +14,18 @@ final _logger = Logger('Connectivity');
 /// A provider that exposes a [Connectivity] instance.
 final connectivityPluginProvider = Provider<Connectivity>((Ref _) => Connectivity());
 
+/// A provider that listens to connectivity changes and exposes a boolean indicating whether the device is online or not.
+///
+/// This provider is derived from [connectivityChangesProvider] and only exposes the `isOnline ` field of the connectivity status.
+final onlineStatusProvider = FutureProvider.autoDispose<bool>((ref) {
+  return ref.watch(connectivityChangesProvider.selectAsync((status) => status.isOnline));
+}, name: 'OnlineChangesProvider');
+
 /// This provider is used to check the device's connectivity status, reacting to
 /// changes in connectivity and app lifecycle events.
+///
+/// **Note**: do not use this provider directly to check if the device is online,
+/// use [onlineStatusProvider] instead, which only exposes the `isOnline` field of the connectivity status.
 ///
 /// - Uses the [Connectivity] plugin to listen to connectivity changes
 /// - Uses [AppLifecycleListener] to check connectivity on app resume

--- a/lib/src/network/connectivity.dart
+++ b/lib/src/network/connectivity.dart
@@ -16,7 +16,7 @@ final connectivityPluginProvider = Provider<Connectivity>((Ref _) => Connectivit
 
 /// A provider that listens to connectivity changes and exposes a boolean indicating whether the device is online or not.
 ///
-/// This provider is derived from [connectivityChangesProvider] and only exposes the `isOnline ` field of the connectivity status.
+/// This provider is derived from [connectivityChangesProvider] and only exposes the `isOnline` field of the connectivity status.
 final onlineStatusProvider = FutureProvider.autoDispose<bool>((ref) {
   return ref.watch(connectivityChangesProvider.selectAsync((status) => status.isOnline));
 }, name: 'OnlineStatusProvider');

--- a/lib/src/view/account/account_drawer.dart
+++ b/lib/src/view/account/account_drawer.dart
@@ -118,9 +118,7 @@ class _AccountDrawerState extends ConsumerState<AccountDrawer> with WidgetsBindi
   @override
   Widget build(BuildContext context) {
     final client = ref.read(defaultClientProvider);
-    final isOnline = ref.watch(
-      connectivityChangesProvider.select((s) => s.value?.isOnline ?? false),
-    );
+    final isOnline = ref.watch(onlineStatusProvider).value ?? false;
     final signInState = ref.watch(signInMutation);
     final signOutState = ref.watch(signOutMutation);
     final account = ref.watch(accountProvider);

--- a/lib/src/view/account/profile_screen.dart
+++ b/lib/src/view/account/profile_screen.dart
@@ -50,7 +50,7 @@ class _ProfileScreenState extends ConsumerState<ProfileScreen> {
   @override
   Widget build(BuildContext context) {
     final account = ref.watch(accountProvider);
-    final online = ref.watch(connectivityChangesProvider).value?.isOnline ?? false;
+    final online = ref.watch(onlineStatusProvider).value ?? false;
     return PlatformScaffold(
       appBar: PlatformAppBar(
         titleSpacing: 0,

--- a/lib/src/view/home/home_tab_screen.dart
+++ b/lib/src/view/home/home_tab_screen.dart
@@ -141,11 +141,11 @@ class _HomeScreenState extends ConsumerState<HomeTabScreen> {
       }
     });
 
-    final connectivity = ref.watch(connectivityChangesProvider);
+    final isOnlineAsync = ref.watch(onlineStatusProvider);
 
-    return connectivity.when(
+    return isOnlineAsync.when(
       skipLoadingOnReload: true,
-      data: (status) {
+      data: (isOnline) {
         final authUser = ref.watch(authControllerProvider);
         final unreadLichessMessage = ref.watch(unreadMessagesProvider).value?.lichess == true;
         final ongoingGames = ref.watch(ongoingGamesProvider);
@@ -153,10 +153,10 @@ class _HomeScreenState extends ConsumerState<HomeTabScreen> {
         final recentGames = ref.watch(myRecentGamesProvider);
         final nbOfGames = ref.watch(userNumberOfGamesProvider(null)).value ?? 0;
         final isTablet = isTabletOrLarger(context);
-        final featuredTournaments = status.isOnline
+        final featuredTournaments = isOnline
             ? ref.watch(featuredTournamentsProvider)
             : const AsyncValue.data(IListConst<LightTournament>([]));
-        final blogPosts = status.isOnline
+        final blogPosts = isOnline
             ? ref.watch(blogCarouselProvider)
             : const AsyncValue.data(IListConst<BlogPost>([]));
 
@@ -232,7 +232,7 @@ class _HomeScreenState extends ConsumerState<HomeTabScreen> {
               )
             else ...[
               ...welcomeWidgets,
-              if (status.isOnline)
+              if (isOnline)
                 const _EditableWidget(
                   widget: HomeEditableWidget.quickPairing,
                   shouldShow: true,
@@ -240,13 +240,13 @@ class _HomeScreenState extends ConsumerState<HomeTabScreen> {
                 ),
               _EditableWidget(
                 widget: HomeEditableWidget.featuredTournaments,
-                shouldShow: status.isOnline,
+                shouldShow: isOnline,
                 child: FeaturedTournamentsWidget(featured: featuredTournaments),
               ),
               if (_worker != null && !isKidMode)
                 _EditableWidget(
                   widget: HomeEditableWidget.blogCarousel,
-                  shouldShow: status.isOnline,
+                  shouldShow: isOnline,
                   child: _BlogCarouselWidget(blogPosts, _worker!),
                 ),
             ],
@@ -262,7 +262,7 @@ class _HomeScreenState extends ConsumerState<HomeTabScreen> {
               const _HomeCustomizationTip(),
               const _NNUEFilesOutdatedTip(),
             ],
-            if (status.isOnline)
+            if (isOnline)
               _EditableWidget(
                 widget: HomeEditableWidget.perfCards,
                 shouldShow: authUser != null,
@@ -276,7 +276,7 @@ class _HomeScreenState extends ConsumerState<HomeTabScreen> {
                     children: [
                       const SizedBox(height: 8.0),
                       const _TabletCreateAGameSection(),
-                      if (status.isOnline)
+                      if (isOnline)
                         _OngoingGamesPreview(ongoingGames, maxGamesToShow: 5)
                       else
                         _OfflineCorrespondencePreview(offlineCorresGames, maxGamesToShow: 5),
@@ -293,7 +293,7 @@ class _HomeScreenState extends ConsumerState<HomeTabScreen> {
                       if (_worker != null && !isKidMode)
                         _EditableWidget(
                           widget: HomeEditableWidget.blogCarousel,
-                          shouldShow: status.isOnline,
+                          shouldShow: isOnline,
                           child: _BlogCarouselWidget(blogPosts, _worker!),
                         ),
                       RecentGamesWidget(recentGames: recentGames, nbOfGames: nbOfGames, user: null),
@@ -305,9 +305,9 @@ class _HomeScreenState extends ConsumerState<HomeTabScreen> {
           ];
         } else {
           final hasOngoingGames =
-              (status.isOnline &&
+              (isOnline &&
                   ongoingGames.maybeWhen(data: (data) => data.isNotEmpty, orElse: () => false)) ||
-              (!status.isOnline &&
+              (!isOnline &&
                   offlineCorresGames.maybeWhen(
                     data: (data) => data.isNotEmpty,
                     orElse: () => false,
@@ -324,32 +324,32 @@ class _HomeScreenState extends ConsumerState<HomeTabScreen> {
             ],
             _EditableWidget(
               widget: HomeEditableWidget.perfCards,
-              shouldShow: authUser != null && status.isOnline,
+              shouldShow: authUser != null && isOnline,
               child: AccountPerfCards(
                 padding: Styles.horizontalBodyPadding.add(Styles.sectionBottomPadding),
               ),
             ),
             _EditableWidget(
               widget: HomeEditableWidget.quickPairing,
-              shouldShow: status.isOnline,
+              shouldShow: isOnline,
               child: const Padding(padding: Styles.bodySectionPadding, child: QuickGameMatrix()),
             ),
             _EditableWidget(
               widget: HomeEditableWidget.ongoingGames,
               shouldShow: hasOngoingGames,
-              child: status.isOnline
+              child: isOnline
                   ? _OngoingGamesCarousel(ongoingGames, maxGamesToShow: 20)
                   : _OfflineCorrespondenceCarousel(offlineCorresGames, maxGamesToShow: 20),
             ),
             _EditableWidget(
               widget: HomeEditableWidget.featuredTournaments,
-              shouldShow: status.isOnline,
+              shouldShow: isOnline,
               child: FeaturedTournamentsWidget(featured: featuredTournaments),
             ),
             if (_worker != null && !isKidMode)
               _EditableWidget(
                 widget: HomeEditableWidget.blogCarousel,
-                shouldShow: status.isOnline,
+                shouldShow: isOnline,
                 child: _BlogCarouselWidget(blogPosts, _worker!),
               ),
             _EditableWidget(
@@ -375,7 +375,7 @@ class _HomeScreenState extends ConsumerState<HomeTabScreen> {
               if (duration.inSeconds < 10) {
                 return;
               }
-              _refreshData(isOnline: status.isOnline);
+              _refreshData(isOnline: isOnline);
             }
           },
           child: _IsEditingHome(
@@ -401,7 +401,7 @@ class _HomeScreenState extends ConsumerState<HomeTabScreen> {
                           ? MediaQuery.paddingOf(context).top + kToolbarHeight
                           : 0.0,
                       key: _refreshKey,
-                      onRefresh: () => _refreshData(isOnline: status.isOnline),
+                      onRefresh: () => _refreshData(isOnline: isOnline),
                       child: content,
                     ),
               bottomNavigationBar: widget.editModeEnabled
@@ -892,13 +892,13 @@ class _PlayerScreenButton extends ConsumerWidget {
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
-    final connectivity = ref.watch(connectivityChangesProvider);
+    final isOnlineAsync = ref.watch(onlineStatusProvider);
 
-    return connectivity.maybeWhen(
-      data: (connectivity) => SemanticIconButton(
+    return isOnlineAsync.maybeWhen(
+      data: (isOnline) => SemanticIconButton(
         icon: const Icon(Icons.group_outlined),
         semanticsLabel: context.l10n.players,
-        onPressed: !connectivity.isOnline
+        onPressed: !isOnline
             ? null
             : () {
                 Navigator.of(context).push(PlayerScreen.buildRoute(context));
@@ -922,7 +922,7 @@ class _ChallengeScreenButton extends ConsumerWidget {
     if (authUser == null) {
       return const SizedBox.shrink();
     }
-    final connectivity = ref.watch(connectivityChangesProvider);
+    final isOnlineAsync = ref.watch(onlineStatusProvider);
     final challenges = ref.watch(challengesProvider);
 
     final inwardCount = challenges.value?.inward.length ?? 0;
@@ -932,15 +932,15 @@ class _ChallengeScreenButton extends ConsumerWidget {
       return const SizedBox.shrink();
     }
 
-    return switch (connectivity) {
-      AsyncData(:final value) => SemanticIconButton(
+    return switch (isOnlineAsync) {
+      AsyncData(value: final isOnline) => SemanticIconButton(
         icon: Badge.count(
           count: inwardCount,
           isLabelVisible: inwardCount > 0,
           child: const Icon(LichessIcons.crossed_swords, size: 18.0),
         ),
         semanticsLabel: context.l10n.preferencesNotifyChallenge,
-        onPressed: !value.isOnline
+        onPressed: !isOnline
             ? null
             : () {
                 ref.invalidate(challengesProvider);

--- a/lib/src/view/learn/learn_tab_screen.dart
+++ b/lib/src/view/learn/learn_tab_screen.dart
@@ -81,7 +81,7 @@ class _Body extends ConsumerWidget {
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
-    final isOnline = ref.watch(connectivityChangesProvider).value?.isOnline ?? false;
+    final isOnline = ref.watch(onlineStatusProvider).value ?? false;
     final authUser = ref.watch(authControllerProvider);
     final haveIStudies = authUser != null && (ref.watch(_myStudiesLengthProvider).value ?? 0) > 0;
     final haveIFavoriteStudies =

--- a/lib/src/view/more/more_tab_screen.dart
+++ b/lib/src/view/more/more_tab_screen.dart
@@ -55,7 +55,7 @@ class _Body extends ConsumerWidget {
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
-    final isOnline = ref.watch(connectivityChangesProvider).value?.isOnline ?? false;
+    final isOnline = ref.watch(onlineStatusProvider).value ?? false;
     final authUser = ref.watch(authControllerProvider);
 
     return ListTileTheme.merge(

--- a/lib/src/view/play/create_game_widget.dart
+++ b/lib/src/view/play/create_game_widget.dart
@@ -22,7 +22,7 @@ class CreateGameWidget extends ConsumerWidget {
   @override
   Widget build(BuildContext context, WidgetRef ref) {
     final playPrefs = ref.watch(gameSetupPreferencesProvider);
-    final isOnline = ref.watch(connectivityChangesProvider).value?.isOnline ?? false;
+    final isOnline = ref.watch(onlineStatusProvider).value ?? false;
     final account = ref.watch(accountProvider).value;
     final userPerf = account?.perfs[playPrefs.realTimePerf];
     final canUseRatingRange = userPerf != null && userPerf.provisional != true;

--- a/lib/src/view/play/play_menu.dart
+++ b/lib/src/view/play/play_menu.dart
@@ -17,7 +17,7 @@ class PlayMenu extends ConsumerWidget {
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
-    final isOnline = ref.watch(connectivityChangesProvider).value?.isOnline ?? false;
+    final isOnline = ref.watch(onlineStatusProvider).value ?? false;
 
     return Column(
       children: [

--- a/lib/src/view/play/quick_game_matrix.dart
+++ b/lib/src/view/play/quick_game_matrix.dart
@@ -94,7 +94,7 @@ class _SectionChoices extends ConsumerWidget {
   @override
   Widget build(BuildContext context, WidgetRef ref) {
     final authUser = ref.watch(authControllerProvider);
-    final isOnline = ref.watch(connectivityChangesProvider).value?.isOnline ?? false;
+    final isOnline = ref.watch(onlineStatusProvider).value ?? false;
     final choiceWidgets = choices
         .mapIndexed((index, choice) {
           return [

--- a/lib/src/view/puzzle/opening_screen.dart
+++ b/lib/src/view/puzzle/opening_screen.dart
@@ -14,7 +14,7 @@ import 'package:lichess_mobile/src/widgets/platform.dart';
 
 final _openingsProvider =
     FutureProvider.autoDispose<(bool, IMap<String, int>, IList<PuzzleOpeningFamily>?)>((ref) async {
-      final connectivity = await ref.watch(connectivityChangesProvider.future);
+      final isOnline = await ref.watch(onlineStatusProvider.future);
       final savedOpenings = await ref.watch(savedOpeningBatchesProvider.future);
       IList<PuzzleOpeningFamily>? onlineOpenings;
       try {
@@ -22,7 +22,7 @@ final _openingsProvider =
       } catch (e) {
         onlineOpenings = null;
       }
-      return (connectivity.isOnline, savedOpenings, onlineOpenings);
+      return (isOnline, savedOpenings, onlineOpenings);
     });
 
 class OpeningThemeScreen extends StatelessWidget {

--- a/lib/src/view/puzzle/puzzle_screen.dart
+++ b/lib/src/view/puzzle/puzzle_screen.dart
@@ -906,7 +906,7 @@ class _PuzzleSettingsBottomSheet extends ConsumerWidget {
     final ctrlProvider = puzzleControllerProvider(initialPuzzleContext);
     final puzzleState = ref.watch(ctrlProvider);
     final difficulty = ref.watch(puzzlePreferencesProvider.select((state) => state.difficulty));
-    final isOnline = ref.watch(connectivityChangesProvider).value?.isOnline ?? false;
+    final isOnline = ref.watch(onlineStatusProvider).value ?? false;
     return BottomSheetScrollableContainer(
       padding: const EdgeInsets.only(bottom: 16),
       children: [

--- a/lib/src/view/puzzle/puzzle_tab_screen.dart
+++ b/lib/src/view/puzzle/puzzle_tab_screen.dart
@@ -249,8 +249,7 @@ class _PuzzleMenu extends ConsumerWidget {
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
-    final connectivity = ref.watch(connectivityChangesProvider);
-    final bool isOnline = connectivity.value?.isOnline ?? false;
+    final isOnline = ref.watch(onlineStatusProvider).value ?? false;
 
     return ListSection(
       hasLeading: true,
@@ -424,7 +423,7 @@ class DailyPuzzle extends ConsumerWidget {
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
-    final isOnline = ref.watch(connectivityChangesProvider).value?.isOnline ?? false;
+    final isOnline = ref.watch(onlineStatusProvider).value ?? false;
     final puzzle = ref.watch(dailyPuzzleProvider);
 
     return puzzle.when(

--- a/lib/src/view/puzzle/puzzle_themes_screen.dart
+++ b/lib/src/view/puzzle/puzzle_themes_screen.dart
@@ -18,10 +18,10 @@ final _themesProvider =
     FutureProvider.autoDispose<
       (bool, IMap<PuzzleThemeKey, int>, IMap<PuzzleThemeKey, PuzzleThemeData>?, bool)
     >((ref) async {
-      final connectivity = await ref.watch(connectivityChangesProvider.future);
+      final isOnline = await ref.watch(onlineStatusProvider.future);
       final savedThemes = await ref.watch(savedThemeBatchesProvider.future);
       IMap<PuzzleThemeKey, PuzzleThemeData>? onlineThemes;
-      if (connectivity.isOnline) {
+      if (isOnline) {
         try {
           onlineThemes = await ref.watch(puzzleThemesProvider.future);
         } catch (e) {
@@ -29,7 +29,7 @@ final _themesProvider =
         }
       }
       final savedOpenings = await ref.watch(savedOpeningBatchesProvider.future);
-      return (connectivity.isOnline, savedThemes, onlineThemes, savedOpenings.isNotEmpty);
+      return (isOnline, savedThemes, onlineThemes, savedOpenings.isNotEmpty);
     });
 
 class PuzzleThemesScreen extends StatelessWidget {

--- a/lib/src/view/settings/settings_screen.dart
+++ b/lib/src/view/settings/settings_screen.dart
@@ -35,9 +35,7 @@ class SettingsScreen extends ConsumerWidget {
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
-    final isOnline = ref.watch(
-      connectivityChangesProvider.select((s) => s.value?.isOnline ?? false),
-    );
+    final isOnline = ref.watch(onlineStatusProvider).value ?? false;
     final generalPrefs = ref.watch(generalPreferencesProvider);
     final packageInfo = ref.read(preloadedDataProvider).requireValue.packageInfo;
     final authUser = ref.watch(authControllerProvider);

--- a/lib/src/view/user/recent_games.dart
+++ b/lib/src/view/user/recent_games.dart
@@ -46,7 +46,7 @@ class RecentGamesWidget extends ConsumerWidget {
           onHeaderTap: nbOfGames > list.length
               ? () {
                   Navigator.of(context).push(
-                    GameHistoryScreen.buildRoute(context, user: user, isOnline: isOnline == true),
+                    GameHistoryScreen.buildRoute(context, user: user, isOnline: isOnline),
                   );
                 }
               : null,

--- a/lib/src/view/user/recent_games.dart
+++ b/lib/src/view/user/recent_games.dart
@@ -32,7 +32,7 @@ class RecentGamesWidget extends ConsumerWidget {
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
-    final connectivity = ref.watch(connectivityChangesProvider);
+    final isOnline = ref.watch(onlineStatusProvider).value ?? false;
 
     return recentGames.when(
       data: (data) {
@@ -46,11 +46,7 @@ class RecentGamesWidget extends ConsumerWidget {
           onHeaderTap: nbOfGames > list.length
               ? () {
                   Navigator.of(context).push(
-                    GameHistoryScreen.buildRoute(
-                      context,
-                      user: user,
-                      isOnline: connectivity.value?.isOnline == true,
-                    ),
+                    GameHistoryScreen.buildRoute(context, user: user, isOnline: isOnline == true),
                   );
                 }
               : null,

--- a/lib/src/view/user/recent_games.dart
+++ b/lib/src/view/user/recent_games.dart
@@ -45,9 +45,9 @@ class RecentGamesWidget extends ConsumerWidget {
           hasLeading: true,
           onHeaderTap: nbOfGames > list.length
               ? () {
-                  Navigator.of(context).push(
-                    GameHistoryScreen.buildRoute(context, user: user, isOnline: isOnline),
-                  );
+                  Navigator.of(
+                    context,
+                  ).push(GameHistoryScreen.buildRoute(context, user: user, isOnline: isOnline));
                 }
               : null,
           children: [for (final item in list) GameListTile(item: item)],

--- a/lib/src/view/user/user_screen.dart
+++ b/lib/src/view/user/user_screen.dart
@@ -169,7 +169,7 @@ class _UserProfileListView extends ConsumerWidget {
   Widget build(BuildContext context, WidgetRef ref) {
     final UserScreenData(:user, :recentGames, :activity, :isPlayingLive, :crosstable) = data;
 
-    final connectivity = ref.watch(connectivityChangesProvider);
+    final isOnline = ref.watch(onlineStatusProvider).value ?? false;
     final nbOfGames = user.count?.all ?? 0;
     final authUser = ref.watch(authControllerProvider);
     final kidMode = ref.watch(kidModeProvider);
@@ -217,7 +217,7 @@ class _UserProfileListView extends ConsumerWidget {
                         GameHistoryScreen.buildRoute(
                           context,
                           user: authUser.user,
-                          isOnline: connectivity.value?.isOnline == true,
+                          isOnline: isOnline == true,
                           gameFilter: GameFilterState(opponent: user),
                         ),
                       );

--- a/lib/src/view/user/user_screen.dart
+++ b/lib/src/view/user/user_screen.dart
@@ -217,7 +217,7 @@ class _UserProfileListView extends ConsumerWidget {
                         GameHistoryScreen.buildRoute(
                           context,
                           user: authUser.user,
-                          isOnline: isOnline == true,
+                          isOnline: isOnline,
                           gameFilter: GameFilterState(opponent: user),
                         ),
                       );

--- a/lib/src/view/watch/watch_tab_screen.dart
+++ b/lib/src/view/watch/watch_tab_screen.dart
@@ -80,7 +80,7 @@ class _WatchScreenState extends ConsumerState<WatchTabScreen> {
       }
     });
 
-    final isOnline = ref.watch(connectivityChangesProvider).value?.isOnline ?? true;
+    final isOnline = ref.watch(onlineStatusProvider).value ?? true;
     return PopScope(
       canPop: false,
       onPopInvokedWithResult: (bool didPop, _) {

--- a/lib/src/widgets/feedback.dart
+++ b/lib/src/widgets/feedback.dart
@@ -149,11 +149,11 @@ class OfflineBanner extends ConsumerWidget {
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
-    final connectivity = ref.watch(connectivityChangesProvider);
+    final isOnlineAsync = ref.watch(onlineStatusProvider);
     final theme = Theme.of(context);
-    return connectivity.when(
-      data: (data) {
-        if (data.isOnline) {
+    return isOnlineAsync.when(
+      data: (isOnline) {
+        if (isOnline) {
           return const SizedBox.shrink();
         }
         return Material(


### PR DESCRIPTION
That fixes an issue where network requests were made for nothing when the app was put into background/resumed.