### PR TITLE
Make it clear when socket is disconnected during a game

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -95,7 +95,7 @@ Direct provider overrides are acceptable for **non-network providers** (reposito
 
 Two rules the analyzer enforces that are easy to miss:
 
-- **`const` constructors**: use `const` (not `final`) when constructing a const-capable class. The analyzer will flag `prefer_const_constructors`. This applies everywhere, including test files.
+- **`const` constructors**: use `const` (not `final`) when constructing a const-capable class. The analyzer will flag `prefer_const_constructors`. This applies everywhere, including test files. When the enclosing expression is not `const` (e.g. a non-const record or class), constructor calls inside it still need their own explicit `const` — e.g. `(time: const Duration(minutes: 3), increment: const Duration(seconds: 2))`.
 - **No leading underscores for local identifiers**: local variables and functions must not start with `_`. Reserve `_` for library-private top-level or class members.
 
 ### Code Quality Checks

--- a/lib/src/view/game/game_body.dart
+++ b/lib/src/view/game/game_body.dart
@@ -129,6 +129,7 @@ class GameBody extends ConsumerWidget {
         final black = GamePlayer(
           game: gameState.game,
           side: Side.black,
+          socketUri: GameController.socketUri(gameState.gameFullId),
           matchupScore: matchupData?.users[gameState.game.black.user!.id],
           materialDiff: boardPreferences.materialDifferenceFormat.visible
               ? gameState.game.materialDiffAt(gameState.stepCursor, Side.black)
@@ -180,6 +181,7 @@ class GameBody extends ConsumerWidget {
         final white = GamePlayer(
           game: gameState.game,
           side: Side.white,
+          socketUri: GameController.socketUri(gameState.gameFullId),
           matchupScore: matchupData?.users[gameState.game.white.user!.id],
           materialDiff: boardPreferences.materialDifferenceFormat.visible
               ? gameState.game.materialDiffAt(gameState.stepCursor, Side.white)

--- a/lib/src/view/game/game_player.dart
+++ b/lib/src/view/game/game_player.dart
@@ -10,6 +10,7 @@ import 'package:lichess_mobile/src/model/common/service/sound_service.dart';
 import 'package:lichess_mobile/src/model/game/game.dart';
 import 'package:lichess_mobile/src/model/game/material_diff.dart';
 import 'package:lichess_mobile/src/model/settings/board_preferences.dart';
+import 'package:lichess_mobile/src/network/socket.dart';
 import 'package:lichess_mobile/src/styles/lichess_colors.dart';
 import 'package:lichess_mobile/src/styles/lichess_icons.dart';
 import 'package:lichess_mobile/src/styles/styles.dart';
@@ -30,6 +31,7 @@ class GamePlayer extends StatelessWidget {
   const GamePlayer({
     required this.game,
     required this.side,
+    this.socketUri,
     this.matchupScore,
     this.clock,
     this.materialDiff,
@@ -46,6 +48,8 @@ class GamePlayer extends StatelessWidget {
 
   final BaseGame game;
   final Side side;
+
+  final Uri? socketUri;
 
   final Widget? clock;
   final MaterialDiffSide? materialDiff;
@@ -107,10 +111,21 @@ class GamePlayer extends StatelessWidget {
                   style: TextStyle(fontSize: playerFontSize, color: textShade(context, 0.7)),
                 ),
               if (player.user != null) ...[
-                ConnectedIcon(
-                  isConnected: player.onGame == true,
-                  shouldShowIsOnGameLabels: true,
-                  size: DefaultTextStyle.of(context).style.fontSize,
+                Consumer(
+                  builder: (context, ref, _) {
+                    bool isPlayerConnected = player.onGame == true;
+                    if (mePlaying && socketUri != null) {
+                      final ping = ref.watch(socketPingProvider(socketUri));
+                      if (ping.rating == 0) {
+                        isPlayerConnected = false;
+                      }
+                    }
+                    return ConnectedIcon(
+                      isConnected: isPlayerConnected,
+                      shouldShowIsOnGameLabels: true,
+                      size: DefaultTextStyle.of(context).style.fontSize,
+                    );
+                  },
                 ),
               ],
               const SizedBox(width: 5),

--- a/lib/src/view/game/game_screen.dart
+++ b/lib/src/view/game/game_screen.dart
@@ -14,6 +14,7 @@ import 'package:lichess_mobile/src/model/lobby/game_setup_preferences.dart';
 import 'package:lichess_mobile/src/model/settings/board_preferences.dart';
 import 'package:lichess_mobile/src/model/settings/general_preferences.dart';
 import 'package:lichess_mobile/src/network/http.dart';
+import 'package:lichess_mobile/src/network/socket.dart';
 import 'package:lichess_mobile/src/utils/duration.dart';
 import 'package:lichess_mobile/src/utils/gestures_exclusion.dart';
 import 'package:lichess_mobile/src/utils/immersive_mode.dart';
@@ -121,8 +122,8 @@ class _GameScreenState extends ConsumerState<GameScreen> {
           resizeToAvoidBottomInset: false,
           appBar: AppBar(
             title: switch (widget.source) {
-              LobbySource(:final seek) => _LobbyGameTitle(seek: seek),
-              _ => const SizedBox.shrink(),
+              LobbySource(:final seek) => _GameTitle(_LobbyTitleVariant(seek)),
+              _ => null,
             },
           ),
           body: const LoadGameError('The game search was cancelled.', showBottomBar: false),
@@ -131,8 +132,8 @@ class _GameScreenState extends ConsumerState<GameScreen> {
         return Scaffold(
           resizeToAvoidBottomInset: false,
           appBar: AppBar(
-            title: _ChallengeGameTitle(
-              challenge: (widget.source as UserChallengeSource).challengeRequest,
+            title: _GameTitle(
+              _ChallengeTitleVariant((widget.source as UserChallengeSource).challengeRequest),
             ),
           ),
           body: const LoadGameError('The challenge was cancelled.', showBottomBar: false),
@@ -145,8 +146,8 @@ class _GameScreenState extends ConsumerState<GameScreen> {
         return Scaffold(
           resizeToAvoidBottomInset: false,
           appBar: AppBar(
-            title: _ChallengeGameTitle(
-              challenge: (widget.source as UserChallengeSource).challengeRequest,
+            title: _GameTitle(
+              _ChallengeTitleVariant((widget.source as UserChallengeSource).challengeRequest),
             ),
           ),
           body: ChallengeDeclinedBoard(
@@ -206,7 +207,11 @@ class _GameScreenState extends ConsumerState<GameScreen> {
           resizeToAvoidBottomInset: false,
           appBar: AppBar(
             leading: isRealTimePlayingGame ? SocketPingRatingIcon(socketUri: socketUri) : null,
-            title: _StandaloneGameTitle(id: createdGameId, lastMoveAt: widget.lastMoveAt),
+            title: _GameTitle(
+              _StandaloneTitleVariant(id: createdGameId, lastMoveAt: widget.lastMoveAt),
+              monitorSocket: isRealTimePlayingGame,
+              socketUri: socketUri,
+            ),
             actions: [
               _WatcherButton(gameId: createdGameId),
               _GameMenu(gameId: createdGameId),
@@ -226,8 +231,9 @@ class _GameScreenState extends ConsumerState<GameScreen> {
           resizeToAvoidBottomInset: false,
           appBar: AppBar(
             leading: const SocketPingRatingIcon(),
-            title: _ChallengeGameTitle(
-              challenge: (widget.source as UserChallengeSource).challengeRequest,
+            title: _GameTitle(
+              _ChallengeTitleVariant((widget.source as UserChallengeSource).challengeRequest),
+              monitorSocket: true,
             ),
           ),
           body: PopScope(
@@ -252,11 +258,12 @@ class _GameScreenState extends ConsumerState<GameScreen> {
           appBar: AppBar(
             leading: const SocketPingRatingIcon(),
             title: switch (widget.source) {
-              LobbySource(:final seek) => _LobbyGameTitle(seek: seek),
-              UserChallengeSource(:final challengeRequest) => _ChallengeGameTitle(
-                challenge: challengeRequest,
+              LobbySource(:final seek) => _GameTitle(_LobbyTitleVariant(seek), monitorSocket: true),
+              UserChallengeSource(:final challengeRequest) => _GameTitle(
+                _ChallengeTitleVariant(challengeRequest),
+                monitorSocket: true,
               ),
-              _ => const SizedBox.shrink(),
+              _ => null,
             },
           ),
           body: PopScope(child: message),
@@ -282,10 +289,10 @@ class _GameScreenState extends ConsumerState<GameScreen> {
           appBar: AppBar(
             leading: const SocketPingRatingIcon(),
             title: switch (widget.source) {
-              LobbySource(:final seek) => _LobbyGameTitle(seek: seek),
+              LobbySource(:final seek) => _GameTitle(_LobbyTitleVariant(seek), monitorSocket: true),
               UserChallengeSource(:final challengeRequest) when challengeRequest.destUser != null =>
-                _ChallengeGameTitle(challenge: challengeRequest),
-              _ => const SizedBox.shrink(),
+                _GameTitle(_ChallengeTitleVariant(challengeRequest), monitorSocket: true),
+              _ => null,
             },
           ),
           body: PopScope(canPop: false, child: WakelockWidget(child: loadingBoard)),
@@ -344,16 +351,58 @@ class _GameMenu extends ConsumerWidget {
   }
 }
 
-class _LobbyGameTitle extends ConsumerWidget {
-  const _LobbyGameTitle({required this.seek});
+sealed class _GameTitleVariant {
+  const _GameTitleVariant();
+}
 
+final class _LobbyTitleVariant extends _GameTitleVariant {
+  const _LobbyTitleVariant(this.seek);
   final GameSeek seek;
+}
+
+final class _ChallengeTitleVariant extends _GameTitleVariant {
+  const _ChallengeTitleVariant(this.challenge);
+  final ChallengeRequest challenge;
+}
+
+final class _StandaloneTitleVariant extends _GameTitleVariant {
+  const _StandaloneTitleVariant({required this.id, this.lastMoveAt});
+  final GameFullId id;
+  final DateTime? lastMoveAt;
+}
+
+/// Single title widget for all GameScreen AppBar configurations.
+///
+/// When [monitorSocket] is true, shows "Reconnecting..." if the socket is
+/// disconnected (ping rating == 0). [socketUri] scopes the ping check to a
+/// specific socket; null monitors the currently active route.
+class _GameTitle extends ConsumerWidget {
+  const _GameTitle(this.variant, {this.monitorSocket = false, this.socketUri});
+
+  final _GameTitleVariant variant;
+  final bool monitorSocket;
+  final Uri? socketUri;
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
+    if (monitorSocket && ref.watch(socketPingProvider(socketUri)).rating == 0) {
+      return AppBarTitleText('${context.l10n.reconnecting}...');
+    }
+
+    return switch (variant) {
+      _LobbyTitleVariant(:final seek) => _buildLobbyContent(context, seek),
+      _ChallengeTitleVariant(:final challenge) => _buildChallengeContent(context, challenge),
+      _StandaloneTitleVariant(:final id, :final lastMoveAt) => _StandaloneGameTitle(
+        id: id,
+        lastMoveAt: lastMoveAt,
+      ),
+    };
+  }
+
+  static Widget _buildLobbyContent(BuildContext context, GameSeek seek) {
     final mode = seek.rated ? ' • ${context.l10n.rated}' : ' • ${context.l10n.casual}';
     return Row(
-      mainAxisAlignment: MainAxisAlignment.center,
+      mainAxisAlignment: .center,
       children: [
         Icon(seek.perf.icon, color: DefaultTextStyle.of(context).style.color),
         const SizedBox(width: 4.0),
@@ -361,18 +410,11 @@ class _LobbyGameTitle extends ConsumerWidget {
       ],
     );
   }
-}
 
-class _ChallengeGameTitle extends ConsumerWidget {
-  const _ChallengeGameTitle({required this.challenge});
-
-  final ChallengeRequest challenge;
-
-  @override
-  Widget build(BuildContext context, WidgetRef ref) {
+  static Widget _buildChallengeContent(BuildContext context, ChallengeRequest challenge) {
     final mode = challenge.rated ? ' • ${context.l10n.rated}' : ' • ${context.l10n.casual}';
     return Row(
-      mainAxisAlignment: MainAxisAlignment.center,
+      mainAxisAlignment: .center,
       children: [
         Icon(challenge.perf.icon, color: DefaultTextStyle.of(context).style.color),
         const SizedBox(width: 4.0),

--- a/lib/src/view/game/game_screen.dart
+++ b/lib/src/view/game/game_screen.dart
@@ -373,7 +373,7 @@ final class _StandaloneTitleVariant extends _GameTitleVariant {
 
 /// Single title widget for all GameScreen AppBar configurations.
 ///
-/// When [monitorSocket] is true, shows "Reconnecting..." if the socket is
+/// When [monitorSocket] is true, shows "Reconnecting" if the socket is
 /// disconnected (ping rating == 0). [socketUri] scopes the ping check to a
 /// specific socket; null monitors the currently active route.
 class _GameTitle extends ConsumerWidget {
@@ -386,7 +386,7 @@ class _GameTitle extends ConsumerWidget {
   @override
   Widget build(BuildContext context, WidgetRef ref) {
     if (monitorSocket && ref.watch(socketPingProvider(socketUri)).rating == 0) {
-      return AppBarTitleText('${context.l10n.reconnecting}...');
+      return AppBarTitleText(context.l10n.reconnecting);
     }
 
     return switch (variant) {

--- a/lib/src/widgets/feedback.dart
+++ b/lib/src/widgets/feedback.dart
@@ -121,7 +121,15 @@ class LagIndicator extends StatelessWidget {
   /// Visual size of the indicator.
   final double size;
 
-  static const materialLevels = {0: Colors.red, 1: Colors.yellow, 2: Colors.green, 3: Colors.green};
+  static const inactiveColor = Color(0x339E9E9E);
+
+  static const materialLevels = {
+    0: inactiveColor,
+    1: Colors.red,
+    2: Colors.yellow,
+    3: Colors.green,
+    4: Colors.green,
+  };
 
   @override
   Widget build(BuildContext context) {
@@ -131,13 +139,14 @@ class LagIndicator extends StatelessWidget {
         children: [
           SignalStrengthIndicator.bars(
             barCount: 4,
-            minValue: 1,
+            minValue: 0,
             maxValue: 4,
             value: lagRating,
             size: size,
-            inactiveColor: Colors.grey.withValues(alpha: 0.2),
+            inactiveColor: inactiveColor,
             levels: materialLevels,
           ),
+          if (lagRating == 0) threeBounceLoadingIndicator,
         ],
       ),
     );

--- a/lib/src/widgets/feedback.dart
+++ b/lib/src/widgets/feedback.dart
@@ -10,8 +10,6 @@ import 'package:popover/popover.dart';
 import 'package:signal_strength_indicator/signal_strength_indicator.dart';
 import 'package:url_launcher/url_launcher.dart';
 
-const threeBounceLoadingIndicator = SpinKitThreeBounce(color: Colors.grey, size: 15);
-
 /// A icon that shows the lag rating of the current socket connection.
 ///
 /// If [socketUri] is provided, it will be used to get the lag rating from that socket route only,
@@ -146,7 +144,10 @@ class LagIndicator extends StatelessWidget {
             inactiveColor: inactiveColor,
             levels: materialLevels,
           ),
-          if (lagRating == 0) threeBounceLoadingIndicator,
+          if (lagRating == 0)
+            Center(
+              child: SpinKitThreeBounce(color: Colors.grey, size: size / 2),
+            ),
         ],
       ),
     );

--- a/test/view/game/game_screen_test.dart
+++ b/test/view/game/game_screen_test.dart
@@ -259,6 +259,37 @@ void main() {
     }
   });
 
+  group('Reconnecting title', () {
+    testWidgets('shows Reconnecting when socket has no ping response during a real-time game', (
+      WidgetTester tester,
+    ) async {
+      final noPongFactory = ListenableFakeWebSocketChannelFactory((route) {
+        final channel = createDefaultFakeWebSocketChannel(route);
+        channel.shouldSendPong = false;
+        return channel;
+      });
+
+      await createTestGame(tester, socketFactory: noPongFactory);
+      // Wait for _isRealTimePlayableGameProvider to resolve so monitorSocket becomes true.
+      await tester.pump();
+
+      // averageLag stays at Duration.zero (no pong ever received), so rating == 0.
+      expect(find.text('Reconnecting...'), findsOneWidget);
+    });
+
+    testWidgets('shows normal game title when socket ping is established', (
+      WidgetTester tester,
+    ) async {
+      await createTestGame(tester);
+      // Wait for _isRealTimePlayableGameProvider to resolve.
+      await tester.pump();
+
+      // createTestGame pumps 10ms, during which the immediate pong is received
+      // (connectionLag = 5ms), so averageLag > 0 and rating > 0.
+      expect(find.text('Reconnecting...'), findsNothing);
+    });
+  });
+
   group('Plays sound for', () {
     testWidgets('move', (WidgetTester tester) async {
       final mockSoundService = MockSoundService();

--- a/test/view/game/game_screen_test.dart
+++ b/test/view/game/game_screen_test.dart
@@ -70,6 +70,28 @@ void main() {
   setUpAll(() {
     registerFallbackValue(Variant.standard);
     registerFallbackValue(Sound.error);
+    registerFallbackValue(
+      const GameSeek(clock: (Duration(minutes: 3), Duration(seconds: 2)), rated: false),
+    );
+    registerFallbackValue(
+      const ChallengeRequest(
+        variant: Variant.standard,
+        timeControl: ChallengeTimeControlType.clock,
+        rated: false,
+        sideChoice: SideChoice.random,
+      ),
+    );
+    registerFallbackValue(
+      const Challenge(
+        id: ChallengeId('challeng'),
+        status: ChallengeStatus.created,
+        variant: Variant.standard,
+        speed: Speed.blitz,
+        timeControl: ChallengeTimeControlType.clock,
+        rated: false,
+        sideChoice: SideChoice.random,
+      ),
+    );
   });
 
   group('Loading', () {
@@ -287,6 +309,246 @@ void main() {
       // createTestGame pumps 10ms, during which the immediate pong is received
       // (connectionLag = 5ms), so averageLag > 0 and rating > 0.
       expect(find.text('Reconnecting...'), findsNothing);
+    });
+  });
+
+  group('AppBar title', () {
+    testWidgets('active real-time game shows time control and mode', (WidgetTester tester) async {
+      await createTestGame(tester);
+      // Wait for _isRealTimePlayableGameProvider to resolve.
+      await tester.pump();
+
+      expect(find.text('3+2 • Casual'), findsOneWidget);
+    });
+
+    testWidgets('lobby loading shows seek time control and mode', (WidgetTester tester) async {
+      const seek = GameSeek(clock: (Duration(minutes: 3), Duration(seconds: 2)), rated: true);
+      final createGameService = MockCreateGameService();
+      when(
+        () => createGameService.newLobbyGame(any()),
+      ).thenAnswer((_) => Completer<GameSeekResponse>().future);
+
+      final app = await makeTestProviderScopeApp(
+        tester,
+        home: const GameScreen(source: LobbySource(seek)),
+        overrides: {
+          createGameServiceProvider: createGameServiceProvider.overrideWith(
+            (_) => createGameService,
+          ),
+        },
+      );
+      await tester.pumpWidget(app);
+      await tester.pump(kFakeWebSocketConnectionLag);
+      await tester.pump();
+
+      expect(find.text('3+2 • Rated'), findsOneWidget);
+    });
+
+    testWidgets('seek cancelled shows seek time control and mode', (WidgetTester tester) async {
+      const seek = GameSeek(clock: (Duration(minutes: 3), Duration(seconds: 2)), rated: true);
+      final createGameService = MockCreateGameService();
+      when(
+        () => createGameService.newLobbyGame(any()),
+      ).thenAnswer((_) async => const GameSeekCancelled());
+
+      final app = await makeTestProviderScopeApp(
+        tester,
+        home: const GameScreen(source: LobbySource(seek)),
+        overrides: {
+          createGameServiceProvider: createGameServiceProvider.overrideWith(
+            (_) => createGameService,
+          ),
+        },
+      );
+      await tester.pumpWidget(app);
+      await tester.pump();
+
+      expect(find.text('3+2 • Rated'), findsOneWidget);
+    });
+
+    testWidgets('challenge loading with destUser shows challenge time control and mode', (
+      WidgetTester tester,
+    ) async {
+      final challengeRequest = ChallengeRequest(
+        destUser: LightUser(id: UserId.fromUserName('bob'), name: 'Bob'),
+        variant: Variant.standard,
+        timeControl: ChallengeTimeControlType.clock,
+        clock: (time: const Duration(minutes: 3), increment: const Duration(seconds: 2)),
+        rated: true,
+        sideChoice: .random,
+      );
+      final createGameService = MockCreateGameService();
+      when(
+        () => createGameService.newOpenOrRealTimeChallenge(any()),
+      ).thenAnswer((_) => Completer<Challenge>().future);
+
+      final app = await makeTestProviderScopeApp(
+        tester,
+        home: GameScreen(source: UserChallengeSource(challengeRequest)),
+        overrides: {
+          createGameServiceProvider: createGameServiceProvider.overrideWith(
+            (_) => createGameService,
+          ),
+        },
+      );
+      await tester.pumpWidget(app);
+      await tester.pump(kFakeWebSocketConnectionLag);
+      await tester.pump();
+
+      expect(find.text('3+2 • Rated'), findsOneWidget);
+    });
+
+    testWidgets('challenge cancelled shows challenge time control and mode', (
+      WidgetTester tester,
+    ) async {
+      final challengeRequest = ChallengeRequest(
+        destUser: LightUser(id: UserId.fromUserName('bob'), name: 'Bob'),
+        variant: Variant.standard,
+        timeControl: ChallengeTimeControlType.clock,
+        clock: (time: const Duration(minutes: 3), increment: const Duration(seconds: 2)),
+        rated: true,
+        sideChoice: .random,
+      );
+      final challenge = Challenge(
+        id: const ChallengeId('challeng'),
+        status: ChallengeStatus.canceled,
+        variant: Variant.standard,
+        speed: Speed.blitz,
+        timeControl: ChallengeTimeControlType.clock,
+        clock: (time: const Duration(minutes: 3), increment: const Duration(seconds: 2)),
+        rated: true,
+        sideChoice: .random,
+        destUser: (
+          user: LightUser(id: UserId.fromUserName('bob'), name: 'Bob'),
+          rating: null,
+          provisionalRating: null,
+          lagRating: null,
+        ),
+      );
+      final createGameService = MockCreateGameService();
+      when(
+        () => createGameService.newOpenOrRealTimeChallenge(any()),
+      ).thenAnswer((_) async => challenge);
+      when(
+        () => createGameService.waitForChallengeResponse(any()),
+      ).thenAnswer((_) async => const ChallengeResponseCancelled());
+
+      final app = await makeTestProviderScopeApp(
+        tester,
+        home: GameScreen(source: UserChallengeSource(challengeRequest)),
+        overrides: {
+          createGameServiceProvider: createGameServiceProvider.overrideWith(
+            (_) => createGameService,
+          ),
+        },
+      );
+      await tester.pumpWidget(app);
+      await tester.pumpAndSettle();
+
+      expect(find.text('3+2 • Rated'), findsOneWidget);
+    });
+
+    testWidgets('challenge declined shows challenge time control and mode', (
+      WidgetTester tester,
+    ) async {
+      final challengeRequest = ChallengeRequest(
+        destUser: LightUser(id: UserId.fromUserName('bob'), name: 'Bob'),
+        variant: Variant.standard,
+        timeControl: ChallengeTimeControlType.clock,
+        clock: (time: const Duration(minutes: 3), increment: const Duration(seconds: 2)),
+        rated: true,
+        sideChoice: .random,
+      );
+      final challenge = Challenge(
+        id: const ChallengeId('challeng'),
+        status: ChallengeStatus.declined,
+        variant: Variant.standard,
+        speed: Speed.blitz,
+        timeControl: ChallengeTimeControlType.clock,
+        clock: (time: const Duration(minutes: 3), increment: const Duration(seconds: 2)),
+        rated: true,
+        sideChoice: .random,
+        destUser: (
+          user: LightUser(id: UserId.fromUserName('bob'), name: 'Bob'),
+          rating: null,
+          provisionalRating: null,
+          lagRating: null,
+        ),
+      );
+      final createGameService = MockCreateGameService();
+      when(
+        () => createGameService.newOpenOrRealTimeChallenge(any()),
+      ).thenAnswer((_) async => challenge);
+      when(() => createGameService.waitForChallengeResponse(any())).thenAnswer(
+        (_) async => ChallengeResponseDeclined(challenge: challenge, declineReason: null),
+      );
+
+      final app = await makeTestProviderScopeApp(
+        tester,
+        home: GameScreen(source: UserChallengeSource(challengeRequest)),
+        overrides: {
+          createGameServiceProvider: createGameServiceProvider.overrideWith(
+            (_) => createGameService,
+          ),
+        },
+      );
+      await tester.pumpWidget(app);
+      await tester.pumpAndSettle();
+
+      expect(find.text('3+2 • Rated'), findsOneWidget);
+    });
+
+    testWidgets('open challenge shows challenge time control and mode', (
+      WidgetTester tester,
+    ) async {
+      const challengeRequest = ChallengeRequest(
+        variant: Variant.standard,
+        timeControl: ChallengeTimeControlType.clock,
+        clock: (time: Duration(minutes: 3), increment: Duration(seconds: 2)),
+        rated: true,
+        sideChoice: .random,
+      );
+      const challenge = Challenge(
+        id: ChallengeId('challeng'),
+        status: ChallengeStatus.created,
+        variant: Variant.standard,
+        speed: Speed.blitz,
+        timeControl: ChallengeTimeControlType.clock,
+        clock: (time: Duration(minutes: 3), increment: Duration(seconds: 2)),
+        rated: true,
+        sideChoice: .random,
+      );
+      final createGameService = MockCreateGameService();
+      when(
+        () => createGameService.newOpenOrRealTimeChallenge(any()),
+      ).thenAnswer((_) async => challenge);
+      when(
+        () => createGameService.waitForChallengeResponse(any()),
+      ).thenAnswer((_) => Completer<ChallengeResponse>().future);
+
+      final app = await makeTestProviderScopeApp(
+        tester,
+        home: const GameScreen(source: UserChallengeSource(challengeRequest)),
+        overrides: {
+          createGameServiceProvider: createGameServiceProvider.overrideWith(
+            (_) => createGameService,
+          ),
+        },
+      );
+      await tester.pumpWidget(app);
+      await tester.pump(); // challenge created, state = OpenChallengeCreatedState
+      await tester.pump(kFakeWebSocketConnectionLag); // wait for socket pong
+      await tester.pump();
+
+      expect(find.text('3+2 • Rated'), findsOneWidget);
+    });
+
+    testWidgets('finished game shows time control and mode', (WidgetTester tester) async {
+      await loadFinishedTestGame(tester);
+      // Pump 500ms to let the game-over popup timer fire and resolve _gameMetaProvider.
+      await tester.pump(const Duration(milliseconds: 500));
+
+      expect(find.text('2+1 • Rated'), findsOneWidget);
     });
   });
 

--- a/test/view/game/game_screen_test.dart
+++ b/test/view/game/game_screen_test.dart
@@ -296,7 +296,7 @@ void main() {
       await tester.pump();
 
       // averageLag stays at Duration.zero (no pong ever received), so rating == 0.
-      expect(find.text('Reconnecting...'), findsOneWidget);
+      expect(find.text('Reconnecting'), findsOneWidget);
     });
 
     testWidgets('shows normal game title when socket ping is established', (
@@ -308,7 +308,7 @@ void main() {
 
       // createTestGame pumps 10ms, during which the immediate pong is received
       // (connectionLag = 5ms), so averageLag > 0 and rating > 0.
-      expect(find.text('Reconnecting...'), findsNothing);
+      expect(find.text('Reconnecting'), findsNothing);
     });
   });
 

--- a/test/widgets/feedback_test.dart
+++ b/test/widgets/feedback_test.dart
@@ -1,0 +1,65 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_spinkit/flutter_spinkit.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:lichess_mobile/src/widgets/feedback.dart';
+import 'package:signal_strength_indicator/signal_strength_indicator.dart';
+
+void main() {
+  group('LagIndicator', () {
+    // lagRating=0 requires a size >= 30 to avoid SpinKitThreeBounce overflow
+    // (SpinKitThreeBounce internally sizes to Size(bounceSize * 2, bounceSize) = Size(30, 15))
+    testWidgets('shows loading indicator when lagRating is 0', (WidgetTester tester) async {
+      await tester.pumpWidget(
+        const MaterialApp(home: Scaffold(body: LagIndicator(lagRating: 0, size: 40.0))),
+      );
+
+      expect(find.byType(SpinKitThreeBounce), findsOneWidget);
+      expect(find.byType(SignalStrengthIndicator), findsOneWidget);
+    });
+
+    testWidgets('does not show loading indicator when lagRating is > 0', (
+      WidgetTester tester,
+    ) async {
+      for (final rating in [1, 2, 3, 4]) {
+        await tester.pumpWidget(
+          MaterialApp(
+            home: Scaffold(body: LagIndicator(lagRating: rating)),
+          ),
+        );
+
+        expect(find.byType(SpinKitThreeBounce), findsNothing, reason: 'lagRating=$rating');
+        expect(find.byType(SignalStrengthIndicator), findsOneWidget, reason: 'lagRating=$rating');
+      }
+    });
+
+    testWidgets('respects the size parameter', (WidgetTester tester) async {
+      const testSize = 32.0;
+
+      await tester.pumpWidget(
+        const MaterialApp(
+          home: Scaffold(body: LagIndicator(lagRating: 2, size: testSize)),
+        ),
+      );
+
+      final sizedBox = tester.widget<SizedBox>(find.byType(SizedBox).first);
+      expect(sizedBox.width, testSize);
+      expect(sizedBox.height, testSize);
+    });
+
+    testWidgets('uses default size of 20.0', (WidgetTester tester) async {
+      await tester.pumpWidget(const MaterialApp(home: Scaffold(body: LagIndicator(lagRating: 1))));
+
+      final sizedBox = tester.widget<SizedBox>(find.byType(SizedBox).first);
+      expect(sizedBox.width, 20.0);
+      expect(sizedBox.height, 20.0);
+    });
+
+    test('throws assertion for lagRating below 0', () {
+      expect(() => LagIndicator(lagRating: -1), throwsA(isA<AssertionError>()));
+    });
+
+    test('throws assertion for lagRating above 4', () {
+      expect(() => LagIndicator(lagRating: 5), throwsA(isA<AssertionError>()));
+    });
+  });
+}


### PR DESCRIPTION
Show a "three-dots" animating loader over the signal bars, and change the title to "Reconnecting...".

Also make sure the player wifi icon is off when socket is disconnected.

<img width="500" height="1122" alt="Screenshot_1778585073" src="https://github.com/user-attachments/assets/0fa74ed9-e405-4a35-9ae5-de2f2f660885" />

Closes #3163 