### PR TITLE
fix errors in tv app link tests

### DIFF
--- a/test/app_links_service_test.dart
+++ b/test/app_links_service_test.dart
@@ -619,6 +619,10 @@ void main() {
       when(() => mockUserRepository.getUser(const UserId('thibault'))).thenAnswer(
         (_) async => const User(id: UserId('thibault'), username: 'Thibault', perfs: IMap.empty()),
       );
+      final testGame = generateExportedGames(count: 1).first;
+      when(
+        () => mockUserRepository.getCurrentGame(const UserId('thibault')),
+      ).thenAnswer((_) async => testGame);
 
       await triggerAppLink(
         tester,
@@ -627,6 +631,20 @@ void main() {
           userRepositoryProvider: userRepositoryProvider.overrideWith((_) => mockUserRepository),
         },
       );
+
+      // Wait a frame for the async getCurrentGame lookup to complete
+      await tester.pump();
+
+      sendServerSocketMessages(Uri(path: '/watch/${testGame.id.value}/white/v6'), [
+        makeFullEvent(
+          testGame.id,
+          '',
+          whiteUserName: testGame.white.user?.name ?? 'White',
+          blackUserName: testGame.black.user?.name ?? 'Black',
+        ),
+      ]);
+      await tester.pump(); // Process socket message
+
       await tester.pumpAndSettle(); // Wait for tv screen to load
 
       expect(
@@ -658,7 +676,37 @@ void main() {
 
     testWidgets('Shows tv screen for /tv/<channel> link', (WidgetTester tester) async {
       final uri = Uri.parse('https://lichess.org/tv/blitz');
-      await triggerAppLink(tester, uri);
+      await triggerAppLink(
+        tester,
+        uri,
+        overrides: {
+          httpClientFactoryProvider: httpClientFactoryProvider.overrideWith((ref) {
+            return FakeHttpClientFactory(
+              () => MockClient((request) async {
+                if (request.url.path == '/api/tv/channels') {
+                  const body = '''
+                  {
+                    "blitz": {"color": "white", "gameId": "v3pIFdTz", "rating": 2615, "user": {"id": "whitePlayer", "name": "whitePlayer"}}
+                  }''';
+                  return http.Response(body, 200, headers: {'content-type': 'application/json'});
+                }
+                return http.Response('', 404);
+              }),
+            );
+          }),
+        },
+      );
+      await tester.pump(kFakeWebSocketConnectionLag);
+      sendServerSocketMessages(Uri(path: '/watch/v3pIFdTz/white/v6'), [
+        makeFullEvent(
+          const GameId('gameid11'),
+          '',
+          whiteUserName: 'whitePlayer',
+          blackUserName: 'blackPlayer',
+        ),
+      ]);
+      await tester.pump(); // Process socket message
+
       await tester.pumpAndSettle(); // Wait for TV screen to load
 
       expect(


### PR DESCRIPTION
fixes two errors/warnings that appeared when running the tests locally:
```
lichess-mobile/test/app_links_service_test.dart: resolveAppLinkUri resolves /@/user/tv link                                                                                                                                                                      
SEVERE: [TvScreen] could not load stream; type 'Null' is not a subtype of type 'Future<ExportedGame>'
#0      MockUserRepository.getCurrentGame (file:///home/noah/Dokumente/lichess/lichess-mobile/test/app_links_service_test.dart:54:7)
#1      TvController._connectWebsocket (package:lichess_mobile/src/model/tv/tv_controller.dart:88:59)
#2      TvController.build (package:lichess_mobile/src/model/tv/tv_controller.dart:61:12)
#3      ElementWithFuture.handleFuture.<anonymous closure> (package:riverpod/src/core/element.dart:206:30)
#4      ElementWithFuture._handleAsync (package:riverpod/src/core/element.dart:270:35)
#5      ElementWithFuture.handleFuture (package:riverpod/src/core/element.dart:200:12)
#6      $AsyncNotifierProviderElement.handleCreate (package:riverpod/src/providers/async_notifier.dart:89:5)
#7      AsyncNotifier.runBuild (package:riverpod/src/providers/async_notifier/orphan.dart:38:22)
#8      $ClassProviderElement.create (package:riverpod/src/core/provider/notifier_provider.dart:560:28)
#9      ProviderElement.buildState (package:riverpod/src/core/element.dart:684:28)
#10     ProviderElement.mount (package:riverpod/src/core/element.dart:537:7)
```
and 
```
lichess-mobile/test/app_links_service_test.dart: resolveAppLinkUri resolves /@/user/tv link                                                                                                                                                                      
SEVERE: [TvScreen] could not load stream; type 'Null' is not a subtype of type 'Future<ExportedGame>'
#0      MockUserRepository.getCurrentGame (file:///home/noah/Dokumente/lichess/lichess-mobile/test/app_links_service_test.dart:54:7)
#1      TvController._connectWebsocket (package:lichess_mobile/src/model/tv/tv_controller.dart:88:59)
#2      TvController.build (package:lichess_mobile/src/model/tv/tv_controller.dart:61:12)
#3      ElementWithFuture.handleFuture.<anonymous closure> (package:riverpod/src/core/element.dart:206:30)
#4      ElementWithFuture._handleAsync (package:riverpod/src/core/element.dart:270:35)
#5      ElementWithFuture.handleFuture (package:riverpod/src/core/element.dart:200:12)
#6      $AsyncNotifierProviderElement.handleCreate (package:riverpod/src/providers/async_notifier.dart:89:5)
#7      AsyncNotifier.runBuild (package:riverpod/src/providers/async_notifier/orphan.dart:38:22)
#8      $ClassProviderElement.create (package:riverpod/src/core/provider/notifier_provider.dart:560:28)
#9      ProviderElement.buildState (package:riverpod/src/core/element.dart:684:28)
#10     ProviderElement.mount (package:riverpod/src/core/element.dart:537:7)
```
Note: That the code I added was mostly generated by a LLM.