### PR TITLE
Fix: Broadcast games screen result display when points scored is 0.5 and not a draw

### DIFF
--- a/lib/src/model/broadcast/broadcast.dart
+++ b/lib/src/model/broadcast/broadcast.dart
@@ -149,9 +149,7 @@ extension BroadcastCustomScoringExt on BroadcastCustomScoring {
                 _ => 0.0,
               }) ??
         0.0;
-    return customScore == 0.5
-        ? result.resultToString(side) // '½' looks nicer than '0.5'
-        : NumberFormat('0.##').format(customScore);
+    return customScore == 0.5 ? '½' : NumberFormat('0.##').format(customScore);
   }
 }
 

--- a/lib/src/model/broadcast/broadcast.dart
+++ b/lib/src/model/broadcast/broadcast.dart
@@ -136,19 +136,17 @@ typedef BroadcastCustomScoring = IMap<Side, BroadcastCustomPointsPerColor>;
 
 extension BroadcastCustomScoringExt on BroadcastCustomScoring {
   String pointsForResult(Side side, BroadcastResult result) {
-    final customScore =
-        (side == Side.white
-            ? switch (result) {
-                BroadcastResult.whiteWins => this[side]?.win,
-                BroadcastResult.draw || BroadcastResult.whiteHalfWins => this[side]?.draw,
-                _ => 0.0,
-              }
-            : switch (result) {
-                BroadcastResult.blackWins => this[side]?.win,
-                BroadcastResult.draw || BroadcastResult.blackHalfWins => this[side]?.draw,
-                _ => 0.0,
-              }) ??
-        0.0;
+    final customScore = (side == Side.white
+        ? switch (result) {
+            BroadcastResult.whiteWins => this[side]?.win,
+            BroadcastResult.draw || BroadcastResult.whiteHalfWins => this[side]?.draw,
+            _ => 0.0,
+          }
+        : switch (result) {
+            BroadcastResult.blackWins => this[side]?.win,
+            BroadcastResult.draw || BroadcastResult.blackHalfWins => this[side]?.draw,
+            _ => 0.0,
+          });
     return customScore == 0.5 ? '½' : NumberFormat('0.##').format(customScore);
   }
 }


### PR DESCRIPTION
|Before|After|
|---|---|
|<img width="611" height="684" alt="Simulator Screenshot - iPhone 17 - 2026-05-28 at 17 37 56" src="https://github.com/user-attachments/assets/a7d1e045-550e-4850-9259-c73994367138" />|<img width="605" height="667" alt="Simulator Screenshot - iPhone 17 - 2026-05-28 at 17 39 53" src="https://github.com/user-attachments/assets/43e01d05-9755-4de4-a47b-b2537186bcac" />|
