### PR TITLE
fix(game): center time-control header on Android (#3074)

### DIFF
--- a/lib/src/view/game/game_screen.dart
+++ b/lib/src/view/game/game_screen.dart
@@ -122,6 +122,7 @@ class _GameScreenState extends ConsumerState<GameScreen> {
         return Scaffold(
           resizeToAvoidBottomInset: false,
           appBar: AppBar(
+            centerTitle: true,
             title: switch (widget.source) {
               LobbySource(:final seek) => _LobbyGameTitle(seek: seek),
               _ => const SizedBox.shrink(),
@@ -133,6 +134,7 @@ class _GameScreenState extends ConsumerState<GameScreen> {
         return Scaffold(
           resizeToAvoidBottomInset: false,
           appBar: AppBar(
+            centerTitle: true,
             title: _ChallengeGameTitle(
               challenge: (widget.source as UserChallengeSource).challengeRequest,
             ),
@@ -147,6 +149,7 @@ class _GameScreenState extends ConsumerState<GameScreen> {
         return Scaffold(
           resizeToAvoidBottomInset: false,
           appBar: AppBar(
+            centerTitle: true,
             title: _ChallengeGameTitle(
               challenge: (widget.source as UserChallengeSource).challengeRequest,
             ),
@@ -208,6 +211,7 @@ class _GameScreenState extends ConsumerState<GameScreen> {
         return Scaffold(
           resizeToAvoidBottomInset: false,
           appBar: AppBar(
+            centerTitle: true,
             leading: isRealTimePlayingGame ? SocketPingRatingIcon(socketUri: socketUri) : null,
             title: _StandaloneGameTitle(id: createdGameId, lastMoveAt: widget.lastMoveAt),
             actions: [
@@ -228,6 +232,7 @@ class _GameScreenState extends ConsumerState<GameScreen> {
         return Scaffold(
           resizeToAvoidBottomInset: false,
           appBar: AppBar(
+            centerTitle: true,
             leading: const SocketPingRatingIcon(),
             title: _ChallengeGameTitle(
               challenge: (widget.source as UserChallengeSource).challengeRequest,
@@ -253,6 +258,7 @@ class _GameScreenState extends ConsumerState<GameScreen> {
         return Scaffold(
           resizeToAvoidBottomInset: false,
           appBar: AppBar(
+            centerTitle: true,
             leading: const SocketPingRatingIcon(),
             title: switch (widget.source) {
               LobbySource(:final seek) => _LobbyGameTitle(seek: seek),
@@ -283,6 +289,7 @@ class _GameScreenState extends ConsumerState<GameScreen> {
         return Scaffold(
           resizeToAvoidBottomInset: false,
           appBar: AppBar(
+            centerTitle: true,
             leading: const SocketPingRatingIcon(),
             title: switch (widget.source) {
               LobbySource(:final seek) => _LobbyGameTitle(seek: seek),


### PR DESCRIPTION
Closes #3074.

## Summary

The active-game `AppBar` in `lib/src/view/game/game_screen.dart` defaulted to the Material left-aligned title on Android, so the time-control header (e.g. `🐢 1+0 • Rated`) sat near the left edge instead of being centered between the leading ping icon and the trailing ⋯ menu.

This adds `centerTitle: true` to the seven `AppBar`s in `_GameScreenState.build` that render time-control / challenge / lobby titles (active game, lobby seek, challenge sent/received, cancelled/declined/errored states, open challenge).

## Proof

Built and ran the BEFORE (main) and AFTER (this branch) APKs on an Android emulator (API 36) with two test accounts pairing on a 1+0 Bullet seek, then measured the title text bounding box in each screenshot.

| Build | Title leftmost | Title rightmost | Title center | Offset from screen center (540 px) |
|---|---|---|---|---|
| BEFORE (main) | x=220 | x=550 | **x=385** | **−155 px (left of center)** |
| AFTER (this PR) | x=362 | x=714 | **x=538** | **−2 px (centered)** |

Screen width is 1080 px. AFTER lands within 2 px of the screen midpoint; BEFORE was off by 155 px.

The lobby-seek-loading AppBar was also tested but is visually unchanged because that variant has no trailing actions, so the M3 layout already centered it. The fix is still applied there for consistency.

| Before | After |
| --- | --- |
| <img width="1080" height="2340" alt="image" src="https://github.com/user-attachments/assets/07e82574-6255-4a49-9b10-04babec0f902" /> | <img width="1080" height="2340" alt="image" src="https://github.com/user-attachments/assets/1926871a-2a3d-4251-977a-b43821bc4220" /> |
| <img width="1080" height="2340" alt="image" src="https://github.com/user-attachments/assets/91cf4cab-7c63-41a2-bada-4de599645a7c" /> | <img width="1080" height="2340" alt="image" src="https://github.com/user-attachments/assets/4d736740-5149-45f1-86cc-a0dffead51e2" /> |

## Test plan

- [x] `flutter analyze` clean
- [x] `flutter test` clean (per pre-merge checklist)
- [x] Android manual smoke (emulator-5554, API 36): paired CD-Test-1 vs CD-Test-2 on 1+0 Bullet, confirmed title centered; tested lobby seek loading state, confirmed unchanged behavior.
