### PR TITLE
feat(puzzle): improve history screen timing and grouping

### DIFF
--- a/lib/src/view/puzzle/puzzle_history_screen.dart
+++ b/lib/src/view/puzzle/puzzle_history_screen.dart
@@ -161,9 +161,16 @@ class _BodyState extends ConsumerState<_Body> {
                 ),
               );
             } else if (element is DateTime) {
-              final title = DateTime.now().difference(element).inDays >= 15
-                  ? _dateFormatter.format(element)
-                  : relativeDate(context.l10n, element);
+              final now = DateTime.now();
+              final today = DateTime(now.year, now.month, now.day);
+              final difference = today.difference(element).inDays;
+              final title = difference == 0
+                  ? context.l10n.today
+                  : difference == 1
+                  ? context.l10n.yesterday
+                  : difference < 15
+                  ? relativeDate(context.l10n, element)
+                  : _dateFormatter.format(element);
               return Padding(
                 padding: const EdgeInsets.only(left: _kPuzzlePadding).add(Styles.sectionTopPadding),
                 child: Text(


### PR DESCRIPTION
### **Description:**
This PR refines the puzzle history screen by introducing explicit "Today" and "Yesterday" headers.

Rationale: Previously, the history screen relied on a generic relative date formatter. Because puzzle attempts are grouped by day (setting the time to 00:00), the formatter would calculate the difference between the current time and midnight. This led to confusing headers for today's puzzles, such as "16 hours ago", instead of simply saying "Today".

By explicitly handling these cases, the history screen now provides a much clearer and more standard overview of recent activity.

### **Changes:**
Puzzle History Headers: Updated PuzzleHistoryScreen to prioritize "Today" and "Yesterday" labels for recent attempts, falling back to relative dates or absolute dates only for older entries.