### PR TITLE
Delay engine move until piece animation completes part 2

### DIFF
--- a/lib/src/model/offline_computer/offline_computer_game_controller.dart
+++ b/lib/src/model/offline_computer/offline_computer_game_controller.dart
@@ -671,8 +671,10 @@ class OfflineComputerGameController extends Notifier<OfflineComputerGameState> {
       if (state.game.playable) {
         _applyMove(move!);
         // After engine move, precompute hints for player's turn (in casual or practice mode)
+        // Wait for the engine move animation to complete before computing hints to avoid stuttering.
         if (state.game.playable && (state.game.casual || state.game.practiceMode)) {
-          _computeHints();
+          await _waitForPlayerMoveAnimation();
+          if (ref.mounted && state.game.playable) _computeHints();
         }
       }
     } on MoveRequestCancelledException {


### PR DESCRIPTION
## Issue
Visible stuttering in the animation during opponent movements (local game on computer). Inspired by the PR https://github.com/lichess-org/mobile/pull/3061

## Change
Wait for _waitForPlayerMoveAnimation to finish executing before calling _computeHints.

## Warning
I'm not sure if this is the correct fix.