### PR TITLE
feat: open imported games

### DIFF
--- a/lib/src/app_links_service.dart
+++ b/lib/src/app_links_service.dart
@@ -266,7 +266,7 @@ class AppLinksService {
 
       if (!context.mounted) return null;
 
-      if (game.finished) {
+      if (game.finished || game.source == .import) {
         return [
           AnalysisScreen.buildRoute(
             context,

--- a/lib/src/model/analysis/analysis_controller.dart
+++ b/lib/src/model/analysis/analysis_controller.dart
@@ -252,7 +252,7 @@ class AnalysisController extends AsyncNotifier<AnalysisState>
 
     final isComputerAnalysisAllowed = switch (options) {
       Pgn(:final isComputerAnalysisAllowed) => isComputerAnalysisAllowed,
-      ArchivedGame() => isGameFinished,
+      ArchivedGame() => isGameFinished || archivedGame?.source == .import,
       Standalone() => true,
       ActiveCorrespondenceGame() => false,
     };
@@ -954,9 +954,10 @@ sealed class AnalysisState
 
   /// Whether the user can request server analysis.
   ///
-  /// It must be a lichess game, which is finished and not already analyzed.
+  /// It must be a lichess game, which is finished and not already analyzed or an imported game.
   bool get canRequestServerAnalysis =>
-      gameId != null && !hasServerAnalysis && pgnHeaders['Result'] != '*';
+      gameId != null && !hasServerAnalysis && pgnHeaders['Result'] != '*' ||
+      archivedGame?.source == .import;
 
   /// Whether the server analysis is available.
   bool get hasServerAnalysis => playersAnalysis != null;


### PR DESCRIPTION
Allows to view imported games from links, so that they do not fail silently after: #3036 
Opens the analysis board now, where I needed to enable computer analysis and server analysis too.
Example link: `https://lichess.org/0Q6BNlj4`

[Screencast_20260425_095942.webm](https://github.com/user-attachments/assets/c1f24f65-6aab-4a57-8712-d9cd7f7fb02a)
