### PR TITLE
allow malformed utf-8 in pgn

### DIFF
--- a/lib/src/app.dart
+++ b/lib/src/app.dart
@@ -1,4 +1,5 @@
 import 'dart:async';
+import 'dart:convert';
 import 'dart:io';
 
 import 'package:flutter/material.dart';
@@ -211,7 +212,8 @@ class _AppState extends ConsumerState<Application> {
       if (context == null || !context.mounted) return;
 
       final file = File(filePath);
-      final pgnText = await file.readAsString();
+      final bytes = await file.readAsBytes();
+      final pgnText = utf8.decode(bytes, allowMalformed: true);
 
       if (context.mounted) {
         ImportPgnScreen.handlePgnText(context, pgnText);

--- a/lib/src/view/more/import_pgn_screen.dart
+++ b/lib/src/view/more/import_pgn_screen.dart
@@ -136,7 +136,7 @@ class _BodyState extends ConsumerState<_Body> {
       final result = await ref.read(pickPgnFileProvider)();
 
       if (result != null && result.files.single.bytes != null) {
-        final content = utf8.decode(result.files.single.bytes!);
+        final content = utf8.decode(result.files.single.bytes!, allowMalformed: true);
         if (mounted) {
           ImportPgnScreen.handlePgnText(context, content);
         }


### PR DESCRIPTION
some files that I tried to import from Chessbase threw errors when decoding, allowing malformed utf8 encoding allows to import them anyways and the PGNs I tested with seemed complete.