### PR TITLE
Display the different lines in the variation bar.

### DIFF
--- a/lib/src/view/analysis/tree_view.dart
+++ b/lib/src/view/analysis/tree_view.dart
@@ -4,6 +4,7 @@ import 'package:lichess_mobile/src/model/analysis/analysis_controller.dart';
 import 'package:lichess_mobile/src/model/analysis/analysis_preferences.dart';
 import 'package:lichess_mobile/src/view/game/game_result_dialog.dart';
 import 'package:lichess_mobile/src/widgets/pgn.dart';
+import 'package:lichess_mobile/src/widgets/variations_bar.dart';
 
 class AnalysisTreeView extends ConsumerWidget {
   const AnalysisTreeView(this.options);
@@ -18,34 +19,47 @@ class AnalysisTreeView extends ConsumerWidget {
     final prefs = ref.watch(analysisPreferencesProvider);
     // enable computer analysis takes effect here only if it's a lichess game
     final enableServerAnalysis = !options.isLichessGameAnalysis || prefs.enableServerAnalysis;
+    final currentNode =
+        analysisState.root.branchesOn(analysisState.currentPath).lastOrNull ?? analysisState.root;
 
-    return SingleChildScrollView(
-      padding: EdgeInsets.zero,
-      child: Column(
-        children: [
-          DebouncedPgnTreeView(
-            root: analysisState.root,
-            currentPath: analysisState.currentPath,
-            livePath: analysisState.pathToLiveMove,
-            pgnRootComments: analysisState.pgnRootComments,
-            notifier: ref.read(ctrlProvider.notifier),
-            // Avoid overlap with the divider of the analysis tab bar
-            showTopDivider: false,
-            shouldShowComputerAnalysis: enableServerAnalysis,
-            shouldShowComments: enableServerAnalysis && prefs.showPgnComments,
-            shouldShowAnnotations: enableServerAnalysis && prefs.showAnnotations,
-            premovePaths: analysisState.forecast?.lines,
-            displayMode: prefs.inlineNotation
-                ? PgnTreeDisplayMode.inlineNotation
-                : PgnTreeDisplayMode.twoColumn,
-          ),
-          if (analysisState.archivedGame != null)
-            Padding(
-              padding: const EdgeInsets.all(8.0),
-              child: GameResult(game: analysisState.archivedGame!),
+    return Column(
+      crossAxisAlignment: .stretch,
+      children: [
+        Expanded(
+          child: SingleChildScrollView(
+            padding: EdgeInsets.zero,
+            child: Column(
+              children: [
+                DebouncedPgnTreeView(
+                  root: analysisState.root,
+                  currentPath: analysisState.currentPath,
+                  livePath: analysisState.pathToLiveMove,
+                  pgnRootComments: analysisState.pgnRootComments,
+                  notifier: ref.read(ctrlProvider.notifier),
+                  // Avoid overlap with the divider of the analysis tab bar
+                  showTopDivider: false,
+                  shouldShowComputerAnalysis: enableServerAnalysis,
+                  shouldShowComments: enableServerAnalysis && prefs.showPgnComments,
+                  shouldShowAnnotations: enableServerAnalysis && prefs.showAnnotations,
+                  premovePaths: analysisState.forecast?.lines,
+                  displayMode: prefs.inlineNotation ? .inlineNotation : .twoColumn,
+                ),
+                if (analysisState.archivedGame != null)
+                  Padding(
+                    padding: const EdgeInsets.all(8.0),
+                    child: GameResult(game: analysisState.archivedGame!),
+                  ),
+              ],
             ),
-        ],
-      ),
+          ),
+        ),
+        VariationsBar(
+          currentNode: currentNode,
+          currentPath: analysisState.currentPath,
+          showAnnotations: enableServerAnalysis && prefs.showAnnotations,
+          onJump: (path) => ref.read(ctrlProvider.notifier).userJump(path),
+        ),
+      ],
     );
   }
 }

--- a/lib/src/view/broadcast/broadcast_game_screen.dart
+++ b/lib/src/view/broadcast/broadcast_game_screen.dart
@@ -39,6 +39,7 @@ import 'package:lichess_mobile/src/widgets/feedback.dart';
 import 'package:lichess_mobile/src/widgets/misc.dart';
 import 'package:lichess_mobile/src/widgets/pgn.dart';
 import 'package:lichess_mobile/src/widgets/platform_context_menu_button.dart';
+import 'package:lichess_mobile/src/widgets/variations_bar.dart';
 import 'package:share_plus/share_plus.dart';
 import 'package:url_launcher/url_launcher_string.dart';
 
@@ -353,24 +354,38 @@ class _BroadcastGameTreeView extends ConsumerWidget {
     final state = ref.watch(ctrlProvider).requireValue;
 
     final broadcastPrefs = ref.watch(broadcastPreferencesProvider);
+    final currentNode = state.root.branchesOn(state.currentPath).lastOrNull ?? state.root;
 
-    return SingleChildScrollView(
-      child: DebouncedPgnTreeView(
-        root: state.root,
-        currentPath: state.currentPath,
-        livePath: state.broadcastLivePath,
-        pgnRootComments: state.pgnRootComments,
-        // Avoid overlap with the divider of the tab bar
-        showTopDivider: false,
-        shouldShowComputerAnalysis: broadcastPrefs.enableServerAnalysis,
-        shouldShowComments: broadcastPrefs.enableServerAnalysis && broadcastPrefs.showPgnComments,
-        shouldShowAnnotations:
-            broadcastPrefs.enableServerAnalysis && broadcastPrefs.showAnnotations,
-        notifier: ref.read(ctrlProvider.notifier),
-        displayMode: broadcastPrefs.inlineNotation
-            ? PgnTreeDisplayMode.inlineNotation
-            : PgnTreeDisplayMode.twoColumn,
-      ),
+    return Column(
+      crossAxisAlignment: .stretch,
+      children: [
+        Expanded(
+          child: SingleChildScrollView(
+            child: DebouncedPgnTreeView(
+              root: state.root,
+              currentPath: state.currentPath,
+              livePath: state.broadcastLivePath,
+              pgnRootComments: state.pgnRootComments,
+              // Avoid overlap with the divider of the tab bar
+              showTopDivider: false,
+              shouldShowComputerAnalysis: broadcastPrefs.enableServerAnalysis,
+              shouldShowComments:
+                  broadcastPrefs.enableServerAnalysis && broadcastPrefs.showPgnComments,
+              shouldShowAnnotations:
+                  broadcastPrefs.enableServerAnalysis && broadcastPrefs.showAnnotations,
+              notifier: ref.read(ctrlProvider.notifier),
+              displayMode: broadcastPrefs.inlineNotation ? .inlineNotation : .twoColumn,
+            ),
+          ),
+        ),
+
+        VariationsBar(
+          currentNode: currentNode,
+          currentPath: state.currentPath,
+          showAnnotations: broadcastPrefs.enableServerAnalysis && broadcastPrefs.showAnnotations,
+          onJump: (path) => ref.read(ctrlProvider.notifier).userJump(path),
+        ),
+      ],
     );
   }
 }

--- a/lib/src/view/study/study_tree_view.dart
+++ b/lib/src/view/study/study_tree_view.dart
@@ -6,6 +6,7 @@ import 'package:lichess_mobile/src/model/common/node.dart';
 import 'package:lichess_mobile/src/model/study/study_controller.dart';
 import 'package:lichess_mobile/src/model/study/study_preferences.dart';
 import 'package:lichess_mobile/src/widgets/pgn.dart';
+import 'package:lichess_mobile/src/widgets/variations_bar.dart';
 
 class StudyTreeView extends ConsumerWidget {
   const StudyTreeView(this.options, {required this.showTopDivider});
@@ -25,28 +26,41 @@ class StudyTreeView extends ConsumerWidget {
 
     final studyPrefs = ref.watch(studyPreferencesProvider);
 
-    return CustomScrollView(
-      slivers: [
-        SliverFillRemaining(
-          hasScrollBody: false,
-          child: Column(
-            crossAxisAlignment: CrossAxisAlignment.start,
-            children: [
-              Expanded(
-                child: DebouncedPgnTreeView(
-                  root: root,
-                  currentPath: studyState.currentPath,
-                  pgnRootComments: studyState.pgnRootComments,
-                  notifier: ref.read(studyControllerProvider(options).notifier),
-                  showTopDivider: showTopDivider,
-                  shouldShowAnnotations: studyPrefs.showAnnotations,
-                  displayMode: studyPrefs.inlineNotation
-                      ? PgnTreeDisplayMode.inlineNotation
-                      : PgnTreeDisplayMode.twoColumn,
+    final currentNode = root.branchesOn(studyState.currentPath).lastOrNull ?? root;
+
+    return Column(
+      crossAxisAlignment: .stretch,
+      children: [
+        Expanded(
+          child: CustomScrollView(
+            slivers: [
+              SliverFillRemaining(
+                hasScrollBody: false,
+                child: Column(
+                  crossAxisAlignment: .start,
+                  children: [
+                    Expanded(
+                      child: DebouncedPgnTreeView(
+                        root: root,
+                        currentPath: studyState.currentPath,
+                        pgnRootComments: studyState.pgnRootComments,
+                        notifier: ref.read(studyControllerProvider(options).notifier),
+                        showTopDivider: showTopDivider,
+                        shouldShowAnnotations: studyPrefs.showAnnotations,
+                        displayMode: studyPrefs.inlineNotation ? .inlineNotation : .twoColumn,
+                      ),
+                    ),
+                  ],
                 ),
               ),
             ],
           ),
+        ),
+        VariationsBar(
+          currentNode: currentNode,
+          currentPath: studyState.currentPath,
+          showAnnotations: studyPrefs.showAnnotations,
+          onJump: (path) => ref.read(studyControllerProvider(options).notifier).userJump(path),
         ),
       ],
     );

--- a/lib/src/widgets/variations_bar.dart
+++ b/lib/src/widgets/variations_bar.dart
@@ -1,0 +1,97 @@
+import 'package:flutter/material.dart';
+import 'package:lichess_mobile/src/model/common/node.dart';
+import 'package:lichess_mobile/src/model/common/uci.dart';
+import 'package:lichess_mobile/src/widgets/pgn.dart';
+
+/// A bar showing the variations branching out of the current position, if there is more than one variation,
+/// each variation is shown as a button with the move SAN, and if annotations are enabled, the move annotation is also shown (e.g. "!" or "?")
+class VariationsBar extends StatelessWidget {
+  const VariationsBar({
+    super.key,
+    required this.currentNode,
+    required this.currentPath,
+    required this.showAnnotations,
+    required this.onJump,
+  });
+
+  final ViewNode currentNode;
+  final UciPath currentPath;
+  final bool showAnnotations;
+  final void Function(UciPath) onJump;
+
+  static const maxVarSize = 55;
+
+  @override
+  Widget build(BuildContext context) {
+    final variations = currentNode.children;
+
+    if (variations.length <= 1) {
+      return const SizedBox.shrink();
+    }
+
+    return LayoutBuilder(
+      builder: (context, constraints) {
+        final crossAxisCount = (constraints.maxWidth / maxVarSize).floor().clamp(1, 8);
+
+        final chunkedRows = <Widget>[];
+        for (var i = 0; i < variations.length; i += crossAxisCount) {
+          final chunk = variations.skip(i).take(crossAxisCount).toList();
+
+          chunkedRows.add(
+            Row(
+              children: chunk.map((child) {
+                final isMainline = child == variations.first;
+                final theme = Theme.of(context);
+                final borderColor = theme.dividerColor;
+
+                final annotation = showAnnotations && child.nags != null && child.nags!.isNotEmpty
+                    ? moveAnnotationChar(child.nags!)
+                    : '';
+
+                final displayText = '${child.sanMove.san}$annotation';
+
+                return Expanded(
+                  child: Container(
+                    decoration: BoxDecoration(
+                      border: Border(
+                        right: BorderSide(color: borderColor, width: 1),
+                        bottom: BorderSide(color: borderColor, width: 1),
+                      ),
+                    ),
+                    child: Material(
+                      color: isMainline
+                          ? theme.colorScheme.primaryContainer
+                          : theme.colorScheme.secondaryContainer,
+                      child: InkWell(
+                        onTap: () => onJump(currentPath + child.id),
+                        child: Container(
+                          constraints: const BoxConstraints(minHeight: kMinInteractiveDimension),
+                          alignment: .center,
+                          padding: const EdgeInsets.symmetric(horizontal: 2.0),
+                          child: FittedBox(
+                            fit: .scaleDown,
+                            child: Text(
+                              displayText,
+                              style: TextStyle(
+                                fontSize: 14,
+                                color: isMainline
+                                    ? theme.colorScheme.onPrimaryContainer
+                                    : theme.colorScheme.onSecondaryContainer,
+                              ),
+                            ),
+                          ),
+                        ),
+                      ),
+                    ),
+                  ),
+                );
+              }).toList(),
+            ),
+          );
+        }
+
+        return Column(crossAxisAlignment: .stretch, children: chunkedRows);
+      },
+    );
+  }
+}

--- a/test/view/analysis/analysis_screen_test.dart
+++ b/test/view/analysis/analysis_screen_test.dart
@@ -28,6 +28,7 @@ import 'package:lichess_mobile/src/view/more/more_tab_screen.dart';
 import 'package:lichess_mobile/src/widgets/bottom_bar.dart';
 import 'package:lichess_mobile/src/widgets/pgn.dart';
 import 'package:lichess_mobile/src/widgets/pockets.dart';
+import 'package:lichess_mobile/src/widgets/variations_bar.dart';
 import 'package:multistockfish/multistockfish.dart';
 
 import '../../binding.dart';
@@ -110,6 +111,73 @@ void main() {
             .isCurrentMove,
         isTrue,
       );
+    });
+    testWidgets('Variations bar displays variations and can be tapped', (tester) async {
+      // A PGN where black has two responses to 1. e4 : e5 and c5
+      const pgn = '1. e4 e5 (1... c5)';
+
+      final app = await makeTestProviderScopeApp(
+        tester,
+        home: const AnalysisScreen(
+          options: AnalysisOptions.pgn(
+            id: StringId('test-id'),
+            pgn: pgn,
+            orientation: Side.white,
+            variant: Variant.standard,
+            isComputerAnalysisAllowed: false,
+            initialMoveCursor: 0,
+          ),
+        ),
+      );
+
+      await tester.pumpWidget(app);
+      await tester.pumpAndSettle();
+
+      // The bar should not be visible when at the root (the root only has 1 child: 1. e4)
+      // So e5 should only be visible in the notation but not in the variations bar
+      expect(find.text('e5'), findsOneWidget);
+      expect(
+        find.descendant(of: find.byType(VariationsBar), matching: find.text('e4')),
+        findsNothing,
+      );
+
+      // go next to play 1. e4
+      await tester.tap(find.byKey(const Key('goto-next')));
+      await tester.pump();
+
+      // The variations bar should now display both e5 and c5
+      expect(find.byType(VariationsBar), findsOneWidget);
+      expect(
+        find.descendant(of: find.byType(VariationsBar), matching: find.text('e5')),
+        findsOneWidget,
+      );
+      expect(
+        find.descendant(of: find.byType(VariationsBar), matching: find.text('c5')),
+        findsOneWidget,
+      );
+
+      // Tap the 'c5' variation in the VariationsBar
+      await tester.tap(find.descendant(of: find.byType(VariationsBar), matching: find.text('c5')));
+      await tester.pump();
+
+      // Verify that the tree successfully jumped to c5
+      expect(boardHasPiece(tester, Square.c5, Piece.blackPawn), isTrue);
+      await tester.tap(find.byKey(const Key('goto-previous')));
+      await tester.pump();
+      // The variations bar should now display both e5 and c5 again
+      expect(find.byType(VariationsBar), findsOneWidget);
+      expect(
+        find.descendant(of: find.byType(VariationsBar), matching: find.text('e5')),
+        findsOneWidget,
+      );
+      expect(
+        find.descendant(of: find.byType(VariationsBar), matching: find.text('c5')),
+        findsOneWidget,
+      );
+      //pressing next should play the mainline move e5, not c5
+      await tester.tap(find.byKey(const Key('goto-next')));
+      await tester.pump();
+      expect(boardHasPiece(tester, Square.e5, Piece.blackPawn), isTrue);
     });
 
     testWidgets('change variant in standalone analysis', (tester) async {

--- a/test/view/broadcast/broadcast_game_screen_test.dart
+++ b/test/view/broadcast/broadcast_game_screen_test.dart
@@ -1,6 +1,7 @@
 import 'dart:convert';
 
 import 'package:chessground/chessground.dart';
+import 'package:dartchess/dartchess.dart';
 import 'package:fl_chart/fl_chart.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
@@ -13,6 +14,7 @@ import 'package:lichess_mobile/src/view/broadcast/broadcast_game_screen.dart';
 import 'package:lichess_mobile/src/view/engine/engine_button.dart';
 import 'package:lichess_mobile/src/view/engine/engine_gauge.dart';
 import 'package:lichess_mobile/src/view/engine/engine_lines.dart';
+import 'package:lichess_mobile/src/widgets/variations_bar.dart';
 
 import '../../model/broadcast/example_data.dart';
 import '../../network/fake_websocket_channel.dart';
@@ -154,6 +156,69 @@ void main() {
       expect(find.text('6300014', findRichText: true), findsOne);
       expect(find.text('BlackFideId: '), findsOne);
       expect(find.text('6336760', findRichText: true), findsOne);
+    });
+    testWidgets('Variations bar displays variations and can be tapped', variant: kPlatformVariant, (
+      tester,
+    ) async {
+      const gameIdVariations = BroadcastGameId('VarTest1');
+      final customClient = MockClient((request) {
+        if (request.url.path == '/api/broadcast/-/-/$_roundId') {
+          return mockResponse(
+            broadcastRoundMockResponses[(_tournamentId, _roundId)]!,
+            200,
+            headers: {'content-type': 'application/json; charset=utf-8'},
+          );
+        }
+        if (request.url.path == '/api/study/$_roundId/$gameIdVariations.pgn') {
+          return mockResponse(
+            '1. d4 d5 (1... Nf6)',
+            200,
+            headers: {'content-type': 'application/x-chess-pgn'},
+          );
+        }
+        return mockResponse('', 404);
+      });
+
+      final app = await makeTestProviderScopeApp(
+        tester,
+        home: const BroadcastGameScreen(
+          tournamentId: _tournamentId,
+          roundId: _roundId,
+          gameId: gameIdVariations,
+        ),
+        overrides: {
+          lichessClientProvider: lichessClientProvider.overrideWith(
+            (ref) => LichessClient(customClient, ref),
+          ),
+        },
+      );
+
+      await tester.pumpWidget(app);
+      await tester.pumpAndSettle(); // Loads the broadcast PGN
+
+      // Jump to 1. d4
+      await tester.tap(find.text('d4'));
+      await tester.pump();
+
+      // The variations bar should now display both d5 and Nf6
+      expect(find.byType(VariationsBar), findsOneWidget);
+
+      expect(
+        find.descendant(of: find.byType(VariationsBar), matching: find.text('d5')),
+        findsOneWidget,
+      );
+      expect(
+        find.descendant(of: find.byType(VariationsBar), matching: find.text('Nf6')),
+        findsOneWidget,
+      );
+
+      // Tap the 'Nf6' variation inside the VariationsBar widget
+      await tester.tap(find.descendant(of: find.byType(VariationsBar), matching: find.text('Nf6')));
+
+      await tester.pump();
+
+      // Verify the board advanced properly (a black knight is placed on f6)
+      expect(boardHasPiece(tester, Square.f6, Piece.blackKnight), isTrue);
     });
 
     testWidgets('PGN tags tab shows dash for empty FIDE ID', variant: kPlatformVariant, (

--- a/test/view/study/study_screen_test.dart
+++ b/test/view/study/study_screen_test.dart
@@ -16,6 +16,7 @@ import 'package:lichess_mobile/src/model/study/study_repository.dart';
 import 'package:lichess_mobile/src/model/user/user.dart';
 import 'package:lichess_mobile/src/view/study/study_screen.dart';
 import 'package:lichess_mobile/src/widgets/platform_context_menu_button.dart';
+import 'package:lichess_mobile/src/widgets/variations_bar.dart';
 import 'package:mocktail/mocktail.dart';
 
 import '../../test_helpers.dart';
@@ -292,6 +293,60 @@ void main() {
 
       expect(find.text('1. e4'), findsOneWidget);
       expect(find.text('e5'), findsOneWidget);
+    });
+    testWidgets('Variations bar displays variations and can be tapped', (
+      WidgetTester tester,
+    ) async {
+      final mockRepository = MockStudyRepository();
+
+      // Return a study that branches: 1. e4 : e5 and c5
+      when(
+        () => mockRepository.getStudy(id: testId),
+      ).thenAnswer((_) async => (makeStudy(), null, '1. e4 e5 (1... c5)'));
+
+      final app = await makeTestProviderScopeApp(
+        tester,
+        home: const StudyScreen(options: (id: testId, initialChapter: null)),
+        overrides: {
+          studyRepositoryProvider: studyRepositoryProvider.overrideWith((ref) => mockRepository),
+        },
+        defaultPreferences: {
+          PrefCategory.study.storageKey: jsonEncode(
+            StudyPrefs.defaults.copyWith(inlineNotation: true).toJson(),
+          ),
+          PrefCategory.engineEvaluation.storageKey: jsonEncode(
+            EngineEvaluationPrefState.defaults.copyWith(isEnabled: false).toJson(),
+          ),
+        },
+      );
+
+      await tester.pumpWidget(app);
+      await tester.pumpAndSettle();
+
+      // Jump to 1. e4
+      await tester.tap(find.textContaining('e4'));
+      await tester.pump();
+
+      // The variations bar should now display both e5 and c5
+      expect(find.byType(VariationsBar), findsOneWidget);
+
+      // Look for e5 and c5 specifically inside the VariationsBar
+      expect(
+        find.descendant(of: find.byType(VariationsBar), matching: find.text('e5')),
+        findsOneWidget,
+      );
+      expect(
+        find.descendant(of: find.byType(VariationsBar), matching: find.text('c5')),
+        findsOneWidget,
+      );
+
+      // Tap the 'c5' variation inside the VariationsBar widget
+      await tester.tap(find.descendant(of: find.byType(VariationsBar), matching: find.text('c5')));
+
+      await tester.pump();
+
+      // Verify a black pawn is placed on c5
+      expect(boardHasPiece(tester, Square.c5, Piece.blackPawn), isTrue);
     });
 
     testWidgets('Can flip the board', (tester) async {


### PR DESCRIPTION
closes #3069

Adds a variation bar to the game notation or broadcasts, analysis board and studies.
This is especially useful for analysis or studies with a lot of lines. 
Mirrors the web behavior, except that I put it under the notation, to make it easier to reach.
The mainline is highlighted and if the user simply presses next it will continue on the mainline.

I also added test cases.

Preview:

[Screencast_20260514_000551.webm](https://github.com/user-attachments/assets/edde0ed1-4663-4180-8c82-e37be214cd85)
