### PR TITLE
Add root: recomputeRootView ? _root.view : state.requireValue.root

### DIFF
--- a/lib/src/model/analysis/retro_controller.dart
+++ b/lib/src/model/analysis/retro_controller.dart
@@ -440,6 +440,7 @@ class RetroController extends AsyncNotifier<RetroState> with EngineEvaluationMix
   void _refreshCurrentNode({bool recomputeRootView = false}) {
     state = AsyncData(
       state.requireValue.copyWith(
+        root: recomputeRootView ? _root.view : state.requireValue.root,
         currentNode: RetroCurrentNode.fromNode(_root.nodeAt(state.requireValue.currentPath)),
       ),
     );


### PR DESCRIPTION
Commit f8d4d69 removed `root: recomputeRootView ? _root.view : state.requireValue.root,`

I believe that was accidental. It makes more sense in its old form:

```
  void _refreshCurrentNode({bool recomputeRootView = false}) {
    state = AsyncData(
      state.requireValue.copyWith(
        root: recomputeRootView ? _root.view : state.requireValue.root,
        currentNode: RetroCurrentNode.fromNode(_root.nodeAt(state.requireValue.currentPath)),
      ),
    );
  }
```

If it is not accidental let's remove the parameter `bool recomputeRootView = false` to make it clear.