### PR TITLE
Fix/add site pgn label to broadcasts pgn labels

### DIFF
--- a/lib/src/view/broadcast/broadcast_game_screen.dart
+++ b/lib/src/view/broadcast/broadcast_game_screen.dart
@@ -386,6 +386,7 @@ enum PgnTags {
   blackFideId('BlackFideId', isLink: true),
   timeControl('TimeControl', isLink: false),
   result('Result', isLink: false),
+  site('Site', isLink: false),
   event('Event', isLink: false),
   round('Round', isLink: false);
 


### PR DESCRIPTION
Bringing back the 'site' pgn label to the broadcasts pgn labels.