### PR TITLE
switch back to singleTop

### DIFF
--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -23,7 +23,7 @@
         <activity
             android:name=".MainActivity"
             android:exported="true"
-            android:launchMode="singleTask"
+            android:launchMode="singleTop"
             android:theme="@style/SplashTheme"
             android:configChanges="orientation|keyboardHidden|keyboard|screenSize|smallestScreenSize|locale|layoutDirection|fontScale|screenLayout|density|uiMode"
             android:hardwareAccelerated="true"


### PR DESCRIPTION
Fixes an issue when logging in with 2FA: [#dev-mobile > login browser gone when re-opening @ 💬](https://hq.lichess.ovh/#narrow/channel/127-dev-mobile/topic/login.20browser.20gone.20when.20re-opening/near/4163306)

I originally changed this to improve the PGN opening behaviour. But actually it didn't have the effect I wanted it to have and thought it will have . 
So probably we can revert back to "singleTop" See the discussion here: https://github.com/lichess-org/mobile/pull/2671
