### PR TITLE
Fix deep link loop for imported games with anonymous players

### DIFF
--- a/test/app_links_service_test.dart
+++ b/test/app_links_service_test.dart
@@ -15,6 +15,7 @@ import 'package:lichess_mobile/src/model/common/chess.dart';
 import 'package:lichess_mobile/src/model/common/game.dart';
 import 'package:lichess_mobile/src/model/common/id.dart';
 import 'package:lichess_mobile/src/model/common/speed.dart';
+import 'package:lichess_mobile/src/model/game/game.dart';
 import 'package:lichess_mobile/src/model/game/game_repository.dart';
 import 'package:lichess_mobile/src/model/game/game_status.dart';
 import 'package:lichess_mobile/src/model/game/player.dart';
@@ -466,6 +467,34 @@ void main() {
             .having((s) => s.options.gameId, 'id', finishedGame.id.value)
             .having((s) => s.options.orientation, 'player color', Side.black),
       );
+    });
+
+    testWidgets('resolves /gameid link for imported game to analysis', (WidgetTester tester) async {
+      final mockGameRepository = MockGameRepository();
+      final importedGame = generateExportedGames(count: 1).first.copyWith(
+        status: GameStatus.started,
+        source: GameSource.import,
+        black: const Player(),
+        white: const Player(),
+      );
+      when(() => mockGameRepository.getGame(importedGame.id)).thenAnswer((_) async => importedGame);
+
+      final uri = Uri.parse('https://lichess.org/${importedGame.id.value}');
+
+      await triggerAppLink(
+        tester,
+        uri,
+        overrides: {
+          gameRepositoryProvider: gameRepositoryProvider.overrideWith((_) => mockGameRepository),
+        },
+      );
+      await tester.pumpAndSettle();
+
+      expect(
+        tester.widget(find.byType(AnalysisScreen)),
+        isA<AnalysisScreen>().having((s) => s.options.gameId, 'id', importedGame.id.value),
+      );
+      expect(find.byType(TvScreen), findsNothing);
     });
 
     testWidgets('resolves /gameid link for ongoing game', (WidgetTester tester) async {


### PR DESCRIPTION
## Summary 
Imported PGNs without a `[Result]` tag and without `[White]`/`[Black]` tags fall into an infinite deep-link loop when shared into the Lichess mobile app. This PR routes those games to the analysis screen instead.

Reproducible by hitting `POST /api/import` with a PGN that lacks a result and player tags and then opening the returned `https://lichess.org/{id}`.

## Root cause 
When a PGN is imported without a `Result` tag, Lichess records the game with `status: "started"`. When `[White]`/`[Black]` tags are missing too, the players come back anonymous (`{"name": "?"}` with no `user`). 

`_tryResolveGameLink` in `app_links_service.dart` then returns `null`, because both, the AnalysisScreen (`game.finished`) and TvScreen (`game.playerOf(orientation).user`) checks fail.

`handleAppLink` falls through to `launchUrl(uri)`, which the OS routes back into the app via the verified `lichess.org/{id}` intent filter, looping indefinitely. 

## Fix
Open the game in `AnalysisScreen` whenever it's finished **or** has no real player on the orientation side. Open in `TvScreen` otherwise.