### PR TITLE
fix infinite loop triggered by imported game deeplinks

### DIFF
--- a/lib/src/app_links_service.dart
+++ b/lib/src/app_links_service.dart
@@ -106,7 +106,8 @@ class AppLinksService {
       return;
     }
     if (context != null && context.mounted) {
-      await handleAppLink(context, uri, animated: animated);
+      // For app deep links, we don't want to allow falling back to the browser as it might trigger an infinite loop if the app isn't properly handling the link
+      await handleAppLink(context, uri, animated: animated, allowBrowserFallback: false);
     }
   }
 
@@ -291,7 +292,12 @@ class AppLinksService {
   }
 
   /// Handles an app link [Uri] by navigating to the corresponding screen(s).
-  Future<void> handleAppLink(BuildContext context, Uri uri, {bool animated = true}) async {
+  Future<void> handleAppLink(
+    BuildContext context,
+    Uri uri, {
+    bool animated = true,
+    bool allowBrowserFallback = true,
+  }) async {
     final routes = await resolveAppLinkUri(context, uri);
     if (!context.mounted) return;
 
@@ -304,7 +310,11 @@ class AppLinksService {
       final isChallengeLink = await _tryResolveChallengeLink(context, uri);
       if (isChallengeLink) return;
 
-      launchUrl(uri);
+      if (allowBrowserFallback) {
+        launchUrl(uri);
+      } else {
+        _logger.warning('Could not resolve app link $uri');
+      }
     }
   }
 


### PR DESCRIPTION
Unhandled Lichess links like imported games ( f.ex. `https://lichess.org/0Q6BNlj4`), currently cause an infinite loop. When the app fails to resolve the link, it tries to open it in the system browser, which the OS immediately redirects back to the app, which will open the browser again ...

To protect against similar cases in the future, this PR adds that deeplinks can not open the in-app browser. 