### PR TITLE
better localize broadcast player tab

### DIFF
--- a/lib/src/view/broadcast/broadcast_players_tab.dart
+++ b/lib/src/view/broadcast/broadcast_players_tab.dart
@@ -1,5 +1,3 @@
-import 'dart:math';
-
 import 'package:fast_immutable_collections/fast_immutable_collections.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
@@ -162,7 +160,6 @@ class _BroadcastPlayersListState extends ConsumerState<BroadcastPlayersList> {
 
   @override
   Widget build(BuildContext context) {
-    final double scoreWidth = max(MediaQuery.sizeOf(context).width * 0.15, 90);
     final sortIcon = (reverse ? Icons.keyboard_arrow_up : Icons.keyboard_arrow_down);
     final withRank = players.any((p) => p.rank != null);
     final showSearchBar = players.length >= 15;
@@ -205,15 +202,15 @@ class _BroadcastPlayersListState extends ConsumerState<BroadcastPlayersList> {
                 if (withRank)
                   Padding(
                     padding: Styles.bodyPadding.copyWith(top: 8.0, bottom: 0.0),
-                    child: const Row(
+                    child: Row(
                       children: [
-                        Icon(Icons.info, size: 16),
-                        SizedBox(width: 8),
+                        const Icon(Icons.info, size: 16),
+                        const SizedBox(width: 8),
                         Expanded(
                           child: Text(
-                            'Standings are calculated using broadcasted games and may differ from official results.',
-                            maxLines: 2,
-                            style: TextStyle(fontSize: 13),
+                            context.l10n.broadcastStandingsDisclaimer,
+                            maxLines: 3,
+                            style: const TextStyle(fontSize: 13, overflow: .ellipsis),
                           ),
                         ),
                       ],
@@ -230,16 +227,13 @@ class _BroadcastPlayersListState extends ConsumerState<BroadcastPlayersList> {
                           sortIcon: (currentSort == _SortingTypes.elo) ? sortIcon : null,
                         ),
                       ),
-                    SizedBox(
-                      width: scoreWidth,
-                      child: _TableTitleCell(
-                        title: Text(
-                          withScores ? context.l10n.broadcastScore : context.l10n.games,
-                          style: _kHeaderTextStyle,
-                        ),
-                        onTap: () => toggleSort(_SortingTypes.score),
-                        sortIcon: (currentSort == _SortingTypes.score) ? sortIcon : null,
+                    _TableTitleCell(
+                      title: Text(
+                        withScores ? context.l10n.broadcastScore : context.l10n.games,
+                        style: _kHeaderTextStyle,
                       ),
+                      onTap: () => toggleSort(_SortingTypes.score),
+                      sortIcon: (currentSort == _SortingTypes.score) ? sortIcon : null,
                     ),
                   ],
                 ),
@@ -284,15 +278,23 @@ class _TableTitleCell extends StatelessWidget {
         child: Padding(
           padding: _kTableRowPadding,
           child: Row(
-            crossAxisAlignment: CrossAxisAlignment.center,
-            mainAxisAlignment: MainAxisAlignment.spaceBetween,
+            mainAxisSize: .min,
+            crossAxisAlignment: .center,
             children: [
-              Expanded(child: title),
-              if (sortIcon != null)
-                Text(
-                  String.fromCharCode(sortIcon!.codePoint),
-                  style: _kHeaderTextStyle.copyWith(fontSize: 16, fontFamily: sortIcon!.fontFamily),
-                ),
+              Flexible(child: title),
+              const SizedBox(width: 4),
+              SizedBox(
+                width: 16,
+                child: sortIcon != null
+                    ? Text(
+                        String.fromCharCode(sortIcon!.codePoint),
+                        style: _kHeaderTextStyle.copyWith(
+                          fontSize: 16,
+                          fontFamily: sortIcon!.fontFamily,
+                        ),
+                      )
+                    : null,
+              ),
             ],
           ),
         ),


### PR DESCRIPTION
Uses the translation string for Standings Disclaimer, increase the max lines to 3 as languages can be verboser than english.
Also fix #2612 
| Before| After|
|-|-|
|<img width="652" height="1455" alt="image" src="https://github.com/user-attachments/assets/1fc60ee3-1dc6-453d-ae50-6bd8dd2b3935" />| <img width="652" height="1448" alt="image" src="https://github.com/user-attachments/assets/97f3856f-0d47-4dff-b930-08c33e83c72a" />|


sorting still works: 

[Screencast_20260607_140422.webm](https://github.com/user-attachments/assets/10f50074-b2bd-4b2d-9dd4-e790ec63d5d5)
