### PR TITLE
Ignore shared URLs in file processor

### DIFF
--- a/lib/src/app.dart
+++ b/lib/src/app.dart
@@ -206,6 +206,10 @@ class _AppState extends ConsumerState<Application> {
   Future<void> _processSharedFiles(List<SharedMediaFile> files) async {
     if (files.isEmpty) return;
     final filePath = files.first.path;
+    if (filePath.startsWith('https://') || filePath.startsWith('http://')) {
+      debugPrint('Ignored shared URL in file processor: $filePath');
+      return;
+    }
     try {
       final context = _navigatorKey.currentContext;
       if (context == null || !context.mounted) return;

--- a/lib/src/app.dart
+++ b/lib/src/app.dart
@@ -206,7 +206,7 @@ class _AppState extends ConsumerState<Application> {
   Future<void> _processSharedFiles(List<SharedMediaFile> files) async {
     if (files.isEmpty) return;
     final filePath = files.first.path;
-    if (filePath.startsWith('https://') || filePath.startsWith('http://')) {
+    if (filePath.startsWith('http')) {
       debugPrint('Ignored shared URL in file processor: $filePath');
       return;
     }


### PR DESCRIPTION
I noticed while debugging that there was an unnecessary attempted file read when opening a deeplink url as ReceiveSharingIntent would also handle it.
`I/flutter (13335): Failed to process incoming file: PathNotFoundException: Cannot open file, path = 'https://lichess.org/iMypvkd1' (OS Error: No such file or directory, errno = 2) `