### PR TITLE
chore: upgrade deps and use pubspec.yaml for actions test

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -6,6 +6,7 @@ on:
       - 'lib/**'
       - '!lib/l10n/**'
       - 'test/**'
+      - 'pubspec.yaml'
     branches:
       - main
       - v0.18.x
@@ -14,6 +15,7 @@ on:
       - 'lib/**'
       - '!lib/l10n/**'
       - 'test/**'
+      - 'pubspec.yaml'
     branches:
       - main
       - v0.18.x
@@ -31,8 +33,11 @@ jobs:
     steps:
       - uses: actions/checkout@v6
 
-      - uses: subosito/flutter-action@v2
-      - run: flutter doctor -v
+      - name: 🐦 Install flutter
+        uses: subosito/flutter-action@v2
+        with:
+          cache: true
+          flutter-version-file: pubspec.yaml
 
       - name: Install requirements for sqflite_common_ffi package
         run: sudo apt-get -y install libsqlite3-0 libsqlite3-dev

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -1830,5 +1830,5 @@ packages:
     source: hosted
     version: "3.1.3"
 sdks:
-  dart: ">=3.11.0 <4.0.0"
-  flutter: ">=3.41.0 <4.0.0"
+  dart: ">=3.11.5 <4.0.0"
+  flutter: "3.41.9"

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -6,68 +6,67 @@ version: 0.23.12+002312 # See README.md for details about versioning
 
 environment:
   # this should be updated with every new flutter stable release
-  sdk: ^3.10.0
-  flutter: ^3.41.0
+  sdk: ^3.11.5
+  flutter: 3.41.9
 
 dependencies:
   app_links: ^7.0.0
   app_settings: ^7.0.0
-  async: ^2.10.0
+  async: ^2.13.1
   auto_size_text: ^3.0.0
   chessground: ^9.0.0
-  clock: ^1.1.1
-  collection: ^1.17.0
-  connectivity_plus: ^7.0.0
-  cronet_http: ^1.3.1
-  crypto: ^3.0.3
-  cupertino_http: ^2.0.0
-  cupertino_icons: ^1.0.2
-  dartchess: ^0.12.0
-  deep_pick: ^1.0.0
-  device_info_plus: ^12.1.0
+  clock: ^1.1.2
+  collection: ^1.19.1
+  connectivity_plus: ^7.1.1
+  cronet_http: ^1.8.0
+  crypto: ^3.0.7
+  cupertino_http: ^2.4.0
+  cupertino_icons: ^1.0.9
+  dartchess: ^0.12.3
+  deep_pick: ^1.1.0
+  device_info_plus: ^12.4.0
   dynamic_system_colors:
     git:
       url: https://github.com/veloce/flutter_dynamic_system_colors.git
       ref: main
-  fast_immutable_collections: ^11.0.0
+  fast_immutable_collections: ^11.2.0
   file_picker: ^11.0.2
-  firebase_core: ^4.0.0
-  firebase_crashlytics: ^5.0.0
-  firebase_messaging: ^16.0.0
-  fl_chart: ^1.0.0
+  firebase_core: ^4.7.0
+  firebase_crashlytics: ^5.2.0
+  firebase_messaging: ^16.2.0
+  fl_chart: ^1.2.0
   flutter:
     sdk: flutter
   flutter_displaymode: ^0.7.0
-  flutter_layout_grid: ^2.0.1
+  flutter_layout_grid: ^2.0.8
   flutter_linkify: ^6.0.0
   flutter_local_notifications: ^21.0.0
   flutter_localizations:
     sdk: flutter
-  flutter_markdown: ^0.7.3+1
-  flutter_native_splash: ^2.3.5
-  flutter_riverpod: ^3.2.0
-  flutter_secure_storage: ^10.0.0-beta.4
-  flutter_slidable: ^4.0.0
-  flutter_spinkit: ^5.2.0
-  freezed_annotation: ^3.0.0
-  home_widget: ^0.9.0
-  http: ^1.1.0
-  image_picker: ^1.1.2
+  flutter_markdown: ^0.7.7+1
+  flutter_native_splash: ^2.4.7
+  flutter_riverpod: ^3.3.1
+  flutter_secure_storage: ^10.0.0
+  flutter_slidable: ^4.0.3
+  flutter_spinkit: ^5.2.2
+  freezed_annotation: ^3.1.0
+  home_widget: ^0.9.1
+  http: ^1.6.0
+  image_picker: ^1.2.2
   intl: ^0.20.2
-  json_annotation: ^4.7.0
+  json_annotation: ^4.11.0
   l10n_esperanto: ^2.0.14
   linkify: ^5.0.0
-  logging: ^1.1.0
+  logging: ^1.3.0
   material_color_utilities: ^0.13.0
-  # TODO remove pin
-  material_symbols_icons: 4.2906.0
-  meta: ^1.8.0
+  material_symbols_icons: 4.2906.0   # Check tree shaking during the production build when updating.
+  meta: ^1.17.0
   multistockfish: ^0.5.0
-  package_info_plus: ^9.0.0
-  path: ^1.8.2
+  package_info_plus: ^9.0.1
+  path: ^1.9.1
   path_provider: ^2.1.5
   popover: ^0.4.0
-  pub_semver: ^2.1.4
+  pub_semver: ^2.2.0
   qr_flutter: ^4.1.0
   quick_actions: ^1.1.0
   receive_sharing_intent:
@@ -88,16 +87,16 @@ dependencies:
   web_socket_channel: ^3.0.0
 
 dev_dependencies:
-  build_runner: ^2.3.2
-  fake_async: ^1.3.1
+  build_runner: ^2.15.0
+  fake_async: ^1.3.3
   flutter_test:
     sdk: flutter
-  freezed: ^3.0.0
-  json_serializable: ^6.5.4
-  lint: ^2.0.1
-  mocktail: ^1.0.0
-  stream_channel: ^2.1.2
-  wakelock_plus_platform_interface: ^1.3.0
+  freezed: ^3.2.5
+  json_serializable: ^6.13.2
+  lint: ^2.8.0
+  mocktail: ^1.0.5
+  stream_channel: ^2.1.4
+  wakelock_plus_platform_interface: ^1.5.0
 
 dependency_overrides:
   flutter_secure_storage_linux:


### PR DESCRIPTION
- set latest version of dart and flutter because ci use latest version.
- update test.yaml for use cache and version in pubspec.yaml
- run `dart pub upgrade --major-versions` and `dart pub upgrade --tighten`