### PR TITLE
fix: prevent eval string wrapping on tablet via FittedBox

### DIFF
--- a/lib/src/view/engine/engine_gauge.dart
+++ b/lib/src/view/engine/engine_gauge.dart
@@ -169,7 +169,12 @@ class _EvalGaugeState extends State<_EvalGauge> {
                           padding: const EdgeInsets.symmetric(horizontal: 1.0, vertical: 3.0),
                           child: Column(
                             mainAxisSize: MainAxisSize.min,
-                            children: [Text(evalDisplay, style: evalStyle)],
+                            children: [
+                              FittedBox(
+                                fit: BoxFit.scaleDown,
+                                child: Text(evalDisplay, style: evalStyle),
+                              ),
+                            ],
                           ),
                         ),
                       )


### PR DESCRIPTION
## Summary of changes

Wrap the eval display `Text` widget in a `FittedBox` with `BoxFit.scaleDown` to auto-size the text and prevent wrapping on tablet devices.

## Root cause / what was fixed

On tablet devices, the eval gauge width (24px) is too narrow for the eval string rendered at 11px font size, causing text to wrap. This was reported in issue #2694 where the eval string wraps within the gauge bar on iPad.

The fix applies the maintainer's suggestion to use auto-size text by wrapping the `Text(evalDisplay, style: evalStyle)` in a `FittedBox(fit: BoxFit.scaleDown, child: ...)`. This ensures the text automatically scales down to fit within the available width without breaking to multiple lines.

## Testing done

- Verified the Flutter analyzer passes: `flutter analyze lib/src/view/engine/engine_gauge.dart`
- The `FittedBox` widget is a standard Flutter widget available in all Flutter versions
- The `BoxFit.scaleDown` fit ensures text only shrinks when needed (never grows beyond original size)
- No behavior change on phones where text already fits — `scaleDown` only activates when content overflows

## Screenshots

N/A — visual change on tablet devices only. The eval string will now scale down to fit rather than wrapping.

Closes #2694