### PR TITLE
Small cleanup of misused set literals

### DIFF
--- a/lib/src/model/analysis/analysis_controller.dart
+++ b/lib/src/model/analysis/analysis_controller.dart
@@ -1061,7 +1061,7 @@ sealed class AnalysisCurrentNode
       return AnalysisCurrentNode(
         sanMove: node.sanMove,
         position: node.position,
-        isRoot: node is Root,
+        isRoot: false,
         hasChild: node.children.isNotEmpty,
         opening: node.opening,
         eval: node.eval,

--- a/lib/src/model/analysis/retro_controller.dart
+++ b/lib/src/model/analysis/retro_controller.dart
@@ -582,7 +582,7 @@ sealed class RetroCurrentNode with _$RetroCurrentNode implements AnalysisCurrent
       return RetroCurrentNode(
         sanMove: node.sanMove,
         position: node.position,
-        isRoot: node is Root,
+        isRoot: false,
         eval: node.eval,
         serverEval: node.externalEval,
         nags: IList(node.nags),

--- a/lib/src/view/board_editor/board_editor_screen.dart
+++ b/lib/src/view/board_editor/board_editor_screen.dart
@@ -259,9 +259,8 @@ class _PieceMenuState extends ConsumerState<_PieceMenu> {
                     ? context.lichessColors.error
                     : Colors.transparent,
                 child: GestureDetector(
-                  onTap: () => {
-                    ref.read(editorController.notifier).updateMode(EditorPointerMode.edit, null),
-                  },
+                  onTap: () =>
+                      ref.read(editorController.notifier).updateMode(EditorPointerMode.edit, null),
                   child: Icon(CupertinoIcons.delete, size: 0.8 * squareSize),
                 ),
               ),

--- a/lib/src/view/relation/friend_screen.dart
+++ b/lib/src/view/relation/friend_screen.dart
@@ -247,11 +247,9 @@ class _Following extends ConsumerWidget {
                   ),
                   child: UserListTile.fromUser(
                     user,
-                    onTap: () => {
-                      Navigator.of(
-                        context,
-                      ).push(UserOrProfileScreen.buildRoute(context, user.lightUser)),
-                    },
+                    onTap: () => Navigator.of(
+                      context,
+                    ).push(UserOrProfileScreen.buildRoute(context, user.lightUser)),
                   ),
                 );
               },

--- a/lib/src/view/settings/background_theme_choice_screen.dart
+++ b/lib/src/view/settings/background_theme_choice_screen.dart
@@ -492,11 +492,9 @@ class _ConfirmImageBackgroundScreenState extends State<ConfirmImageBackgroundScr
                           ? context.l10n.mobileSettingsPickAnImageHideBoard
                           : context.l10n.mobileSettingsPickAnImageShowBoard,
                     ),
-                    onPressed: () => {
-                      setState(() {
-                        showBoard = !showBoard;
-                      }),
-                    },
+                    onPressed: () => setState(() {
+                      showBoard = !showBoard;
+                    }),
                   ),
                   Row(
                     mainAxisSize: MainAxisSize.min,


### PR DESCRIPTION
Small cleanup. Slight improvement in readability as well.
 `=>` automatically returns the value of the expression following it.
`() => { ... }` returns a set literal which is not needed here.

Also simplifies `node is root` to false for Branch nodes because they cannot be root by definition.