### PR TITLE
ci(crowdin-pull): guard crowdin pull jobs by repository owner

### DIFF
--- a/.github/workflows/crowdin-pull.yml
+++ b/.github/workflows/crowdin-pull.yml
@@ -11,6 +11,7 @@ permissions:
 
 jobs:
   crowdin-pull-mobile:
+    if: github.repository_owner == 'lichess-org'
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
@@ -37,6 +38,7 @@ jobs:
           CROWDIN_PERSONAL_TOKEN: ${{ secrets.CROWDIN_PERSONAL_TOKEN }}
 
   crowdin-pull-lila:
+    if: github.repository_owner == 'lichess-org'
     runs-on: ubuntu-latest
     steps:
       - name: Checkout


### PR DESCRIPTION
CI is also launching on forks via the schedule.

The only approach I’ve found is to add an if statement to the job.

https://github.com/orgs/community/discussions/26409#discussioncomment-3251822