### PR TITLE
Fix gestures_exclusions sending null to Android

### DIFF
--- a/android/app/src/main/kotlin/org/lichess/mobileV2/MainActivity.kt
+++ b/android/app/src/main/kotlin/org/lichess/mobileV2/MainActivity.kt
@@ -4,6 +4,7 @@ import android.app.ActivityManager
 import android.content.Context
 import android.graphics.Rect
 import android.os.Bundle
+import android.util.Log
 import androidx.core.splashscreen.SplashScreen.Companion.installSplashScreen
 import androidx.core.view.ViewCompat
 import io.flutter.embedding.android.FlutterActivity
@@ -57,14 +58,21 @@ class MainActivity: FlutterActivity() {
     }
   }
 
-  private fun decodeExclusionRects(inputRects: List<Map<String, Int>>): List<Rect> =
-    inputRects.mapIndexed { index, item ->
-      Rect(
-        item["left"] ?: error("rect at index $index doesn't contain 'left' property"),
-        item["top"] ?: error("rect at index $index doesn't contain 'top' property"),
-        item["right"] ?: error("rect at index $index doesn't contain 'right' property"),
-        item["bottom"] ?: error("rect at index $index doesn't contain 'bottom' property")
-      )
+private fun decodeExclusionRects(inputRects: List<Map<String, Int>>): List<Rect> =
+    inputRects.mapNotNull { item ->
+        val left = item["left"]
+        val top = item["top"]
+        val right = item["right"]
+        val bottom = item["bottom"]
+
+        // If any of these are null, the whole block returns null
+        if (left != null && top != null && right != null && bottom != null) {
+            Rect(left, top, right, bottom)
+        } else {
+            // Log a warning instead
+            Log.w("RectDecoder", "Skipping malformed rect: $item")
+            null
+        }
     }
 
   private fun getAvailableMemory(): ActivityManager.MemoryInfo {

--- a/lib/src/utils/gestures_exclusion.dart
+++ b/lib/src/utils/gestures_exclusion.dart
@@ -4,7 +4,6 @@ import 'package:device_info_plus/device_info_plus.dart';
 import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
-import 'package:flutter/widgets.dart';
 import 'package:lichess_mobile/src/utils/focus_detector.dart';
 import 'package:lichess_mobile/src/utils/screen.dart';
 
@@ -123,7 +122,7 @@ Future<void> setAndroidBoardGesturesExclusion(
         squareSize,
         height + verticalThreshold,
       );
-      GesturesExclusion.instance.setRects([leftRect, rightRect]);
+      await GesturesExclusion.instance.setRects([leftRect, rightRect]);
     }
   }
 }
@@ -134,8 +133,8 @@ Future<void> clearAndroidBoardGesturesExclusion() async {
   if (defaultTargetPlatform == TargetPlatform.android) {
     final androidInfo = await _deviceInfoPlugin.androidInfo;
     if (androidInfo.version.sdkInt >= 29) {
-      SystemChrome.setEnabledSystemUIMode(SystemUiMode.edgeToEdge);
-      GesturesExclusion.instance.clearRects();
+      await SystemChrome.setEnabledSystemUIMode(SystemUiMode.edgeToEdge);
+      await GesturesExclusion.instance.clearRects();
     }
   }
 }
@@ -153,15 +152,14 @@ class GesturesExclusion {
     }
 
     final rectsAsMaps = rects
+        .where((r) => !r.hasNaN && !r.isInfinite) // Filter out bad rects first
         .map(
-          (r) => r.hasNaN || r.isInfinite
-              ? null
-              : {
-                  'left': r.left.floor(),
-                  'top': r.top.floor(),
-                  'right': r.right.floor(),
-                  'bottom': r.bottom.floor(),
-                },
+          (r) => {
+            'left': r.left.floor(),
+            'top': r.top.floor(),
+            'right': r.right.floor(),
+            'bottom': r.bottom.floor(),
+          },
         )
         .toList();
 
@@ -178,7 +176,7 @@ class GesturesExclusion {
     }
 
     try {
-      await _channel.invokeMethod<void>('setSystemGestureExclusionRects', <Rect>[]);
+      await _channel.invokeMethod<void>('setSystemGestureExclusionRects', <Map<String, int>>[]);
     } on PlatformException catch (e) {
       debugPrint('Failed to clear rects: ${e.message}');
     }


### PR DESCRIPTION
The main idea here is to prevent gestures_exclusions from sending null to Android.

The Kotlin code has also been made more defensive.

Added `await` to some lines that are dealing with a `Future`.

Changed `<Rect>[]` to `<Map<String, int>>[]` to explicitly match the Kotlin function signature and use standard serializable types.

I only stopped importing `widgets.dart` here because it was redundant. material.dart transitively imports widgets.dart. You can leave that in if it's your preference.