### PR TITLE
feat: navigate to user profile on spectator name tap

### DIFF
--- a/lib/src/view/game/watcher_list_bottom_sheet.dart
+++ b/lib/src/view/game/watcher_list_bottom_sheet.dart
@@ -1,5 +1,8 @@
 import 'package:fast_immutable_collections/fast_immutable_collections.dart';
 import 'package:flutter/material.dart';
+import 'package:lichess_mobile/src/model/common/id.dart';
+import 'package:lichess_mobile/src/model/user/user.dart';
+import 'package:lichess_mobile/src/view/user/user_or_profile_screen.dart';
 
 class WatcherListBottomSheet extends StatelessWidget {
   const WatcherListBottomSheet({required this.nbWatchers, required this.watcherNames, super.key});
@@ -63,6 +66,19 @@ class WatcherListBottomSheet extends StatelessWidget {
                   dense: true,
                   leading: const Icon(Icons.person_outline, size: 20),
                   title: Text(shownNames[index]),
+                  onTap: () {
+                    debugPrint('Tapped on: ${shownNames[index]}');
+                    Navigator.of(context, rootNavigator: true).pop();
+                    Navigator.of(context, rootNavigator: true).push(
+                      UserOrProfileScreen.buildRoute(
+                        context,
+                        LightUser(
+                          id: UserId(shownNames[index].toLowerCase()),
+                          name: shownNames[index],
+                        ),
+                      ),
+                    );
+                  },
                 );
               },
             ),

--- a/lib/src/view/game/watcher_list_bottom_sheet.dart
+++ b/lib/src/view/game/watcher_list_bottom_sheet.dart
@@ -67,11 +67,9 @@ class WatcherListBottomSheet extends StatelessWidget {
                   leading: const Icon(Icons.person_outline, size: 20),
                   title: Text(shownNames[index]),
                   onTap: () {
-                    debugPrint('Tapped on: ${shownNames[index]}');
                     Navigator.of(context, rootNavigator: true).pop();
                     Navigator.of(context, rootNavigator: true).push(
                       UserOrProfileScreen.buildRoute(
-                        context,
                         LightUser(
                           id: UserId(shownNames[index].toLowerCase()),
                           name: shownNames[index],


### PR DESCRIPTION
Tapping a spectator name in the watcher list bottom sheet now navigates to their profile using UserOrProfileScreen, consistent with how the rest of the app handles profile navigation.

Closes #3140

here is a screen recording to show how it works:

https://github.com/user-attachments/assets/a68d8079-86bc-45e9-a3d8-d40499ae3e75

