### PR TITLE
feat(study): sync `promoteVariation` with the server

### DIFF
--- a/lib/src/model/study/study_controller.dart
+++ b/lib/src/model/study/study_controller.dart
@@ -382,6 +382,12 @@ class StudyController extends AsyncNotifier<StudyState>
     this.state = AsyncValue.data(
       state.copyWith(isOnMainline: _root.isOnMainline(state.currentPath), root: _root.view),
     );
+
+    _recordChange('promote', {
+      'toMainline': toMainline,
+      'path': path.value,
+      'ch': state.currentChapter.id.value,
+    });
   }
 
   @override


### PR DESCRIPTION
Manually tested with https://preview.test.lichess.app/study/snKtWA6W, variant promotion now correctly syncs with the server.