### PR TITLE
fix: center time control header in active game

### DIFF
--- a/lib/src/view/game/game_screen.dart
+++ b/lib/src/view/game/game_screen.dart
@@ -209,6 +209,7 @@ class _GameScreenState extends ConsumerState<GameScreen> {
           resizeToAvoidBottomInset: false,
           appBar: AppBar(
             leading: isRealTimePlayingGame ? SocketPingRatingIcon(socketUri: socketUri) : null,
+            centerTitle: true,
             title: _StandaloneGameTitle(id: createdGameId, lastMoveAt: widget.lastMoveAt),
             actions: [
               _WatcherButton(gameId: createdGameId),


### PR DESCRIPTION
fixes #3074 

The AppBar for the active game screen was missing centerTitle: true, causing the time control header to appear left-aligned on Android.