### PR TITLE
feat(editor): implement separate function board clearing logic

### DIFF
--- a/lib/src/model/board_editor/board_editor_controller.dart
+++ b/lib/src/model/board_editor/board_editor_controller.dart
@@ -108,6 +108,20 @@ class BoardEditorController extends Notifier<BoardEditorState> {
     }
   }
 
+  void clearBoard() {
+    state = state.copyWith(
+      pieces: IMap(const {}), // No pieces
+      castlingRights: IMap(const {
+        CastlingRight.whiteKing: false,
+        CastlingRight.whiteQueen: false,
+        CastlingRight.blackKing: false,
+        CastlingRight.blackQueen: false,
+      }),
+      enPassantOptions: SquareSet.empty,
+      enPassantSquare: null,
+    );
+  }
+
   IMap<CastlingRight, bool> _getCastlingRights(Variant variant, Setup setup) {
     final position = Position.setupPosition(variant.rule, setup, ignoreImpossibleCheck: true);
     return IMap({

--- a/lib/src/view/board_editor/board_editor_screen.dart
+++ b/lib/src/view/board_editor/board_editor_screen.dart
@@ -387,7 +387,7 @@ class _BottomBar extends ConsumerWidget {
               BottomSheetAction(
                 makeLabel: (context) => Text(context.l10n.clearBoard),
                 onPressed: () {
-                  ref.read(editorController.notifier).loadFen(kEmptyFEN);
+                  ref.read(editorController.notifier).clearBoard();
                 },
               ),
             ],

--- a/test/view/board_editor/board_editor_screen_test.dart
+++ b/test/view/board_editor/board_editor_screen_test.dart
@@ -309,6 +309,25 @@ void main() {
       );
     });
 
+    testWidgets('Clear board removes all pieces', (tester) async {
+      final app = await makeTestProviderScopeApp(tester, home: const BoardEditorScreen());
+      await tester.pumpWidget(app);
+
+      await tester.tap(find.bySemanticsLabel('Menu'));
+      await tester.pumpAndSettle();
+
+      await tester.tap(find.text('Clear board'));
+      await tester.pumpAndSettle();
+
+      final editor = tester.widget<ChessboardEditor>(find.byType(ChessboardEditor));
+      expect(editor.pieces, isEmpty);
+
+      final container = ProviderScope.containerOf(tester.element(find.byType(ChessboardEditor)));
+      final controllerProvider = boardEditorControllerProvider(null);
+      // Verify the FEN reflects an empty board
+      expect(container.read(controllerProvider).fen, '8/8/8/8/8/8/8/8 w - - 0 1');
+    });
+
     testWidgets('Delete pieces with tapping square again', (tester) async {
       final app = await makeTestProviderScopeApp(tester, home: const BoardEditorScreen());
       await tester.pumpWidget(app);


### PR DESCRIPTION
**Summary**
This PR fixes a bug in the Board Editor where the **"Clear Board"** action would fail or cause an invalid state. The previous implementation attempted to load an empty FEN string, which triggers Position.setupPosition validation. Since a valid chess position requires kings, the empty FEN was rejected, leading to crashes or the board not updating.

**Changes**
BoardEditorController: Added a dedicated **clearBoard()** method. This method bypasses FEN parsing and directly updates the state with an empty piece map and reset metadata (castling rights, en passant, etc.).
BoardEditorScreen: Updated the "Clear Board" bottom sheet action to call the new clearBoard() method instead of loadFen(kEmptyFEN).