### PR TITLE
fix/removed site and event from broadcasts pgnlabels

### DIFF
--- a/lib/src/view/broadcast/broadcast_game_screen.dart
+++ b/lib/src/view/broadcast/broadcast_game_screen.dart
@@ -387,8 +387,6 @@ enum PgnTags {
   blackFideId('BlackFideId', isLink: true),
   timeControl('TimeControl', isLink: false),
   result('Result', isLink: false),
-  site('Site', isLink: false),
-  event('Event', isLink: false),
   round('Round', isLink: false);
 
   const PgnTags(this.tagName, {required this.isLink});


### PR DESCRIPTION
I made the new pgnlabels on the broadcasts screen inline with the website. I removed the Event and Site label.

See video for new mobile version and screenshot with current website labels.

https://github.com/user-attachments/assets/96a4df3f-aa25-4251-9178-f6d147e24758

<img width="1858" height="1027" alt="Broadcasts-pgnlabels-website" src="https://github.com/user-attachments/assets/03669ef5-ecb8-4d20-98a6-9e0a2a103bbf" />

Fixes: #3136 