### PR TITLE
fix puzzle nav bug on long press

### DIFF
--- a/lib/src/widgets/buttons.dart
+++ b/lib/src/widgets/buttons.dart
@@ -130,6 +130,15 @@ class _RepeatButtonState extends State<RepeatButton> {
   Timer? _holdTimer;
 
   @override
+  void didUpdateWidget(RepeatButton oldWidget) {
+    super.didUpdateWidget(oldWidget);
+    // If the button becomes disabled mid-press stop the press
+    if (oldWidget.onLongPress != null && widget.onLongPress == null) {
+      _onPressEnd();
+    }
+  }
+
+  @override
   void dispose() {
     _holdTimer?.cancel();
     super.dispose();


### PR DESCRIPTION
fix #3059 

stopp the press if the `RepeatButton` becomes disabled midpress.