### PR TITLE
fix: dispose TextEditingController and remove listener in MessageInput

### DIFF
--- a/lib/src/view/message/conversation_screen.dart
+++ b/lib/src/view/message/conversation_screen.dart
@@ -411,11 +411,20 @@ class _MessageInputState extends ConsumerState<_MessageInput> {
   @override
   void initState() {
     super.initState();
-    controller.addListener(() {
-      if (controller.text.isNotEmpty) {
-        ref.read(conversationControllerProvider(widget.user.id).notifier).setTyping(widget.user.id);
-      }
-    });
+    controller.addListener(_handleTypingStatus);
+  }
+
+  void _handleTypingStatus() {
+    if (controller.text.isNotEmpty && mounted) {
+      ref.read(conversationControllerProvider(widget.user.id).notifier).setTyping(widget.user.id);
+    }
+  }
+
+  @override
+  void dispose() {
+    controller.removeListener(_handleTypingStatus);
+    controller.dispose();
+    super.dispose();
   }
 
   @override


### PR DESCRIPTION
`TextEditingController` in `_MessageInputState` was initialized but never disposed.

The listener in `initState` remains active even after the widget is removed from the tree.

I also added a `mounted` check to the listener logic for safety.