### PR TITLE
Fix #2387: refresh account rating when rated game ends

### DIFF
--- a/lib/src/model/game/game_controller.dart
+++ b/lib/src/model/game/game_controller.dart
@@ -10,6 +10,7 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:freezed_annotation/freezed_annotation.dart';
 import 'package:lichess_mobile/src/binding.dart';
 import 'package:lichess_mobile/src/model/account/account_preferences.dart';
+import 'package:lichess_mobile/src/model/account/account_repository.dart';
 import 'package:lichess_mobile/src/model/account/account_service.dart';
 import 'package:lichess_mobile/src/model/account/ongoing_game.dart';
 import 'package:lichess_mobile/src/model/analysis/analysis_controller.dart';
@@ -785,6 +786,13 @@ class GameController extends AsyncNotifier<GameState> {
           ),
           premove: null,
         );
+
+        // A rated game just changed the user's rating. Invalidate accountProvider
+        // so the next consumer (e.g. "New Opponent" rebuilding a lobby seek from
+        // the ratingDelta) reads the updated rating instead of the stale cache.
+        if (curState.game.meta.rated && endData.ratingDiff != null) {
+          ref.invalidate(accountProvider);
+        }
 
         if (endData.clock != null) {
           newState = newState.copyWith.game.clock!(

--- a/test/model/game/game_controller_test.dart
+++ b/test/model/game/game_controller_test.dart
@@ -1,0 +1,209 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:http/testing.dart';
+import 'package:lichess_mobile/src/model/account/account_repository.dart';
+import 'package:lichess_mobile/src/model/common/id.dart';
+import 'package:lichess_mobile/src/model/game/game_controller.dart';
+import 'package:lichess_mobile/src/network/http.dart';
+
+import '../../network/fake_http_client_factory.dart';
+import '../../network/fake_websocket_channel.dart';
+import '../../test_container.dart';
+import '../../test_helpers.dart';
+import '../auth/fake_auth_storage.dart';
+
+const _ratedBlitzFullEvent = '''
+{
+  "t": "full",
+  "d": {
+    "game": {
+      "id": "qVChCOTc",
+      "variant": {"key": "standard", "name": "Standard", "short": "Std"},
+      "speed": "blitz",
+      "perf": "blitz",
+      "rated": true,
+      "source": "lobby",
+      "status": {"id": 20, "name": "started"},
+      "createdAt": 1685698678928,
+      "pgn": ""
+    },
+    "white": {"user": {"name": "testUser", "id": "testuser"}, "rating": 1500, "onGame": true},
+    "black": {"user": {"name": "opponent", "id": "opponent"}, "rating": 1500, "onGame": true},
+    "clock": {
+      "running": false,
+      "initial": 180,
+      "increment": 2,
+      "white": 180,
+      "black": 180,
+      "emerg": 30,
+      "moretime": 15
+    },
+    "youAre": "white",
+    "socket": 0,
+    "expiration": {"idleMillis": 245, "millisToMove": 30000},
+    "chat": {"lines": []}
+  }
+}
+''';
+
+const _unratedBlitzFullEvent = '''
+{
+  "t": "full",
+  "d": {
+    "game": {
+      "id": "qVChCOTc",
+      "variant": {"key": "standard", "name": "Standard", "short": "Std"},
+      "speed": "blitz",
+      "perf": "blitz",
+      "rated": false,
+      "source": "lobby",
+      "status": {"id": 20, "name": "started"},
+      "createdAt": 1685698678928,
+      "pgn": ""
+    },
+    "white": {"user": {"name": "testUser", "id": "testuser"}, "rating": 1500, "onGame": true},
+    "black": {"user": {"name": "opponent", "id": "opponent"}, "rating": 1500, "onGame": true},
+    "clock": {
+      "running": false,
+      "initial": 180,
+      "increment": 2,
+      "white": 180,
+      "black": 180,
+      "emerg": 30,
+      "moretime": 15
+    },
+    "youAre": "white",
+    "socket": 0,
+    "expiration": {"idleMillis": 245, "millisToMove": 30000},
+    "chat": {"lines": []}
+  }
+}
+''';
+
+String _accountResponse({required int blitzRating}) =>
+    '''
+{
+  "id": "testuser",
+  "username": "testUser",
+  "createdAt": 1290415680000,
+  "seenAt": 1290415680000,
+  "perfs": {
+    "blitz": {"games": 2340, "rating": $blitzRating, "rd": 30, "prog": 10}
+  }
+}
+''';
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  group('GameController — account refresh on game end (issue #2387)', () {
+    test('refreshes accountProvider when a rated game ends with a ratingDiff', () async {
+      const gameFullId = GameFullId('ratedGameAAA');
+      final gameSocketUri = GameController.socketUri(gameFullId);
+
+      var accountRequestCount = 0;
+
+      final mockClient = MockClient((request) {
+        if (request.url.path == '/api/account') {
+          accountRequestCount += 1;
+          final rating = accountRequestCount == 1 ? 1500 : 1510;
+          return mockResponse(_accountResponse(blitzRating: rating), 200);
+        }
+        return mockResponse('', 404);
+      });
+
+      final container = await makeContainer(
+        authUser: fakeAuthUser,
+        overrides: {
+          httpClientFactoryProvider: httpClientFactoryProvider.overrideWith((ref) {
+            return FakeHttpClientFactory(() => mockClient);
+          }),
+        },
+      );
+
+      // Keep accountProvider alive across invalidation; otherwise autoDispose
+      // would clear the cache between reads and mask the bug.
+      container.listen(accountProvider, (_, _) {});
+
+      // Prime the account cache — stale, pre-game rating.
+      final before = await container.read(accountProvider.future);
+      expect(accountRequestCount, 1);
+      expect(before, isNotNull);
+
+      // Start the game controller and initialize with a 'full' event. Keep
+      // the controller alive (it's autoDispose) so its ref stays valid across
+      // the async gap where the full event arrives.
+      container.listen(gameControllerProvider(gameFullId), (_, _) {});
+      final controllerFuture = container.read(gameControllerProvider(gameFullId).future);
+      await Future<void>.delayed(kFakeWebSocketConnectionLag);
+      sendServerSocketMessages(gameSocketUri, [_ratedBlitzFullEvent]);
+      // wait for build() to resolve on the full event
+      await controllerFuture;
+
+      // Rated game ends with a rating change.
+      const ratedEndData =
+          '{"t":"endData","d":{"status":"resign","winner":"black","ratingDiff":{"white":-10,"black":10}}}';
+      sendServerSocketMessages(gameSocketUri, [ratedEndData]);
+      await Future<void>.delayed(const Duration(milliseconds: 10));
+
+      // Re-read accountProvider. With the fix in place, the prior endData
+      // invalidated the cached account, so this read triggers a fresh HTTP
+      // fetch and returns the updated rating. Without the fix, the cache is
+      // still warm and no second request is made.
+      final after = await container.read(accountProvider.future);
+      expect(
+        accountRequestCount,
+        2,
+        reason:
+            'endData for a rated game should invalidate accountProvider so the '
+            "next consumer (e.g. 'New Opponent') sees the updated rating",
+      );
+      expect(after, isNotNull);
+    });
+
+    test('does not refresh accountProvider for unrated games', () async {
+      const gameFullId = GameFullId('unratedGmBBB');
+      final gameSocketUri = GameController.socketUri(gameFullId);
+
+      var accountRequestCount = 0;
+
+      final mockClient = MockClient((request) {
+        if (request.url.path == '/api/account') {
+          accountRequestCount += 1;
+          return mockResponse(_accountResponse(blitzRating: 1500), 200);
+        }
+        return mockResponse('', 404);
+      });
+
+      final container = await makeContainer(
+        authUser: fakeAuthUser,
+        overrides: {
+          httpClientFactoryProvider: httpClientFactoryProvider.overrideWith((ref) {
+            return FakeHttpClientFactory(() => mockClient);
+          }),
+        },
+      );
+
+      container.listen(accountProvider, (_, _) {});
+      await container.read(accountProvider.future);
+      expect(accountRequestCount, 1);
+
+      container.listen(gameControllerProvider(gameFullId), (_, _) {});
+      final controllerFuture = container.read(gameControllerProvider(gameFullId).future);
+      await Future<void>.delayed(kFakeWebSocketConnectionLag);
+      sendServerSocketMessages(gameSocketUri, [_unratedBlitzFullEvent]);
+      await controllerFuture;
+
+      sendServerSocketMessages(gameSocketUri, [
+        '{"t":"endData","d":{"status":"resign","winner":"black"}}',
+      ]);
+      await Future<void>.delayed(const Duration(milliseconds: 10));
+
+      await container.read(accountProvider.future);
+      expect(
+        accountRequestCount,
+        1,
+        reason: 'an unrated game does not change the rating, so no refresh is needed',
+      );
+    });
+  });
+}


### PR DESCRIPTION
## Summary

Fixes #2387. When a user sets a rating filter, plays a rated lobby game, and taps **New Opponent**, the new seek is built against the user's **pre-game** rating instead of the post-game rating. If the user was 1500 ± 100 and became 1510, the seek still searches `1400-1600` centered on 1500 instead of `1410-1610`.

## Root cause

`GameSetupPrefs.customRatingDelta` is a delta (tuple `(subtract, add)`). It is resolved to an absolute `ratingRange` only at seek-send time in `CreateGameService.newLobbyGame`:

```dart
if (seek.ratingDelta != null) {
  final account = await ref.read(accountProvider.future);  // stale
  if (account != null) {
    actualSeek = actualSeek.withRatingRangeOf(account);
  }
}
```

`accountProvider` is a `FutureProvider.autoDispose` that is never invalidated at game end, so `userPerf.rating` is the value from before the game.

## Fix

In `GameController._handleSocketEvent` (case `endData`), invalidate `accountProvider` when the game was rated and the server reported a `ratingDiff`:

```dart
if (curState.game.meta.rated && endData.ratingDiff != null) {
  ref.invalidate(accountProvider);
}
```

Rationale:
- `endData` is the single choke-point where the server tells us a game ended and the rating changed.
- Guard on `rated && ratingDiff != null` so aborts and unrated games don't trigger unnecessary HTTP refetches.
- `GameSeek.withRatingRangeOf` already short-circuits for provisional ratings; no extra handling needed.

The next `accountProvider.future` read — typically inside `newLobbyGame` when the user taps New Opponent — lazily refetches and uses the updated rating.

## Tests

Adds `test/model/game/game_controller_test.dart` with two cases. Both use a `MockClient` that counts `/api/account` requests, and drive the `GameController` through its real socket using `sendServerSocketMessages`:

- **rated game end → invalidated**: after sending `endData` with a `ratingDiff`, a re-read of `accountProvider.future` must trigger a second `/api/account` fetch. This test **fails without the fix** (count stays at 1) and passes with it.
- **unrated game end → no refetch**: sanity check that unrated games don't waste a request.

## Test plan

- [x] `flutter test test/model/game/game_controller_test.dart` — both pass
- [x] `flutter test test/view/game/game_screen_test.dart test/model/game/ test/model/lobby/` — no regressions
- [x] `flutter analyze` clean on both changed files
- [x] `dart format` clean
- [ ] Manual: set rating filter to e.g. `-50/+50`, play and finish a rated game that changes the rating, tap New Opponent, inspect the `POST /api/board/seek` body — `ratingRange` should be centered on the **new** rating.

🤖 Generated with [Claude Code](https://claude.com/claude-code)