### PR TITLE
fix/FEN import ignores side to move

### DIFF
--- a/lib/src/model/board_editor/board_editor_controller.dart
+++ b/lib/src/model/board_editor/board_editor_controller.dart
@@ -93,7 +93,37 @@ class BoardEditorController extends Notifier<BoardEditorState> {
   }
 
   void loadFen(String fen) {
-    _updatePosition(readFen(fen).lock);
+    final fenParts = fen.trim().split(RegExp(r'\s+'));
+    final setup = Setup.parseFen(fen);
+    final pieces = readFen(fen).lock;
+
+    if (fenParts.length == 1) {
+      // Partial FEN (piece placement only): preserve existing state for side to play,
+      // castling rights, etc. Castling is filtered by piece positions in _castlingRightsPart.
+      _updatePosition(pieces);
+    } else {
+      // Full FEN: update all fields from the parsed FEN.
+      final position = Position.setupPosition(
+        state.variant.rule,
+        setup,
+        ignoreImpossibleCheck: true,
+      );
+      final castlingRights = IMap({
+        CastlingRight.whiteKing: position.castles.rookOf(Side.white, CastlingSide.king) != null,
+        CastlingRight.whiteQueen: position.castles.rookOf(Side.white, CastlingSide.queen) != null,
+        CastlingRight.blackKing: position.castles.rookOf(Side.black, CastlingSide.king) != null,
+        CastlingRight.blackQueen: position.castles.rookOf(Side.black, CastlingSide.queen) != null,
+      });
+      state = state.copyWith(
+        pieces: pieces,
+        sideToPlay: setup.turn,
+        castlingRights: castlingRights,
+        enPassantOptions: _calculateEnPassantOptions(pieces, setup.turn),
+        enPassantSquare: setup.epSquare,
+        halfmoves: setup.halfmoves,
+        fullmoves: setup.fullmoves,
+      );
+    }
   }
 
   /// Calculates the squares where an en passant capture could be possible.

--- a/test/view/board_editor/board_editor_screen_test.dart
+++ b/test/view/board_editor/board_editor_screen_test.dart
@@ -385,6 +385,27 @@ void main() {
         expect(find.byKey(const Key('f1-whitebishop')), findsNothing);
       });
 
+      testWidgets('Pasting FEN with black to move correctly sets side to play', (tester) async {
+        // Same position as above but with black to move
+        const fen = 'r1bqkbnr/pppp1ppp/2n5/4p3/2B1P3/5N2/PPPP1PPP/RNBQK2R b KQkq - 2 3';
+        _mockClipboard(fen);
+
+        final app = await makeTestProviderScopeApp(tester, home: const BoardEditorScreen());
+        await tester.pumpWidget(app);
+
+        await tester.tap(find.byIcon(Icons.edit));
+        await tester.pumpAndSettle();
+
+        await tester.tap(find.byIcon(Icons.paste));
+        await tester.pumpAndSettle();
+
+        final container = ProviderScope.containerOf(
+          tester.element(find.byType(BoardEditorScreen)),
+        );
+        final state = container.read(boardEditorControllerProvider(null));
+        expect(state.sideToPlay, Side.black);
+      });
+
       testWidgets('Pasting invalid FEN closes dialog and shows snackbar', (tester) async {
         _mockClipboard('not a valid fen');
 

--- a/test/view/board_editor/board_editor_screen_test.dart
+++ b/test/view/board_editor/board_editor_screen_test.dart
@@ -399,9 +399,7 @@ void main() {
         await tester.tap(find.byIcon(Icons.paste));
         await tester.pumpAndSettle();
 
-        final container = ProviderScope.containerOf(
-          tester.element(find.byType(BoardEditorScreen)),
-        );
+        final container = ProviderScope.containerOf(tester.element(find.byType(BoardEditorScreen)));
         final state = container.read(boardEditorControllerProvider(null));
         expect(state.sideToPlay, Side.black);
       });


### PR DESCRIPTION
**Fix: Board editor FEN paste ignores side to move (and castling rights)**

**Root cause**
loadFen in BoardEditorController only called _updatePosition, which updates piece positions but leaves all other state (sideToPlay, castlingRights, enPassantSquare, etc.) unchanged. Pasting a FEN where black is to move had no effect on the side to play.

**Fix**
loadFen now distinguishes between two cases:

- Partial FEN (piece placement only, 1 field): preserves the old behavior, only pieces are updated, castling rights remain in state and are filtered by piece positions via _castlingRightsPart.
- Full FEN (2+ fields): all fields are read from the parsed FEN, sideToPlay, castlingRights, enPassantSquare, halfmoves, and fullmoves are all updated.

**Test added**
A new test Pasting FEN with black to move correctly sets side to play was added to test/view/board_editor/board_editor_screen_test.dart. It pastes a full FEN with black to move and verifies that sideToPlay is correctly set to Side.black after the paste.

**Note**
The FEN parsing logic in loadFen (for the full FEN case) is similar to the inline logic in build(). Should this be extracted into a shared helper method, or is the current duplication acceptable?

In the videos i used this FEN: r1bqkbnr/pppp1ppp/2n5/4p3/2B1P3/5N2/PPPP1PPP/RNBQK2R b KQkq - 2 3

**Bug**
https://github.com/user-attachments/assets/28160b2f-c85f-4f4b-8e19-2551a86c6771

**Fixed**
https://github.com/user-attachments/assets/320e4e4e-9a70-4b14-9ea1-b84b444c5330

Fixes: #3111 

