### PR TITLE
Fix variant handling in explorer and tablebase

### DIFF
--- a/lib/src/model/explorer/opening_explorer.dart
+++ b/lib/src/model/explorer/opening_explorer.dart
@@ -4,7 +4,6 @@ import 'package:freezed_annotation/freezed_annotation.dart';
 import 'package:lichess_mobile/src/model/common/chess.dart';
 import 'package:lichess_mobile/src/model/common/id.dart';
 import 'package:lichess_mobile/src/model/common/perf.dart';
-import 'package:lichess_mobile/src/model/explorer/opening_explorer_preferences.dart';
 
 part 'opening_explorer.freezed.dart';
 part 'opening_explorer.g.dart';
@@ -97,11 +96,3 @@ sealed class OpeningExplorerGame with _$OpeningExplorerGame {
 }
 
 enum GameMode { casual, rated }
-
-@freezed
-sealed class OpeningExplorerCacheKey with _$OpeningExplorerCacheKey {
-  const factory OpeningExplorerCacheKey({
-    required String fen,
-    required OpeningExplorerPrefs prefs,
-  }) = _OpeningExplorerCacheKey;
-}

--- a/lib/src/model/explorer/opening_explorer_repository.dart
+++ b/lib/src/model/explorer/opening_explorer_repository.dart
@@ -5,6 +5,7 @@ import 'package:fast_immutable_collections/fast_immutable_collections.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:http/http.dart';
 import 'package:lichess_mobile/src/constants.dart';
+import 'package:lichess_mobile/src/model/common/chess.dart' show Variant;
 import 'package:lichess_mobile/src/model/common/speed.dart';
 import 'package:lichess_mobile/src/model/explorer/opening_explorer.dart';
 import 'package:lichess_mobile/src/model/explorer/opening_explorer_preferences.dart';
@@ -12,14 +13,17 @@ import 'package:lichess_mobile/src/network/http.dart';
 import 'package:lichess_mobile/src/utils/riverpod.dart';
 
 final openingExplorerProvider = AsyncNotifierProvider.autoDispose
-    .family<OpeningExplorer, ({OpeningExplorerEntry entry, bool isIndexing})?, String>(
-      OpeningExplorer.new,
-      name: 'OpeningExplorerProvider',
-    );
+    .family<
+      OpeningExplorer,
+      ({OpeningExplorerEntry entry, bool isIndexing})?,
+      ({String fen, Variant variant})
+    >((request) => OpeningExplorer(request.fen, request.variant), name: 'OpeningExplorerProvider');
 
 class OpeningExplorer extends AsyncNotifier<({OpeningExplorerEntry entry, bool isIndexing})?> {
-  OpeningExplorer(this.fen);
+  OpeningExplorer(this.fen, this.variant);
+
   final String fen;
+  final Variant variant;
 
   StreamSubscription<OpeningExplorerEntry>? _openingExplorerSubscription;
 
@@ -43,6 +47,7 @@ class OpeningExplorer extends AsyncNotifier<({OpeningExplorerEntry entry, bool i
       case OpeningDatabase.lichess:
         final openingExplorer = await repository.getLichessDatabase(
           fen,
+          variant: variant,
           speeds: prefs.lichessDb.speeds,
           ratings: prefs.lichessDb.ratings,
           since: prefs.lichessDb.since,
@@ -51,6 +56,7 @@ class OpeningExplorer extends AsyncNotifier<({OpeningExplorerEntry entry, bool i
       case OpeningDatabase.player:
         final openingExplorerStream = await repository.getPlayerDatabase(
           fen,
+          variant: variant,
           // null check handled by widget
           usernameOrId: prefs.playerDb.username!,
           color: prefs.playerDb.side,
@@ -103,6 +109,7 @@ class OpeningExplorerRepository {
 
   Future<OpeningExplorerEntry> getLichessDatabase(
     String fen, {
+    required Variant variant,
     required ISet<Speed> speeds,
     required ISet<int> ratings,
     DateTime? since,
@@ -110,6 +117,7 @@ class OpeningExplorerRepository {
     return client.readJson(
       _explorerUri('/lichess', {
         'source': 'mobile',
+        'variant': _openingExplorerVariantKey(variant),
         'fen': fen,
         if (speeds.isNotEmpty) 'speeds': speeds.map((speed) => speed.name).join(','),
         if (ratings.isNotEmpty) 'ratings': ratings.join(','),
@@ -121,6 +129,7 @@ class OpeningExplorerRepository {
 
   Future<Stream<OpeningExplorerEntry>> getPlayerDatabase(
     String fen, {
+    required Variant variant,
     required String usernameOrId,
     required Side color,
     required ISet<Speed> speeds,
@@ -130,6 +139,7 @@ class OpeningExplorerRepository {
     return client.readNdJsonStream(
       _explorerUri('/player', {
         'source': 'mobile',
+        'variant': _openingExplorerVariantKey(variant),
         'fen': fen,
         'player': usernameOrId,
         'color': color.name,
@@ -141,3 +151,6 @@ class OpeningExplorerRepository {
     );
   }
 }
+
+String _openingExplorerVariantKey(Variant variant) =>
+    variant == Variant.fromPosition ? Variant.standard.name : variant.name;

--- a/lib/src/model/explorer/opening_explorer_repository.dart
+++ b/lib/src/model/explorer/opening_explorer_repository.dart
@@ -152,5 +152,7 @@ class OpeningExplorerRepository {
   }
 }
 
+// Opening explorer treats imported/custom positions as standard chess.
+// Other variants must be explicit or the API falls back to standard data.
 String _openingExplorerVariantKey(Variant variant) =>
     variant == Variant.fromPosition ? Variant.standard.name : variant.name;

--- a/lib/src/model/explorer/opening_explorer_repository.dart
+++ b/lib/src/model/explorer/opening_explorer_repository.dart
@@ -36,8 +36,9 @@ class OpeningExplorer extends AsyncNotifier<({OpeningExplorerEntry entry, bool i
     await ref.debounce(const Duration(milliseconds: 300));
 
     final prefs = ref.watch(openingExplorerPreferencesProvider);
+    final db = _openingExplorerDatabaseFor(prefs.db, variant);
     final repository = ref.read(openingExplorerRepositoryProvider);
-    switch (prefs.db) {
+    switch (db) {
       case OpeningDatabase.master:
         final openingExplorer = await repository.getMasterDatabase(
           fen,
@@ -156,3 +157,14 @@ class OpeningExplorerRepository {
 // Other variants must be explicit or the API falls back to standard data.
 String _openingExplorerVariantKey(Variant variant) =>
     variant == Variant.fromPosition ? Variant.standard.name : variant.name;
+
+OpeningDatabase _openingExplorerDatabaseFor(OpeningDatabase db, Variant variant) {
+  // The masters endpoint has no variant parameter. For variants, fall back to
+  // Lichess DB instead of asking users to change their persisted setting.
+  if (db == OpeningDatabase.master &&
+      variant != Variant.standard &&
+      variant != Variant.fromPosition) {
+    return OpeningDatabase.lichess;
+  }
+  return db;
+}

--- a/lib/src/model/explorer/tablebase_repository.dart
+++ b/lib/src/model/explorer/tablebase_repository.dart
@@ -38,6 +38,8 @@ class TablebaseRepository {
 }
 
 String _tablebasePath(Variant variant) {
+  // Standard, imported positions, and Chess960 all use the standard tablebase
+  // endpoint; only variants with dedicated tablebases get their own path.
   return switch (variant) {
     Variant.standard || Variant.fromPosition || Variant.chess960 => '/standard',
     Variant.atomic => '/atomic',

--- a/lib/src/model/explorer/tablebase_repository.dart
+++ b/lib/src/model/explorer/tablebase_repository.dart
@@ -3,20 +3,21 @@ import 'dart:async';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:http/http.dart';
 import 'package:lichess_mobile/src/constants.dart';
+import 'package:lichess_mobile/src/model/common/chess.dart' show Variant;
 import 'package:lichess_mobile/src/model/explorer/tablebase.dart';
 import 'package:lichess_mobile/src/network/http.dart';
 import 'package:lichess_mobile/src/utils/riverpod.dart';
 
 /// A provider for fetching tablebase entries.
-final tablebaseProvider = FutureProvider.autoDispose.family<TablebaseEntry?, String>((
-  ref,
-  fen,
-) async {
-  await ref.debounce(const Duration(milliseconds: 300));
+final tablebaseProvider = FutureProvider.autoDispose
+    .family<TablebaseEntry?, ({String fen, Variant variant})>((ref, request) async {
+      await ref.debounce(const Duration(milliseconds: 300));
 
-  final tablebaseEntry = await ref.read(tablebaseRepositoryProvider).getTablebaseEntry(fen);
-  return tablebaseEntry;
-}, name: 'TablebaseProvider');
+      final tablebaseEntry = await ref
+          .read(tablebaseRepositoryProvider)
+          .getTablebaseEntry(request.fen, request.variant);
+      return tablebaseEntry;
+    }, name: 'TablebaseProvider');
 
 final tablebaseRepositoryProvider = Provider<TablebaseRepository>((ref) {
   final client = ref.watch(lichessClientProvider);
@@ -28,10 +29,19 @@ class TablebaseRepository {
 
   final Client client;
 
-  Future<TablebaseEntry> getTablebaseEntry(String fen) {
+  Future<TablebaseEntry> getTablebaseEntry(String fen, Variant variant) {
     return client.readJson(
-      Uri.https(kLichessTablebaseHost, '/standard', {'source': 'mobile', 'fen': fen}),
+      Uri.https(kLichessTablebaseHost, _tablebasePath(variant), {'source': 'mobile', 'fen': fen}),
       mapper: TablebaseEntry.fromJson,
     );
   }
+}
+
+String _tablebasePath(Variant variant) {
+  return switch (variant) {
+    Variant.standard || Variant.fromPosition || Variant.chess960 => '/standard',
+    Variant.atomic => '/atomic',
+    Variant.antichess => '/antichess',
+    _ => throw ArgumentError.value(variant, 'variant', 'Unsupported tablebase variant.'),
+  };
 }

--- a/lib/src/model/offline_computer/offline_computer_game_controller.dart
+++ b/lib/src/model/offline_computer/offline_computer_game_controller.dart
@@ -635,7 +635,9 @@ class OfflineComputerGameController extends Notifier<OfflineComputerGameState> {
   /// Returns null if the network request fails or the entry is not conclusive.
   Future<ClientEval?> _fetchTablebaseEval(Position position) async {
     try {
-      final entry = await ref.read(tablebaseRepositoryProvider).getTablebaseEntry(position.fen);
+      final entry = await ref
+          .read(tablebaseRepositoryProvider)
+          .getTablebaseEntry(position.fen, Variant.fromRule(position.rule));
       return tablebaseEntryToCloudEval(entry, position);
     } catch (e) {
       _logger.fine('Could not get tablebase eval: $e');

--- a/lib/src/view/explorer/explorer_view.dart
+++ b/lib/src/view/explorer/explorer_view.dart
@@ -56,13 +56,13 @@ class ExplorerView extends ConsumerWidget {
       return Center(child: Text(context.l10n.insufficientMaterial));
     }
 
-    if (tablebaseRelevant && isComputerAnalysisAllowed) {
-      return TablebaseView(position: position, onMoveSelected: onMoveSelected);
-    }
-
     final isLoggedIn = ref.watch(isLoggedInProvider);
     if (!isLoggedIn) {
       return Center(child: Text(context.l10n.youNeedAnAccountToDoThat));
+    }
+
+    if (tablebaseRelevant && isComputerAnalysisAllowed) {
+      return TablebaseView(position: position, onMoveSelected: onMoveSelected);
     }
 
     return OpeningExplorerView(

--- a/lib/src/view/explorer/explorer_view.dart
+++ b/lib/src/view/explorer/explorer_view.dart
@@ -56,13 +56,13 @@ class ExplorerView extends ConsumerWidget {
       return Center(child: Text(context.l10n.insufficientMaterial));
     }
 
+    if (tablebaseRelevant && isComputerAnalysisAllowed) {
+      return TablebaseView(position: position, onMoveSelected: onMoveSelected);
+    }
+
     final isLoggedIn = ref.watch(isLoggedInProvider);
     if (!isLoggedIn) {
       return Center(child: Text(context.l10n.youNeedAnAccountToDoThat));
-    }
-
-    if (tablebaseRelevant && isComputerAnalysisAllowed) {
-      return TablebaseView(position: position, onMoveSelected: onMoveSelected);
     }
 
     return OpeningExplorerView(

--- a/lib/src/view/explorer/opening_explorer_view.dart
+++ b/lib/src/view/explorer/opening_explorer_view.dart
@@ -44,6 +44,8 @@ class OpeningExplorerView extends ConsumerStatefulWidget {
 }
 
 class _OpeningExplorerState extends ConsumerState<OpeningExplorerView> {
+  // Variant is part of the key because the same FEN string can be queried
+  // against different explorer datasets.
   final Map<({String fen, Variant variant, OpeningExplorerPrefs prefs}), OpeningExplorerEntry>
   cache = {};
 
@@ -65,6 +67,8 @@ class _OpeningExplorerState extends ConsumerState<OpeningExplorerView> {
     final prefs = ref.watch(openingExplorerPreferencesProvider);
     final variant = Variant.fromRule(widget.position.rule);
 
+    // The masters endpoint has no variant parameter, so avoid silently showing
+    // standard master games for variant positions.
     if (prefs.db == OpeningDatabase.master && !_isMasterDatabaseAvailableFor(variant)) {
       return const Center(
         child: Padding(

--- a/lib/src/view/explorer/opening_explorer_view.dart
+++ b/lib/src/view/explorer/opening_explorer_view.dart
@@ -67,17 +67,6 @@ class _OpeningExplorerState extends ConsumerState<OpeningExplorerView> {
     final prefs = ref.watch(openingExplorerPreferencesProvider);
     final variant = Variant.fromRule(widget.position.rule);
 
-    // The masters endpoint has no variant parameter, so avoid silently showing
-    // standard master games for variant positions.
-    if (prefs.db == OpeningDatabase.master && !_isMasterDatabaseAvailableFor(variant)) {
-      return const Center(
-        child: Padding(
-          padding: EdgeInsets.all(16.0),
-          child: Text('Masters database is only available for standard chess.'),
-        ),
-      );
-    }
-
     if (prefs.db == OpeningDatabase.player && prefs.playerDb.username == null) {
       return const Center(
         // TODO: l10n
@@ -200,9 +189,6 @@ class _OpeningExplorerState extends ConsumerState<OpeningExplorerView> {
     }
   }
 }
-
-bool _isMasterDatabaseAvailableFor(Variant variant) =>
-    variant == Variant.standard || variant == Variant.fromPosition;
 
 class _ExplorerListView extends StatelessWidget {
   const _ExplorerListView({

--- a/lib/src/view/explorer/opening_explorer_view.dart
+++ b/lib/src/view/explorer/opening_explorer_view.dart
@@ -44,7 +44,8 @@ class OpeningExplorerView extends ConsumerStatefulWidget {
 }
 
 class _OpeningExplorerState extends ConsumerState<OpeningExplorerView> {
-  final Map<OpeningExplorerCacheKey, OpeningExplorerEntry> cache = {};
+  final Map<({String fen, Variant variant, OpeningExplorerPrefs prefs}), OpeningExplorerEntry>
+  cache = {};
 
   /// Last explorer content that was successfully loaded. This is used to
   /// display a loading indicator while the new content is being fetched.
@@ -62,6 +63,16 @@ class _OpeningExplorerState extends ConsumerState<OpeningExplorerView> {
     }
 
     final prefs = ref.watch(openingExplorerPreferencesProvider);
+    final variant = Variant.fromRule(widget.position.rule);
+
+    if (prefs.db == OpeningDatabase.master && !_isMasterDatabaseAvailableFor(variant)) {
+      return const Center(
+        child: Padding(
+          padding: EdgeInsets.all(16.0),
+          child: Text('Masters database is only available for standard chess.'),
+        ),
+      );
+    }
 
     if (prefs.db == OpeningDatabase.player && prefs.playerDb.username == null) {
       return const Center(
@@ -70,14 +81,15 @@ class _OpeningExplorerState extends ConsumerState<OpeningExplorerView> {
       );
     }
 
-    final cacheKey = OpeningExplorerCacheKey(fen: widget.position.fen, prefs: prefs);
+    final request = (fen: widget.position.fen, variant: variant);
+    final cacheKey = (fen: widget.position.fen, variant: variant, prefs: prefs);
     final cacheOpeningExplorer = cache[cacheKey];
     final openingExplorerAsync = cacheOpeningExplorer != null
         ? AsyncValue.data((entry: cacheOpeningExplorer, isIndexing: false))
-        : ref.watch(openingExplorerProvider(widget.position.fen));
+        : ref.watch(openingExplorerProvider(request));
 
     if (cacheOpeningExplorer == null) {
-      ref.listen(openingExplorerProvider(widget.position.fen), (_, curAsync) {
+      ref.listen(openingExplorerProvider(request), (_, curAsync) {
         curAsync.whenData((cur) {
           if (cur != null && !cur.isIndexing) {
             cache[cacheKey] = cur.entry;
@@ -184,6 +196,9 @@ class _OpeningExplorerState extends ConsumerState<OpeningExplorerView> {
     }
   }
 }
+
+bool _isMasterDatabaseAvailableFor(Variant variant) =>
+    variant == Variant.standard || variant == Variant.fromPosition;
 
 class _ExplorerListView extends StatelessWidget {
   const _ExplorerListView({

--- a/lib/src/view/explorer/tablebase_view.dart
+++ b/lib/src/view/explorer/tablebase_view.dart
@@ -1,6 +1,7 @@
 import 'package:dartchess/dartchess.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:lichess_mobile/src/model/common/chess.dart' show Variant;
 import 'package:lichess_mobile/src/model/explorer/tablebase.dart';
 import 'package:lichess_mobile/src/model/explorer/tablebase_repository.dart';
 import 'package:lichess_mobile/src/network/connectivity.dart';
@@ -17,7 +18,9 @@ class TablebaseView extends ConsumerWidget {
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
-    final tablebaseAsync = ref.watch(tablebaseProvider(position.fen));
+    final tablebaseAsync = ref.watch(
+      tablebaseProvider((fen: position.fen, variant: Variant.fromRule(position.rule))),
+    );
 
     switch (tablebaseAsync) {
       case AsyncData(:final value):

--- a/test/model/explorer/opening_explorer_repository_test.dart
+++ b/test/model/explorer/opening_explorer_repository_test.dart
@@ -2,6 +2,7 @@ import 'package:dartchess/dartchess.dart';
 import 'package:fast_immutable_collections/fast_immutable_collections.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:http/testing.dart';
+import 'package:lichess_mobile/src/model/common/chess.dart';
 import 'package:lichess_mobile/src/model/common/speed.dart';
 import 'package:lichess_mobile/src/model/explorer/opening_explorer.dart';
 import 'package:lichess_mobile/src/model/explorer/opening_explorer_repository.dart';
@@ -75,6 +76,7 @@ void main() {
 
       final mockClient = MockClient((request) {
         if (request.url.path == '/masters') {
+          expect(request.url.queryParameters.containsKey('variant'), isFalse);
           return mockResponse(response, 200);
         }
         return mockResponse('', 404);
@@ -136,6 +138,7 @@ void main() {
 
       final mockClient = MockClient((request) {
         if (request.url.path == '/lichess') {
+          expect(request.url.queryParameters['variant'], 'crazyhouse');
           return mockResponse(response, 200);
         }
         return mockResponse('', 404);
@@ -147,6 +150,7 @@ void main() {
 
       final result = await repo.getLichessDatabase(
         'fen',
+        variant: Variant.crazyhouse,
         speeds: const ISetConst({Speed.rapid}),
         ratings: const ISetConst({1000, 1200}),
       );
@@ -204,6 +208,7 @@ void main() {
 
       final mockClient = MockClient((request) {
         if (request.url.path == '/player') {
+          expect(request.url.queryParameters['variant'], 'crazyhouse');
           return mockResponse(response, 200);
         }
         return mockResponse('', 404);
@@ -215,6 +220,7 @@ void main() {
 
       final results = await repo.getPlayerDatabase(
         'fen',
+        variant: Variant.crazyhouse,
         usernameOrId: 'baz',
         color: Side.white,
         speeds: const ISetConst({Speed.bullet}),

--- a/test/model/explorer/tablebase_repository_test.dart
+++ b/test/model/explorer/tablebase_repository_test.dart
@@ -1,5 +1,6 @@
 import 'package:flutter_test/flutter_test.dart';
 import 'package:http/testing.dart';
+import 'package:lichess_mobile/src/model/common/chess.dart';
 import 'package:lichess_mobile/src/model/explorer/tablebase.dart';
 import 'package:lichess_mobile/src/model/explorer/tablebase_repository.dart';
 import 'package:lichess_mobile/src/network/http.dart';
@@ -174,7 +175,10 @@ void main() {
 
       final repo = TablebaseRepository(client);
 
-      final result = await repo.getTablebaseEntry('4k3/8/4q3/4PR2/5P2/6NK/8/8 w - - 3 131');
+      final result = await repo.getTablebaseEntry(
+        '4k3/8/4q3/4PR2/5P2/6NK/8/8 w - - 3 131',
+        Variant.standard,
+      );
       expect(result, isA<TablebaseEntry>());
       expect(result.moves.length, 9);
       expect(result.checkmate, false);
@@ -203,6 +207,36 @@ void main() {
       expect(winMove.san, 'Nf1');
       expect(winMove.category, TablebaseCategory.win);
       expect(winMove.dtz, 1);
+    });
+
+    test('uses variant endpoint', () async {
+      final paths = <String>[];
+      final mockClient = MockClient((request) {
+        paths.add(request.url.path);
+        return mockResponse('''
+{
+  "checkmate": false,
+  "stalemate": false,
+  "insufficient_material": false,
+  "dtz": 0,
+  "dtc": null,
+  "dtm": null,
+  "category": "draw",
+  "moves": []
+}
+          ''', 200);
+      });
+
+      final container = await lichessClientContainer(mockClient);
+      final client = container.read(lichessClientProvider);
+      final repo = TablebaseRepository(client);
+
+      await repo.getTablebaseEntry('fen', Variant.standard);
+      await repo.getTablebaseEntry('fen', Variant.chess960);
+      await repo.getTablebaseEntry('fen', Variant.atomic);
+      await repo.getTablebaseEntry('fen', Variant.antichess);
+
+      expect(paths, ['/standard', '/standard', '/atomic', '/antichess']);
     });
   });
 }

--- a/test/view/explorer/explorer_view_test.dart
+++ b/test/view/explorer/explorer_view_test.dart
@@ -100,13 +100,16 @@ void main() {
       expect(find.byType(TablebaseView), findsNothing);
     });
 
-    testWidgets('shows unavailable message for crazyhouse master database', (
+    testWidgets('uses lichess database for crazyhouse when masters is selected', (
       WidgetTester tester,
     ) async {
-      var openingExplorerRequests = 0;
+      Uri? openingExplorerUrl;
       final mockClient = MockClient((request) {
         if (request.url.host == kLichessOpeningExplorerHost) {
-          openingExplorerRequests++;
+          openingExplorerUrl = request.url;
+          if (request.url.path == '/lichess') {
+            return mockResponse(mastersOpeningExplorerResponse, 200);
+          }
         }
         return mockResponse('', 404);
       });
@@ -131,8 +134,8 @@ void main() {
       await tester.pumpWidget(app);
       await tester.pump(const Duration(milliseconds: 350));
 
-      expect(find.text('Masters database is only available for standard chess.'), findsOneWidget);
-      expect(openingExplorerRequests, 0);
+      expect(openingExplorerUrl?.path, '/lichess');
+      expect(openingExplorerUrl?.queryParameters['variant'], 'crazyhouse');
     });
 
     testWidgets('sends variant for crazyhouse lichess database', (WidgetTester tester) async {
@@ -163,8 +166,8 @@ void main() {
             return FakeHttpClientFactory(() => mockClient);
           }),
         },
-        // The default is the masters database, which is intentionally blocked
-        // for variants; seed Lichess DB prefs to exercise the variant request.
+        // Seed Lichess DB prefs to exercise the direct variant request path;
+        // the default Masters setting is covered by the fallback test above.
         defaultPreferences: {
           SessionPreferencesStorage.key(
             PrefCategory.openingExplorer.storageKey,

--- a/test/view/explorer/explorer_view_test.dart
+++ b/test/view/explorer/explorer_view_test.dart
@@ -163,6 +163,8 @@ void main() {
             return FakeHttpClientFactory(() => mockClient);
           }),
         },
+        // The default is the masters database, which is intentionally blocked
+        // for variants; seed Lichess DB prefs to exercise the variant request.
         defaultPreferences: {
           SessionPreferencesStorage.key(
             PrefCategory.openingExplorer.storageKey,
@@ -240,33 +242,6 @@ void main() {
       // Check if the specific move is parsed correctly
       expect(find.text('Winning'), findsOneWidget);
       expect(find.text('Kh4'), findsOneWidget);
-    });
-
-    testWidgets('shows tablebase without login', (WidgetTester tester) async {
-      final position = Chess.fromSetup(Setup.parseFen('4k3/8/4q3/4PR2/5P2/6NK/8/8 w - - 3 131'));
-
-      final app = await makeTestProviderScopeApp(
-        tester,
-        home: Scaffold(
-          body: ExplorerView(
-            pov: Side.white,
-            position: position,
-            onMoveSelected: (move) => {},
-            isComputerAnalysisAllowed: true,
-          ),
-        ),
-        overrides: {
-          httpClientFactoryProvider: httpClientFactoryProvider.overrideWith((ref) {
-            return FakeHttpClientFactory(() => mockClient);
-          }),
-        },
-      );
-      await tester.pumpWidget(app);
-
-      await tester.pump(const Duration(milliseconds: 350));
-
-      expect(find.byType(TablebaseView), findsOneWidget);
-      expect(find.text('You need an account to do that.'), findsNothing);
     });
 
     testWidgets('shows checkmate message for checkmate position', (WidgetTester tester) async {

--- a/test/view/explorer/explorer_view_test.dart
+++ b/test/view/explorer/explorer_view_test.dart
@@ -242,6 +242,33 @@ void main() {
       expect(find.text('Kh4'), findsOneWidget);
     });
 
+    testWidgets('shows tablebase without login', (WidgetTester tester) async {
+      final position = Chess.fromSetup(Setup.parseFen('4k3/8/4q3/4PR2/5P2/6NK/8/8 w - - 3 131'));
+
+      final app = await makeTestProviderScopeApp(
+        tester,
+        home: Scaffold(
+          body: ExplorerView(
+            pov: Side.white,
+            position: position,
+            onMoveSelected: (move) => {},
+            isComputerAnalysisAllowed: true,
+          ),
+        ),
+        overrides: {
+          httpClientFactoryProvider: httpClientFactoryProvider.overrideWith((ref) {
+            return FakeHttpClientFactory(() => mockClient);
+          }),
+        },
+      );
+      await tester.pumpWidget(app);
+
+      await tester.pump(const Duration(milliseconds: 350));
+
+      expect(find.byType(TablebaseView), findsOneWidget);
+      expect(find.text('You need an account to do that.'), findsNothing);
+    });
+
     testWidgets('shows checkmate message for checkmate position', (WidgetTester tester) async {
       // Fool's mate position
       final position = Chess.fromSetup(

--- a/test/view/explorer/explorer_view_test.dart
+++ b/test/view/explorer/explorer_view_test.dart
@@ -1,3 +1,5 @@
+import 'dart:convert';
+
 import 'package:dartchess/dartchess.dart';
 import 'package:fast_immutable_collections/fast_immutable_collections.dart';
 import 'package:flutter/material.dart';
@@ -7,6 +9,8 @@ import 'package:lichess_mobile/src/constants.dart';
 import 'package:lichess_mobile/src/model/auth/auth_controller.dart';
 import 'package:lichess_mobile/src/model/common/id.dart';
 import 'package:lichess_mobile/src/model/explorer/opening_explorer.dart';
+import 'package:lichess_mobile/src/model/explorer/opening_explorer_preferences.dart';
+import 'package:lichess_mobile/src/model/settings/preferences_storage.dart';
 import 'package:lichess_mobile/src/model/user/user.dart';
 import 'package:lichess_mobile/src/network/http.dart';
 import 'package:lichess_mobile/src/view/explorer/explorer_view.dart';
@@ -94,6 +98,87 @@ void main() {
 
       expect(find.byType(OpeningExplorerView), findsOneWidget);
       expect(find.byType(TablebaseView), findsNothing);
+    });
+
+    testWidgets('shows unavailable message for crazyhouse master database', (
+      WidgetTester tester,
+    ) async {
+      var openingExplorerRequests = 0;
+      final mockClient = MockClient((request) {
+        if (request.url.host == kLichessOpeningExplorerHost) {
+          openingExplorerRequests++;
+        }
+        return mockResponse('', 404);
+      });
+
+      final app = await makeTestProviderScopeApp(
+        tester,
+        home: Scaffold(
+          body: ExplorerView(
+            pov: Side.white,
+            position: Crazyhouse.initial,
+            onMoveSelected: (move) {},
+            isComputerAnalysisAllowed: true,
+          ),
+        ),
+        authUser: authUser,
+        overrides: {
+          httpClientFactoryProvider: httpClientFactoryProvider.overrideWith((ref) {
+            return FakeHttpClientFactory(() => mockClient);
+          }),
+        },
+      );
+      await tester.pumpWidget(app);
+      await tester.pump(const Duration(milliseconds: 350));
+
+      expect(find.text('Masters database is only available for standard chess.'), findsOneWidget);
+      expect(openingExplorerRequests, 0);
+    });
+
+    testWidgets('sends variant for crazyhouse lichess database', (WidgetTester tester) async {
+      Uri? openingExplorerUrl;
+      final mockClient = MockClient((request) {
+        if (request.url.host == kLichessOpeningExplorerHost) {
+          openingExplorerUrl = request.url;
+          if (request.url.path == '/lichess') {
+            return mockResponse(mastersOpeningExplorerResponse, 200);
+          }
+        }
+        return mockResponse('', 404);
+      });
+
+      final app = await makeTestProviderScopeApp(
+        tester,
+        home: Scaffold(
+          body: ExplorerView(
+            pov: Side.white,
+            position: Crazyhouse.initial,
+            onMoveSelected: (move) {},
+            isComputerAnalysisAllowed: true,
+          ),
+        ),
+        authUser: authUser,
+        overrides: {
+          httpClientFactoryProvider: httpClientFactoryProvider.overrideWith((ref) {
+            return FakeHttpClientFactory(() => mockClient);
+          }),
+        },
+        defaultPreferences: {
+          SessionPreferencesStorage.key(
+            PrefCategory.openingExplorer.storageKey,
+            authUser,
+          ): jsonEncode(
+            OpeningExplorerPrefs.defaults(
+              user: user,
+            ).copyWith(db: OpeningDatabase.lichess).toJson(),
+          ),
+        },
+      );
+      await tester.pumpWidget(app);
+      await tester.pump(const Duration(milliseconds: 350));
+
+      expect(openingExplorerUrl?.path, '/lichess');
+      expect(openingExplorerUrl?.queryParameters['variant'], 'crazyhouse');
     });
 
     testWidgets('shows tablebase for 8-piece endgame', (WidgetTester tester) async {


### PR DESCRIPTION
## Summary

Fix variant handling for opening explorer and tablebase requests.  #3168 

This PR makes explorer requests variant-aware so non-standard positions no longer fall back to standard data by accident. It also prevents the Masters database from being shown for variants where the endpoint does not support variant selection.

## Changes

- Pass the current position variant through `OpeningExplorerView` and `openingExplorerProvider`.
- Add the `variant` query parameter for Lichess and player opening explorer requests.
- Keep `fromPosition` mapped to `standard`, since it is an imported/custom standard chess position rather than a real variant.
- Block Masters DB for non-standard variants because the `/masters` endpoint has no variant parameter.
- Route tablebase requests to variant-specific endpoints:
  - `/standard` for standard, from-position, and Chess960
  - `/atomic` for Atomic
  - `/antichess` for Antichess

## Screenshot

Combined screenshot:
1. Standard opening explorer
2. Antichess opening explorer
3. Antichess with Masters DB unavailable message
4. Antichess tablebase


<img width="1370" height="750" alt="image" src="https://github.com/user-attachments/assets/84a0496e-6a82-4161-910e-45605b808629" />
