### PR TITLE
replace generic analysisboard header

### DIFF
--- a/lib/src/view/analysis/analysis_screen.dart
+++ b/lib/src/view/analysis/analysis_screen.dart
@@ -119,14 +119,19 @@ class _AnalysisScreenState extends ConsumerState<_AnalysisScreen>
 
     switch (asyncState) {
       case AsyncData(:final value):
+        Widget appBarTitle;
+        if (value.archivedGame != null) {
+          final title =
+              '${value.archivedGame!.data.clockDisplay(context.l10n)} • ${value.archivedGame!.meta.speed.label} • ${value.archivedGame!.meta.rated ? context.l10n.rated : context.l10n.casual}';
+          appBarTitle = VariantAppBarTitle(variant: value.variant, title: title);
+        } else {
+          appBarTitle = VariantAppBarTitle(variant: value.variant, title: context.l10n.analysis);
+        }
+
         return WakelockWidget(
           child: Scaffold(
             resizeToAvoidBottomInset: false,
-            appBar: AppBar(
-              centerTitle: false,
-              title: VariantAppBarTitle(variant: value.variant, title: context.l10n.analysis),
-              actions: appBarActions,
-            ),
+            appBar: AppBar(centerTitle: false, title: appBarTitle, actions: appBarActions),
             body: _Body(options: widget.options, controller: _tabController, tabs: tabs),
           ),
         );

--- a/test/view/game/game_screen_test.dart
+++ b/test/view/game/game_screen_test.dart
@@ -1484,7 +1484,7 @@ void main() {
       await tester.tap(find.text('Analysis board'));
       await tester.pumpAndSettle(); // wait for analysis screen to open
       expect(
-        find.widgetWithText(AppBar, 'Analysis board'),
+        find.descendant(of: find.byType(AppBar), matching: find.textContaining('Rated')),
         findsOneWidget,
       ); // analysis screen is now open
       expect(find.byType(Chessboard), findsOneWidget);


### PR DESCRIPTION
Replaces the generic "Analysis board" header to display the time control and if the game was rated. Previously this information wasn't visible in the analysis board.

<img width="521" height="1169" alt="image" src="https://github.com/user-attachments/assets/1013dbfc-cde5-4020-8d0b-621a9ef72458" />

<img width="522" height="1141" alt="image" src="https://github.com/user-attachments/assets/3c9335d6-a0d2-43fa-9fd0-066329c13f27" />




