### PR TITLE
improve pgn loading speeds

### DIFF
--- a/lib/src/view/analysis/pgn_games_list_screen.dart
+++ b/lib/src/view/analysis/pgn_games_list_screen.dart
@@ -24,9 +24,9 @@ typedef _GameData = ({
 class PgnGamesListScreen extends StatefulWidget {
   const PgnGamesListScreen({required this.games, super.key});
 
-  final IList<PgnGame> games;
+  final IList<PgnLazyGame> games;
 
-  static Route<dynamic> buildRoute(IList<PgnGame> games) {
+  static Route<dynamic> buildRoute(IList<PgnLazyGame> games) {
     return buildScreenRoute(screen: PgnGamesListScreen(games: games));
   }
 
@@ -113,22 +113,22 @@ class _PgnGamesListScreenState extends State<PgnGamesListScreen> {
         separatorBuilder: (context, index) =>
             const Divider(height: 1, thickness: 1, indent: 16, endIndent: 16),
         itemBuilder: (context, index) {
-          final game = widget.games[filteredIndices[index]];
           final gameData = _gameData[filteredIndices[index]];
           return ListTile(
             title: Text(gameData.title, maxLines: 2, overflow: .ellipsis),
             subtitle: Text(gameData.subtitle, overflow: .ellipsis, maxLines: 1),
             onTap: () {
+              final game = widget.games[filteredIndices[index]];
               Navigator.of(context, rootNavigator: true).push(
                 AnalysisScreen.buildRoute(
                   AnalysisOptions.pgn(
                     // TODO generate unique id for each game, maybe based on the PGN headers?
                     id: const StringId('pgn_import_game'),
                     orientation: .white,
-                    pgn: game.makePgn(),
+                    pgn: game.rawPgn,
                     variant: gameData.variant,
                     isComputerAnalysisAllowed: true,
-                    initialMoveCursor: game.moves.mainline().isEmpty ? 0 : 1,
+                    initialMoveCursor: 1,
                   ),
                 ),
               );
@@ -148,7 +148,7 @@ bool _matchesSearchQuery(_GameData gameData, String query) {
       gameData.subtitle.toLowerCase().contains(lowerQuery);
 }
 
-String _buildGameSubtitle(PgnGame game) {
+String _buildGameSubtitle(PgnLazyGame game) {
   final event = game.headers['Event'];
   final round = game.headers['Round'];
   final site = game.headers['Site'];

--- a/lib/src/view/more/import_pgn_screen.dart
+++ b/lib/src/view/more/import_pgn_screen.dart
@@ -31,7 +31,7 @@ class ImportPgnScreen extends StatelessWidget {
 
   static void handlePgnText(BuildContext context, String text) {
     try {
-      final games = PgnGame.parseMultiGamePgn(text);
+      final games = PgnGame.parseMultiGameLazy(text);
 
       if (games.isEmpty) {
         showSnackBar(context, context.l10n.invalidPgn, type: .error);
@@ -49,7 +49,7 @@ class ImportPgnScreen extends StatelessWidget {
               orientation: .white,
               pgn: text,
               isComputerAnalysisAllowed: true,
-              initialMoveCursor: game.moves.mainline().isEmpty ? 0 : 1,
+              initialMoveCursor: 1,
               variant: rule != null ? Variant.fromRule(rule) : .standard,
             ),
           ),

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -310,10 +310,10 @@ packages:
     dependency: "direct main"
     description:
       name: dartchess
-      sha256: "0f2413624840484c1c316dbbbea7d777c83f7dccb8b8b00e5ca55c2058d2fa23"
+      sha256: d1750f765be1c81bbd529413e4bf4804dd9814a871cbce5f427cb4d1e7a3ae7a
       url: "https://pub.dev"
     source: hosted
-    version: "0.13.0"
+    version: "0.13.1"
   dbus:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -25,7 +25,7 @@ dependencies:
   crypto: ^3.0.7
   cupertino_http: ^2.4.0
   cupertino_icons: ^1.0.9
-  dartchess: ^0.13.0
+  dartchess: ^0.13.1
   deep_pick: ^1.1.0
   device_info_plus: ^13.1.0
   dynamic_system_colors:


### PR DESCRIPTION
Improves the loading speed of huge PGNs by a lot, as it only parses the header instead of creating whole tree.

Also the pgn game is not parsed to conditionally jump to the first move. Instead initialMoveCursor is set to 1. (if there are no moves there is already logic to not crash)

~~needs https://github.com/lichess-org/dartchess/pull/54~~