### PR TITLE
less visible viewer badge + zen mode respected while playing

### DIFF
--- a/lib/src/view/game/game_screen.dart
+++ b/lib/src/view/game/game_screen.dart
@@ -509,7 +509,7 @@ class _WatcherButton extends ConsumerWidget {
         label: Text('$nb'),
         backgroundColor: Theme.of(context).colorScheme.surfaceContainerHighest,
         textColor: Theme.of(context).colorScheme.onSurfaceVariant,
-        child: const Icon(Icons.person_outline, size: 20),
+        child: const Icon(Icons.person_outline),
       ),
     );
   }

--- a/lib/src/view/game/game_screen.dart
+++ b/lib/src/view/game/game_screen.dart
@@ -492,7 +492,8 @@ class _WatcherButton extends ConsumerWidget {
   Widget build(BuildContext context, WidgetRef ref) {
     final state = ref.watch(gameControllerProvider(gameId).select((s) => s.value));
     final nb = state?.nbWatchers ?? 0;
-    if (nb <= 0) return const SizedBox.shrink();
+    final isZenModeActive = state?.isZenModeActive ?? false;
+    if (nb <= 0 || isZenModeActive) return const SizedBox.shrink();
     return SemanticIconButton(
       semanticsLabel: context.l10n.spectatorRoom,
       onPressed: () {
@@ -504,7 +505,12 @@ class _WatcherButton extends ConsumerWidget {
               WatcherListBottomSheet(nbWatchers: s.nbWatchers, watcherNames: s.watcherNames),
         );
       },
-      icon: Badge(label: Text('$nb'), child: const Icon(Icons.person_outline)),
+      icon: Badge(
+        label: Text('$nb'),
+        backgroundColor: Theme.of(context).colorScheme.surfaceContainerHighest,
+        textColor: Theme.of(context).colorScheme.onSurfaceVariant,
+        child: const Icon(Icons.person_outline, size: 20),
+      ),
     );
   }
 }

--- a/lib/src/view/watch/tv_screen.dart
+++ b/lib/src/view/watch/tv_screen.dart
@@ -293,13 +293,11 @@ class _WatcherButton extends ConsumerWidget {
     if (nb <= 0) return const SizedBox.shrink();
     return Padding(
       padding: const EdgeInsets.symmetric(horizontal: 8.0),
-      child: Row(
-        mainAxisSize: MainAxisSize.min,
-        children: [
-          const Icon(Icons.person_outlined, size: 20),
-          const SizedBox(width: 4),
-          Text('$nb', style: Theme.of(context).textTheme.bodyMedium),
-        ],
+      child: Badge(
+        label: Text('$nb'),
+        backgroundColor: Theme.of(context).colorScheme.surfaceContainerHighest,
+        textColor: Theme.of(context).colorScheme.onSurfaceVariant,
+        child: const Icon(Icons.person_outlined, size: 20),
       ),
     );
   }

--- a/lib/src/view/watch/tv_screen.dart
+++ b/lib/src/view/watch/tv_screen.dart
@@ -297,7 +297,7 @@ class _WatcherButton extends ConsumerWidget {
         label: Text('$nb'),
         backgroundColor: Theme.of(context).colorScheme.surfaceContainerHighest,
         textColor: Theme.of(context).colorScheme.onSurfaceVariant,
-        child: const Icon(Icons.person_outlined, size: 20),
+        child: const Icon(Icons.person_outlined),
       ),
     );
   }


### PR DESCRIPTION
I think viewer badge was way too noticeable, surely should not be red. Also stops displaying it in zen mode. Also use a badge for the tv_screen,
Before: 
<img width="658" height="1417" alt="image" src="https://github.com/user-attachments/assets/80df1952-9571-4f37-ab4e-218eb4236fb7" />

After:
<img width="651" height="1463" alt="image" src="https://github.com/user-attachments/assets/744e788c-cd8e-4514-b63a-01c3ecc528f2" />

fix #3071 