### PR TITLE
refactor: simpler fix for #2564 and #2750

### DIFF
--- a/lib/src/model/analysis/retro_controller.dart
+++ b/lib/src/model/analysis/retro_controller.dart
@@ -21,7 +21,7 @@ import 'package:lichess_mobile/src/model/engine/evaluation_preferences.dart';
 import 'package:lichess_mobile/src/model/explorer/opening_explorer_preferences.dart';
 import 'package:lichess_mobile/src/model/explorer/opening_explorer_repository.dart';
 import 'package:lichess_mobile/src/model/game/exported_game.dart';
-import 'package:lichess_mobile/src/model/game/game_repository_providers.dart';
+import 'package:lichess_mobile/src/model/game/game_repository.dart';
 import 'package:lichess_mobile/src/network/socket.dart';
 import 'package:lichess_mobile/src/view/engine/engine_gauge.dart';
 import 'package:logging/logging.dart';
@@ -108,7 +108,10 @@ class RetroController extends AsyncNotifier<RetroState> with EngineEvaluationMix
 
     socketClient = ref.watch(socketPoolProvider).open(AnalysisController.socketUri);
 
-    _game = await ref.watch(archivedGameProvider(options.id).future);
+    // Don't use archivedGameProvider, as its value gets cached when we watch it in AnalysisController,
+    // so when a server analysis is already running, _game.serverAnalysis would still be null.
+    // Request directly from the API instead to get the latest value.
+    _game = await ref.read(gameRepositoryProvider).getGame(options.id);
 
     _root = _game.makeTree();
 
@@ -137,34 +140,11 @@ class RetroController extends AsyncNotifier<RetroState> with EngineEvaluationMix
       // so we don't miss the first progress event.
       serverAnalysisService.lastAnalysisEvent.addListener(_listenToServerAnalysisEvents);
 
-      // Reuse an already available event immediately if it belongs to this game.
-      final existingEvent = serverAnalysisService.lastAnalysisEvent.value;
-      if (existingEvent != null && existingEvent.$1 == options.id) {
-        ServerAnalysisService.mergeOngoingAnalysis(_root, existingEvent.$2.tree);
-
-        final progress =
-            existingEvent.$2.evals.where((e) => e.hasEval).length / _root.mainline.length;
-
-        state = AsyncValue.data(state.requireValue.copyWith(serverAnalysisProgress: progress));
-
-        if (existingEvent.$2.isAnalysisComplete) {
-          if (!_serverAnalysisCompleter.isCompleted) {
-            _serverAnalysisCompleter.complete();
-          }
-
-          state = AsyncData(await _computeMistakes(options.initialSide));
-
-          socketClient.firstConnection.then((_) {
-            requestEval();
-          });
-
-          return state.requireValue;
-        }
-      }
-
-      // Only request analysis if this exact game is not already being analyzed.
       if (serverAnalysisService.currentAnalysis.value != options.id) {
         await serverAnalysisService.requestAnalysis(options.id);
+      } else {
+        // Analysis is already running, call the listener immediately to update the progress bar.
+        _listenToServerAnalysisEvents();
       }
 
       unawaited(

--- a/test/view/analysis/retro_screen_test.dart
+++ b/test/view/analysis/retro_screen_test.dart
@@ -3,17 +3,21 @@ import 'dart:convert';
 import 'package:dartchess/dartchess.dart';
 import 'package:fast_immutable_collections/fast_immutable_collections.dart';
 import 'package:flutter/widgets.dart';
+import 'package:flutter_riverpod/misc.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:http/testing.dart';
 import 'package:lichess_mobile/src/constants.dart';
 import 'package:lichess_mobile/src/model/analysis/analysis_controller.dart';
+import 'package:lichess_mobile/src/model/analysis/server_analysis_service.dart';
 import 'package:lichess_mobile/src/model/common/chess.dart';
 import 'package:lichess_mobile/src/model/common/eval.dart';
 import 'package:lichess_mobile/src/model/common/id.dart';
 import 'package:lichess_mobile/src/model/common/uci.dart';
 import 'package:lichess_mobile/src/model/explorer/opening_explorer.dart';
+import 'package:lichess_mobile/src/model/game/game_socket_events.dart';
 import 'package:lichess_mobile/src/network/http.dart';
 import 'package:lichess_mobile/src/view/analysis/retro_screen.dart';
+import 'package:mocktail/mocktail.dart';
 
 import '../../network/fake_http_client_factory.dart';
 import '../../network/fake_websocket_channel.dart';
@@ -22,11 +26,15 @@ import '../../test_provider_scope.dart';
 
 const testId = GameId('abcdefgh');
 
+class MockServerAnalysisService extends Mock implements ServerAnalysisService {}
+
 Future<Widget> makeTestApp(
   WidgetTester tester, {
   required String moves,
   Iterable<ExternalEval>? evals,
   IMap<String, OpeningExplorerEntry> openingExplorerEntries = const IMap.empty(),
+  bool alreadyHasServerAnalysis = true,
+  Map<ProviderOrFamily, Override> overrides = const {},
 }) async {
   final mockClient = MockClient((request) {
     if (request.url.path == '/game/export/$testId') {
@@ -43,32 +51,22 @@ Future<Widget> makeTestApp(
   "status": "resign",
   "players": {
     "white": {
+      ${alreadyHasServerAnalysis ? '"analysis": {"inaccuracy": 2, "mistake": 1, "blunder": 3, "acpl": 90},' : ""}
       "user": {
         "name": "veloce",
         "id": "veloce"
       },
       "rating": 1789,
-      "ratingDiff": 9,
-      "analysis": {
-        "inaccuracy": 2,
-        "mistake": 1,
-        "blunder": 3,
-        "acpl": 90
-      }
+      "ratingDiff": 9
     },
     "black": {
+      ${alreadyHasServerAnalysis ? '"analysis": {"inaccuracy": 3, "mistake": 0, "blunder": 5, "acpl": 135},' : ""}
       "user": {
         "name": "chabrot",
         "id": "chabrot"
       },
       "rating": 1810,
-      "ratingDiff": -9,
-      "analysis": {
-        "inaccuracy": 3,
-        "mistake": 0,
-        "blunder": 5,
-        "acpl": 135
-      }
+      "ratingDiff": -9
     }
   },
   "winner": "white",
@@ -126,6 +124,7 @@ Future<Widget> makeTestApp(
       httpClientFactoryProvider: httpClientFactoryProvider.overrideWith((ref) {
         return FakeHttpClientFactory(() => mockClient);
       }),
+      ...overrides,
     },
     defaultPreferences: {},
   );
@@ -308,6 +307,81 @@ void main() {
       await playMove(tester, 'd2', 'd4');
       expect(find.text('Good move'), findsOneWidget);
       expect(find.text('Next'), findsOneWidget);
+    });
+
+    testWidgets('Requests server analysis if not already running', (WidgetTester tester) async {
+      final mockAnalysisService = MockServerAnalysisService();
+      final currentAnalysis = ValueNotifier<GameId?>(null);
+      final evalEvents = ValueNotifier<(GameAnyId, ServerEvalEvent)?>(null);
+      when(() => mockAnalysisService.currentAnalysis).thenReturn(currentAnalysis);
+      when(() => mockAnalysisService.lastAnalysisEvent).thenReturn(evalEvents);
+      when(() => mockAnalysisService.requestAnalysis(testId)).thenAnswer((_) async {
+        currentAnalysis.value = testId;
+      });
+
+      await tester.pumpWidget(
+        await makeTestApp(
+          tester,
+          moves: 'e4 e5',
+          alreadyHasServerAnalysis: false,
+          overrides: {
+            serverAnalysisServiceProvider: serverAnalysisServiceProvider.overrideWithValue(
+              mockAnalysisService,
+            ),
+          },
+        ),
+      );
+
+      // Wait for loading screen to appear
+      await tester.pump();
+
+      expect(find.text('Calculating moves...'), findsOneWidget);
+
+      expect(currentAnalysis.value, testId);
+
+      // Finish analysis
+      evalEvents.value = (
+        testId,
+        ServerEvalEvent(evals: <ExternalEval>[].lock, tree: {}, isAnalysisComplete: true),
+      );
+      await tester.pump(); // Wait for eval event to be processed
+      expect(find.text('No significant mistakes found for White'), findsOneWidget);
+    });
+
+    testWidgets('Does not request analysis if already running', (WidgetTester tester) async {
+      final mockAnalysisService = MockServerAnalysisService();
+      final currentAnalysis = ValueNotifier<GameId?>(testId);
+      final evalEvents = ValueNotifier<(GameAnyId, ServerEvalEvent)?>(null);
+      when(() => mockAnalysisService.currentAnalysis).thenReturn(currentAnalysis);
+      when(() => mockAnalysisService.lastAnalysisEvent).thenReturn(evalEvents);
+
+      await tester.pumpWidget(
+        await makeTestApp(
+          tester,
+          moves: 'e4 e5',
+          alreadyHasServerAnalysis: false,
+          overrides: {
+            serverAnalysisServiceProvider: serverAnalysisServiceProvider.overrideWithValue(
+              mockAnalysisService,
+            ),
+          },
+        ),
+      );
+
+      // Wait for loading screen to appear
+      await tester.pump();
+
+      expect(find.text('Calculating moves...'), findsOneWidget);
+
+      // Finish analysis
+      evalEvents.value = (
+        testId,
+        ServerEvalEvent(evals: <ExternalEval>[].lock, tree: {}, isAnalysisComplete: true),
+      );
+      await tester.pump(); // Wait for eval event to be processed
+      expect(find.text('No significant mistakes found for White'), findsOneWidget);
+
+      verifyNever(() => mockAnalysisService.requestAnalysis(testId));
     });
   });
 }


### PR DESCRIPTION
Previous fix was in #2859, but this PR fixes the root cause instead of adding a workaround.

The root cause of this problem was that we check
`_game.serverAnalysis == null` to check if the RetroController needs to trigger server analysis in case it isn't already running. When the server analysis was already triggered by the `AnalysisController`, the problem was that `archivedGameProvider` is not invalidated and still returns `null` for the server analysis field. By using the `GameRepository` directly instead, we get a fresh response from the server which correctly has a non-null `serverAnalysis`.

An alternative fix would be to add
`ref.invalidate(archivedGameProvider(gameId))` when a server analysis request is triggered in the analysis screen, however this leads to the analysis screen being rebuilt when triggering server analysis, which causes a short flicker of the screen during the reload.

To verify that everything still works, I successfully tested the following scenarios:

1) Trigger server analysis in analysis screen and immediately open
   "Learn From Your Mistakes"
   -> The loading bar correctly displays server analysis progress,
      once analysis is finished Learn from your mistakes is available.
2) Trigger server analysis in analysis screen, wait for it to finish
   and only then open "Learn From Your Mistakes"
   -> Learn from your mistakes is available immediately without any
      loading bar.
3) Trigger server analysis, wait for it to finish and then close the
   analysis screen. Open analysis again for the same game and open
  "Learn from your Mistakes".
   -> Learn from your mistakes is available immediately without any
      loading bar.