### PR TITLE
Fix last move highlights in offline games

### DIFF
--- a/lib/src/view/correspondence/offline_correspondence_game_screen.dart
+++ b/lib/src/view/correspondence/offline_correspondence_game_screen.dart
@@ -193,7 +193,6 @@ class _BodyState extends ConsumerState<_Body> {
                 youAre: youAre!,
                 isBoardTurned: isBoardTurned,
               ),
-              lastMove: game.moveAt(stepCursor),
               explosionSquares: stepCursor > 0
                   ? atomicExplosionSquares(game.positionAt(stepCursor - 1), game.moveAt(stepCursor))
                   : null,
@@ -205,6 +204,7 @@ class _BodyState extends ConsumerState<_Body> {
                           ? PlayerSide.white
                           : PlayerSide.black
                     : PlayerSide.none,
+                lastMove: game.moveAt(stepCursor),
                 onMove: (move, {viaDragAndDrop}) {
                   onUserMove(move);
                 },

--- a/lib/src/view/offline_computer/offline_computer_game_screen.dart
+++ b/lib/src/view/offline_computer/offline_computer_game_screen.dart
@@ -253,7 +253,6 @@ class _BodyState extends ConsumerState<_Body> {
                       youAre: orientation,
                       isBoardTurned: isBoardFlipped,
                     ),
-                    lastMove: gameState.lastMove,
                     explosionSquares: gameState.stepCursor > 0
                         ? atomicExplosionSquares(
                             gameState.game.stepAt(gameState.stepCursor - 1).position,
@@ -270,6 +269,7 @@ class _BodyState extends ConsumerState<_Body> {
                           : isPlayerTurn && !gameState.isEvaluatingMove
                           ? (orientation == Side.white ? PlayerSide.white : PlayerSide.black)
                           : PlayerSide.none,
+                      lastMove: gameState.lastMove,
                       onMove: (move, {viaDragAndDrop}) {
                         ref.read(offlineComputerGameControllerProvider.notifier).makeMove(move);
                       },

--- a/lib/src/view/over_the_board/over_the_board_screen.dart
+++ b/lib/src/view/over_the_board/over_the_board_screen.dart
@@ -250,7 +250,6 @@ class _BodyState extends ConsumerState<_Body> {
                     bottomTableUpsideDown:
                         overTheBoardPrefs.flipPiecesAfterMove && orientation != gameState.turn,
                     orientation: orientation,
-                    lastMove: gameState.lastMove,
                     explosionSquares: gameState.stepCursor > 0
                         ? atomicExplosionSquares(
                             gameState.game.stepAt(gameState.stepCursor - 1).position,
@@ -265,6 +264,7 @@ class _BodyState extends ConsumerState<_Body> {
                           : gameState.turn == Side.white
                           ? PlayerSide.white
                           : PlayerSide.black,
+                      lastMove: gameState.lastMove,
                       onMove: (move, {viaDragAndDrop}) {
                         ref.read(overTheBoardGameControllerProvider.notifier).makeMove(move);
                         ref


### PR DESCRIPTION
## Summary

Fixes missing last move highlights/animations in offline interactive game screens.

After the recent `GameLayout` controller refactor, interactive boards now read the last move from `GameBoardParams.interactive.lastMove`, while `GameLayout.lastMove` is only used for readonly boards. Some offline interactive screens were still passing `lastMove` to `GameLayout`, so the board controller never received it.

Updated:
- offline computer games
- over-the-board games
- offline correspondence games