### PR TITLE
Replace deprecated linkify package

### DIFF
--- a/lib/src/app_links_service.dart
+++ b/lib/src/app_links_service.dart
@@ -29,8 +29,8 @@ import 'package:lichess_mobile/src/view/study/study_screen.dart';
 import 'package:lichess_mobile/src/view/tournament/tournament_screen.dart';
 import 'package:lichess_mobile/src/view/user/user_or_profile_screen.dart';
 import 'package:lichess_mobile/src/view/watch/tv_screen.dart';
+import 'package:lichess_mobile/src/widgets/app_link.dart';
 import 'package:lichess_mobile/src/widgets/feedback.dart';
-import 'package:linkify/linkify.dart';
 import 'package:logging/logging.dart';
 import 'package:url_launcher/url_launcher.dart';
 
@@ -387,23 +387,21 @@ class AppLinksService {
     return route;
   }
 
-  static const kLichessLinkifiers = [UrlLinkifier(), EmailLinkifier(), UserTagLinkifier()];
-
   /// Handles link clicks in Linkify widgets throughout the app.
-  Future<void> onLinkifyOpen(BuildContext context, LinkableElement link) async {
-    if (link is UrlElement && link.url.startsWith(RegExp('https?:\\/\\/$kLichessHost'))) {
-      // Handle Lichess links specifically
-      final appLinkUri = Uri.parse(link.url);
-      await handleAppLink(context, appLinkUri);
-    } else if (link.originText.startsWith('@')) {
-      final username = link.originText.substring(1);
-      Navigator.of(context).push(
-        UserOrProfileScreen.buildRoute(
-          LightUser(id: UserId.fromUserName(username), name: username),
-        ),
-      );
-    } else {
-      launchUrl(Uri.parse(link.url));
+  Future<void> onLinkTap(BuildContext context, AppLink link) async {
+    switch (link) {
+      case MentionLink(:final username):
+        Navigator.of(context).push(
+          UserOrProfileScreen.buildRoute(
+            LightUser(id: UserId.fromUserName(username), name: username),
+          ),
+        );
+      case UrlLink(:final uri):
+        if (uri.host == kLichessHost) {
+          await handleAppLink(context, uri);
+        } else {
+          await launchUrl(uri);
+        }
     }
   }
 }

--- a/lib/src/view/chat/chat_screen.dart
+++ b/lib/src/view/chat/chat_screen.dart
@@ -1,5 +1,4 @@
 import 'package:flutter/material.dart';
-import 'package:flutter_linkify/flutter_linkify.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:lichess_mobile/src/app_links_service.dart';
 import 'package:lichess_mobile/src/model/auth/auth_controller.dart';
@@ -12,6 +11,7 @@ import 'package:lichess_mobile/src/utils/navigation.dart';
 import 'package:lichess_mobile/src/view/chat/chat_context_menu.dart';
 import 'package:lichess_mobile/src/view/user/user_or_profile_screen.dart';
 import 'package:lichess_mobile/src/widgets/adaptive_bottom_sheet.dart';
+import 'package:lichess_mobile/src/widgets/app_linkify.dart';
 import 'package:lichess_mobile/src/widgets/bottom_bar.dart';
 import 'package:lichess_mobile/src/widgets/buttons.dart';
 import 'package:lichess_mobile/src/widgets/user.dart';
@@ -203,13 +203,11 @@ class _MessageBubble extends ConsumerWidget {
                     onTap: () =>
                         Navigator.of(context).push(UserOrProfileScreen.buildRoute(message.user!)),
                   ),
-                Linkify(
-                  onOpen: (link) async =>
-                      await ref.read(appLinksServiceProvider).onLinkifyOpen(context, link),
-                  linkifiers: AppLinksService.kLichessLinkifiers,
+                AppLinkify(
                   text: message.message,
                   style: TextStyle(color: _textColor(context)),
                   linkStyle: Styles.linkStyle,
+                  linkService: ref.read(appLinksServiceProvider),
                 ),
               ],
             ),

--- a/lib/src/view/message/conversation_screen.dart
+++ b/lib/src/view/message/conversation_screen.dart
@@ -1,5 +1,4 @@
 import 'package:flutter/material.dart';
-import 'package:flutter_linkify/flutter_linkify.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:intl/intl.dart';
 import 'package:lichess_mobile/src/app_links_service.dart';
@@ -13,6 +12,7 @@ import 'package:lichess_mobile/src/utils/l10n_context.dart';
 import 'package:lichess_mobile/src/utils/navigation.dart';
 import 'package:lichess_mobile/src/view/chat/chat_context_menu.dart';
 import 'package:lichess_mobile/src/view/user/user_or_profile_screen.dart';
+import 'package:lichess_mobile/src/widgets/app_linkify.dart';
 import 'package:lichess_mobile/src/widgets/platform.dart';
 import 'package:lichess_mobile/src/widgets/user.dart';
 import 'package:lichess_mobile/src/widgets/yes_no_dialog.dart';
@@ -403,13 +403,11 @@ class _MessageBubble extends ConsumerWidget {
           child: Column(
             crossAxisAlignment: CrossAxisAlignment.end,
             children: [
-              Linkify(
-                onOpen: (link) async =>
-                    await ref.read(appLinksServiceProvider).onLinkifyOpen(context, link),
-                linkifiers: AppLinksService.kLichessLinkifiers,
+              AppLinkify(
                 text: message.text,
                 style: TextStyle(color: _textColor(context)),
                 linkStyle: Styles.linkStyle,
+                linkService: ref.read(appLinksServiceProvider),
               ),
               const SizedBox(height: 4),
               Text(

--- a/lib/src/view/study/study_gamebook.dart
+++ b/lib/src/view/study/study_gamebook.dart
@@ -1,9 +1,9 @@
 import 'package:flutter/material.dart';
-import 'package:flutter_linkify/flutter_linkify.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:lichess_mobile/src/app_links_service.dart';
 import 'package:lichess_mobile/src/model/study/study_controller.dart';
 import 'package:lichess_mobile/src/utils/l10n_context.dart';
-import 'package:url_launcher/url_launcher.dart';
+import 'package:lichess_mobile/src/widgets/app_linkify.dart';
 
 class StudyGamebook extends StatelessWidget {
   const StudyGamebook(this.options);
@@ -45,6 +45,7 @@ class _CommentState extends ConsumerState<_Comment> {
   @override
   Widget build(BuildContext context) {
     final state = ref.watch(studyControllerProvider(widget.options)).requireValue;
+    final service = ref.read<AppLinksService>(appLinksServiceProvider);
 
     final comment =
         state.gamebookComment ??
@@ -63,12 +64,10 @@ class _CommentState extends ConsumerState<_Comment> {
           controller: _scrollController,
           child: Padding(
             padding: const EdgeInsets.only(right: 5),
-            child: Linkify(
+            child: AppLinkify(
               text: comment,
               style: const TextStyle(fontSize: 16),
-              onOpen: (link) {
-                launchUrl(Uri.parse(link.url));
-              },
+              linkService: service,
             ),
           ),
         ),

--- a/lib/src/view/user/user_context_menu.dart
+++ b/lib/src/view/user/user_context_menu.dart
@@ -1,5 +1,4 @@
 import 'package:flutter/material.dart';
-import 'package:flutter_linkify/flutter_linkify.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:lichess_mobile/src/app_links_service.dart';
 import 'package:lichess_mobile/src/model/auth/auth_controller.dart';
@@ -13,6 +12,7 @@ import 'package:lichess_mobile/src/view/user/user_or_profile_screen.dart';
 import 'package:lichess_mobile/src/view/user/user_screen.dart';
 import 'package:lichess_mobile/src/view/watch/tv_screen.dart';
 import 'package:lichess_mobile/src/widgets/adaptive_bottom_sheet.dart';
+import 'package:lichess_mobile/src/widgets/app_linkify.dart';
 import 'package:lichess_mobile/src/widgets/feedback.dart';
 import 'package:lichess_mobile/src/widgets/list.dart';
 import 'package:lichess_mobile/src/widgets/user.dart';
@@ -44,10 +44,7 @@ class UserContextMenu extends ConsumerWidget {
                   UserFullNameWidget(user: value.lightUser, style: Styles.title),
                   const SizedBox(height: 8.0),
                   if (value.profile?.bio != null)
-                    Linkify(
-                      onOpen: (link) async =>
-                          await ref.read(appLinksServiceProvider).onLinkifyOpen(context, link),
-                      linkifiers: AppLinksService.kLichessLinkifiers,
+                    AppLinkify(
                       text: value.profile!.bio!,
                       maxLines: 20,
                       overflow: TextOverflow.ellipsis,
@@ -55,6 +52,7 @@ class UserContextMenu extends ConsumerWidget {
                         color: Colors.blueAccent,
                         decoration: TextDecoration.none,
                       ),
+                      linkService: ref.read(appLinksServiceProvider),
                     ),
                 ],
               ),

--- a/lib/src/view/user/user_profile.dart
+++ b/lib/src/view/user/user_profile.dart
@@ -1,5 +1,4 @@
 import 'package:flutter/material.dart';
-import 'package:flutter_linkify/flutter_linkify.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:intl/intl.dart';
 import 'package:lichess_mobile/l10n/l10n.dart';
@@ -14,6 +13,7 @@ import 'package:lichess_mobile/src/utils/l10n.dart';
 import 'package:lichess_mobile/src/utils/l10n_context.dart';
 import 'package:lichess_mobile/src/utils/lichess_assets.dart';
 import 'package:lichess_mobile/src/view/user/countries.dart';
+import 'package:lichess_mobile/src/widgets/app_linkify.dart';
 import 'package:lichess_mobile/src/widgets/network_image.dart';
 import 'package:url_launcher/url_launcher.dart';
 
@@ -63,15 +63,13 @@ class UserProfileWidget extends ConsumerWidget {
             if (userFullName != null)
               Padding(padding: const EdgeInsets.only(bottom: 5), child: userFullName),
             if (user.profile?.bio != null)
-              Linkify(
-                onOpen: (link) async =>
-                    await ref.read(appLinksServiceProvider).onLinkifyOpen(context, link),
-                linkifiers: AppLinksService.kLichessLinkifiers,
+              AppLinkify(
                 text: user.profile!.bio!,
                 maxLines: bioMaxLines,
                 style: bioStyle,
                 overflow: TextOverflow.ellipsis,
                 linkStyle: Styles.linkStyle,
+                linkService: ref.read(appLinksServiceProvider),
               ),
             const SizedBox(height: 10),
             if (user.profile?.fideRating != null)

--- a/lib/src/widgets/app_link.dart
+++ b/lib/src/widgets/app_link.dart
@@ -1,0 +1,15 @@
+sealed class AppLink {
+  const AppLink();
+}
+
+final class UrlLink extends AppLink {
+  const UrlLink(this.uri);
+
+  final Uri uri;
+}
+
+final class MentionLink extends AppLink {
+  const MentionLink(this.username);
+
+  final String username;
+}

--- a/lib/src/widgets/app_link_parser.dart
+++ b/lib/src/widgets/app_link_parser.dart
@@ -1,0 +1,56 @@
+import 'package:lichess_mobile/src/widgets/app_link.dart';
+
+sealed class AppLinkSpan {
+  const AppLinkSpan();
+}
+
+final class TextChunk extends AppLinkSpan {
+  const TextChunk(this.text);
+
+  final String text;
+}
+
+final class LinkChunk extends AppLinkSpan {
+  const LinkChunk({required this.text, required this.link});
+
+  final String text;
+  final AppLink link;
+}
+
+class AppLinkParser {
+  const AppLinkParser._();
+
+  static final _pattern = RegExp(
+    r'((?:https?://)(?:[^\s<>()]+|\([^\s<>()]*\))+(?:[^\s`!()\[\]{};:".,<>?«»“”‘’]))'
+    '|(@[A-Za-z0-9_-]+)',
+    caseSensitive: false,
+  );
+
+  static List<AppLinkSpan> parse(String text) {
+    final result = <AppLinkSpan>[];
+
+    int lastEnd = 0;
+
+    for (final match in _pattern.allMatches(text)) {
+      if (match.start > lastEnd) {
+        result.add(TextChunk(text.substring(lastEnd, match.start)));
+      }
+
+      final token = match.group(0)!;
+
+      if (token.startsWith('@')) {
+        result.add(LinkChunk(text: token, link: MentionLink(token.substring(1))));
+      } else {
+        result.add(LinkChunk(text: token, link: UrlLink(Uri.parse(token))));
+      }
+
+      lastEnd = match.end;
+    }
+
+    if (lastEnd < text.length) {
+      result.add(TextChunk(text.substring(lastEnd)));
+    }
+
+    return result;
+  }
+}

--- a/lib/src/widgets/app_linkify.dart
+++ b/lib/src/widgets/app_linkify.dart
@@ -1,0 +1,52 @@
+import 'package:flutter/gestures.dart';
+import 'package:flutter/material.dart';
+
+import 'package:lichess_mobile/src/app_links_service.dart';
+import 'package:lichess_mobile/src/widgets/app_link_parser.dart';
+
+class AppLinkify extends StatelessWidget {
+  const AppLinkify({
+    super.key,
+    required this.text,
+    required this.linkService,
+    this.style,
+    this.linkStyle,
+    this.maxLines,
+    this.overflow = TextOverflow.clip,
+  });
+
+  final String text;
+  final AppLinksService linkService;
+
+  final TextStyle? style;
+  final TextStyle? linkStyle;
+  final int? maxLines;
+  final TextOverflow overflow;
+
+  @override
+  Widget build(BuildContext context) {
+    final chunks = AppLinkParser.parse(text);
+
+    return RichText(
+      maxLines: maxLines,
+      overflow: overflow,
+      text: TextSpan(
+        style: style,
+        children: chunks.map((chunk) {
+          if (chunk is TextChunk) {
+            return TextSpan(text: chunk.text);
+          }
+
+          final link = chunk as LinkChunk;
+
+          return TextSpan(
+            text: link.text,
+            style: linkStyle,
+            recognizer: TapGestureRecognizer()
+              ..onTap = () => linkService.onLinkTap(context, link.link),
+          );
+        }).toList(),
+      ),
+    );
+  }
+}

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -558,14 +558,6 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "2.0.8"
-  flutter_linkify:
-    dependency: "direct main"
-    description:
-      name: flutter_linkify
-      sha256: "74669e06a8f358fee4512b4320c0b80e51cffc496607931de68d28f099254073"
-      url: "https://pub.dev"
-    source: hosted
-    version: "6.0.0"
   flutter_local_notifications:
     dependency: "direct main"
     description:
@@ -966,14 +958,6 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "3.0.2"
-  linkify:
-    dependency: "direct main"
-    description:
-      name: linkify
-      sha256: "4139ea77f4651ab9c315b577da2dd108d9aa0bd84b5d03d33323f1970c645832"
-      url: "https://pub.dev"
-    source: hosted
-    version: "5.0.0"
   lint:
     dependency: "direct dev"
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -37,7 +37,6 @@ dependencies:
   flutter_appauth: ^12.0.1
   flutter_displaymode: ^0.7.0
   flutter_layout_grid: ^2.0.8
-  flutter_linkify: ^6.0.0
   flutter_local_notifications: ^22.0.0
   flutter_localizations:
     sdk: flutter
@@ -54,7 +53,6 @@ dependencies:
   intl: ^0.20.2
   json_annotation: ^4.12.0
   l10n_esperanto: ^2.0.14
-  linkify: ^5.0.0
   logging: ^1.3.0
   material_color_utilities: ^0.13.0
   material_symbols_icons: ^4.2928.1

--- a/test/utils/app_link_test.dart
+++ b/test/utils/app_link_test.dart
@@ -1,0 +1,71 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:lichess_mobile/src/widgets/app_link.dart';
+import 'package:lichess_mobile/src/widgets/app_link_parser.dart';
+
+void main() {
+  group('AppLinkParser', () {
+    test('returns single TextChunk when no links', () {
+      final result = AppLinkParser.parse('hello world');
+
+      expect(result.length, 1);
+      expect(result.first, isA<TextChunk>());
+      expect((result.first as TextChunk).text, 'hello world');
+    });
+
+    test('parses mention only', () {
+      final result = AppLinkParser.parse('@user');
+
+      expect(result.length, 1);
+      final chunk = result.first as LinkChunk;
+
+      expect(chunk.text, '@user');
+      expect(chunk.link, isA<MentionLink>());
+      expect((chunk.link as MentionLink).username, 'user');
+    });
+
+    test('parses url only', () {
+      final result = AppLinkParser.parse('https://example.com');
+
+      expect(result.length, 1);
+      final chunk = result.first as LinkChunk;
+
+      expect(chunk.text, 'https://example.com');
+      expect(chunk.link, isA<UrlLink>());
+      expect((chunk.link as UrlLink).uri.toString(), 'https://example.com');
+    });
+
+    test('parses mixed text with mention and url', () {
+      final result = AppLinkParser.parse('hi @user visit https://example.com');
+
+      expect(result.length, 4);
+      expect(result[0], isA<TextChunk>()); // "hi "
+      expect(result[1], isA<LinkChunk>()); // @user
+      expect(result[2], isA<TextChunk>()); // " visit "
+      expect(result[3], isA<LinkChunk>()); // url
+    });
+
+    test('preserves text between links', () {
+      final result = AppLinkParser.parse('a @user b');
+
+      expect(result.length, 3);
+      expect((result[0] as TextChunk).text, 'a ');
+      expect((result[1] as LinkChunk).text, '@user');
+      expect((result[2] as TextChunk).text, ' b');
+    });
+
+    test('handles adjacent tokens', () {
+      final result = AppLinkParser.parse('@user@admin');
+
+      expect(result.length, 2);
+      expect((result[0] as LinkChunk).text, '@user');
+      expect((result[1] as LinkChunk).text, '@admin');
+    });
+
+    test('handles trailing text', () {
+      final result = AppLinkParser.parse('@user end');
+
+      expect(result.length, 2);
+      expect((result[1] as TextChunk).text, ' end');
+    });
+  });
+}

--- a/test/widgets/app_linkify_test.dart
+++ b/test/widgets/app_linkify_test.dart
@@ -1,0 +1,135 @@
+import 'package:flutter/gestures.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:lichess_mobile/src/app_links_service.dart';
+import 'package:lichess_mobile/src/widgets/app_link.dart';
+import 'package:lichess_mobile/src/widgets/app_linkify.dart';
+
+class FakeAppLinksService implements AppLinksService {
+  AppLink? tappedLink;
+  BuildContext? tappedContext;
+
+  @override
+  Future<void> onLinkTap(BuildContext context, AppLink link) async {
+    tappedContext = context;
+    tappedLink = link;
+  }
+
+  @override
+  void dispose() {}
+
+  @override
+  Future<void> handleAppLink(
+    BuildContext context,
+    Uri uri, {
+    bool animated = true,
+    bool allowBrowserFallback = true,
+  }) async {}
+
+  @override
+  Future<void> handleDailyPuzzleLink(
+    BuildContext context,
+    String? puzzleId, {
+    bool animated = true,
+  }) async {}
+
+  @override
+  Ref get ref => throw UnimplementedError('FakeAppLinksService does not support Riverpod ref');
+
+  @override
+  Future<List<Route<dynamic>>?> resolveAppLinkUri(BuildContext context, Uri appLinkUri) async {
+    return null;
+  }
+
+  @override
+  Future<void> start() async {}
+}
+
+void main() {
+  group('AppLinkify', () {
+    testWidgets('parses and renders spans correctly', (tester) async {
+      final service = FakeAppLinksService();
+
+      await tester.pumpWidget(
+        MaterialApp(
+          home: AppLinkify(text: 'hi @user visit https://example.com', linkService: service),
+        ),
+      );
+
+      final richText = tester.widget<RichText>(find.byType(RichText));
+      final span = richText.text as TextSpan;
+
+      final texts = <String>[];
+
+      void collect(TextSpan s) {
+        if (s.text != null) texts.add(s.text!);
+        s.children?.forEach((child) {
+          if (child is TextSpan) collect(child);
+        });
+      }
+
+      collect(span);
+
+      expect(texts.contains('hi '), true);
+      expect(texts.contains('@user'), true);
+      expect(texts.contains(' visit '), true);
+      expect(texts.contains('https://example.com'), true);
+    });
+
+    testWidgets('calls linkService.onLinkTap when tapped', (tester) async {
+      final service = FakeAppLinksService();
+
+      await tester.pumpWidget(
+        MaterialApp(
+          home: AppLinkify(text: 'hi @user', linkService: service),
+        ),
+      );
+
+      final richText = tester.widget<RichText>(find.byType(RichText));
+      final span = richText.text as TextSpan;
+
+      TapGestureRecognizer? recognizer;
+
+      final recognizers = <TapGestureRecognizer>[];
+
+      void collect(TextSpan s) {
+        final r = s.recognizer;
+        if (r is TapGestureRecognizer) recognizers.add(r);
+
+        s.children?.forEach((child) {
+          if (child is TextSpan) collect(child);
+        });
+      }
+
+      collect(span);
+
+      expect(recognizers, isNotEmpty);
+      recognizer = recognizers.first;
+
+      recognizer.onTap?.call();
+
+      expect(service.tappedLink, isA<MentionLink>());
+      expect(service.tappedLink is MentionLink, true);
+    });
+
+    testWidgets('applies linkStyle to link spans', (tester) async {
+      const linkStyle = TextStyle(color: Colors.red);
+
+      final service = FakeAppLinksService();
+
+      await tester.pumpWidget(
+        MaterialApp(
+          home: AppLinkify(text: '@user', linkService: service, linkStyle: linkStyle),
+        ),
+      );
+
+      final richText = tester.widget<RichText>(find.byType(RichText));
+      final span = richText.text as TextSpan;
+
+      final linkSpan = span.children!.first as TextSpan;
+
+      expect(linkSpan.style, linkStyle);
+    });
+  });
+}


### PR DESCRIPTION
I looked at some other packages but they were also either unmaintained or had few stars to be a reliable dependency. Since our linkify use case in this app is minimal, I decided to rewrite a small custom version without external deps.

I would appreciate any guidance since I have not written any Flutter code before.

Closes #2092 