### PR TITLE
Updated MediaQuery in some files to avoid unnecessary rebuilds

### DIFF
--- a/lib/src/utils/gestures_exclusion.dart
+++ b/lib/src/utils/gestures_exclusion.dart
@@ -52,7 +52,7 @@ class _AndroidGesturesExclusionWidgetState extends State<AndroidGesturesExclusio
 
   @override
   Widget build(BuildContext context) {
-    initialViewPadding ??= MediaQuery.of(context).viewPadding;
+    initialViewPadding ??= MediaQuery.viewPaddingOf(context);
 
     return MediaQuery(
       // Always set the view padding to the initial value to avoid an UI shift when immersive mode

--- a/lib/src/view/game/game_list_detail_tile.dart
+++ b/lib/src/view/game/game_list_detail_tile.dart
@@ -44,7 +44,7 @@ class GameListDetailTile extends StatelessWidget {
       height: 1,
     );
 
-    final scaledTitleFontSize = MediaQuery.of(context).textScaler.scale(titleFontSize);
+    final scaledTitleFontSize = MediaQuery.textScalerOf(context).scale(titleFontSize);
 
     return InkWell(
       onLongPress: () {

--- a/lib/src/view/game/game_result_dialog.dart
+++ b/lib/src/view/game/game_result_dialog.dart
@@ -312,7 +312,7 @@ class _ResultDialog extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    final screenWidth = MediaQuery.of(context).size.width;
+    final screenWidth = MediaQuery.sizeOf(context).width;
     final paddedContent = Padding(padding: const EdgeInsets.all(16.0), child: child);
     final sizedContent = SizedBox(
       width: min(screenWidth, kMaterialPopupMenuMaxWidth),

--- a/lib/src/widgets/adaptive_action_sheet.dart
+++ b/lib/src/widgets/adaptive_action_sheet.dart
@@ -139,7 +139,7 @@ Future<T?> showMaterialActionSheet<T>({
 }) {
   final actionTextStyle = TextTheme.of(context).titleMedium ?? const TextStyle(fontSize: 18);
 
-  final screenWidth = MediaQuery.of(context).size.width;
+  final screenWidth = MediaQuery.sizeOf(context).width;
   return showDialog<T>(
     context: context,
     barrierDismissible: isDismissible,


### PR DESCRIPTION
We still had a few MediaQuery.of(context) that were used for only one property of MediaQueryData. This could cause unnecessary rebuilds.