### PR TITLE
Fix/promotion correspondence with confirm overlay issue

### DIFF
--- a/lib/src/model/game/game_controller.dart
+++ b/lib/src/model/game/game_controller.dart
@@ -185,7 +185,7 @@ class GameController extends AsyncNotifier<GameState> {
     }
 
     if (curState.shouldConfirmMove && isPremove != true) {
-      state = AsyncValue.data(curState.copyWith(moveToConfirm: move));
+      state = AsyncValue.data(curState.copyWith(moveToConfirm: move, promotionMove: null));
       return;
     }
 

--- a/test/view/game/game_screen_test.dart
+++ b/test/view/game/game_screen_test.dart
@@ -299,14 +299,11 @@ void main() {
     testWidgets('promotion with move confirmation closes promotion picker after piece selection', (
       WidgetTester tester,
     ) async {
-      // Position: white pawn on e7 ready to promote, black king on g8, white king on e1.
-      // Black king must not be on d8 or f8 (pawn attack squares).
-      const promotionFen = '6k1/4P3/8/8/8/8/8/4K3 w - - 0 1';
-
+      // White pawn on e7 ready to promote (king on g8 avoids pawn attack on d8/f8)
       await createTestGame(
         tester,
         variant: Variant.fromPosition,
-        initialFen: promotionFen,
+        initialFen: '6k1/4P3/8/8/8/8/8/4K3 w - - 0 1',
         serverPrefs: const ServerGamePrefs(
           showRatings: true,
           enablePremove: true,
@@ -319,22 +316,18 @@ void main() {
 
       expect(find.byType(Chessboard), findsOneWidget);
 
-      // Play pawn from e7 to e8 to trigger the promotion picker
       await playMove(tester, 'e7', 'e8');
 
       final container = ProviderScope.containerOf(tester.element(find.byType(GameScreen)));
       final ctrlProvider = gameControllerProvider(const GameFullId('qVChCOTcHSeW'));
 
-      // Promotion picker must be showing, no move pending confirmation yet
       expect(container.read(ctrlProvider).requireValue.promotionMove, isNotNull);
       expect(container.read(ctrlProvider).requireValue.moveToConfirm, isNull);
 
-      // Select the queen (displayed at the e8 square in the promotion picker)
       final boardRect = tester.getRect(find.byType(Chessboard));
       await tester.tapAt(squareOffset(Square.fromName('e8'), boardRect));
       await tester.pump();
 
-      // After piece selection: promotion picker must be gone and move must await confirmation
       expect(container.read(ctrlProvider).requireValue.promotionMove, isNull);
       expect(container.read(ctrlProvider).requireValue.moveToConfirm, isNotNull);
     });

--- a/test/view/game/game_screen_test.dart
+++ b/test/view/game/game_screen_test.dart
@@ -6,6 +6,7 @@ import 'package:dartchess/dartchess.dart';
 import 'package:flutter/cupertino.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart' show ProviderScope;
 import 'package:flutter_riverpod/misc.dart' show Override, ProviderOrFamily;
 import 'package:flutter_test/flutter_test.dart';
 import 'package:http/testing.dart';
@@ -295,6 +296,49 @@ void main() {
   });
 
   group('Game actions', () {
+    testWidgets('promotion with move confirmation closes promotion picker after piece selection', (
+      WidgetTester tester,
+    ) async {
+      // Position: white pawn on e7 ready to promote, black king on g8, white king on e1.
+      // Black king must not be on d8 or f8 (pawn attack squares).
+      const promotionFen = '6k1/4P3/8/8/8/8/8/4K3 w - - 0 1';
+
+      await createTestGame(
+        tester,
+        variant: Variant.fromPosition,
+        initialFen: promotionFen,
+        serverPrefs: const ServerGamePrefs(
+          showRatings: true,
+          enablePremove: true,
+          autoQueen: AutoQueen.never,
+          confirmResign: true,
+          submitMove: true,
+          zenMode: Zen.no,
+        ),
+      );
+
+      expect(find.byType(Chessboard), findsOneWidget);
+
+      // Play pawn from e7 to e8 to trigger the promotion picker
+      await playMove(tester, 'e7', 'e8');
+
+      final container = ProviderScope.containerOf(tester.element(find.byType(GameScreen)));
+      final ctrlProvider = gameControllerProvider(const GameFullId('qVChCOTcHSeW'));
+
+      // Promotion picker must be showing, no move pending confirmation yet
+      expect(container.read(ctrlProvider).requireValue.promotionMove, isNotNull);
+      expect(container.read(ctrlProvider).requireValue.moveToConfirm, isNull);
+
+      // Select the queen (displayed at the e8 square in the promotion picker)
+      final boardRect = tester.getRect(find.byType(Chessboard));
+      await tester.tapAt(squareOffset(Square.fromName('e8'), boardRect));
+      await tester.pump();
+
+      // After piece selection: promotion picker must be gone and move must await confirmation
+      expect(container.read(ctrlProvider).requireValue.promotionMove, isNull);
+      expect(container.read(ctrlProvider).requireValue.moveToConfirm, isNotNull);
+    });
+
     testWidgets('move confirmation', (WidgetTester tester) async {
       await createTestGame(
         tester,


### PR DESCRIPTION
**Root cause**
In game_controller.dart, userMove() has two sequential early-return checks:

1. When a pawn reaches the promotion square, the move arrives without a promotion role (promotion: null). The controller detects this, stores the move in promotionMove, and returns early, which causes the promotion picker to appear so the player can choose a piece.
2.  If move confirmation is enabled, the controller stores the move in moveToConfirm and returns early, showing the confirmation UI. 

When the player selects a piece in the promotion picker, onPromotionSelection calls userMove again, this time with the chosen role set on the move (e.g. promotion: Role.queen). The first check is now skipped, and the second check fires, but it only set moveToConfirm without clearing promotionMove. This left both promotionMove and moveToConfirm set simultaneously, causing both the promotion picker and the confirmation UI to be visible at the same time.

**Fix**
One addition in game_controller.dart: when setting moveToConfirm, also clear promotionMove:
``` state = AsyncValue.data(curState.copyWith(moveToConfirm: move, promotionMove: null)); ```

**Test added**
A new test in test/view/game/game_screen_test.dart:

_promotion_ with move confirmation closes promotion picker after piece selection

- Sets up a game using Variant.fromPosition with a custom FEN (6k1/4P3/8/8/8/8/8/4K3 w - - 0 1), autoQueen: AutoQueen.never so the promotion picker is shown, and submitMove: true for move confirmation.
- Plays e7–e8, then verifies promotionMove is set and moveToConfirm is null.
- Selects the queen, then verifies promotionMove is null and moveToConfirm is set.

Fixes: #3116 