### PR TITLE
Broadcast Team Results

### DIFF
--- a/lib/src/view/broadcast/broadcast_players_tab.dart
+++ b/lib/src/view/broadcast/broadcast_players_tab.dart
@@ -105,6 +105,7 @@ class _BroadcastPlayersListState extends ConsumerState<BroadcastPlayersList> {
   ) => (p1, p2) {
     final field1 = picker(p1);
     final field2 = picker(p2);
+    if (field1 == null && field2 == null) return 0;
     if (field1 == null) return -1;
     if (field2 == null) return 1;
 

--- a/lib/src/view/broadcast/broadcast_team_screen.dart
+++ b/lib/src/view/broadcast/broadcast_team_screen.dart
@@ -215,6 +215,7 @@ class _TeamPlayersListState extends State<_TeamPlayersList> {
   ) => (p1, p2) {
     final field1 = picker(p1);
     final field2 = picker(p2);
+    if (field1 == null && field2 == null) return 0;
     if (field1 == null) return -1;
     if (field2 == null) return 1;
 

--- a/lib/src/view/broadcast/broadcast_team_standings_screen.dart
+++ b/lib/src/view/broadcast/broadcast_team_standings_screen.dart
@@ -20,7 +20,7 @@ enum _SortingTypes { elo, score }
 typedef _TeamPicker<T> = T? Function(BroadcastTeamStanding team);
 
 const _kTableRowPadding = EdgeInsets.symmetric(horizontal: 8.0, vertical: 12.0);
-const _kHeaderTextStyle = TextStyle(fontWeight: FontWeight.bold, overflow: .ellipsis);
+const _kHeaderTextStyle = TextStyle(fontWeight: .bold, overflow: .ellipsis);
 
 class BroadcastTeamStandingsScreen extends ConsumerWidget {
   const BroadcastTeamStandingsScreen({super.key, required this.tournamentId});
@@ -39,8 +39,10 @@ class BroadcastTeamStandingsScreen extends ConsumerWidget {
     return PlatformScaffold(
       appBar: PlatformAppBar(title: AppBarTitleText(context.l10n.broadcastTeamResults)),
       body: switch ((standingsAsync, tournamentAsync)) {
-        (AsyncData(value: final teams), AsyncData()) when teams.isNotEmpty =>
-          BroadcastTeamStandingsList(teams: teams, tournamentId: tournamentId),
+        (AsyncData(value: final teams), AsyncData()) =>
+          teams.isNotEmpty
+              ? BroadcastTeamStandingsList(teams: teams, tournamentId: tournamentId)
+              : Center(child: Text(context.l10n.nothingToSeeHere)),
         (AsyncError(:final error), _) ||
         (_, AsyncError(:final error)) => Center(child: Text('Cannot load data: $error')),
         _ => const Center(child: CircularProgressIndicator.adaptive()),
@@ -91,6 +93,7 @@ class _BroadcastTeamStandingsListState extends ConsumerState<BroadcastTeamStandi
   ) => (team1, team2) {
     final field1 = picker(team1);
     final field2 = picker(team2);
+    if (field1 == null && field2 == null) return 0;
     if (field1 == null) return -1;
     if (field2 == null) return 1;
     return field1.compareTo(field2);
@@ -175,8 +178,9 @@ class _BroadcastTeamStandingsListState extends ConsumerState<BroadcastTeamStandi
                       Expanded(
                         child: _TableTitleCell(
                           title: Text(
-                            '${context.l10n.broadcastTeams} (avg. Elo)',
+                            '${context.l10n.broadcastTeams} (${context.l10n.averageElo})',
                             style: _kHeaderTextStyle,
+                            maxLines: 2,
                           ),
                           onTap: () => toggleSort(.elo),
                           sortIcon: currentSort == .elo ? sortIcon : null,
@@ -192,7 +196,12 @@ class _BroadcastTeamStandingsListState extends ConsumerState<BroadcastTeamStandi
                     SizedBox(
                       width: scoreWidth,
                       child: _TableTitleCell(
-                        title: const Text('Match\nPoints', style: _kHeaderTextStyle, maxLines: 2),
+                        title: Text(
+                          context.l10n.broadcastMatchPoints,
+                          style: _kHeaderTextStyle,
+                          maxLines: 2,
+                          textAlign: .right,
+                        ),
                         onTap: () => toggleSort(.score),
                         sortIcon: currentSort == .score ? sortIcon : null,
                         mainAxisAlignment: .end,
@@ -200,10 +209,10 @@ class _BroadcastTeamStandingsListState extends ConsumerState<BroadcastTeamStandi
                     ),
                     SizedBox(
                       width: scoreWidth,
-                      child: const Padding(
+                      child: Padding(
                         padding: _kTableRowPadding,
                         child: Text(
-                          'Game\nPoints',
+                          context.l10n.broadcastGamePoints,
                           textAlign: .right,
                           style: _kHeaderTextStyle,
                           maxLines: 2,

--- a/lib/src/view/broadcast/broadcast_team_standings_screen.dart
+++ b/lib/src/view/broadcast/broadcast_team_standings_screen.dart
@@ -1,0 +1,355 @@
+import 'dart:math';
+
+import 'package:fast_immutable_collections/fast_immutable_collections.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:intl/intl.dart';
+import 'package:lichess_mobile/src/model/broadcast/broadcast.dart';
+import 'package:lichess_mobile/src/model/broadcast/broadcast_providers.dart';
+import 'package:lichess_mobile/src/model/common/id.dart';
+import 'package:lichess_mobile/src/styles/styles.dart';
+import 'package:lichess_mobile/src/theme.dart';
+import 'package:lichess_mobile/src/utils/l10n_context.dart';
+import 'package:lichess_mobile/src/utils/navigation.dart';
+import 'package:lichess_mobile/src/view/broadcast/broadcast_team_screen.dart';
+import 'package:lichess_mobile/src/widgets/misc.dart';
+import 'package:lichess_mobile/src/widgets/platform.dart';
+
+enum _SortingTypes { elo, score }
+
+typedef _TeamPicker<T> = T? Function(BroadcastTeamStanding team);
+
+const _kTableRowPadding = EdgeInsets.symmetric(horizontal: 8.0, vertical: 12.0);
+const _kHeaderTextStyle = TextStyle(fontWeight: FontWeight.bold, overflow: .ellipsis);
+
+class BroadcastTeamStandingsScreen extends ConsumerWidget {
+  const BroadcastTeamStandingsScreen({super.key, required this.tournamentId});
+
+  final BroadcastTournamentId tournamentId;
+
+  static Route<dynamic> buildRoute(BroadcastTournamentId tournamentId) {
+    return buildScreenRoute(screen: BroadcastTeamStandingsScreen(tournamentId: tournamentId));
+  }
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final standingsAsync = ref.watch(broadcastTeamStandingsProvider(tournamentId));
+    final tournamentAsync = ref.watch(broadcastTournamentProvider(tournamentId));
+
+    return PlatformScaffold(
+      appBar: PlatformAppBar(title: AppBarTitleText(context.l10n.broadcastTeamResults)),
+      body: switch ((standingsAsync, tournamentAsync)) {
+        (AsyncData(value: final teams), AsyncData()) when teams.isNotEmpty =>
+          BroadcastTeamStandingsList(teams: teams, tournamentId: tournamentId),
+        (AsyncError(:final error), _) ||
+        (_, AsyncError(:final error)) => Center(child: Text('Cannot load data: $error')),
+        _ => const Center(child: CircularProgressIndicator.adaptive()),
+      },
+    );
+  }
+}
+
+class BroadcastTeamStandingsList extends ConsumerStatefulWidget {
+  const BroadcastTeamStandingsList({required this.teams, required this.tournamentId});
+
+  final IList<BroadcastTeamStanding> teams;
+  final BroadcastTournamentId tournamentId;
+
+  @override
+  ConsumerState<BroadcastTeamStandingsList> createState() => _BroadcastTeamStandingsListState();
+}
+
+class _BroadcastTeamStandingsListState extends ConsumerState<BroadcastTeamStandingsList> {
+  late IList<BroadcastTeamStanding> teams;
+  late _SortingTypes currentSort;
+  bool reverse = false;
+
+  bool get withRating => teams.any((team) => team.averageRating != null);
+
+  @override
+  void initState() {
+    super.initState();
+    teams = widget.teams;
+    currentSort = .score;
+    sort();
+  }
+
+  @override
+  void didUpdateWidget(BroadcastTeamStandingsList oldWidget) {
+    super.didUpdateWidget(oldWidget);
+    if (oldWidget.teams != widget.teams) {
+      teams = widget.teams;
+      sort();
+    }
+  }
+
+  /// Sort items by values from the [picker] in increasing order.
+  ///
+  /// Null values are smaller than any other value.
+  Comparator<BroadcastTeamStanding> nullableCompare<T extends Comparable<T>>(
+    _TeamPicker<T> picker,
+  ) => (team1, team2) {
+    final field1 = picker(team1);
+    final field2 = picker(team2);
+    if (field1 == null) return -1;
+    if (field2 == null) return 1;
+    return field1.compareTo(field2);
+  };
+
+  /// Sort items first by values from the [picker1] and solve ties by values from the [picker2].
+  ///
+  /// Null values are smaller than any other value.
+  Comparator<BroadcastTeamStanding> bothCompare<T extends Comparable<T>, U extends Comparable<U>>(
+    _TeamPicker<T> picker1,
+    _TeamPicker<U> picker2,
+  ) => (team1, team2) {
+    final value = nullableCompare(picker1)(team1, team2);
+    if (value == 0) {
+      return nullableCompare(picker2)(team1, team2);
+    }
+    return value;
+  };
+
+  void toggleSort(_SortingTypes newSort) {
+    if (currentSort != newSort) {
+      currentSort = newSort;
+      reverse = false;
+    } else {
+      reverse = !reverse;
+    }
+    sort();
+  }
+
+  void sort() {
+    final compare = switch (currentSort) {
+      _SortingTypes.elo => (BroadcastTeamStanding t1, BroadcastTeamStanding t2) => bothCompare(
+        (t) => t.averageRating,
+        (t) => t.mp,
+      )(t2, t1),
+      _SortingTypes.score => (BroadcastTeamStanding t1, BroadcastTeamStanding t2) => bothCompare(
+        (t) => t.mp,
+        (t) => t.gp,
+      )(t2, t1),
+    };
+
+    setState(() {
+      teams = reverse ? teams.sortReversed(compare) : teams.sort(compare);
+    });
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final scoreWidth = max(MediaQuery.sizeOf(context).width * 0.15, 90.0);
+    final sortIcon = reverse ? Icons.keyboard_arrow_up : Icons.keyboard_arrow_down;
+    final mediaQueryPadding = MediaQuery.paddingOf(context);
+    final scoreFormat = NumberFormat('#.#');
+
+    return CustomScrollView(
+      slivers: [
+        SliverSafeArea(
+          bottom: false,
+          sliver: SliverToBoxAdapter(
+            child: Column(
+              mainAxisSize: .min,
+              children: [
+                Padding(
+                  padding: Styles.bodyPadding.copyWith(top: 8.0, bottom: 0.0),
+                  child: Row(
+                    children: [
+                      const Icon(Icons.info, size: 16),
+                      const SizedBox(width: 8),
+                      Expanded(
+                        child: Text(
+                          context.l10n.broadcastStandingsDisclaimer,
+                          maxLines: 3,
+                          style: const TextStyle(fontSize: 13, overflow: .ellipsis),
+                        ),
+                      ),
+                    ],
+                  ),
+                ),
+                Row(
+                  crossAxisAlignment: .center,
+                  children: [
+                    if (withRating)
+                      Expanded(
+                        child: _TableTitleCell(
+                          title: Text(
+                            '${context.l10n.broadcastTeams} (avg. Elo)',
+                            style: _kHeaderTextStyle,
+                          ),
+                          onTap: () => toggleSort(.elo),
+                          sortIcon: currentSort == .elo ? sortIcon : null,
+                        ),
+                      )
+                    else
+                      Expanded(
+                        child: Padding(
+                          padding: _kTableRowPadding,
+                          child: Text(context.l10n.broadcastTeams, style: _kHeaderTextStyle),
+                        ),
+                      ),
+                    SizedBox(
+                      width: scoreWidth,
+                      child: _TableTitleCell(
+                        title: const Text('Match\nPoints', style: _kHeaderTextStyle, maxLines: 2),
+                        onTap: () => toggleSort(.score),
+                        sortIcon: currentSort == .score ? sortIcon : null,
+                        mainAxisAlignment: .end,
+                      ),
+                    ),
+                    SizedBox(
+                      width: scoreWidth,
+                      child: const Padding(
+                        padding: _kTableRowPadding,
+                        child: Text(
+                          'Game\nPoints',
+                          textAlign: .right,
+                          style: _kHeaderTextStyle,
+                          maxLines: 2,
+                        ),
+                      ),
+                    ),
+                  ],
+                ),
+              ],
+            ),
+          ),
+        ),
+        SliverPadding(
+          padding: EdgeInsets.only(bottom: mediaQueryPadding.bottom),
+          sliver: SliverList(
+            delegate: SliverChildBuilderDelegate(
+              (context, index) => _BroadcastTeamStandingRow(
+                index: index,
+                team: teams[index],
+                tournamentId: widget.tournamentId,
+                scoreWidth: scoreWidth,
+                scoreFormat: scoreFormat,
+              ),
+              childCount: teams.length,
+            ),
+          ),
+        ),
+      ],
+    );
+  }
+}
+
+class _TableTitleCell extends StatelessWidget {
+  const _TableTitleCell({
+    required this.title,
+    required this.onTap,
+    this.sortIcon,
+    this.mainAxisAlignment = .start,
+  });
+
+  final Widget title;
+  final void Function() onTap;
+  final IconData? sortIcon;
+  final MainAxisAlignment mainAxisAlignment;
+
+  @override
+  Widget build(BuildContext context) {
+    return SizedBox(
+      height: 72,
+      child: InkWell(
+        onTap: onTap,
+        child: Padding(
+          padding: _kTableRowPadding,
+          child: Row(
+            mainAxisAlignment: mainAxisAlignment,
+            crossAxisAlignment: .center,
+            children: [
+              Flexible(child: title),
+              const SizedBox(width: 4),
+              SizedBox(
+                width: 16,
+                child: sortIcon != null
+                    ? Text(
+                        String.fromCharCode(sortIcon!.codePoint),
+                        style: _kHeaderTextStyle.copyWith(
+                          fontSize: 16,
+                          fontFamily: sortIcon!.fontFamily,
+                        ),
+                      )
+                    : null,
+              ),
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+}
+
+class _BroadcastTeamStandingRow extends StatelessWidget {
+  const _BroadcastTeamStandingRow({
+    required this.index,
+    required this.team,
+    required this.tournamentId,
+    required this.scoreWidth,
+    required this.scoreFormat,
+  });
+
+  final int index;
+  final BroadcastTeamStanding team;
+  final BroadcastTournamentId tournamentId;
+  final double scoreWidth;
+  final NumberFormat scoreFormat;
+
+  @override
+  Widget build(BuildContext context) {
+    return ListTile(
+      contentPadding: const EdgeInsetsDirectional.only(start: 16.0, end: 8.0),
+      visualDensity: .compact,
+      tileColor: index.isEven ? context.lichessTheme.rowEven : context.lichessTheme.rowOdd,
+      title: Text(team.name, maxLines: 2, overflow: .ellipsis),
+      subtitle: team.averageRating != null
+          ? Text(
+              'Ø ${team.averageRating}',
+              style: TextStyle(fontSize: 13, color: textShade(context, Styles.subtitleOpacity)),
+            )
+          : null,
+      trailing: SizedBox(
+        width: scoreWidth * 2,
+        child: Row(
+          children: [
+            SizedBox(
+              width: scoreWidth,
+              child: Align(
+                alignment: .centerRight,
+                child: Text(
+                  scoreFormat.format(team.mp),
+                  style: const TextStyle(
+                    fontSize: 14,
+                    fontWeight: .bold,
+                    fontFeatures: [FontFeature.tabularFigures()],
+                  ),
+                ),
+              ),
+            ),
+            SizedBox(
+              width: scoreWidth,
+              child: Align(
+                alignment: .centerRight,
+                child: Text(
+                  scoreFormat.format(team.gp),
+                  style: const TextStyle(
+                    fontSize: 14,
+                    fontFeatures: [FontFeature.tabularFigures()],
+                  ),
+                ),
+              ),
+            ),
+          ],
+        ),
+      ),
+      onTap: () {
+        Navigator.of(
+          context,
+        ).push(BroadcastTeamScreen.buildRoute(context, tournamentId, team.name));
+      },
+    );
+  }
+}

--- a/lib/src/view/broadcast/broadcast_team_standings_screen.dart
+++ b/lib/src/view/broadcast/broadcast_team_standings_screen.dart
@@ -316,7 +316,7 @@ class _BroadcastTeamStandingRow extends StatelessWidget {
       title: Text(team.name, maxLines: 2, overflow: .ellipsis),
       subtitle: team.averageRating != null
           ? Text(
-              'Ø ${team.averageRating}',
+              '${team.averageRating}',
               style: TextStyle(fontSize: 13, color: textShade(context, Styles.subtitleOpacity)),
             )
           : null,

--- a/lib/src/view/broadcast/broadcast_teams_tab.dart
+++ b/lib/src/view/broadcast/broadcast_teams_tab.dart
@@ -124,7 +124,7 @@ class _TeamStandingsButton extends StatelessWidget {
     final colorScheme = Theme.of(context).colorScheme;
 
     return Padding(
-      padding: const EdgeInsets.fromLTRB(4.0, 12.0, 4.0, 8.0),
+      padding: Styles.horizontalBodyPadding.copyWith(top: 12.0, bottom: 8.0),
       child: OutlinedButton(
         style: OutlinedButton.styleFrom(
           padding: const EdgeInsets.all(16.0),

--- a/lib/src/view/broadcast/broadcast_teams_tab.dart
+++ b/lib/src/view/broadcast/broadcast_teams_tab.dart
@@ -11,10 +11,12 @@ import 'package:lichess_mobile/src/model/common/eval.dart';
 import 'package:lichess_mobile/src/model/common/id.dart';
 import 'package:lichess_mobile/src/styles/styles.dart';
 import 'package:lichess_mobile/src/theme.dart';
+import 'package:lichess_mobile/src/utils/l10n_context.dart';
 import 'package:lichess_mobile/src/utils/screen.dart';
 import 'package:lichess_mobile/src/view/broadcast/broadcast_game_screen.dart';
 import 'package:lichess_mobile/src/view/broadcast/broadcast_player_widget.dart';
 import 'package:lichess_mobile/src/view/broadcast/broadcast_team_screen.dart';
+import 'package:lichess_mobile/src/view/broadcast/broadcast_team_standings_screen.dart';
 import 'package:lichess_mobile/src/view/engine/engine_gauge.dart';
 import 'package:visibility_detector/visibility_detector.dart';
 
@@ -83,27 +85,73 @@ class BroadcastTeamsList extends ConsumerWidget {
     );
 
     return switch (round) {
-      AsyncData(:final value) => ListView.builder(
-        itemCount: teamMatches.length,
-        itemBuilder: (context, index) {
-          final match = teamMatches[index];
-          return _TeamMatchCard(
-            match: match,
-            games: value.games,
-            tournamentId: tournamentId,
-            roundId: roundId,
-            tournamentSlug: tournamentSlug,
-            roundSlug: value.round.slug,
-            title: value.round.name,
-            showEvaluationGauge: showEvaluationGauges,
-            customScoring: value.round.customScoring,
-            showTeamScores: showTeamScores,
-          );
-        },
+      AsyncData(:final value) => CustomScrollView(
+        slivers: [
+          if (showTeamScores)
+            SliverToBoxAdapter(child: _TeamStandingsButton(tournamentId: tournamentId)),
+          SliverList(
+            delegate: SliverChildBuilderDelegate((context, index) {
+              final match = teamMatches[index];
+              return _TeamMatchCard(
+                match: match,
+                games: value.games,
+                tournamentId: tournamentId,
+                roundId: roundId,
+                tournamentSlug: tournamentSlug,
+                roundSlug: value.round.slug,
+                title: value.round.name,
+                showEvaluationGauge: showEvaluationGauges,
+                customScoring: value.round.customScoring,
+                showTeamScores: showTeamScores,
+              );
+            }, childCount: teamMatches.length),
+          ),
+        ],
       ),
       AsyncError(:final error) => Center(child: Text('Cannot load games data: $error')),
       _ => const Center(child: CircularProgressIndicator.adaptive()),
     };
+  }
+}
+
+class _TeamStandingsButton extends StatelessWidget {
+  const _TeamStandingsButton({required this.tournamentId});
+
+  final BroadcastTournamentId tournamentId;
+
+  @override
+  Widget build(BuildContext context) {
+    final colorScheme = Theme.of(context).colorScheme;
+
+    return Padding(
+      padding: const EdgeInsets.fromLTRB(4.0, 12.0, 4.0, 8.0),
+      child: OutlinedButton(
+        style: OutlinedButton.styleFrom(
+          padding: const EdgeInsets.all(16.0),
+          shape: RoundedRectangleBorder(borderRadius: .circular(8.0)),
+          side: BorderSide(color: colorScheme.primary, width: 0.8),
+        ),
+        onPressed: () {
+          Navigator.of(context).push(BroadcastTeamStandingsScreen.buildRoute(tournamentId));
+        },
+        child: Row(
+          mainAxisAlignment: .spaceBetween,
+          children: [
+            Row(
+              children: [
+                Icon(Icons.leaderboard, color: colorScheme.secondary),
+                const SizedBox(width: 12),
+                Text(
+                  context.l10n.broadcastTeamResults,
+                  style: TextStyle(fontWeight: .bold, color: colorScheme.secondary, fontSize: 16),
+                ),
+              ],
+            ),
+            Icon(Icons.chevron_right, color: colorScheme.secondary),
+          ],
+        ),
+      ),
+    );
   }
 }
 
@@ -144,7 +192,8 @@ class _TeamMatchCard extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     return Card(
-      shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(16.0)),
+      shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(8.0)),
+      clipBehavior: .hardEdge,
       elevation: 2,
       child: Column(
         crossAxisAlignment: CrossAxisAlignment.start,

--- a/test/view/broadcast/broadcast_round_screen_test.dart
+++ b/test/view/broadcast/broadcast_round_screen_test.dart
@@ -518,8 +518,13 @@ void main() {
 
       await tester.pumpWidget(app);
 
+      // Load the tournament
       await tester.pump();
+
+      // Load the round
       await tester.pump();
+
+      // Load the teams data
       await tester.pump();
 
       expect(find.text('Team Results'), findsOneWidget);

--- a/test/view/broadcast/broadcast_round_screen_test.dart
+++ b/test/view/broadcast/broadcast_round_screen_test.dart
@@ -501,6 +501,37 @@ void main() {
 
       expect(find.byType(Card), findsNWidgets(2));
     });
+
+    testWidgets('Check team standings screen opens from teams tab', (tester) async {
+      final app = await makeTestProviderScopeApp(
+        tester,
+        home: BroadcastRoundScreen(
+          broadcast: _liveTeamBroadcast,
+          initialTab: BroadcastRoundTab.teams,
+        ),
+        overrides: {
+          lichessClientProvider: lichessClientProvider.overrideWith(
+            (ref) => LichessClient(_liveTeamBroadcastClient, ref),
+          ),
+        },
+      );
+
+      await tester.pumpWidget(app);
+
+      await tester.pump();
+      await tester.pump();
+      await tester.pump();
+
+      expect(find.text('Team Results'), findsOneWidget);
+      expect(find.text('5.5'), findsNothing);
+
+      await tester.tap(find.text('Team Results'));
+      await tester.pumpAndSettle();
+
+      expect(find.text('5.5'), findsOneWidget);
+      expect(find.text('12'), findsOneWidget);
+      expect(find.text('Team A'), findsOneWidget);
+    });
   });
 }
 
@@ -2128,6 +2159,13 @@ final _liveTeamBroadcastClient = MockClient((request) {
       headers: {'content-type': 'application/json; charset=utf-8'},
     );
   }
+  if (request.url.path == '/broadcast/AAAAAAAA/teams/standings') {
+    return mockResponse(
+      _teamStandingsResponse,
+      200,
+      headers: {'content-type': 'application/json; charset=utf-8'},
+    );
+  }
   return mockResponse('', 404);
 });
 
@@ -2141,7 +2179,8 @@ const _liveTeamTournamentResponse = '''
       1735671720000
     ],
     "image": "",
-    "teamTable": true
+    "teamTable": true,
+    "showTeamScores": true
   },
   "rounds": [
     {
@@ -2164,6 +2203,7 @@ final _liveTeamBroadcast = Broadcast(
     description: null,
     tier: null,
     teamTable: true,
+    showTeamScores: true,
     information: (
       dates: (startsAt: DateTime.fromMillisecondsSinceEpoch(1735671720000), endsAt: null),
       format: null,
@@ -2187,6 +2227,48 @@ final _liveTeamBroadcast = Broadcast(
   roundToLinkId: const BroadcastRoundId('00000000'),
   group: null,
 );
+
+const _teamStandingsResponse = '''
+[
+  {
+    "name": "Team A",
+    "mp": 5.5,
+    "gp": 12,
+    "matches": [
+      {
+        "roundId": "00000000",
+        "opponent": "Team B",
+        "points": "1",
+        "mp": 1,
+        "gp": 6
+      },
+      {
+        "roundId": "00000001",
+        "opponent": "Team C",
+        "points": "1",
+        "mp": 1,
+        "gp": 6
+      }
+    ],
+    "players": []
+  },
+  {
+    "name": "Team B",
+    "mp": 4,
+    "gp": 10.5,
+    "matches": [
+      {
+        "roundId": "00000000",
+        "opponent": "Team A",
+        "points": "0",
+        "mp": 0,
+        "gp": 4
+      }
+    ],
+    "players": []
+  }
+]
+''';
 
 const _teamMatchesResponse = '''
 {


### PR DESCRIPTION
close #2614 

|||||
|-|-|-|-|
|<img width="527" height="1177" alt="image" src="https://github.com/user-attachments/assets/f724c10f-792c-4c80-b68a-d60d440de973" />|<img width="556" height="1187" alt="image" src="https://github.com/user-attachments/assets/a8b60d83-251a-4533-a559-e8ddec726c12" />|<img width="532" height="1180" alt="image" src="https://github.com/user-attachments/assets/fc25e3ba-39b7-465a-b0ef-ce01bd5d8934" />|<img width="530" height="1178" alt="image" src="https://github.com/user-attachments/assets/3856a9e7-f93d-4c68-b71f-2762a7b9737a" />|

I decided to put the team results on top of the teams tab, to not overload the tab bar.

A lot of code from the player screen I could reuse and adjust. 
One problem is the table headers as they take to much space to put on one line, I put them on two. But with this approach we can not use the current localization.
added one simple test