### PR TITLE
Fix: broadcasts result showing "½" when points scored was 0

### DIFF
--- a/lib/src/view/broadcast/broadcast_player_results_screen.dart
+++ b/lib/src/view/broadcast/broadcast_player_results_screen.dart
@@ -558,7 +558,7 @@ class _GameResultListTile extends StatelessWidget {
                     mainAxisSize: .min,
                     children: [
                       Text(
-                        customPoints != null && customPoints != 0.0 && customPoints != points?.value
+                        customPoints != null && customPoints != points?.value
                             ? NumberFormat('0.##').format(customPoints)
                             : points?.resultFor(color).resultToString(color) ??
                                   (ongoing ? '*' : ''),

--- a/test/view/broadcast/broadcast_player_results_screen_test.dart
+++ b/test/view/broadcast/broadcast_player_results_screen_test.dart
@@ -151,7 +151,7 @@ void main() {
         tester,
       ) async {
         await pumpPlayerResultsScreen(tester, points: '1/2', customPoints: 0.0);
-        expectGameTileShows('½');
+        expectGameTileShows('0');
       });
     });
 


### PR DESCRIPTION
For context: https://github.com/lichess-org/mobile/pull/2943#issuecomment-4554151067