### PR TITLE
Deeplink support for player stats in tournament

### DIFF
--- a/lib/src/app_links_service.dart
+++ b/lib/src/app_links_service.dart
@@ -157,7 +157,9 @@ class AppLinksService {
         }
       case 'tournament':
         final tournamentId = TournamentId(appLinkUri.pathSegments[1]);
-        return [TournamentScreen.buildRoute(tournamentId)];
+        final playerName = appLinkUri.queryParameters['player'];
+        final playerId = playerName != null ? UserId.fromUserName(playerName) : null;
+        return [TournamentScreen.buildRoute(tournamentId, initialPlayerId: playerId)];
       case 'training':
         final id = appLinkUri.pathSegments[1];
         return [PuzzleScreen.buildRoute(angle: PuzzleAngle.fromKey('mix'), puzzleId: PuzzleId(id))];

--- a/lib/src/view/tournament/tournament_screen.dart
+++ b/lib/src/view/tournament/tournament_screen.dart
@@ -50,15 +50,16 @@ import 'package:path_provider/path_provider.dart' show getTemporaryDirectory;
 import 'package:share_plus/share_plus.dart';
 
 class TournamentScreen extends ConsumerStatefulWidget {
-  const TournamentScreen({required this.id});
+  const TournamentScreen({required this.id, this.initialPlayerId});
 
   final TournamentId id;
+  final UserId? initialPlayerId;
 
   static const String routeName = '/tournament';
 
-  static Route<void> buildRoute(TournamentId id) {
+  static Route<void> buildRoute(TournamentId id, {UserId? initialPlayerId}) {
     return buildScreenRoute(
-      screen: TournamentScreen(id: id),
+      screen: TournamentScreen(id: id, initialPlayerId: initialPlayerId),
       settings: const RouteSettings(name: routeName),
     );
   }
@@ -68,6 +69,18 @@ class TournamentScreen extends ConsumerStatefulWidget {
 }
 
 class _TournamentScreenState extends ConsumerState<TournamentScreen> with RouteAware {
+  @override
+  void initState() {
+    super.initState();
+    if (widget.initialPlayerId != null) {
+      WidgetsBinding.instance.addPostFrameCallback((_) {
+        if (mounted) {
+          _showPlayerDetails(context, widget.id, widget.initialPlayerId!);
+        }
+      });
+    }
+  }
+
   @override
   void didChangeDependencies() {
     super.didChangeDependencies();

--- a/test/app_links_service_test.dart
+++ b/test/app_links_service_test.dart
@@ -294,7 +294,23 @@ void main() {
       await tester.pumpAndSettle(); // Wait tournament screen to load
       expect(
         tester.widget(find.byType(TournamentScreen)),
-        isA<TournamentScreen>().having((s) => s.id, 'id', '61044'),
+        isA<TournamentScreen>()
+            .having((s) => s.id, 'id', '61044')
+            .having((s) => s.initialPlayerId, 'initialPlayerId', isNull),
+      );
+    });
+
+    testWidgets('resolves /tournament/{id}?player={name} to TournamentScreen with initialPlayerId', (
+      WidgetTester tester,
+    ) async {
+      final uri = Uri.parse('https://lichess.org/tournament/spring26?player=realcyberbird');
+      await triggerAppLink(tester, uri);
+      await tester.pumpAndSettle();
+      expect(
+        tester.widget(find.byType(TournamentScreen)),
+        isA<TournamentScreen>()
+            .having((s) => s.id, 'id', 'spring26')
+            .having((s) => s.initialPlayerId, 'initialPlayerId', const UserId('realcyberbird')),
       );
     });
 

--- a/test/app_links_service_test.dart
+++ b/test/app_links_service_test.dart
@@ -300,19 +300,20 @@ void main() {
       );
     });
 
-    testWidgets('resolves /tournament/{id}?player={name} to TournamentScreen with initialPlayerId', (
-      WidgetTester tester,
-    ) async {
-      final uri = Uri.parse('https://lichess.org/tournament/spring26?player=realcyberbird');
-      await triggerAppLink(tester, uri);
-      await tester.pumpAndSettle();
-      expect(
-        tester.widget(find.byType(TournamentScreen)),
-        isA<TournamentScreen>()
-            .having((s) => s.id, 'id', 'spring26')
-            .having((s) => s.initialPlayerId, 'initialPlayerId', const UserId('realcyberbird')),
-      );
-    });
+    testWidgets(
+      'resolves /tournament/{id}?player={name} to TournamentScreen with initialPlayerId',
+      (WidgetTester tester) async {
+        final uri = Uri.parse('https://lichess.org/tournament/spring26?player=realcyberbird');
+        await triggerAppLink(tester, uri);
+        await tester.pumpAndSettle();
+        expect(
+          tester.widget(find.byType(TournamentScreen)),
+          isA<TournamentScreen>()
+              .having((s) => s.id, 'id', 'spring26')
+              .having((s) => s.initialPlayerId, 'initialPlayerId', const UserId('realcyberbird')),
+        );
+      },
+    );
 
     testWidgets('resolves /broadcast/.../{roundId}#players to players tab', (
       WidgetTester tester,


### PR DESCRIPTION
### **Summary**


- Extend tournament deeplinks to support an optional ?player=<username> query parameter (e.g. https://lichess.org/tournament/spring26?player=realcyberbird)
- When the parameter is present, the tournament screen opens and immediately shows the player details bottom sheet for that user
- No behavior change for plain tournament links without the player param

[https://github.com/lichess-org/mobile/issues/3204](https://github.com/lichess-org/mobile/issues/3204)


https://github.com/user-attachments/assets/0da91fe3-3ab0-4559-948b-69e076674538
