### PR TITLE
fix/add event pgnlabel to broadcasts pgn labels

### DIFF
--- a/lib/src/view/broadcast/broadcast_game_screen.dart
+++ b/lib/src/view/broadcast/broadcast_game_screen.dart
@@ -385,6 +385,7 @@ enum PgnTags {
   blackFideId('BlackFideId', isLink: true),
   timeControl('TimeControl', isLink: false),
   result('Result', isLink: false),
+  event('Event', isLink: false),
   round('Round', isLink: false);
 
   const PgnTags(this.tagName, {required this.isLink});


### PR DESCRIPTION
Bring back the Event pgn label to the broadcasts pgn labels. I was i bit to quick with removing it. 

See [comment](https://github.com/lichess-org/mobile/issues/3136#issuecomment-4422986406)