### PR TITLE
fix markdown line break for broadcast overview

### DIFF
--- a/lib/src/view/broadcast/broadcast_overview_tab.dart
+++ b/lib/src/view/broadcast/broadcast_overview_tab.dart
@@ -81,6 +81,7 @@ class BroadcastOverviewTab extends ConsumerWidget {
                   if (url == null) return;
                   launchUrl(Uri.https('lichess.org').resolve(url));
                 },
+                softLineBreak: true,
               ),
             ],
           ],


### PR DESCRIPTION
noticed while creating #3195 that in the broadcast overview tab, line breaks are not respected in the markdown:

| Before | After |
|--------|-------|
| <img width="639" height="1426" alt="image" src="https://github.com/user-attachments/assets/1dece8a6-f9df-4742-b515-a3d479bd7257" /> | <img width="643" height="1428" alt="image" src="https://github.com/user-attachments/assets/f7b02b35-e4ed-4b86-981c-d4a2a135b864" /> |
