### PR TITLE
fix: handle drop moves in crazyhouse TV

### DIFF
--- a/lib/src/model/tv/tv_controller.dart
+++ b/lib/src/model/tv/tv_controller.dart
@@ -214,7 +214,7 @@ class TvController extends AsyncNotifier<TvState> {
         }
       case 'rematchTaken':
         _onReload?.call();
-      case 'move':
+      case 'move' || 'drop':
         final curState = state.requireValue;
         final data = MoveEvent.fromJson(event.data as Map<String, dynamic>);
         final lastPos = curState.game.lastPosition;


### PR DESCRIPTION
can't test right now because `flutter upgrade` broke my Android build, but it's the exact same fix as https://github.com/lichess-org/mobile/commit/9919aea406#diff-ce2bf5ada85564dfe3cfec40a8970fa0f0d6bc1e5fc4ec27bcc821533ae770ebR650 so I don't see a reason why it shouldn't work.