### PR TITLE
fix showTenths in duration.dart

### DIFF
--- a/lib/src/utils/duration.dart
+++ b/lib/src/utils/duration.dart
@@ -1,13 +1,13 @@
 import 'package:lichess_mobile/l10n/l10n.dart';
 
 extension DurationExtensions on Duration {
-  /// Returns a string representation of this duration, like H:MM:SS.mm.
+  /// Returns a string representation of this duration, like H:MM:SS.m
   ///
   /// If [showTenths] is `true` and the duration is less than one hour, the
-  /// representation is H:MM:SS.mm, otherwise it is H:MM:SS.
+  /// representation is H:MM:SS.m, otherwise it is H:MM:SS.
   String toHoursMinutesSeconds({bool showTenths = false}) {
     if (inHours == 0) {
-      return '${inMinutes.remainder(60).toString().padLeft(2, '0')}:${inSeconds.remainder(60).toString().padLeft(2, '0')}${showTenths ? '.${inMilliseconds.remainder(1000) ~/ 10 % 10}' : ''}';
+      return '${inMinutes.remainder(60).toString().padLeft(2, '0')}:${inSeconds.remainder(60).toString().padLeft(2, '0')}${showTenths ? '.${inMilliseconds.remainder(1000) ~/ 100}' : ''}';
     } else {
       return '$inHours:${inMinutes.remainder(60).toString().padLeft(2, '0')}:${inSeconds.remainder(60).toString().padLeft(2, '0')}';
     }

--- a/test/utils/duration_test.dart
+++ b/test/utils/duration_test.dart
@@ -63,6 +63,30 @@ void main() {
       testTimeStr(mockAppLocalizations, 0, 0, 0, '0 minutes');
     });
   });
+  group('DurationExtensions.toHoursMinutesSeconds()', () {
+    test('formats without tenths correctly', () {
+      const d = Duration(minutes: 5, seconds: 30, milliseconds: 600);
+      expect(d.toHoursMinutesSeconds(showTenths: false), '05:30');
+    });
+
+    test('formats with tenths correctly under an hour', () {
+      const d = Duration(minutes: 5, seconds: 30, milliseconds: 600);
+      expect(d.toHoursMinutesSeconds(showTenths: true), '05:30.6');
+    });
+
+    test('correct tenth truncation', () {
+      const d = Duration(seconds: 120, milliseconds: 30);
+      expect(d.toHoursMinutesSeconds(showTenths: true), '02:00.0');
+
+      const d2 = Duration(seconds: 120, milliseconds: 880);
+      expect(d2.toHoursMinutesSeconds(showTenths: true), '02:00.8');
+    });
+
+    test('does not show tenths for durations over an hour even if showTenths is true', () {
+      const d = Duration(hours: 1, minutes: 5, seconds: 30, milliseconds: 600);
+      expect(d.toHoursMinutesSeconds(showTenths: true), '1:05:30');
+    });
+  });
 }
 
 void testTimeStr(


### PR DESCRIPTION
We displayed the hundreds of the second not the tenths currently, this PR fixes this and introduces tests.