### PR TITLE
try flag in github workflow

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -56,5 +56,5 @@ jobs:
       #   run: dart run custom_lint
 
       - name: Run unit tests
-        run: flutter test
+        run: flutter test --reporter=github
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -56,5 +56,5 @@ jobs:
       #   run: dart run custom_lint
 
       - name: Run unit tests
-        run: flutter test --reporter=github
+        run: flutter test --reporter=failures-only
 

--- a/test/app_links_service_test.dart
+++ b/test/app_links_service_test.dart
@@ -680,7 +680,7 @@ void main() {
       await triggerAppLink(tester, uri);
       await tester.pumpAndSettle();
 
-      expect(find.byType(TvScreen), findsNothing);
+      expect(find.byType(TvScreen), findsOneWidget);
       expect(find.text('Invalid TV channel: not-a-real-channel'), findsOneWidget);
     });
   });

--- a/test/app_links_service_test.dart
+++ b/test/app_links_service_test.dart
@@ -680,7 +680,7 @@ void main() {
       await triggerAppLink(tester, uri);
       await tester.pumpAndSettle();
 
-      expect(find.byType(TvScreen), findsOneWidget);
+      expect(find.byType(TvScreen), findsNothing);
       expect(find.text('Invalid TV channel: not-a-real-channel'), findsOneWidget);
     });
   });


### PR DESCRIPTION
It removes a lot of unnecessary output lines from the CI test with goal to see the failing once faster, but the failures are not marked with ❌ so I am unsure how big of an improvement it actually is. 
See here how it looks: https://github.com/lichess-org/mobile/actions/runs/24939910760/job/73031778428
