### PR TITLE
Localize chess mode labels

### DIFF
--- a/lib/src/model/common/perf.dart
+++ b/lib/src/model/common/perf.dart
@@ -1,6 +1,7 @@
 import 'package:deep_pick/deep_pick.dart';
 import 'package:fast_immutable_collections/fast_immutable_collections.dart';
 import 'package:flutter/widgets.dart';
+import 'package:lichess_mobile/l10n/l10n.dart';
 import 'package:lichess_mobile/src/model/common/chess.dart';
 import 'package:lichess_mobile/src/model/common/speed.dart';
 import 'package:lichess_mobile/src/styles/lichess_icons.dart';
@@ -31,6 +32,50 @@ enum Perf {
   final String title;
   final String shortTitle;
   final IconData icon;
+
+  String label(AppLocalizations l10n) {
+    switch (this) {
+      case Perf.ultraBullet:
+        return l10n.ultraBullet;
+      case Perf.bullet:
+        return l10n.bullet;
+      case Perf.blitz:
+        return l10n.blitz;
+      case Perf.rapid:
+        return l10n.rapid;
+      case Perf.classical:
+        return l10n.classical;
+      case Perf.correspondence:
+        return l10n.correspondence;
+      case Perf.fromPosition:
+        return l10n.variantFromPosition;
+      case Perf.chess960:
+        return l10n.variantChess960;
+      case Perf.antichess:
+        return l10n.variantAntichess;
+      case Perf.kingOfTheHill:
+        return l10n.variantKingOfTheHill;
+      case Perf.threeCheck:
+        return l10n.variantThreeCheck;
+      case Perf.atomic:
+        return l10n.variantAtomic;
+      case Perf.horde:
+        return l10n.variantHorde;
+      case Perf.racingKings:
+        return l10n.variantRacingKings;
+      case Perf.crazyhouse:
+        return l10n.variantCrazyhouse;
+      case Perf.puzzle:
+        return l10n.puzzles;
+      case Perf.storm:
+      case Perf.streak:
+        return title;
+    }
+  }
+
+  String shortLabel(AppLocalizations l10n) {
+    return l10n.localeName.startsWith('en') ? shortTitle : label(l10n);
+  }
 
   factory Perf.fromVariantAndSpeed(Variant variant, Speed speed) {
     switch (variant) {

--- a/lib/src/model/common/perf.dart
+++ b/lib/src/model/common/perf.dart
@@ -74,7 +74,7 @@ enum Perf {
   }
 
   String shortLabel(AppLocalizations l10n) {
-    return l10n.localeName.startsWith('en') ? shortTitle : label(l10n);
+    return shortTitle;
   }
 
   factory Perf.fromVariantAndSpeed(Variant variant, Speed speed) {

--- a/lib/src/model/game/game.dart
+++ b/lib/src/model/game/game.dart
@@ -75,7 +75,7 @@ abstract mixin class BaseGame {
   Position get lastPosition;
 
   String shareTitle(AppLocalizations l10n) =>
-      '${meta.perf.title} • ${l10n.resVsX(white.fullName(l10n), black.fullName(l10n))}';
+      '${meta.perf.label(l10n)} • ${l10n.resVsX(white.fullName(l10n), black.fullName(l10n))}';
 
   /// Returns the side of the player with the given id, or null if the player is not in the game.
   Side? playerSideOf(UserId id) {

--- a/lib/src/model/game/game_filter.dart
+++ b/lib/src/model/game/game_filter.dart
@@ -45,7 +45,7 @@ sealed class GameFilterState with _$GameFilterState {
     final labels = fields
         .map(
           (field) => field is ISet<Perf>
-              ? field.map((e) => e.shortTitle).join(', ')
+              ? field.map((e) => e.shortLabel(l10n)).join(', ')
               : (field as Side?) != null
               ? field == Side.white
                     ? l10n.white
@@ -54,7 +54,7 @@ sealed class GameFilterState with _$GameFilterState {
         )
         .where((label) => label != null && label.isNotEmpty)
         .toList();
-    return labels.isEmpty ? 'All' : labels.join(', ');
+    return labels.isEmpty ? l10n.mobileAllGames : labels.join(', ');
   }
 
   int get count {

--- a/lib/src/model/tv/tv_channel.dart
+++ b/lib/src/model/tv/tv_channel.dart
@@ -1,6 +1,7 @@
 import 'package:deep_pick/deep_pick.dart';
 import 'package:fast_immutable_collections/fast_immutable_collections.dart';
 import 'package:flutter/widgets.dart';
+import 'package:lichess_mobile/l10n/l10n.dart';
 import 'package:lichess_mobile/src/styles/lichess_icons.dart';
 
 enum TvChannel {
@@ -25,6 +26,43 @@ enum TvChannel {
 
   final String label;
   final IconData icon;
+
+  String localizedLabel(AppLocalizations l10n) {
+    switch (this) {
+      case TvChannel.best:
+        return l10n.topGames;
+      case TvChannel.bullet:
+        return l10n.bullet;
+      case TvChannel.blitz:
+        return l10n.blitz;
+      case TvChannel.rapid:
+        return l10n.rapid;
+      case TvChannel.classical:
+        return l10n.classical;
+      case TvChannel.chess960:
+        return l10n.variantChess960;
+      case TvChannel.kingOfTheHill:
+        return l10n.variantKingOfTheHill;
+      case TvChannel.threeCheck:
+        return l10n.variantThreeCheck;
+      case TvChannel.antichess:
+        return l10n.variantAntichess;
+      case TvChannel.atomic:
+        return l10n.variantAtomic;
+      case TvChannel.horde:
+        return l10n.variantHorde;
+      case TvChannel.racingKings:
+        return l10n.variantRacingKings;
+      case TvChannel.crazyhouse:
+        return l10n.variantCrazyhouse;
+      case TvChannel.ultraBullet:
+        return l10n.ultraBullet;
+      case TvChannel.bot:
+        return l10n.onlineBots;
+      case TvChannel.computer:
+        return l10n.computer;
+    }
+  }
 
   static final IMap<String, TvChannel> nameMap = IMap(TvChannel.values.asNameMap());
 }

--- a/lib/src/model/tv/tv_channel.dart
+++ b/lib/src/model/tv/tv_channel.dart
@@ -5,29 +5,28 @@ import 'package:lichess_mobile/l10n/l10n.dart';
 import 'package:lichess_mobile/src/styles/lichess_icons.dart';
 
 enum TvChannel {
-  best('Top Rated', LichessIcons.crown),
-  bullet('Bullet', LichessIcons.bullet),
-  blitz('Blitz', LichessIcons.blitz),
-  rapid('Rapid', LichessIcons.rapid),
-  classical('Classical', LichessIcons.classical),
-  chess960('Chess960', LichessIcons.die_six),
-  kingOfTheHill('King of the Hill', LichessIcons.flag),
-  threeCheck('Three Check', LichessIcons.three_check),
-  antichess('Antichess', LichessIcons.antichess),
-  atomic('Atomic', LichessIcons.atom),
-  horde('Horde', LichessIcons.horde),
-  racingKings('Racing Kings', LichessIcons.racing_kings),
-  crazyhouse('Crazyhouse', LichessIcons.h_square),
-  ultraBullet('UltraBullet', LichessIcons.ultrabullet),
-  bot('Bot', LichessIcons.cogs),
-  computer('Computer', LichessIcons.cogs);
+  best(LichessIcons.crown),
+  bullet(LichessIcons.bullet),
+  blitz(LichessIcons.blitz),
+  rapid(LichessIcons.rapid),
+  classical(LichessIcons.classical),
+  chess960(LichessIcons.die_six),
+  kingOfTheHill(LichessIcons.flag),
+  threeCheck(LichessIcons.three_check),
+  antichess(LichessIcons.antichess),
+  atomic(LichessIcons.atom),
+  horde(LichessIcons.horde),
+  racingKings(LichessIcons.racing_kings),
+  crazyhouse(LichessIcons.h_square),
+  ultraBullet(LichessIcons.ultrabullet),
+  bot(LichessIcons.cogs),
+  computer(LichessIcons.cogs);
 
-  const TvChannel(this.label, this.icon);
+  const TvChannel(this.icon);
 
-  final String label;
   final IconData icon;
 
-  String localizedLabel(AppLocalizations l10n) {
+  String label(AppLocalizations l10n) {
     switch (this) {
       case TvChannel.best:
         return l10n.topGames;

--- a/lib/src/quick_actions.dart
+++ b/lib/src/quick_actions.dart
@@ -87,7 +87,7 @@ class QuickActionService {
         final variant = (seek.variant == Variant.standard)
             ? ''
             : (seek.variant != null && seek.timeIncrement != null)
-            ? ' • ${Perf.fromVariantAndSpeed(seek.variant!, Speed.fromTimeIncrement(seek.timeIncrement!)).shortTitle}'
+            ? ' • ${Perf.fromVariantAndSpeed(seek.variant!, Speed.fromTimeIncrement(seek.timeIncrement!)).shortLabel(l10n)}'
             : '';
 
         return ShortcutItem(

--- a/lib/src/view/explorer/opening_explorer_settings.dart
+++ b/lib/src/view/explorer/opening_explorer_settings.dart
@@ -2,8 +2,6 @@ import 'package:dartchess/dartchess.dart';
 import 'package:flutter/gestures.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
-import 'package:lichess_mobile/src/model/common/chess.dart';
-import 'package:lichess_mobile/src/model/common/perf.dart';
 import 'package:lichess_mobile/src/model/explorer/opening_explorer.dart';
 import 'package:lichess_mobile/src/model/explorer/opening_explorer_preferences.dart';
 import 'package:lichess_mobile/src/utils/l10n_context.dart';
@@ -49,7 +47,7 @@ class OpeningExplorerSettings extends ConsumerWidget {
                     String.fromCharCode(speed.icon.codePoint),
                     style: TextStyle(fontFamily: speed.icon.fontFamily, fontSize: 18.0),
                   ),
-                  tooltip: Perf.fromVariantAndSpeed(Variant.standard, speed).title,
+                  tooltip: speed.label(context.l10n),
                   selected: prefs.lichessDb.speeds.contains(speed),
                   onSelected: (_) => ref
                       .read(openingExplorerPreferencesProvider.notifier)
@@ -159,7 +157,7 @@ class OpeningExplorerSettings extends ConsumerWidget {
                     String.fromCharCode(speed.icon.codePoint),
                     style: TextStyle(fontFamily: speed.icon.fontFamily, fontSize: 18.0),
                   ),
-                  tooltip: Perf.fromVariantAndSpeed(Variant.standard, speed).title,
+                  tooltip: speed.label(context.l10n),
                   selected: prefs.playerDb.speeds.contains(speed),
                   onSelected: (_) => ref
                       .read(openingExplorerPreferencesProvider.notifier)

--- a/lib/src/view/explorer/opening_explorer_settings.dart
+++ b/lib/src/view/explorer/opening_explorer_settings.dart
@@ -2,6 +2,8 @@ import 'package:dartchess/dartchess.dart';
 import 'package:flutter/gestures.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:lichess_mobile/src/model/common/chess.dart';
+import 'package:lichess_mobile/src/model/common/perf.dart';
 import 'package:lichess_mobile/src/model/explorer/opening_explorer.dart';
 import 'package:lichess_mobile/src/model/explorer/opening_explorer_preferences.dart';
 import 'package:lichess_mobile/src/utils/l10n_context.dart';
@@ -47,7 +49,7 @@ class OpeningExplorerSettings extends ConsumerWidget {
                     String.fromCharCode(speed.icon.codePoint),
                     style: TextStyle(fontFamily: speed.icon.fontFamily, fontSize: 18.0),
                   ),
-                  tooltip: speed.label(context.l10n),
+                  tooltip: Perf.fromVariantAndSpeed(Variant.standard, speed).label(context.l10n),
                   selected: prefs.lichessDb.speeds.contains(speed),
                   onSelected: (_) => ref
                       .read(openingExplorerPreferencesProvider.notifier)
@@ -157,7 +159,7 @@ class OpeningExplorerSettings extends ConsumerWidget {
                     String.fromCharCode(speed.icon.codePoint),
                     style: TextStyle(fontFamily: speed.icon.fontFamily, fontSize: 18.0),
                   ),
-                  tooltip: speed.label(context.l10n),
+                  tooltip: Perf.fromVariantAndSpeed(Variant.standard, speed).label(context.l10n),
                   selected: prefs.playerDb.speeds.contains(speed),
                   onSelected: (_) => ref
                       .read(openingExplorerPreferencesProvider.notifier)

--- a/lib/src/view/game/game_screen.dart
+++ b/lib/src/view/game/game_screen.dart
@@ -500,7 +500,7 @@ class _StandaloneGameTitle extends ConsumerWidget {
             else if (meta.daysPerTurn != null)
               Flexible(child: AppBarTitleText('${context.l10n.nbDays(meta.daysPerTurn!)}$info'))
             else
-              Flexible(child: AppBarTitleText('${meta.perf.title}$info')),
+              Flexible(child: AppBarTitleText('${meta.perf.label(context.l10n)}$info')),
           ],
         );
       },

--- a/lib/src/view/tournament/tournament_faq.dart
+++ b/lib/src/view/tournament/tournament_faq.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/material.dart';
+import 'package:lichess_mobile/src/model/common/chess.dart';
 import 'package:lichess_mobile/src/styles/styles.dart';
 import 'package:lichess_mobile/src/utils/l10n_context.dart';
 import 'package:lichess_mobile/src/utils/navigation.dart';
@@ -114,20 +115,47 @@ class TournamentFAQScreen extends StatelessWidget {
                         ),
                       ),
                     ],
-                    rows: const [
-                      DataRow(
-                        cells: [DataCell(Text('Standard, Chess960, Horde')), DataCell(Text('30'))],
-                      ),
+                    rows: [
                       DataRow(
                         cells: [
-                          DataCell(Text('Antichess, Crazyhouse, King of the Hill')),
-                          DataCell(Text('20')),
+                          DataCell(
+                            Text(
+                              _variantLabels(context, [
+                                Variant.standard,
+                                Variant.chess960,
+                                Variant.horde,
+                              ]),
+                            ),
+                          ),
+                          const DataCell(Text('30')),
                         ],
                       ),
                       DataRow(
                         cells: [
-                          DataCell(Text('Three-check, Atomic, Racing Kings')),
-                          DataCell(Text('10')),
+                          DataCell(
+                            Text(
+                              _variantLabels(context, [
+                                Variant.antichess,
+                                Variant.crazyhouse,
+                                Variant.kingOfTheHill,
+                              ]),
+                            ),
+                          ),
+                          const DataCell(Text('20')),
+                        ],
+                      ),
+                      DataRow(
+                        cells: [
+                          DataCell(
+                            Text(
+                              _variantLabels(context, [
+                                Variant.threeCheck,
+                                Variant.atomic,
+                                Variant.racingKings,
+                              ]),
+                            ),
+                          ),
+                          const DataCell(Text('10')),
                         ],
                       ),
                     ],
@@ -141,3 +169,6 @@ class TournamentFAQScreen extends StatelessWidget {
     );
   }
 }
+
+String _variantLabels(BuildContext context, Iterable<Variant> variants) =>
+    variants.map((variant) => variant.label(context.l10n)).join(', ');

--- a/lib/src/view/tournament/tournament_screen.dart
+++ b/lib/src/view/tournament/tournament_screen.dart
@@ -12,6 +12,7 @@ import 'package:lichess_mobile/src/constants.dart';
 import 'package:lichess_mobile/src/model/account/account_repository.dart';
 import 'package:lichess_mobile/src/model/analysis/analysis_controller.dart';
 import 'package:lichess_mobile/src/model/auth/auth_controller.dart';
+import 'package:lichess_mobile/src/model/common/chess.dart';
 import 'package:lichess_mobile/src/model/common/id.dart';
 import 'package:lichess_mobile/src/model/game/game_history.dart';
 import 'package:lichess_mobile/src/model/game/game_status.dart';
@@ -438,20 +439,47 @@ class _TournamentHelp extends StatelessWidget {
                       ),
                     ),
                   ],
-                  rows: const [
-                    DataRow(
-                      cells: [DataCell(Text('Standard, Chess960, Horde')), DataCell(Text('30'))],
-                    ),
+                  rows: [
                     DataRow(
                       cells: [
-                        DataCell(Text('Antichess, Crazyhouse, King of the Hill')),
-                        DataCell(Text('20')),
+                        DataCell(
+                          Text(
+                            _variantLabels(context, [
+                              Variant.standard,
+                              Variant.chess960,
+                              Variant.horde,
+                            ]),
+                          ),
+                        ),
+                        const DataCell(Text('30')),
                       ],
                     ),
                     DataRow(
                       cells: [
-                        DataCell(Text('Three-check, Atomic, Racing Kings')),
-                        DataCell(Text('10')),
+                        DataCell(
+                          Text(
+                            _variantLabels(context, [
+                              Variant.antichess,
+                              Variant.crazyhouse,
+                              Variant.kingOfTheHill,
+                            ]),
+                          ),
+                        ),
+                        const DataCell(Text('20')),
+                      ],
+                    ),
+                    DataRow(
+                      cells: [
+                        DataCell(
+                          Text(
+                            _variantLabels(context, [
+                              Variant.threeCheck,
+                              Variant.atomic,
+                              Variant.racingKings,
+                            ]),
+                          ),
+                        ),
+                        const DataCell(Text('10')),
                       ],
                     ),
                   ],
@@ -464,6 +492,9 @@ class _TournamentHelp extends StatelessWidget {
     );
   }
 }
+
+String _variantLabels(BuildContext context, Iterable<Variant> variants) =>
+    variants.map((variant) => variant.label(context.l10n)).join(', ');
 
 class _ExpandableDescription extends ConsumerWidget {
   const _ExpandableDescription({required this.description});
@@ -785,7 +816,7 @@ class _TournamentInfo extends StatelessWidget {
             crossAxisAlignment: CrossAxisAlignment.start,
             children: [
               Text(
-                '${tournament.meta.timeIncrement.display} • ${tournament.meta.perf.title} • ${context.l10n.nbMinutes(tournament.meta.duration.inMinutes)}',
+                '${tournament.meta.timeIncrement.display} • ${tournament.meta.perf.label(context.l10n)} • ${context.l10n.nbMinutes(tournament.meta.duration.inMinutes)}',
               ),
               Text(
                 '${tournament.meta.rated ? context.l10n.rated : context.l10n.casual} • ${context.l10n.arenaArena}',

--- a/lib/src/view/user/game_history_screen.dart
+++ b/lib/src/view/user/game_history_screen.dart
@@ -480,7 +480,7 @@ class _FilterGamesState extends ConsumerState<_FilterGames> {
     filterType: FilterType.multipleChoice,
     choices: choices,
     choiceSelected: (choice) => filter.perfs.contains(choice),
-    choiceLabel: (t) => Text(t.shortTitle),
+    choiceLabel: (t) => Text(t.shortLabel(context.l10n)),
     onSelected: (value, selected) => setState(() {
       filter = filter.copyWith(
         perfs: selected ? filter.perfs.add(value) : filter.perfs.remove(value),

--- a/lib/src/view/user/leaderboard_screen.dart
+++ b/lib/src/view/user/leaderboard_screen.dart
@@ -3,6 +3,7 @@ import 'dart:math' as math;
 import 'package:flutter/material.dart';
 import 'package:flutter_layout_grid/flutter_layout_grid.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:lichess_mobile/src/model/common/perf.dart';
 import 'package:lichess_mobile/src/model/user/leaderboard.dart';
 import 'package:lichess_mobile/src/model/user/user_repository_providers.dart';
 import 'package:lichess_mobile/src/styles/lichess_icons.dart';
@@ -40,19 +41,19 @@ class _Body extends ConsumerWidget {
     return leaderboard.when(
       data: (data) {
         final List<Widget> list = [
-          _Leaderboard(data.bullet, LichessIcons.bullet, 'BULLET'),
-          _Leaderboard(data.blitz, LichessIcons.blitz, 'BLITZ'),
-          _Leaderboard(data.rapid, LichessIcons.rapid, 'RAPID'),
-          _Leaderboard(data.classical, LichessIcons.classical, 'CLASSICAL'),
-          _Leaderboard(data.ultrabullet, LichessIcons.ultrabullet, 'ULTRA BULLET'),
-          _Leaderboard(data.crazyhouse, LichessIcons.h_square, 'CRAZYHOUSE'),
-          _Leaderboard(data.chess960, LichessIcons.die_six, 'CHESS 960'),
-          _Leaderboard(data.kingOfThehill, LichessIcons.bullet, 'KING OF THE HILL'),
-          _Leaderboard(data.threeCheck, LichessIcons.three_check, 'THREE CHECK'),
-          _Leaderboard(data.atomic, LichessIcons.atom, 'ATOMIC'),
-          _Leaderboard(data.horde, LichessIcons.horde, 'HORDE'),
-          _Leaderboard(data.antichess, LichessIcons.antichess, 'ANTICHESS'),
-          _Leaderboard(data.racingKings, LichessIcons.racing_kings, 'RACING KINGS'),
+          _Leaderboard(data.bullet, Perf.bullet),
+          _Leaderboard(data.blitz, Perf.blitz),
+          _Leaderboard(data.rapid, Perf.rapid),
+          _Leaderboard(data.classical, Perf.classical),
+          _Leaderboard(data.ultrabullet, Perf.ultraBullet),
+          _Leaderboard(data.crazyhouse, Perf.crazyhouse),
+          _Leaderboard(data.chess960, Perf.chess960),
+          _Leaderboard(data.kingOfThehill, Perf.kingOfTheHill),
+          _Leaderboard(data.threeCheck, Perf.threeCheck),
+          _Leaderboard(data.atomic, Perf.atomic),
+          _Leaderboard(data.horde, Perf.horde),
+          _Leaderboard(data.antichess, Perf.antichess),
+          _Leaderboard(data.racingKings, Perf.racingKings),
         ];
 
         return SafeArea(
@@ -138,10 +139,9 @@ class _Progress extends StatelessWidget {
 }
 
 class _Leaderboard extends StatelessWidget {
-  const _Leaderboard(this.userList, this.iconData, this.title);
+  const _Leaderboard(this.userList, this.perf);
   final List<LeaderboardUser> userList;
-  final IconData iconData;
-  final String title;
+  final Perf perf;
 
   @override
   Widget build(BuildContext context) {
@@ -151,9 +151,9 @@ class _Leaderboard extends StatelessWidget {
         hasLeading: false,
         header: Row(
           children: [
-            Icon(iconData, color: context.lichessColors.brag),
+            Icon(perf.icon, color: context.lichessColors.brag),
             const SizedBox(width: 10.0),
-            Text(title),
+            Text(perf.label(context.l10n)),
           ],
         ),
         children: userList.map((user) => LeaderboardListTile(user: user)).toList(),

--- a/lib/src/view/user/perf_cards.dart
+++ b/lib/src/view/user/perf_cards.dart
@@ -4,6 +4,7 @@ import 'package:lichess_mobile/src/model/common/perf.dart';
 import 'package:lichess_mobile/src/model/user/user.dart';
 import 'package:lichess_mobile/src/styles/lichess_icons.dart';
 import 'package:lichess_mobile/src/styles/styles.dart';
+import 'package:lichess_mobile/src/utils/l10n_context.dart';
 import 'package:lichess_mobile/src/view/account/rating_pref_aware.dart';
 import 'package:lichess_mobile/src/view/puzzle/storm_dashboard.dart';
 import 'package:lichess_mobile/src/view/user/perf_stats_screen.dart';
@@ -88,7 +89,12 @@ class PerfCards extends StatelessWidget {
                         child: Column(
                           mainAxisAlignment: MainAxisAlignment.spaceAround,
                           children: [
-                            Text(perf.shortTitle, style: TextStyle(color: textShade(context, 0.7))),
+                            Text(
+                              perf.shortLabel(context.l10n),
+                              maxLines: 1,
+                              overflow: TextOverflow.ellipsis,
+                              style: TextStyle(color: textShade(context, 0.7)),
+                            ),
                             Icon(perf.icon, color: textShade(context, 0.6)),
                             Row(
                               mainAxisAlignment: MainAxisAlignment.center,

--- a/lib/src/view/user/perf_stats_screen.dart
+++ b/lib/src/view/user/perf_stats_screen.dart
@@ -89,7 +89,10 @@ class _Title extends StatelessWidget {
           mainAxisSize: MainAxisSize.min,
           children: [
             Icon(perf.icon),
-            Text(' ${context.l10n.perfStatPerfStats(perf.title)}', overflow: TextOverflow.ellipsis),
+            Text(
+              ' ${context.l10n.perfStatPerfStats(perf.label(context.l10n))}',
+              overflow: TextOverflow.ellipsis,
+            ),
             const Icon(Icons.arrow_drop_down),
           ],
         ),
@@ -106,7 +109,7 @@ class _Title extends StatelessWidget {
                       Icon(p.icon),
                       const SizedBox(width: 6),
                       Text(
-                        context.l10n.perfStatPerfStats(p.title),
+                        context.l10n.perfStatPerfStats(p.label(context.l10n)),
                         overflow: TextOverflow.ellipsis,
                       ),
                     ],
@@ -235,12 +238,12 @@ class _Body extends ConsumerWidget {
                           (loggedInUser != null && loggedInUser.user.id == user.id)
                               ? context.l10n.youAreBetterThanPercentOfPerfTypePlayers(
                                   '${data.percentile!.toStringAsFixed(2)}%',
-                                  perf.title,
+                                  perf.label(context.l10n),
                                 )
                               : context.l10n.userIsBetterThanPercentOfPerfTypePlayers(
                                   user.username,
                                   '${data.percentile!.toStringAsFixed(2)}%',
-                                  perf.title,
+                                  perf.label(context.l10n),
                                 ),
                           style: TextStyle(color: textShade(context, 0.7)),
                         ),

--- a/lib/src/view/user/user_activity.dart
+++ b/lib/src/view/user/user_activity.dart
@@ -84,7 +84,7 @@ class UserActivityEntry extends ConsumerWidget {
               leading: Icon(gameEntry.key.icon, size: leadingIconSize),
               title: context.l10n.activityPlayedNbGames(
                 gameEntry.value.win + gameEntry.value.draw + gameEntry.value.loss,
-                gameEntry.key.title,
+                gameEntry.key.label(context.l10n),
               ),
               subtitle: RatingPrefAware(
                 child: Row(
@@ -192,7 +192,7 @@ class UserActivityEntry extends ConsumerWidget {
                       corresEndEntry.value.win +
                           corresEndEntry.value.draw +
                           corresEndEntry.value.loss,
-                      corresEndEntry.key.title,
+                      corresEndEntry.key.label(context.l10n),
                     ),
               subtitle: emptySubtitle,
               trailing: BriefGameResultBox(

--- a/lib/src/view/watch/live_tv_channels_screen.dart
+++ b/lib/src/view/watch/live_tv_channels_screen.dart
@@ -72,7 +72,7 @@ class _Body extends ConsumerWidget {
                 mainAxisSize: MainAxisSize.max,
                 mainAxisAlignment: MainAxisAlignment.spaceBetween,
                 children: [
-                  Text(game.channel.localizedLabel(context.l10n), style: Styles.boardPreviewTitle),
+                  Text(game.channel.label(context.l10n), style: Styles.boardPreviewTitle),
                   Icon(game.channel.icon, size: 32),
                   UserFullNameWidget.player(
                     user: game.player.asPlayer.user,

--- a/lib/src/view/watch/live_tv_channels_screen.dart
+++ b/lib/src/view/watch/live_tv_channels_screen.dart
@@ -5,6 +5,7 @@ import 'package:lichess_mobile/src/model/tv/live_tv_channels.dart';
 import 'package:lichess_mobile/src/model/tv/tv_channel.dart';
 import 'package:lichess_mobile/src/styles/styles.dart';
 import 'package:lichess_mobile/src/utils/focus_detector.dart';
+import 'package:lichess_mobile/src/utils/l10n_context.dart';
 import 'package:lichess_mobile/src/utils/navigation.dart';
 import 'package:lichess_mobile/src/view/watch/tv_screen.dart';
 import 'package:lichess_mobile/src/widgets/board_preview.dart';
@@ -71,7 +72,7 @@ class _Body extends ConsumerWidget {
                 mainAxisSize: MainAxisSize.max,
                 mainAxisAlignment: MainAxisAlignment.spaceBetween,
                 children: [
-                  Text(game.channel.label, style: Styles.boardPreviewTitle),
+                  Text(game.channel.localizedLabel(context.l10n), style: Styles.boardPreviewTitle),
                   Icon(game.channel.icon, size: 32),
                   UserFullNameWidget.player(
                     user: game.player.asPlayer.user,

--- a/lib/src/view/watch/tv_screen.dart
+++ b/lib/src/view/watch/tv_screen.dart
@@ -77,8 +77,8 @@ class _TvScreenState extends ConsumerState<TvScreen> {
       child: WakelockWidget(
         child: Scaffold(
           appBar: AppBar(
-            title: widget.channel?.label != null
-                ? Text('${widget.channel!.label} TV')
+            title: widget.channel != null
+                ? Text('${widget.channel!.localizedLabel(context.l10n)} TV')
                 : Row(
                     mainAxisSize: MainAxisSize.min,
                     children: [

--- a/lib/src/view/watch/tv_screen.dart
+++ b/lib/src/view/watch/tv_screen.dart
@@ -78,7 +78,7 @@ class _TvScreenState extends ConsumerState<TvScreen> {
         child: Scaffold(
           appBar: AppBar(
             title: widget.channel != null
-                ? Text('${widget.channel!.localizedLabel(context.l10n)} TV')
+                ? Text('${widget.channel!.label(context.l10n)} TV')
                 : Row(
                     mainAxisSize: MainAxisSize.min,
                     children: [

--- a/lib/src/view/watch/watch_tab_screen.dart
+++ b/lib/src/view/watch/watch_tab_screen.dart
@@ -274,7 +274,7 @@ class _WatchTvWidget extends ConsumerWidget {
                   trailing: Theme.of(context).platform == TargetPlatform.iOS
                       ? const CupertinoListTileChevron()
                       : null,
-                  title: Text(snapshot.channel.localizedLabel(context.l10n)),
+                  title: Text(snapshot.channel.label(context.l10n)),
                   subtitle: UserFullNameWidget.player(
                     user: snapshot.player.asPlayer.user,
                     aiLevel: snapshot.player.asPlayer.aiLevel,

--- a/lib/src/view/watch/watch_tab_screen.dart
+++ b/lib/src/view/watch/watch_tab_screen.dart
@@ -274,7 +274,7 @@ class _WatchTvWidget extends ConsumerWidget {
                   trailing: Theme.of(context).platform == TargetPlatform.iOS
                       ? const CupertinoListTileChevron()
                       : null,
-                  title: Text(snapshot.channel.label),
+                  title: Text(snapshot.channel.localizedLabel(context.l10n)),
                   subtitle: UserFullNameWidget.player(
                     user: snapshot.player.asPlayer.user,
                     aiLevel: snapshot.player.asPlayer.aiLevel,


### PR DESCRIPTION
## Summary

Localize chess mode, speed, variant, and TV channel labels across the mobile UI instead of displaying hardcoded English names such as `Bullet`, `King of the Hill`, or `Rapid`.

This adds centralized localization helpers for `Perf` and TV channels, then applies them to user-facing screens where those labels are shown.

## Localization coverage

- Added localized `Perf` labels:
  - standard speeds: UltraBullet, Bullet, Blitz, Rapid, Classical, Correspondence
  - variants: From Position, Chess960, Antichess, King of the Hill, Three-check, Atomic, Horde, Racing Kings, Crazyhouse
  - puzzle perf uses the existing puzzle localization
  - English keeps existing short labels where compact UI needs them

- Added localized TV channel labels:
  - Best, Blitz, Rapid, Classical, Bullet, UltraBullet
  - Bot, Computer, Horde, Racing Kings, Crazyhouse
  - Chess960, King of the Hill, Three-check, Antichess, Atomic

- Updated Watch / TV surfaces:
  - live TV channel list
  - watch tab TV card
  - TV screen title

- Updated user profile and stats surfaces:
  - perf cards
  - perf stats screen
  - user activity entries
  - leaderboard labels

- Updated game-related labels:
  - game screen title when showing a perf name
  - shared game title
  - game history perf filter labels
  - game filter selection summary
  - recent seek quick actions

- Updated Opening Explorer settings:
  - speed filter chip tooltips now use localized speed labels

- Updated tournament-related static labels:
  - tournament info line uses localized perf labels
  - tournament FAQ/help variant tables use localized variant names

## Notes

PGN metadata still uses the original English perf title, so exported/shared PGN data is not affected.

Tournament list names are not rewritten in this PR because they currently come from the server-provided tournament `fullName`. Web has a separate `tourname` translation layer for that, which would be a separate follow-up.