### PR TITLE
Bump json_annotation from 4.7.0 to 4.11.0

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -54,7 +54,7 @@ dependencies:
   http: ^1.1.0
   image_picker: ^1.1.2
   intl: ^0.20.2
-  json_annotation: ^4.7.0
+  json_annotation: ^4.11.0
   l10n_esperanto: ^2.0.14
   linkify: ^5.0.0
   logging: ^1.1.0


### PR DESCRIPTION
This is what is already being used in `pubspec.lock`

If I run `flutter pub downgrade` I can get `json_annotation` down to 4.9.0 but no lower. I think it should be raised at least that high, depending on your preference.