### PR TITLE
automatically expand the current children node

### DIFF
--- a/lib/src/model/analysis/analysis_controller.dart
+++ b/lib/src/model/analysis/analysis_controller.dart
@@ -484,16 +484,21 @@ class AnalysisController extends AsyncNotifier<AnalysisState>
     }
   }
 
-  void userPrevious() {
-    _setPath(state.requireValue.currentPath.penultimate, isNavigating: true);
+  void userPrevious({bool fastSeek = false}) {
+    _setPath(
+      state.requireValue.currentPath.penultimate,
+      isNavigating: true,
+      keepCollapsed: fastSeek,
+    );
   }
 
-  void userNext() {
+  void userNext({bool fastSeek = false}) {
     final curState = state.requireValue;
     if (!curState.currentNode.hasChild) return;
     _setPath(
       curState.currentPath + _root.nodeAt(curState.currentPath).children.first.id,
       isNavigating: true,
+      keepCollapsed: fastSeek,
     );
   }
 
@@ -681,6 +686,7 @@ class AnalysisController extends AsyncNotifier<AnalysisState>
 
     /// Whether the user is navigating through the moves (as opposed to playing a move).
     bool isNavigating = false,
+    bool keepCollapsed = false,
   }) {
     _currentPath = path;
     final curState = state.requireValue;
@@ -688,7 +694,7 @@ class AnalysisController extends AsyncNotifier<AnalysisState>
     final (currentNode, opening) = _nodeOpeningAt(_root, path);
 
     bool pathWasExpanded = false;
-    if (pathChange) {
+    if (pathChange && !keepCollapsed) {
       for (final child in currentNode.children) {
         if (child.isCollapsed) {
           child.isCollapsed = false;

--- a/lib/src/model/analysis/analysis_controller.dart
+++ b/lib/src/model/analysis/analysis_controller.dart
@@ -687,6 +687,16 @@ class AnalysisController extends AsyncNotifier<AnalysisState>
     final pathChange = curState.currentPath != path;
     final (currentNode, opening) = _nodeOpeningAt(_root, path);
 
+    bool pathWasExpanded = false;
+    if (pathChange) {
+      for (final child in currentNode.children) {
+        if (child.isCollapsed) {
+          child.isCollapsed = false;
+          pathWasExpanded = true;
+        }
+      }
+    }
+
     // always show variation if the user plays a move
     if (shouldForceShowVariation && currentNode is Branch && currentNode.isCollapsed) {
       _root.updateAt(path, (node) {
@@ -697,7 +707,7 @@ class AnalysisController extends AsyncNotifier<AnalysisState>
     // root view is only used to display move list, so we need to
     // recompute the root view only when the nodelist length changes
     // or a variation is hidden/shown
-    final rootView = shouldForceShowVariation || shouldRecomputeRootView
+    final rootView = shouldForceShowVariation || shouldRecomputeRootView || pathWasExpanded
         ? _root.view
         : curState.root;
 

--- a/lib/src/model/study/study_controller.dart
+++ b/lib/src/model/study/study_controller.dart
@@ -287,18 +287,23 @@ class StudyController extends AsyncNotifier<StudyState>
     onUserMove(state.requireValue.currentNode.children.first);
   }
 
-  void userPrevious() {
+  void userPrevious({bool fastSeek = false}) {
     if (state.hasValue) {
-      _setPath(state.requireValue.currentPath.penultimate, isNavigating: true);
+      _setPath(
+        state.requireValue.currentPath.penultimate,
+        isNavigating: true,
+        keepCollapsed: fastSeek,
+      );
     }
   }
 
-  void userNext() {
+  void userNext({bool fastSeek = false}) {
     final state = this.state.value;
     if (state!.currentNode.children.isEmpty) return;
     _setPath(
       state.currentPath + _root.nodeAt(state.currentPath).children.first.id,
       isNavigating: true,
+      keepCollapsed: fastSeek,
     );
   }
 
@@ -430,6 +435,7 @@ class StudyController extends AsyncNotifier<StudyState>
 
     /// Whether the user is navigating through the moves (as opposed to playing a move).
     bool isNavigating = false,
+    bool keepCollapsed = false,
   }) {
     final state = this.state.value;
     if (state == null) return;
@@ -438,7 +444,7 @@ class StudyController extends AsyncNotifier<StudyState>
     final currentNode = _root.nodeAt(path);
 
     bool pathWasExpanded = false;
-    if (pathChange) {
+    if (pathChange && !keepCollapsed) {
       for (final child in currentNode.children) {
         if (child.isCollapsed) {
           child.isCollapsed = false;

--- a/lib/src/model/study/study_controller.dart
+++ b/lib/src/model/study/study_controller.dart
@@ -437,6 +437,16 @@ class StudyController extends AsyncNotifier<StudyState>
     final pathChange = state.currentPath != path;
     final currentNode = _root.nodeAt(path);
 
+    bool pathWasExpanded = false;
+    if (pathChange) {
+      for (final child in currentNode.children) {
+        if (child.isCollapsed) {
+          child.isCollapsed = false;
+          pathWasExpanded = true;
+        }
+      }
+    }
+
     // always show variation if the user plays a move
     if (shouldForceShowVariation && currentNode is Branch && currentNode.isCollapsed) {
       _root.updateAt(path, (node) {
@@ -447,7 +457,9 @@ class StudyController extends AsyncNotifier<StudyState>
     // root view is only used to display move list, so we need to
     // recompute the root view only when the nodelist length changes
     // or a variation is hidden/shown
-    final rootView = shouldForceShowVariation || shouldRecomputeRootView ? _root.view : state.root;
+    final rootView = shouldForceShowVariation || shouldRecomputeRootView || pathWasExpanded
+        ? _root.view
+        : state.root;
 
     final isForward = path.size > state.currentPath.size;
     if (currentNode is Branch) {

--- a/lib/src/view/analysis/analysis_screen.dart
+++ b/lib/src/view/analysis/analysis_screen.dart
@@ -494,7 +494,7 @@ class _BottomBar extends ConsumerWidget {
             },
           ),
         RepeatButton(
-          onLongPress: analysisState.canGoBack ? () => _moveBackward(ref) : null,
+          onLongPress: analysisState.canGoBack ? () => _moveBackward(ref, fastSeek: true) : null,
           child: BottomBarButton(
             key: const ValueKey('goto-previous'),
             onTap: analysisState.canGoBack ? () => _moveBackward(ref) : null,
@@ -504,7 +504,7 @@ class _BottomBar extends ConsumerWidget {
           ),
         ),
         RepeatButton(
-          onLongPress: analysisState.canGoNext ? () => _moveForward(ref) : null,
+          onLongPress: analysisState.canGoNext ? () => _moveForward(ref, fastSeek: true) : null,
           child: BottomBarButton(
             key: const ValueKey('goto-next'),
             icon: CupertinoIcons.chevron_forward,
@@ -517,11 +517,11 @@ class _BottomBar extends ConsumerWidget {
     );
   }
 
-  void _moveForward(WidgetRef ref) =>
-      ref.read(analysisControllerProvider(options).notifier).userNext();
+  void _moveForward(WidgetRef ref, {bool fastSeek = false}) =>
+      ref.read(analysisControllerProvider(options).notifier).userNext(fastSeek: fastSeek);
 
-  void _moveBackward(WidgetRef ref) =>
-      ref.read(analysisControllerProvider(options).notifier).userPrevious();
+  void _moveBackward(WidgetRef ref, {bool fastSeek = false}) =>
+      ref.read(analysisControllerProvider(options).notifier).userPrevious(fastSeek: fastSeek);
 
   Future<void> _showAnalysisMenu(BuildContext context, WidgetRef ref) {
     final analysisState = ref.read(analysisControllerProvider(options)).requireValue;

--- a/lib/src/view/study/study_bottom_bar.dart
+++ b/lib/src/view/study/study_bottom_bar.dart
@@ -85,7 +85,10 @@ class _AnalysisBottomBar extends ConsumerWidget {
             },
           ),
         RepeatButton(
-          onLongPress: onGoBack,
+          onLongPress: state.canGoBack
+              ? () =>
+                    ref.read(studyControllerProvider(options).notifier).userPrevious(fastSeek: true)
+              : null,
           child: BottomBarButton(
             key: const ValueKey('goto-previous'),
             onTap: onGoBack,
@@ -96,7 +99,9 @@ class _AnalysisBottomBar extends ConsumerWidget {
           ),
         ),
         RepeatButton(
-          onLongPress: onGoForward,
+          onLongPress: state.canGoNext
+              ? () => ref.read(studyControllerProvider(options).notifier).userNext(fastSeek: true)
+              : null,
           child: BottomBarButton(
             key: const ValueKey('goto-next'),
             icon: CupertinoIcons.chevron_forward,


### PR DESCRIPTION
Automatically expand the children of the currentNode, closes #2494

The perf impact is negligible, as only the current children get looped.

[Screencast_20260514_173011.webm](https://github.com/user-attachments/assets/9438b0e2-687b-45cc-8b47-d6fedddef172)

I implemented for studies and analysis, I do not see a reason to do it for broadcasts.
