### PR TITLE
Fix best move arrow not shown when engine lines set to zero

### DIFF
--- a/lib/src/view/analysis/analysis_board.dart
+++ b/lib/src/view/analysis/analysis_board.dart
@@ -1,3 +1,5 @@
+import 'dart:math' as math;
+
 import 'package:chessground/chessground.dart';
 import 'package:dartchess/dartchess.dart';
 import 'package:fast_immutable_collections/fast_immutable_collections.dart';
@@ -99,7 +101,7 @@ abstract class AnalysisBoardState<
 
     final bestMoveShapes = computeBestMoveShapes(
       // cloud eval might have more lines than local eval so make sure to only show as many as allowed
-      eval.bestMoves.take(enginePrefs.numEvalLines).toIList(),
+      eval.bestMoves.take(math.max(1, enginePrefs.numEvalLines)).toIList(),
       currentPosition.turn,
       pieceAssets,
       // Same colors as in the Web UI with a slightly different opacity

--- a/test/view/analysis/analysis_screen_test.dart
+++ b/test/view/analysis/analysis_screen_test.dart
@@ -1077,6 +1077,13 @@ void main() {
         await tester.pump(kRequestEvalDebounceDelay + kEngineEvalEmissionThrottleDelay);
         expect(find.byType(BoardShapeWidget), findsOne);
       });
+
+      testWidgets('is displayed even when number of engine lines is set to 0', (tester) async {
+        await makeEngineTestApp(tester, numEvalLines: 0);
+        // ensure that the eval is displayed and pending eval throttle time is over
+        await tester.pump(kRequestEvalDebounceDelay + kEngineEvalEmissionThrottleDelay);
+        expect(find.byType(BoardShapeWidget), findsOne);
+      });
     });
 
     group('show threat button', () {


### PR DESCRIPTION
**Fix: Best move arrow not shown when engine lines is set to 0**

When the "Show best move arrow" option was enabled but the number of engine lines was set to 0, the best move arrow was not displayed on the board.

**Root cause**
In analysis_board.dart, the best moves were filtered using .take(enginePrefs.numEvalLines). When numEvalLines is 0, .take(0) returns an empty list, so no arrow was drawn. This was inconsistent with the UCI protocol layer in uci_protocol.dart, which already uses math.max(1, multiPv) to ensure Stockfish always evaluates at least one line.

**Fix**
Changed .take(enginePrefs.numEvalLines) to .take(math.max(1, enginePrefs.numEvalLines)) in analysis_board.dart, so that at least the best move is always passed to computeBestMoveShapes() when the engine is running, regardless of the number of displayed lines.

**Test**
A new test was added to the Engine best move arrow group in analysis_screen_test.dart, verifying that the best move arrow is displayed even when the number of engine lines is set to 0.

Fixes: #2871 