### PR TITLE
fix: restore Android sign-in by routing OAuth callback through a trampoline activity

### DIFF
--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -62,13 +62,6 @@
                 <data android:mimeType="text/x-chess-pgn" />
             </intent-filter>
 
-            <intent-filter>
-                <action android:name="android.intent.action.VIEW" />
-                <category android:name="android.intent.category.DEFAULT" />
-                <category android:name="android.intent.category.BROWSABLE" />
-                <data android:scheme="org.lichess.mobile" android:host="login-callback" />
-            </intent-filter>
-
             <!-- App Links verified against https://lichess.org/.well-known/assetlinks.json -->
             <intent-filter android:autoVerify="true">
                 <action android:name="android.intent.action.VIEW" />
@@ -103,6 +96,21 @@
             </intent-filter>
             <meta-data android:name="flutter_deeplinking_enabled" android:value="false" />
         </activity>
+        <!-- Trampoline for the OAuth redirect URI. Receives org.lichess.mobile://login-callback,
+             forwards it to the running MainActivity via FLAG_ACTIVITY_CLEAR_TOP|SINGLE_TOP so
+             that onNewIntent is called on the existing instance, then finishes immediately. -->
+        <activity
+            android:name=".OAuthCallbackActivity"
+            android:exported="true"
+            android:theme="@android:style/Theme.NoDisplay">
+            <intent-filter>
+                <action android:name="android.intent.action.VIEW" />
+                <category android:name="android.intent.category.DEFAULT" />
+                <category android:name="android.intent.category.BROWSABLE" />
+                <data android:scheme="org.lichess.mobile" android:host="login-callback" />
+            </intent-filter>
+        </activity>
+
         <receiver android:exported="false"
             android:name="com.dexterous.flutterlocalnotifications.ActionBroadcastReceiver"/>
         <!-- Don't delete the meta-data below.

--- a/android/app/src/main/kotlin/org/lichess/mobileV2/OAuthCallbackActivity.kt
+++ b/android/app/src/main/kotlin/org/lichess/mobileV2/OAuthCallbackActivity.kt
@@ -17,7 +17,11 @@ class OAuthCallbackActivity : Activity() {
                 Intent(this, MainActivity::class.java).apply {
                     action = Intent.ACTION_VIEW
                     data = uri
-                    addFlags(Intent.FLAG_ACTIVITY_CLEAR_TOP or Intent.FLAG_ACTIVITY_SINGLE_TOP)
+                    addFlags(
+                        Intent.FLAG_ACTIVITY_NEW_TASK or
+                            Intent.FLAG_ACTIVITY_CLEAR_TOP or
+                            Intent.FLAG_ACTIVITY_SINGLE_TOP,
+                    )
                 },
             )
         }

--- a/android/app/src/main/kotlin/org/lichess/mobileV2/OAuthCallbackActivity.kt
+++ b/android/app/src/main/kotlin/org/lichess/mobileV2/OAuthCallbackActivity.kt
@@ -1,0 +1,26 @@
+package org.lichess.mobileV2
+
+import android.app.Activity
+import android.content.Intent
+import android.os.Bundle
+
+// Trampoline activity that receives the OAuth redirect URI (org.lichess.mobile://login-callback)
+// and forwards it to the existing MainActivity via onNewIntent, then finishes immediately.
+//
+// This keeps MainActivity as singleTop (correct back-navigation behavior) while ensuring the
+// OAuth callback is always delivered to the running instance rather than a new one.
+class OAuthCallbackActivity : Activity() {
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+        intent.data?.let { uri ->
+            startActivity(
+                Intent(this, MainActivity::class.java).apply {
+                    action = Intent.ACTION_VIEW
+                    data = uri
+                    addFlags(Intent.FLAG_ACTIVITY_CLEAR_TOP or Intent.FLAG_ACTIVITY_SINGLE_TOP)
+                },
+            )
+        }
+        finish()
+    }
+}


### PR DESCRIPTION
## Problem                                                                                                                                                                          
                                                                                                                                                                                      
  `android:launchMode="singleTop"` was restored in #3080. With `singleTop`, when Chrome Custom Tab                                                                                    
  redirects to `org.lichess.mobile://login-callback`, Android creates a **new `MainActivity`
  instance** (because the existing one is not at the top of the task stack — the Custom Tab is).                                                                                      
  That new instance gets a new Flutter engine and a separate Dart isolate, so the OAuth callback URI
  never reaches the `callbackCompleter` waiting in the original `signIn()` call. The app lifecycle's                                                                                  
  `onResume` fires, the 300 ms cancellation guard trips, and sign-in silently fails.
                                                                                                                                                                                      
  ## Fix                                                                                                                                                                              
   
  Introduce `OAuthCallbackActivity`, a minimal trampoline with no UI (`Theme.NoDisplay`) that owns                                                                                    
  the `org.lichess.mobile://login-callback` intent filter instead of `MainActivity`. When the
  redirect fires it immediately forwards the URI to the existing `MainActivity` via:

  FLAG_ACTIVITY_NEW_TASK | FLAG_ACTIVITY_CLEAR_TOP | FLAG_ACTIVITY_SINGLE_TOP

  - `NEW_TASK` crosses the task boundary if Chrome launched the trampoline in its own task
  - `CLEAR_TOP` finds the existing `MainActivity` in the app's task
  - `SINGLE_TOP` calls `onNewIntent` on it rather than recreating it                                                                                                                  
   
  `onNewIntent` is delivered before `onResume`, so `app_links` routes the URI through `uriLinkStream`                                                                                 
  and the `callbackCompleter` completes successfully before the cancellation timer can fire.
  `MainActivity` stays `singleTop`, preserving correct back-navigation when opening the app from                                                                                      
  external intents (e.g. file manager).