### PR TITLE
fix(move_list): apply piece notation font and padding scroll in stacked mode

### DIFF
--- a/lib/src/widgets/move_list.dart
+++ b/lib/src/widgets/move_list.dart
@@ -113,41 +113,39 @@ class _MoveListState extends ConsumerState<MoveList> {
             ),
           )
         : Card(
-            child: Padding(
+            child: SingleChildScrollView(
               padding: const EdgeInsets.all(16.0),
-              child: SingleChildScrollView(
-                child: Column(
-                  children: widget.slicedMoves
-                      .mapIndexed(
-                        (index, moves) => Row(
-                          mainAxisSize: MainAxisSize.max,
-                          mainAxisAlignment: MainAxisAlignment.start,
-                          children: [
-                            StackedMoveCount(count: index + 1),
-                            Expanded(
-                              child: Row(
-                                children: [
-                                  ...moves.map((move) {
-                                    // cursor index starts at 0, move index starts at 1
-                                    final isCurrentMove = widget.currentMoveIndex == move.key + 1;
-                                    return Expanded(
-                                      child: StackedMoveItem(
-                                        key: isCurrentMove ? currentMoveKey : null,
-                                        move: move,
-                                        pieceNotation: pieceNotation,
-                                        current: isCurrentMove,
-                                        onSelectMove: widget.onSelectMove,
-                                      ),
-                                    );
-                                  }),
-                                ],
-                              ),
+              child: Column(
+                children: widget.slicedMoves
+                    .mapIndexed(
+                      (index, moves) => Row(
+                        mainAxisSize: MainAxisSize.max,
+                        mainAxisAlignment: MainAxisAlignment.start,
+                        children: [
+                          StackedMoveCount(count: index + 1),
+                          Expanded(
+                            child: Row(
+                              children: [
+                                ...moves.map((move) {
+                                  // cursor index starts at 0, move index starts at 1
+                                  final isCurrentMove = widget.currentMoveIndex == move.key + 1;
+                                  return Expanded(
+                                    child: StackedMoveItem(
+                                      key: isCurrentMove ? currentMoveKey : null,
+                                      move: move,
+                                      pieceNotation: pieceNotation,
+                                      current: isCurrentMove,
+                                      onSelectMove: widget.onSelectMove,
+                                    ),
+                                  );
+                                }),
+                              ],
                             ),
-                          ],
-                        ),
-                      )
-                      .toList(growable: false),
-                ),
+                          ),
+                        ],
+                      ),
+                    )
+                    .toList(growable: false),
               ),
             ),
           );

--- a/lib/src/widgets/move_list.dart
+++ b/lib/src/widgets/move_list.dart
@@ -92,11 +92,7 @@ class _MoveListState extends ConsumerState<MoveList> {
                     .mapIndexed(
                       (index, moves) => Row(
                         children: [
-                          InlineMoveCount(
-                            pieceNotation: pieceNotation,
-                            count: index + 1,
-                            color: widget.inlineColor,
-                          ),
+                          InlineMoveCount(count: index + 1, color: widget.inlineColor),
                           ...moves.map((move) {
                             // cursor index starts at 0, move index starts at 1
                             final isCurrentMove = widget.currentMoveIndex == move.key + 1;
@@ -138,6 +134,7 @@ class _MoveListState extends ConsumerState<MoveList> {
                                       child: StackedMoveItem(
                                         key: isCurrentMove ? currentMoveKey : null,
                                         move: move,
+                                        pieceNotation: pieceNotation,
                                         current: isCurrentMove,
                                         onSelectMove: widget.onSelectMove,
                                       ),
@@ -158,9 +155,8 @@ class _MoveListState extends ConsumerState<MoveList> {
 }
 
 class InlineMoveCount extends StatelessWidget {
-  const InlineMoveCount({required this.count, required this.pieceNotation, this.color});
+  const InlineMoveCount({required this.count, this.color});
 
-  final PieceNotation pieceNotation;
   final int count;
 
   final Color? color;
@@ -174,7 +170,6 @@ class InlineMoveCount extends StatelessWidget {
         style: TextStyle(
           fontWeight: FontWeight.w500,
           color: color?.withValues(alpha: _moveListOpacity) ?? textShade(context, _moveListOpacity),
-          fontFamily: pieceNotation == PieceNotation.symbol ? 'ChessFont' : null,
         ),
       ),
     );
@@ -239,9 +234,16 @@ class StackedMoveCount extends StatelessWidget {
 }
 
 class StackedMoveItem extends StatelessWidget {
-  const StackedMoveItem({required this.move, this.current, this.onSelectMove, super.key});
+  const StackedMoveItem({
+    required this.move,
+    required this.pieceNotation,
+    this.current,
+    this.onSelectMove,
+    super.key,
+  });
 
   final MapEntry<int, String> move;
+  final PieceNotation pieceNotation;
   final bool? current;
   final void Function(int moveIndex)? onSelectMove;
 
@@ -254,6 +256,7 @@ class StackedMoveItem extends StatelessWidget {
         child: Text(
           move.value,
           style: TextStyle(
+            fontFamily: pieceNotation == PieceNotation.symbol ? 'ChessFont' : null,
             fontWeight: current == true ? FontWeight.bold : null,
             color: current != true ? textShade(context, 0.8) : null,
           ),


### PR DESCRIPTION
I spent a bit of time trying to refactor move_list.
I noticed that in the stacked version, the Chess font wasn’t being used.
And same bug on padding and scroll view in stacked mode

| Before | After |
| - | - |
|<img width="536" height="125" alt="Capture d&#39;écran 2026-05-07 210849" src="https://github.com/user-attachments/assets/1ea91c39-6c5d-4a57-9b1b-899bf9a68278" />|<img width="532" height="93" alt="Capture d&#39;écran 2026-05-07 210600" src="https://github.com/user-attachments/assets/fb4e25a4-43a2-4ab7-a8a4-1345f92e57f5" />|
|<img width="543" height="45" alt="Capture d&#39;écran 2026-05-07 212427" src="https://github.com/user-attachments/assets/4f7e871c-d591-40ae-a4a8-5cc33870133b" />|<img width="546" height="34" alt="image" src="https://github.com/user-attachments/assets/6d260268-dba2-4b95-9d51-136ff3e5c7b4" />|

---

I haven't included this in the PR, but `inlineColor` and `inlineDecoration` are never used by the calling widgets.