### PR TITLE
feat: add a tab indicator to analysis bottom tabs to make them more discoverable

### DIFF
--- a/lib/src/view/analysis/analysis_layout.dart
+++ b/lib/src/view/analysis/analysis_layout.dart
@@ -10,8 +10,6 @@ import 'package:lichess_mobile/src/styles/styles.dart';
 import 'package:lichess_mobile/src/utils/l10n_context.dart';
 import 'package:lichess_mobile/src/utils/screen.dart';
 import 'package:lichess_mobile/src/view/engine/engine_gauge.dart';
-import 'package:lichess_mobile/src/widgets/adaptive_action_sheet.dart';
-import 'package:lichess_mobile/src/widgets/buttons.dart';
 import 'package:lichess_mobile/src/widgets/pockets.dart';
 
 /// The height of the board header or footer in the analysis layout.
@@ -29,7 +27,6 @@ enum AnalysisTab {
   explorer(Icons.explore),
   moves(LichessIcons.flow_cascade),
   summary(Icons.area_chart),
-  // TODO add hint dialog on new install to show this tab
   conditionalPremoves(Icons.save);
 
   const AnalysisTab(this.icon);
@@ -50,74 +47,6 @@ enum AnalysisTab {
   }
 }
 
-/// Indicator for the analysis tab, typically shown in the app bar.
-class AppBarAnalysisTabIndicator extends StatefulWidget {
-  const AppBarAnalysisTabIndicator({required this.tabs, required this.controller, super.key});
-
-  final TabController controller;
-
-  /// Typically a list of two or more [AnalysisTab] widgets.
-  ///
-  /// The length of this list must match the [controller]'s [TabController.length]
-  /// and the length of the [AnalysisLayout.children] list.
-  final List<AnalysisTab> tabs;
-
-  @override
-  State<AppBarAnalysisTabIndicator> createState() => _AppBarAnalysisTabIndicatorState();
-}
-
-class _AppBarAnalysisTabIndicatorState extends State<AppBarAnalysisTabIndicator> {
-  @override
-  void didChangeDependencies() {
-    super.didChangeDependencies();
-    widget.controller.animation?.addListener(_handleTabAnimationTick);
-    widget.controller.addListener(_handleTabChange);
-  }
-
-  @override
-  void dispose() {
-    widget.controller.animation?.removeListener(_handleTabAnimationTick);
-    widget.controller.removeListener(_handleTabChange);
-    super.dispose();
-  }
-
-  void _handleTabAnimationTick() {
-    if (widget.controller.indexIsChanging) {
-      setState(() {
-        // Rebuild the widget when the tab index is changing.
-      });
-    }
-  }
-
-  void _handleTabChange() {
-    setState(() {
-      // Rebuild the widget when the tab changes.
-    });
-  }
-
-  @override
-  Widget build(BuildContext context) {
-    return SemanticIconButton(
-      icon: Icon(widget.tabs[widget.controller.index].icon),
-      semanticsLabel: widget.tabs[widget.controller.index].l10n(context.l10n),
-      onPressed: () {
-        showAdaptiveActionSheet<void>(
-          context: context,
-          actions: widget.tabs.map((tab) {
-            return BottomSheetAction(
-              leading: Icon(tab.icon),
-              makeLabel: (context) => Text(tab.l10n(context.l10n)),
-              onPressed: () {
-                widget.controller.animateTo(widget.tabs.indexOf(tab));
-              },
-            );
-          }).toList(),
-        );
-      },
-    );
-  }
-}
-
 /// Layout for the analysis and similar screens (study, broadcast, etc.).
 ///
 /// The layout is responsive and adapts to the screen size and orientation.
@@ -130,6 +59,7 @@ class _AppBarAnalysisTabIndicatorState extends State<AppBarAnalysisTabIndicator>
 class AnalysisLayout extends ConsumerWidget {
   const AnalysisLayout({
     this.tabController,
+    this.tabs,
     required this.boardBuilder,
     required this.children,
     required this.pov,
@@ -145,6 +75,9 @@ class AnalysisLayout extends ConsumerWidget {
 
   /// The tab controller for the tab view.
   final TabController? tabController;
+
+  /// If non-null, a tab indicator bar will be shown above the tab view.
+  final List<AnalysisTab>? tabs;
 
   /// The builder for the board widget.
   final BoardBuilder boardBuilder;
@@ -170,7 +103,7 @@ class AnalysisLayout extends ConsumerWidget {
   /// The children of the tab view.
   ///
   /// The length of this list must match the [tabController]'s [TabController.length]
-  /// and the length of the [AppBarAnalysisTabIndicator.tabs] list.
+  /// and the length of the [tabs] list.
   final List<Widget> children;
 
   /// A builder for the engine gauge widget.
@@ -314,7 +247,11 @@ class AnalysisLayout extends ConsumerWidget {
                                 child: Card(
                                   clipBehavior: Clip.hardEdge,
                                   semanticContainer: false,
-                                  child: TabBarView(controller: tabController, children: children),
+                                  child: _AnalysisTabView(
+                                    tabs: tabs,
+                                    controller: tabController,
+                                    children: children,
+                                  ),
                                 ),
                               ),
                               if (pockets != null)
@@ -443,7 +380,11 @@ class AnalysisLayout extends ConsumerWidget {
                             decoration: BoxDecoration(
                               color: ColorScheme.of(context).surfaceContainerLowest,
                             ),
-                            child: TabBarView(controller: tabController, children: children),
+                            child: _AnalysisTabView(
+                              tabs: tabs,
+                              controller: tabController,
+                              children: children,
+                            ),
                           ),
                         ),
                       ),
@@ -455,6 +396,42 @@ class AnalysisLayout extends ConsumerWidget {
           ),
         ),
         if (bottomBar != null) bottomBar!,
+      ],
+    );
+  }
+}
+
+class _AnalysisTabView extends StatelessWidget {
+  const _AnalysisTabView({required this.tabs, required this.controller, required this.children});
+
+  final List<AnalysisTab>? tabs;
+  final TabController? controller;
+  final List<Widget> children;
+
+  @override
+  Widget build(BuildContext context) {
+    const iconSize = 18.0;
+
+    return Column(
+      children: [
+        if (tabs != null && tabs!.length > 1)
+          Container(
+            decoration: BoxDecoration(color: ColorScheme.of(context).surfaceDim),
+            child: TabBar(
+              controller: controller,
+              tabs: tabs!
+                  .map(
+                    (tab) => Tab(
+                      height: iconSize + 8.0,
+                      icon: Icon(tab.icon, size: iconSize, semanticLabel: tab.l10n(context.l10n)),
+                    ),
+                  )
+                  .toList(),
+            ),
+          ),
+        Expanded(
+          child: TabBarView(controller: controller, children: children),
+        ),
       ],
     );
   }

--- a/lib/src/view/analysis/analysis_screen.dart
+++ b/lib/src/view/analysis/analysis_screen.dart
@@ -115,10 +115,7 @@ class _AnalysisScreenState extends ConsumerState<_AnalysisScreen>
     final ctrlProvider = analysisControllerProvider(widget.options);
     final asyncState = ref.watch(ctrlProvider);
 
-    final appBarActions = [
-      AppBarAnalysisTabIndicator(tabs: tabs, controller: _tabController),
-      _AnalysisMenu(options: widget.options, state: asyncState),
-    ];
+    final appBarActions = [_AnalysisMenu(options: widget.options, state: asyncState)];
 
     switch (asyncState) {
       case AsyncData(:final value):
@@ -130,7 +127,7 @@ class _AnalysisScreenState extends ConsumerState<_AnalysisScreen>
               title: VariantAppBarTitle(variant: value.variant, title: context.l10n.analysis),
               actions: appBarActions,
             ),
-            body: _Body(options: widget.options, controller: _tabController),
+            body: _Body(options: widget.options, controller: _tabController, tabs: tabs),
           ),
         );
       case AsyncError(:final error, :final stackTrace):
@@ -210,10 +207,11 @@ class _AnalysisMenu extends ConsumerWidget {
 }
 
 class _Body extends ConsumerWidget {
-  const _Body({required this.options, required this.controller});
+  const _Body({required this.options, required this.controller, required this.tabs});
 
   final TabController controller;
   final AnalysisOptions options;
+  final List<AnalysisTab> tabs;
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
@@ -299,6 +297,7 @@ class _Body extends ConsumerWidget {
         }
       },
       child: AnalysisLayout(
+        tabs: tabs,
         tabController: controller,
         pov: pov,
         sideToMove: analysisState.currentPosition.turn,

--- a/lib/src/view/analysis/tree_view.dart
+++ b/lib/src/view/analysis/tree_view.dart
@@ -29,6 +29,8 @@ class AnalysisTreeView extends ConsumerWidget {
             livePath: analysisState.pathToLiveMove,
             pgnRootComments: analysisState.pgnRootComments,
             notifier: ref.read(ctrlProvider.notifier),
+            // Avoid overlap with the divider of the analysis tab bar
+            showTopDivider: false,
             shouldShowComputerAnalysis: enableServerAnalysis,
             shouldShowComments: enableServerAnalysis && prefs.showPgnComments,
             shouldShowAnnotations: enableServerAnalysis && prefs.showAnnotations,

--- a/lib/src/view/broadcast/broadcast_game_screen.dart
+++ b/lib/src/view/broadcast/broadcast_game_screen.dart
@@ -118,7 +118,6 @@ class _BroadcastGameScreenState extends ConsumerState<BroadcastGameScreen>
       appBar: AppBar(
         title: title,
         actions: [
-          AppBarAnalysisTabIndicator(tabs: tabs, controller: _tabController),
           _BroadcastGameMenu(
             roundId: widget.roundId,
             gameId: widget.gameId,
@@ -134,6 +133,7 @@ class _BroadcastGameScreenState extends ConsumerState<BroadcastGameScreen>
         widget.tournamentSlug,
         widget.roundSlug,
         tabController: _tabController,
+        tabs: tabs,
       ),
     );
   }
@@ -248,6 +248,7 @@ class _Body extends ConsumerWidget {
     this.tournamentSlug,
     this.roundSlug, {
     required this.tabController,
+    required this.tabs,
   });
 
   final BroadcastTournamentId? tournamentId;
@@ -256,6 +257,7 @@ class _Body extends ConsumerWidget {
   final String? tournamentSlug;
   final String? roundSlug;
   final TabController tabController;
+  final List<AnalysisTab> tabs;
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
@@ -275,6 +277,7 @@ class _Body extends ConsumerWidget {
             pov: pov,
             sideToMove: state.currentPosition.turn,
             tabController: tabController,
+            tabs: tabs,
             boardBuilder: (context, boardSize, borderRadius) => BroadcastAnalysisBoard(
               roundId: roundId,
               gameId: gameId,
@@ -353,6 +356,8 @@ class _BroadcastGameTreeView extends ConsumerWidget {
         currentPath: state.currentPath,
         livePath: state.broadcastLivePath,
         pgnRootComments: state.pgnRootComments,
+        // Avoid overlap with the divider of the tab bar
+        showTopDivider: false,
         shouldShowComputerAnalysis: broadcastPrefs.enableServerAnalysis,
         shouldShowComments: broadcastPrefs.enableServerAnalysis && broadcastPrefs.showPgnComments,
         shouldShowAnnotations:

--- a/lib/src/view/study/study_screen.dart
+++ b/lib/src/view/study/study_screen.dart
@@ -199,10 +199,7 @@ class _StudyScreenState extends ConsumerState<_StudyScreen> with TickerProviderS
             Flexible(child: AppBarTitleText(widget.studyState.currentChapterTitle)),
           ],
         ),
-        actions: [
-          if (tabs.length > 1) AppBarAnalysisTabIndicator(tabs: tabs, controller: _tabController),
-          _StudyMenu(options: widget.options),
-        ],
+        actions: [_StudyMenu(options: widget.options)],
       ),
       body: _Body(options: widget.options, tabController: _tabController, tabs: tabs),
     );
@@ -441,7 +438,9 @@ class _Body extends ConsumerWidget {
     final isLocalEvaluationEnabled = studyState.isEngineAvailable(enginePrefs);
     final pov = studyState.pov;
 
-    final bottomChild = gamebookActive ? StudyGamebook(options) : StudyTreeView(options);
+    final bottomChild = gamebookActive
+        ? StudyGamebook(options)
+        : StudyTreeView(options, showTopDivider: tabs.length == 1);
 
     return AnalysisLayout(
       tabController: tabController,
@@ -468,6 +467,7 @@ class _Body extends ConsumerWidget {
           : null,
       bottomBar: StudyBottomBar(options: options),
       pockets: studyState.currentPosition?.pockets,
+      tabs: tabs,
       children: tabs.map((tab) {
         switch (tab) {
           case AnalysisTab.explorer:

--- a/lib/src/view/study/study_tree_view.dart
+++ b/lib/src/view/study/study_tree_view.dart
@@ -8,9 +8,11 @@ import 'package:lichess_mobile/src/model/study/study_preferences.dart';
 import 'package:lichess_mobile/src/widgets/pgn.dart';
 
 class StudyTreeView extends ConsumerWidget {
-  const StudyTreeView(this.options);
+  const StudyTreeView(this.options, {required this.showTopDivider});
 
   final StudyOptions options;
+
+  final bool showTopDivider;
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
@@ -36,6 +38,7 @@ class StudyTreeView extends ConsumerWidget {
                   currentPath: studyState.currentPath,
                   pgnRootComments: studyState.pgnRootComments,
                   notifier: ref.read(studyControllerProvider(options).notifier),
+                  showTopDivider: showTopDivider,
                   shouldShowAnnotations: studyPrefs.showAnnotations,
                   displayMode: studyPrefs.inlineNotation
                       ? PgnTreeDisplayMode.inlineNotation

--- a/lib/src/widgets/pgn.dart
+++ b/lib/src/widgets/pgn.dart
@@ -155,6 +155,7 @@ class DebouncedPgnTreeView extends ConsumerStatefulWidget {
     this.premovePaths,
     required this.pgnRootComments,
     this.notifier,
+    this.showTopDivider = true,
     this.shouldShowComputerAnalysis = true,
     this.shouldShowAnnotations = true,
     this.shouldShowComments = true,
@@ -179,6 +180,9 @@ class DebouncedPgnTreeView extends ConsumerStatefulWidget {
 
   /// Callbacks for when the user interacts with the tree view, e.g. selecting a different move or collapsing variations
   final PgnTreeNotifier? notifier;
+
+  /// Whether to show a divider line above the first mainline part.
+  final bool showTopDivider;
 
   /// Whether to show computer analysis informations.
   ///
@@ -290,6 +294,7 @@ class _DebouncedPgnTreeViewState extends ConsumerState<DebouncedPgnTreeView> {
         pathToCurrentMove: pathToCurrentMove,
         pathToLiveMove: pathToLiveMove,
         premovePaths: widget.premovePaths,
+        showTopDivider: widget.showTopDivider,
         displayMode: widget.displayMode,
         notifier: widget.notifier,
       ),
@@ -310,6 +315,9 @@ typedef _PgnTreeViewParams = ({
 
   /// Paths relative to [_PgnTreeViewParams.pathToLiveMove] that are currently saved as premoves in an ongoing correspondence game.
   IList<UciPath>? premovePaths,
+
+  /// Whether to show a divider line above the first mainline part.
+  bool showTopDivider,
 
   /// Whether to show analysis variations.
   bool shouldShowComputerAnalysis,
@@ -769,6 +777,8 @@ class _TwoColumnMainlinePart extends ConsumerWidget {
 
     final initialFullmoves = nodes.first.position.fullmoves;
 
+    final isFirstPart = initialPath.isEmpty;
+
     return Column(
       crossAxisAlignment: CrossAxisAlignment.start,
       children: [
@@ -779,7 +789,9 @@ class _TwoColumnMainlinePart extends ConsumerWidget {
                 ? const Color(0x0BFFFFFF)
                 : const Color(0x05000000),
             border: Border(
-              top: BorderSide(color: dividerColor),
+              top: isFirstPart && !params.showTopDivider
+                  ? BorderSide.none
+                  : BorderSide(color: dividerColor),
               bottom: BorderSide(color: dividerColor),
             ),
           ),

--- a/test/view/analysis/analysis_screen_test.dart
+++ b/test/view/analysis/analysis_screen_test.dart
@@ -20,7 +20,6 @@ import 'package:lichess_mobile/src/model/settings/board_preferences.dart';
 import 'package:lichess_mobile/src/model/settings/preferences_storage.dart';
 import 'package:lichess_mobile/src/network/http.dart';
 import 'package:lichess_mobile/src/network/socket.dart';
-import 'package:lichess_mobile/src/styles/lichess_icons.dart';
 import 'package:lichess_mobile/src/view/analysis/analysis_screen.dart';
 import 'package:lichess_mobile/src/view/engine/engine_button.dart';
 import 'package:lichess_mobile/src/view/engine/engine_gauge.dart';
@@ -1447,25 +1446,18 @@ void main() {
 
       await tester.pumpWidget(app);
 
-      expect(find.byIcon(LichessIcons.flow_cascade), findsOneWidget);
-      await tester.tap(find.byIcon(LichessIcons.flow_cascade));
+      expect(find.bySemanticsLabel(RegExp('Moves played')), findsOneWidget);
+      expect(find.bySemanticsLabel(RegExp('Opening explorer & tablebase')), findsOneWidget);
 
-      // Wait for menu to open
-      await tester.pumpAndSettle();
-
-      // Menu should not contain conditional premoves tab
-      expect(find.byIcon(Icons.save), findsNothing);
+      // Should not display the conditional premoves tab.
+      expect(find.bySemanticsLabel(RegExp('Conditional premoves')), findsNothing);
     });
 
     Future<void> switchToPremoveTab(WidgetTester tester) async {
-      expect(find.byIcon(LichessIcons.flow_cascade), findsOneWidget);
-      await tester.tap(find.byIcon(LichessIcons.flow_cascade));
+      // Wait for analysis tabs to be rendered if necessary
+      await tester.pump();
 
-      // Wait for menu to open
-      await tester.pumpAndSettle();
-
-      expect(find.byIcon(Icons.save), findsOneWidget);
-      await tester.tap(find.byIcon(Icons.save));
+      await tester.tap(find.bySemanticsLabel(RegExp('Conditional premoves')));
 
       // Wait for premove tab to open
       await tester.pumpAndSettle();

--- a/test/view/broadcast/broadcast_game_screen_test.dart
+++ b/test/view/broadcast/broadcast_game_screen_test.dart
@@ -9,7 +9,6 @@ import 'package:lichess_mobile/src/model/common/id.dart';
 import 'package:lichess_mobile/src/model/engine/evaluation_mixin.dart';
 import 'package:lichess_mobile/src/model/engine/evaluation_service.dart';
 import 'package:lichess_mobile/src/network/http.dart';
-import 'package:lichess_mobile/src/styles/lichess_icons.dart';
 import 'package:lichess_mobile/src/view/broadcast/broadcast_game_screen.dart';
 import 'package:lichess_mobile/src/view/engine/engine_button.dart';
 import 'package:lichess_mobile/src/view/engine/engine_gauge.dart';
@@ -140,12 +139,7 @@ void main() {
       // Load the broadcast round game provider
       await tester.pump();
 
-      expect(find.byIcon(LichessIcons.flow_cascade), findsOne);
-      await tester.tap(find.byIcon(LichessIcons.flow_cascade));
-      //allow animation on iOS to complete
-      await tester.pumpAndSettle();
-      expect(find.text('Computer analysis'), findsOne);
-      await tester.tap(find.text('Computer analysis'));
+      await tester.tap(find.bySemanticsLabel(RegExp('Computer analysis')));
       //allow switching tabs animation to complete
       await tester.pumpAndSettle();
       expect(find.text('61%'), findsOne);

--- a/test/view/game/game_screen_test.dart
+++ b/test/view/game/game_screen_test.dart
@@ -1029,11 +1029,9 @@ void main() {
       expect(find.byKey(const Key('d3-whitebishop')), findsOneWidget);
       expect(find.byKey(const Key('b5-lastMove')), findsOneWidget);
       expect(find.byKey(const Key('d3-lastMove')), findsOneWidget);
-      await tester.tap(find.byIcon(LichessIcons.flow_cascade));
-      await tester.pumpAndSettle(); // wait for the moves tab menu to open
-      expect(find.text('Moves played'), findsOneWidget);
+      expect(find.bySemanticsLabel(RegExp('Moves played')), findsOneWidget);
       // computer analysis is not available when game is not finished
-      expect(find.text('Computer analysis'), findsNothing);
+      expect(find.bySemanticsLabel(RegExp('Computer analysis')), findsNothing);
     });
 
     testWidgets('for a finished game', (WidgetTester tester) async {
@@ -1053,10 +1051,11 @@ void main() {
       expect(find.byKey(const Key('e6-whitequeen')), findsOneWidget);
       expect(find.byKey(const Key('d5-lastMove')), findsOneWidget);
       expect(find.byKey(const Key('e6-lastMove')), findsOneWidget);
-      await tester.tap(find.byIcon(LichessIcons.flow_cascade));
-      await tester.pumpAndSettle(); // wait for the moves tab menu to open
-      expect(find.text('Moves played'), findsOneWidget);
-      expect(find.text('Computer analysis'), findsOneWidget); // computer analysis is available
+      expect(find.bySemanticsLabel(RegExp('Moves played')), findsOneWidget);
+      expect(
+        find.bySemanticsLabel(RegExp('Computer analysis')),
+        findsOneWidget,
+      ); // computer analysis is available
     });
   });
 

--- a/test/view/study/study_screen_test.dart
+++ b/test/view/study/study_screen_test.dart
@@ -28,6 +28,7 @@ StudyChapter makeChapter({
   required StudyChapterId id,
   Side orientation = Side.white,
   bool gamebook = false,
+  StudyChapterFeatures? features,
 }) {
   return StudyChapter(
     id: id,
@@ -38,7 +39,7 @@ StudyChapter makeChapter({
       fromFen: null,
     ),
     conceal: null,
-    features: (computer: false, explorer: false),
+    features: features ?? (computer: false, explorer: false),
     gamebook: gamebook,
     practise: false,
   );
@@ -112,7 +113,10 @@ void main() {
       final mockRepository = MockStudyRepository();
 
       final studyChapter1 = makeStudy(
-        chapter: makeChapter(id: const StudyChapterId('1')),
+        chapter: makeChapter(
+          id: const StudyChapterId('1'),
+          features: (computer: false, explorer: false),
+        ),
         chapters: IList(const [
           StudyChapterMeta(id: StudyChapterId('1'), name: 'Chapter 1', fen: null),
           StudyChapterMeta(id: StudyChapterId('2'), name: 'Chapter 2', fen: null),
@@ -120,7 +124,10 @@ void main() {
       );
 
       final studyChapter2 = studyChapter1.copyWith(
-        chapter: makeChapter(id: const StudyChapterId('2')),
+        chapter: makeChapter(
+          id: const StudyChapterId('2'),
+          features: (computer: false, explorer: true),
+        ),
       );
 
       when(
@@ -149,6 +156,9 @@ void main() {
 
       expect(find.text('pgn 1'), findsOneWidget);
       expect(find.text('pgn 2'), findsNothing);
+
+      // First chapter does not allow opening explorer
+      expect(find.bySemanticsLabel(RegExp('Opening explorer & tablebase')), findsNothing);
 
       // 2nd press should not have any effect, we're already at the last chapter
       await tester.tap(find.text('Next chapter'));
@@ -187,6 +197,9 @@ void main() {
       await tester.tap(find.text('1 Chapter 1', findRichText: true));
       // Wait for chapter to load
       await tester.pumpAndSettle();
+
+      // Second chapter allows opening explorer, so tab should be displayed now.
+      expect(find.bySemanticsLabel(RegExp('Opening explorer & tablebase')), findsOneWidget);
 
       expect(find.text('1. Chapter 1'), findsOneWidget);
       expect(find.text('2. Chapter 2'), findsNothing);


### PR DESCRIPTION
## Problem

For users, it's currently very hard to discover that the bottom view in the analysis board can be swiped. This leads to users not finding important features like server analysis or conditional premoves. A tour would help, but it's also a fact that users like to skip those and then complain anyway. Also, we have different tabs on different screens (e.g. conditional premoves is only on correspondence analysis board), making it hard to remember for the user which screen has which tabs available.

## Solution

Add a small `TabBar` above the `TabBarView`. This way, it's immediately obvious which additional tabs are available.

This takes away roughly one row from the PGN move list, so I'd say the UX benefits outweigh the loss of space here.

## Demo

[tabbar.webm](https://github.com/user-attachments/assets/a46b90f4-fa2f-463a-a826-eea3b6ae2c16)
