### PR TITLE
Add notifications for broadcast

### DIFF
--- a/lib/src/app.dart
+++ b/lib/src/app.dart
@@ -16,6 +16,7 @@ import 'package:lichess_mobile/src/model/account/ongoing_games_notifier.dart';
 import 'package:lichess_mobile/src/model/analysis/analysis_preferences.dart';
 import 'package:lichess_mobile/src/model/announce/announce_service.dart';
 import 'package:lichess_mobile/src/model/broadcast/broadcast_preferences.dart';
+import 'package:lichess_mobile/src/model/broadcast/broadcast_service.dart';
 import 'package:lichess_mobile/src/model/challenge/challenge_service.dart';
 import 'package:lichess_mobile/src/model/common/preloaded_data.dart';
 import 'package:lichess_mobile/src/model/correspondence/correspondence_service.dart';
@@ -146,6 +147,7 @@ class _AppState extends ConsumerState<Application> {
     ref.read(announceServiceProvider).start();
     ref.read(appLinksServiceProvider).start();
     ref.read(sharedPgnServiceProvider).start();
+    ref.read(broadcastServiceProvider).start();
 
     if (Platform.isIOS) {
       HomeWidget.setAppGroupId(_kIosAppGroupId);

--- a/lib/src/model/broadcast/broadcast_analysis_controller.dart
+++ b/lib/src/model/broadcast/broadcast_analysis_controller.dart
@@ -36,7 +36,11 @@ part 'broadcast_analysis_controller.freezed.dart';
 
 final _logger = Logger('BroadcastAnalysisController');
 
-typedef BroadcastAnalysisControllerParams = ({BroadcastRoundId roundId, BroadcastGameId gameId});
+typedef BroadcastAnalysisControllerParams = ({
+  BroadcastRoundId roundId,
+  BroadcastGameId gameId,
+  Side initialPov,
+});
 
 /// A provider for [BroadcastAnalysisController].
 final broadcastAnalysisControllerProvider = AsyncNotifierProvider.autoDispose
@@ -142,7 +146,7 @@ class BroadcastAnalysisController extends AsyncNotifier<BroadcastAnalysisState>
       pgnHeaders: pgnHeaders,
       pgnRootComments: rootComments,
       lastMove: lastMove,
-      pov: Side.white,
+      pov: params.initialPov,
       isServerAnalysisEnabled: prefs.enableServerAnalysis,
       clocks: _getClocks(currentPath),
       analysisSummary: pgnWithAnalysisSummary.analysisSummary,

--- a/lib/src/model/broadcast/broadcast_service.dart
+++ b/lib/src/model/broadcast/broadcast_service.dart
@@ -1,0 +1,80 @@
+import 'dart:async';
+
+import 'package:dartchess/dartchess.dart';
+import 'package:flutter/widgets.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:lichess_mobile/src/model/common/id.dart';
+import 'package:lichess_mobile/src/model/notifications/notification_service.dart';
+import 'package:lichess_mobile/src/model/notifications/notifications.dart';
+import 'package:lichess_mobile/src/tab_navigation.dart';
+import 'package:lichess_mobile/src/view/broadcast/broadcast_game_screen.dart';
+import 'package:lichess_mobile/src/view/broadcast/broadcast_round_screen.dart';
+
+/// A provider for [BroadcastService].
+final broadcastServiceProvider = Provider<BroadcastService>((Ref ref) {
+  final service = BroadcastService(ref);
+  ref.onDispose(service.dispose);
+  return service;
+}, name: 'BroadcastServiceProvider');
+
+class BroadcastService {
+  BroadcastService(this.ref);
+
+  final Ref ref;
+
+  StreamSubscription<ParsedLocalNotification>? _notificationResponseSubscription;
+
+  void start() {
+    _notificationResponseSubscription = NotificationService.responseStream.listen((data) {
+      final (_, notification) = data;
+      switch (notification) {
+        case BroadcastRoundNotification(:final roundId):
+          _onBroadcastRoundNotification(roundId);
+        case BroadcastPlayerFollowNotification(:final roundId, :final gameId, :final pov):
+          _onBroadcastPlayerFollowNotification(roundId, gameId, pov);
+        case _:
+          break;
+      }
+    });
+  }
+
+  NavigatorState? _getRootNavigator() {
+    final context = ref.read(currentNavigatorKeyProvider).currentContext;
+    if (context == null || !context.mounted) return null;
+
+    final navigator = Navigator.of(context, rootNavigator: true);
+
+    if (navigator.canPop()) {
+      navigator.popUntil((route) => route.isFirst);
+    }
+
+    return navigator;
+  }
+
+  Future<void> _onBroadcastRoundNotification(BroadcastRoundId roundId) async {
+    final navigator = _getRootNavigator();
+    if (navigator == null) return;
+    navigator.push(
+      BroadcastRoundScreenLoading.buildRoute(roundId, initialTab: BroadcastRoundTab.boards),
+    );
+  }
+
+  Future<void> _onBroadcastPlayerFollowNotification(
+    BroadcastRoundId roundId,
+    BroadcastGameId gameId,
+    Side pov,
+  ) async {
+    final navigator = _getRootNavigator();
+    if (navigator == null) return;
+    navigator.push(
+      BroadcastRoundScreenLoading.buildRoute(roundId, initialTab: BroadcastRoundTab.boards),
+    );
+    navigator.push(
+      BroadcastGameScreen.buildRoute(roundId: roundId, gameId: gameId, initialPov: pov),
+    );
+  }
+
+  void dispose() {
+    _notificationResponseSubscription?.cancel();
+  }
+}

--- a/lib/src/model/notifications/notification_service.dart
+++ b/lib/src/model/notifications/notification_service.dart
@@ -271,6 +271,28 @@ class NotificationService {
           notification,
         ));
 
+      case final BroadcastRoundFcmMessage roundMessage:
+        final notification = BroadcastRoundNotification.fromFcmMessage(roundMessage);
+        _responseStreamController.add((
+          NotificationResponse(
+            notificationResponseType: NotificationResponseType.selectedNotification,
+            id: notification.id,
+            payload: jsonEncode(notification.payload),
+          ),
+          notification,
+        ));
+
+      case final BroadcastPlayerFollowFcmMessage playerFollowMessage:
+        final notification = BroadcastPlayerFollowNotification.fromFcmMessage(playerFollowMessage);
+        _responseStreamController.add((
+          NotificationResponse(
+            notificationResponseType: NotificationResponseType.selectedNotification,
+            id: notification.id,
+            payload: jsonEncode(notification.payload),
+          ),
+          notification,
+        ));
+
       // TODO: handle other notification types
       case UnhandledFcmMessage(data: final data):
         _logger.warning('Received unhandled FCM notification type: ${data['lichess.type']}');
@@ -326,6 +348,29 @@ class NotificationService {
         if (fromBackground == false && notification != null) {
           await show(
             ChallengeAcceptedNotification(fullId, notification.title!, notification.body!),
+          );
+        }
+
+      case BroadcastRoundFcmMessage(:final roundId, :final notification):
+        if (fromBackground == false && notification != null) {
+          await show(BroadcastRoundNotification(roundId, notification.title!, notification.body!));
+        }
+
+      case BroadcastPlayerFollowFcmMessage(
+        :final roundId,
+        :final gameId,
+        :final pov,
+        :final notification,
+      ):
+        if (fromBackground == false && notification != null) {
+          await show(
+            BroadcastPlayerFollowNotification(
+              roundId,
+              gameId,
+              pov,
+              notification.title!,
+              notification.body!,
+            ),
           );
         }
 

--- a/lib/src/model/notifications/notifications.dart
+++ b/lib/src/model/notifications/notifications.dart
@@ -1,5 +1,6 @@
 import 'dart:convert';
 
+import 'package:dartchess/dartchess.dart';
 import 'package:deep_pick/deep_pick.dart';
 import 'package:firebase_messaging/firebase_messaging.dart';
 import 'package:flutter_local_notifications/flutter_local_notifications.dart';
@@ -92,6 +93,34 @@ sealed class FcmMessage {
           } else {
             return MalformedFcmMessage(message.data);
           }
+        case 'broadcast':
+          final rawUrl = message.data['lichess.url'] as String?;
+          if (rawUrl == null) return MalformedFcmMessage(message.data);
+          final url = Uri.tryParse(rawUrl);
+          switch (url) {
+            case Uri(pathSegments: ['broadcast', _, _, final roundId]):
+              return BroadcastRoundFcmMessage(
+                BroadcastRoundId(roundId),
+                notification: message.notification,
+              );
+            case Uri(
+              pathSegments: ['broadcast', _, _, final roundId, final gameId],
+              queryParameters: {'pov': final pov},
+            ):
+              final side = Side.values.where((s) => s.name == pov).firstOrNull;
+              if (side == null) {
+                return MalformedFcmMessage(message.data);
+              }
+
+              return BroadcastPlayerFollowFcmMessage(
+                BroadcastRoundId(roundId),
+                BroadcastGameId(gameId),
+                side,
+                notification: message.notification,
+              );
+            case _:
+              return MalformedFcmMessage(message.data);
+          }
         default:
           return UnhandledFcmMessage(message.data);
       }
@@ -143,6 +172,35 @@ class ChallengeAcceptFcmMessage extends FcmMessage {
 
   final ChallengeId id;
   final GameFullId fullId;
+
+  @override
+  final RemoteNotification? notification;
+}
+
+/// An [FcmMessage] sent when a broadcast round a user subscribed to starts.
+@immutable
+class BroadcastRoundFcmMessage extends FcmMessage {
+  const BroadcastRoundFcmMessage(this.roundId, {required this.notification});
+
+  final BroadcastRoundId roundId;
+
+  @override
+  final RemoteNotification? notification;
+}
+
+/// An [FcmMessage] sent when a followed player starts a broadcast game.
+@immutable
+class BroadcastPlayerFollowFcmMessage extends FcmMessage {
+  const BroadcastPlayerFollowFcmMessage(
+    this.roundId,
+    this.gameId,
+    this.pov, {
+    required this.notification,
+  });
+
+  final BroadcastRoundId roundId;
+  final BroadcastGameId gameId;
+  final Side pov;
 
   @override
   final RemoteNotification? notification;
@@ -229,6 +287,10 @@ sealed class LocalNotification {
         return ChallengeCreatedNotification.fromJson(json);
       case 'announce':
         return AnnounceNotification.fromJson(json);
+      case 'broadcastRound':
+        return BroadcastRoundNotification.fromJson(json);
+      case 'broadcastPlayerFollow':
+        return BroadcastPlayerFollowNotification.fromJson(json);
       default:
         throw ArgumentError('Unknown notification channel: $channel');
     }
@@ -700,4 +762,139 @@ class ChallengeNotification extends LocalNotification {
           DarwinNotificationCategoryOption.hiddenPreviewShowTitle,
         },
       );
+}
+
+/// A notification for when a broadcast round starts.
+///
+/// This notification is shown when a broadcast round the user subscribed to starts.
+class BroadcastRoundNotification extends LocalNotification {
+  const BroadcastRoundNotification(this.roundId, String title, String body)
+    : _title = title,
+      _body = body;
+
+  final BroadcastRoundId roundId;
+
+  final String _title;
+  final String _body;
+
+  // The Android notification channel ID
+  static const _channelId = 'broadcast';
+
+  factory BroadcastRoundNotification.fromJson(Map<String, dynamic> json) {
+    final roundId = BroadcastRoundId(json['roundId'] as String);
+    final title = json['title'] as String;
+    final body = json['body'] as String;
+    return BroadcastRoundNotification(roundId, title, body);
+  }
+
+  factory BroadcastRoundNotification.fromFcmMessage(BroadcastRoundFcmMessage broadcast) {
+    return BroadcastRoundNotification(
+      broadcast.roundId,
+      broadcast.notification?.title ?? '',
+      broadcast.notification?.body ?? '',
+    );
+  }
+
+  @override
+  // Used to identify the notification type when reconstructing it from the
+  // Android local notification payload. This is not the Android notification
+  // channel ID.
+  String get channelId => 'broadcastRound';
+
+  @override
+  int get id => roundId.hashCode;
+
+  @override
+  Map<String, dynamic> get _concretePayload => {
+    'roundId': roundId.value,
+    'title': _title,
+    'body': _body,
+  };
+
+  @override
+  String title(_) => _title;
+
+  @override
+  String? body(_) => _body;
+
+  @override
+  NotificationDetails details(AppLocalizations l10n) => NotificationDetails(
+    android: AndroidNotificationDetails(_channelId, l10n.broadcastBroadcasts),
+    iOS: const DarwinNotificationDetails(threadIdentifier: _channelId),
+  );
+}
+
+/// A notification for when a followed player starts a broadcast game.
+///
+/// This notification is shown when a FIDE player followed by the user begins a game in a broadcast.
+class BroadcastPlayerFollowNotification extends LocalNotification {
+  const BroadcastPlayerFollowNotification(
+    this.roundId,
+    this.gameId,
+    this.pov,
+    String title,
+    String body,
+  ) : _title = title,
+      _body = body;
+
+  final BroadcastRoundId roundId;
+  final BroadcastGameId gameId;
+  final Side pov;
+
+  final String _title;
+  final String _body;
+
+  // The Android notification channel ID
+  static const _channelId = 'broadcast';
+
+  factory BroadcastPlayerFollowNotification.fromJson(Map<String, dynamic> json) {
+    final roundId = BroadcastRoundId(json['roundId'] as String);
+    final gameId = BroadcastGameId(json['gameId'] as String);
+    final pov = Side.values.byName(json['pov'] as String);
+    final title = json['title'] as String;
+    final body = json['body'] as String;
+    return BroadcastPlayerFollowNotification(roundId, gameId, pov, title, body);
+  }
+
+  factory BroadcastPlayerFollowNotification.fromFcmMessage(
+    BroadcastPlayerFollowFcmMessage broadcast,
+  ) {
+    return BroadcastPlayerFollowNotification(
+      broadcast.roundId,
+      broadcast.gameId,
+      broadcast.pov,
+      broadcast.notification?.title ?? '',
+      broadcast.notification?.body ?? '',
+    );
+  }
+
+  @override
+  // Used to identify the notification type when reconstructing it from the
+  // Android local notification payload. This is not the Android notification
+  // channel ID.
+  String get channelId => 'broadcastPlayerFollow';
+
+  @override
+  int get id => gameId.hashCode;
+
+  @override
+  Map<String, dynamic> get _concretePayload => {
+    'roundId': roundId.value,
+    'gameId': gameId.value,
+    'pov': pov.name,
+    'title': _title,
+    'body': _body,
+  };
+
+  @override
+  String title(_) => _title;
+
+  @override
+  String? body(_) => _body;
+
+  @override
+  NotificationDetails details(AppLocalizations l10n) => NotificationDetails(
+    android: AndroidNotificationDetails(_channelId, l10n.broadcastBroadcasts),
+    iOS: const DarwinNotificationDetails(threadIdentifier: _channelId),
+  );
 }

--- a/lib/src/view/broadcast/broadcast_game_screen.dart
+++ b/lib/src/view/broadcast/broadcast_game_screen.dart
@@ -49,6 +49,7 @@ class BroadcastGameScreen extends ConsumerStatefulWidget {
   final String? tournamentSlug;
   final String? roundSlug;
   final String? title;
+  final Side initialPov;
 
   const BroadcastGameScreen({
     this.tournamentId,
@@ -57,6 +58,7 @@ class BroadcastGameScreen extends ConsumerStatefulWidget {
     this.tournamentSlug,
     this.roundSlug,
     this.title,
+    this.initialPov = Side.white,
   });
 
   static Route<dynamic> buildRoute({
@@ -66,6 +68,7 @@ class BroadcastGameScreen extends ConsumerStatefulWidget {
     String? tournamentSlug,
     String? roundSlug,
     String? title,
+    Side initialPov = Side.white,
   }) {
     return buildScreenRoute(
       screen: BroadcastGameScreen(
@@ -75,6 +78,7 @@ class BroadcastGameScreen extends ConsumerStatefulWidget {
         tournamentSlug: tournamentSlug,
         roundSlug: roundSlug,
         title: title,
+        initialPov: initialPov,
       ),
     );
   }
@@ -115,6 +119,12 @@ class _BroadcastGameScreenState extends ConsumerState<BroadcastGameScreen>
             ),
             _ => const SizedBox.shrink(),
           };
+    final roundControllerParams = (roundId: widget.roundId, gameId: widget.gameId);
+    final controllerParams = (
+      roundId: widget.roundId,
+      gameId: widget.gameId,
+      initialPov: widget.initialPov,
+    );
 
     return Scaffold(
       appBar: AppBar(
@@ -123,6 +133,7 @@ class _BroadcastGameScreenState extends ConsumerState<BroadcastGameScreen>
           _BroadcastGameMenu(
             roundId: widget.roundId,
             gameId: widget.gameId,
+            controllerParams: controllerParams,
             tournamentSlug: widget.tournamentSlug,
             roundSlug: widget.roundSlug,
           ),
@@ -131,7 +142,8 @@ class _BroadcastGameScreenState extends ConsumerState<BroadcastGameScreen>
       body: _Body(
         widget.tournamentId,
         widget.roundId,
-        widget.gameId,
+        roundControllerParams,
+        controllerParams,
         widget.tournamentSlug,
         widget.roundSlug,
         tabController: _tabController,
@@ -145,12 +157,14 @@ class _BroadcastGameMenu extends ConsumerWidget {
   const _BroadcastGameMenu({
     required this.roundId,
     required this.gameId,
+    required this.controllerParams,
     this.tournamentSlug,
     this.roundSlug,
   });
 
   final BroadcastRoundId roundId;
   final BroadcastGameId gameId;
+  final BroadcastAnalysisControllerParams controllerParams;
   final String? tournamentSlug;
   final String? roundSlug;
 
@@ -223,7 +237,8 @@ class _Body extends ConsumerWidget {
   const _Body(
     this.tournamentId,
     this.roundId,
-    this.gameId,
+    this.roundGameParams,
+    this.controllerParams,
     this.tournamentSlug,
     this.roundSlug, {
     required this.tabController,
@@ -232,7 +247,8 @@ class _Body extends ConsumerWidget {
 
   final BroadcastTournamentId? tournamentId;
   final BroadcastRoundId roundId;
-  final BroadcastGameId gameId;
+  final BroadcastRoundGameParams roundGameParams;
+  final BroadcastAnalysisControllerParams controllerParams;
   final String? tournamentSlug;
   final String? roundSlug;
   final TabController tabController;
@@ -240,7 +256,7 @@ class _Body extends ConsumerWidget {
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
-    switch (ref.watch(broadcastAnalysisControllerProvider((roundId: roundId, gameId: gameId)))) {
+    switch (ref.watch(broadcastAnalysisControllerProvider(controllerParams))) {
       case AsyncValue(value: final state?, hasValue: true):
         final broadcastPrefs = ref.watch(broadcastPreferencesProvider);
         final enginePrefs = ref.watch(engineEvaluationPreferencesProvider);
@@ -258,8 +274,7 @@ class _Body extends ConsumerWidget {
             tabController: tabController,
             tabs: tabs,
             boardBuilder: (context, boardSize, borderRadius) => BroadcastAnalysisBoard(
-              roundId: roundId,
-              gameId: gameId,
+              controllerParams: controllerParams,
               boardSize: boardSize,
               boardRadius: borderRadius,
             ),
@@ -267,13 +282,15 @@ class _Body extends ConsumerWidget {
             boardHeader: _PlayerWidget(
               tournamentId: tournamentId,
               roundId: roundId,
-              gameId: gameId,
+              roundGameParams: roundGameParams,
+              controllerParams: controllerParams,
               widgetPosition: _PlayerWidgetPosition.top,
             ),
             boardFooter: _PlayerWidget(
               tournamentId: tournamentId,
               roundId: roundId,
-              gameId: gameId,
+              roundGameParams: roundGameParams,
+              controllerParams: controllerParams,
               widgetPosition: _PlayerWidgetPosition.bottom,
             ),
             engineGaugeBuilder: state.hasAvailableEval(enginePrefs) && showEvaluationGauge
@@ -287,26 +304,20 @@ class _Body extends ConsumerWidget {
                     filters: (id: state.evaluationContext.id, path: state.currentPath),
                     analysisState: state,
                     onTapMove: ref
-                        .read(
-                          broadcastAnalysisControllerProvider((
-                            roundId: roundId,
-                            gameId: gameId,
-                          )).notifier,
-                        )
+                        .read(broadcastAnalysisControllerProvider(controllerParams).notifier)
                         .onUserMove,
                   )
                 : null,
             bottomBar: _BroadcastGameBottomBar(
-              roundId: roundId,
-              gameId: gameId,
+              controllerParams: controllerParams,
               tournamentSlug: tournamentSlug,
               roundSlug: roundSlug,
             ),
             children: [
-              _PgnTagsView(roundId, gameId),
-              _OpeningExplorerTab(roundId, gameId),
-              _BroadcastGameTreeView(roundId, gameId),
-              BroadcastGameSummary(roundId: roundId, gameId: gameId),
+              _PgnTagsView(controllerParams),
+              _OpeningExplorerTab(controllerParams),
+              _BroadcastGameTreeView(controllerParams),
+              BroadcastGameSummary(controllerParams),
             ],
           ),
         );
@@ -319,14 +330,13 @@ class _Body extends ConsumerWidget {
 }
 
 class _BroadcastGameTreeView extends ConsumerWidget {
-  const _BroadcastGameTreeView(this.roundId, this.gameId);
+  const _BroadcastGameTreeView(this.controllerParams);
 
-  final BroadcastRoundId roundId;
-  final BroadcastGameId gameId;
+  final BroadcastAnalysisControllerParams controllerParams;
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
-    final ctrlProvider = broadcastAnalysisControllerProvider((roundId: roundId, gameId: gameId));
+    final ctrlProvider = broadcastAnalysisControllerProvider(controllerParams);
     final state = ref.watch(ctrlProvider).requireValue;
 
     final broadcastPrefs = ref.watch(broadcastPreferencesProvider);
@@ -399,14 +409,13 @@ enum PgnTags {
 }
 
 class _PgnTagsView extends ConsumerWidget {
-  const _PgnTagsView(this.roundId, this.gameId);
+  const _PgnTagsView(this.controllerParams);
 
-  final BroadcastRoundId roundId;
-  final BroadcastGameId gameId;
+  final BroadcastAnalysisControllerParams controllerParams;
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
-    final ctrlProvider = broadcastAnalysisControllerProvider((roundId: roundId, gameId: gameId));
+    final ctrlProvider = broadcastAnalysisControllerProvider(controllerParams);
     final state = ref.watch(ctrlProvider).requireValue;
     final pgnHeaders = state.pgnHeaders;
 
@@ -459,14 +468,13 @@ class _PgnTagsView extends ConsumerWidget {
 }
 
 class _OpeningExplorerTab extends ConsumerWidget {
-  const _OpeningExplorerTab(this.roundId, this.gameId);
+  const _OpeningExplorerTab(this.controllerParams);
 
-  final BroadcastRoundId roundId;
-  final BroadcastGameId gameId;
+  final BroadcastAnalysisControllerParams controllerParams;
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
-    final ctrlProvider = broadcastAnalysisControllerProvider((roundId: roundId, gameId: gameId));
+    final ctrlProvider = broadcastAnalysisControllerProvider(controllerParams);
     final state = ref.watch(ctrlProvider).requireValue;
 
     return ExplorerView(
@@ -487,14 +495,12 @@ class _OpeningExplorerTab extends ConsumerWidget {
 
 class BroadcastAnalysisBoard extends AnalysisBoard {
   const BroadcastAnalysisBoard({
-    required this.roundId,
-    required this.gameId,
+    required this.controllerParams,
     required super.boardSize,
     super.boardRadius,
   });
 
-  final BroadcastRoundId roundId;
-  final BroadcastGameId gameId;
+  final BroadcastAnalysisControllerParams controllerParams;
 
   @override
   ConsumerState<BroadcastAnalysisBoard> createState() => _BroadcastAnalysisBoardState();
@@ -503,25 +509,20 @@ class BroadcastAnalysisBoard extends AnalysisBoard {
 class _BroadcastAnalysisBoardState
     extends AnalysisBoardState<BroadcastAnalysisBoard, BroadcastAnalysisState, BroadcastPrefs> {
   @override
-  BroadcastAnalysisState? readCurrentState() => ref
-      .read(broadcastAnalysisControllerProvider((roundId: widget.roundId, gameId: widget.gameId)))
-      .value;
+  BroadcastAnalysisState? readCurrentState() =>
+      ref.read(broadcastAnalysisControllerProvider(widget.controllerParams)).value;
 
   @override
   void listenToStateChanges(
     void Function(BroadcastAnalysisState? prev, BroadcastAnalysisState? next) listener,
   ) => ref.listenManual<BroadcastAnalysisState?>(
-    broadcastAnalysisControllerProvider((
-      roundId: widget.roundId,
-      gameId: widget.gameId,
-    )).select((v) => v.value),
+    broadcastAnalysisControllerProvider(widget.controllerParams).select((v) => v.value),
     listener,
   );
 
   @override
-  BroadcastAnalysisState get analysisState => ref
-      .watch(broadcastAnalysisControllerProvider((roundId: widget.roundId, gameId: widget.gameId)))
-      .requireValue;
+  BroadcastAnalysisState get analysisState =>
+      ref.watch(broadcastAnalysisControllerProvider(widget.controllerParams)).requireValue;
 
   @override
   BroadcastPrefs get analysisPrefs => ref.watch(broadcastPreferencesProvider);
@@ -532,12 +533,7 @@ class _BroadcastAnalysisBoardState
 
   @override
   void onUserMove(Move move) => ref
-      .read(
-        broadcastAnalysisControllerProvider((
-          roundId: widget.roundId,
-          gameId: widget.gameId,
-        )).notifier,
-      )
+      .read(broadcastAnalysisControllerProvider(widget.controllerParams).notifier)
       .onUserMove(move);
 
   @override
@@ -554,21 +550,23 @@ class _PlayerWidget extends ConsumerWidget {
   const _PlayerWidget({
     this.tournamentId,
     required this.roundId,
-    required this.gameId,
+    required this.roundGameParams,
+    required this.controllerParams,
     required this.widgetPosition,
   });
 
   final BroadcastTournamentId? tournamentId;
   final BroadcastRoundId roundId;
-  final BroadcastGameId gameId;
+  final BroadcastRoundGameParams roundGameParams;
+  final BroadcastAnalysisControllerParams controllerParams;
   final _PlayerWidgetPosition widgetPosition;
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
-    switch (ref.watch(broadcastRoundGameProvider((roundId: roundId, gameId: gameId)))) {
+    switch (ref.watch(broadcastRoundGameProvider(roundGameParams))) {
       case AsyncValue(value: final game?, hasValue: true):
         final broadcastAnalysisState = ref
-            .watch(broadcastAnalysisControllerProvider((roundId: roundId, gameId: gameId)))
+            .watch(broadcastAnalysisControllerProvider(controllerParams))
             .requireValue;
 
         final isCursorOnLiveMove =
@@ -692,20 +690,18 @@ class _Clock extends StatelessWidget {
 
 class _BroadcastGameBottomBar extends ConsumerWidget {
   const _BroadcastGameBottomBar({
-    required this.roundId,
-    required this.gameId,
+    required this.controllerParams,
     this.tournamentSlug,
     this.roundSlug,
   });
 
-  final BroadcastRoundId roundId;
-  final BroadcastGameId gameId;
+  final BroadcastAnalysisControllerParams controllerParams;
   final String? tournamentSlug;
   final String? roundSlug;
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
-    final ctrlProvider = broadcastAnalysisControllerProvider((roundId: roundId, gameId: gameId));
+    final ctrlProvider = broadcastAnalysisControllerProvider(controllerParams);
     final broadcastAnalysisState = ref.watch(ctrlProvider).requireValue;
 
     return BottomBar(
@@ -768,7 +764,7 @@ class _BroadcastGameBottomBar extends ConsumerWidget {
   }
 
   Future<void> _showMenu(BuildContext context, WidgetRef ref) {
-    final ctrlProvider = broadcastAnalysisControllerProvider((roundId: roundId, gameId: gameId));
+    final ctrlProvider = broadcastAnalysisControllerProvider(controllerParams);
 
     return showAdaptiveActionSheet(
       context: context,
@@ -777,7 +773,7 @@ class _BroadcastGameBottomBar extends ConsumerWidget {
           makeLabel: (context) => Text(context.l10n.settingsSettings),
           onPressed: () => Navigator.of(
             context,
-          ).push(BroadcastGameSettingsScreen.buildRoute(roundId: roundId, gameId: gameId)),
+          ).push(BroadcastGameSettingsScreen.buildRoute(controllerParams: controllerParams)),
         ),
         BottomSheetAction(
           makeLabel: (context) => Text(context.l10n.flipBoard),
@@ -787,10 +783,8 @@ class _BroadcastGameBottomBar extends ConsumerWidget {
     );
   }
 
-  void _moveForward(WidgetRef ref) => ref
-      .read(broadcastAnalysisControllerProvider((roundId: roundId, gameId: gameId)).notifier)
-      .userNext();
-  void _moveBackward(WidgetRef ref) => ref
-      .read(broadcastAnalysisControllerProvider((roundId: roundId, gameId: gameId)).notifier)
-      .userPrevious();
+  void _moveForward(WidgetRef ref) =>
+      ref.read(broadcastAnalysisControllerProvider(controllerParams).notifier).userNext();
+  void _moveBackward(WidgetRef ref) =>
+      ref.read(broadcastAnalysisControllerProvider(controllerParams).notifier).userPrevious();
 }

--- a/lib/src/view/broadcast/broadcast_game_screen_providers.dart
+++ b/lib/src/view/broadcast/broadcast_game_screen_providers.dart
@@ -3,13 +3,13 @@ import 'package:lichess_mobile/src/model/broadcast/broadcast.dart';
 import 'package:lichess_mobile/src/model/broadcast/broadcast_round_controller.dart';
 import 'package:lichess_mobile/src/model/common/id.dart';
 
-typedef BroadcastRoundGameParam = ({BroadcastRoundId roundId, BroadcastGameId gameId});
+typedef BroadcastRoundGameParams = ({BroadcastRoundId roundId, BroadcastGameId gameId});
 
-/// A provider that exposes the [BroadcastGame] for the given [BroadcastRoundGameParam].
+/// A provider that exposes the [BroadcastGame] for the given [BroadcastRoundGameParams].
 final broadcastRoundGameProvider = FutureProvider.autoDispose
-    .family<BroadcastGame, BroadcastRoundGameParam>((
+    .family<BroadcastGame, BroadcastRoundGameParams>((
       Ref ref,
-      BroadcastRoundGameParam params,
+      BroadcastRoundGameParams params,
     ) async {
       final round = await ref.watch(broadcastRoundControllerProvider(params.roundId).future);
       return round.games[params.gameId]!;

--- a/lib/src/view/broadcast/broadcast_game_settings_screen.dart
+++ b/lib/src/view/broadcast/broadcast_game_settings_screen.dart
@@ -2,7 +2,6 @@ import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:lichess_mobile/src/model/broadcast/broadcast_analysis_controller.dart';
 import 'package:lichess_mobile/src/model/broadcast/broadcast_preferences.dart';
-import 'package:lichess_mobile/src/model/common/id.dart';
 import 'package:lichess_mobile/src/model/settings/general_preferences.dart';
 import 'package:lichess_mobile/src/utils/l10n_context.dart';
 import 'package:lichess_mobile/src/utils/navigation.dart';
@@ -12,21 +11,17 @@ import 'package:lichess_mobile/src/widgets/list.dart';
 import 'package:lichess_mobile/src/widgets/settings.dart';
 
 class BroadcastGameSettingsScreen extends ConsumerWidget {
-  const BroadcastGameSettingsScreen(this.roundId, this.gameId);
+  const BroadcastGameSettingsScreen(this.controllerParams);
 
-  final BroadcastRoundId roundId;
-  final BroadcastGameId gameId;
+  final BroadcastAnalysisControllerParams controllerParams;
 
-  static Route<dynamic> buildRoute({
-    required BroadcastRoundId roundId,
-    required BroadcastGameId gameId,
-  }) {
-    return buildScreenRoute(screen: BroadcastGameSettingsScreen(roundId, gameId));
+  static Route<dynamic> buildRoute({required BroadcastAnalysisControllerParams controllerParams}) {
+    return buildScreenRoute(screen: BroadcastGameSettingsScreen(controllerParams));
   }
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
-    final controller = broadcastAnalysisControllerProvider((roundId: roundId, gameId: gameId));
+    final controller = broadcastAnalysisControllerProvider(controllerParams);
 
     final broadcastPrefs = ref.watch(broadcastPreferencesProvider);
     final isSoundEnabled = ref.watch(generalPreferencesProvider).isSoundEnabled;

--- a/lib/src/view/broadcast/broadcast_game_summary.dart
+++ b/lib/src/view/broadcast/broadcast_game_summary.dart
@@ -3,20 +3,18 @@ import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:lichess_mobile/src/model/broadcast/broadcast_analysis_controller.dart';
 import 'package:lichess_mobile/src/model/broadcast/broadcast_preferences.dart';
-import 'package:lichess_mobile/src/model/common/id.dart';
 import 'package:lichess_mobile/src/widgets/acpl_chart.dart';
 import 'package:lichess_mobile/src/widgets/game_summary_table.dart';
 
 class BroadcastGameSummary extends ConsumerWidget {
-  const BroadcastGameSummary({required this.roundId, required this.gameId, super.key});
+  const BroadcastGameSummary(this.controllerParams);
 
-  final BroadcastRoundId roundId;
-  final BroadcastGameId gameId;
+  final BroadcastAnalysisControllerParams controllerParams;
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
     final broadcastPrefs = ref.watch(broadcastPreferencesProvider);
-    final ctrlProvider = broadcastAnalysisControllerProvider((roundId: roundId, gameId: gameId));
+    final ctrlProvider = broadcastAnalysisControllerProvider(controllerParams);
     final analysisState = ref.watch(ctrlProvider).requireValue;
 
     if (!broadcastPrefs.enableServerAnalysis || analysisState.analysisSummary == null) {
@@ -25,22 +23,21 @@ class BroadcastGameSummary extends ConsumerWidget {
 
     return ListView(
       children: [
-        _BroadcastAcplChart(roundId: roundId, gameId: gameId),
-        _GameSummaryTable(roundId: roundId, gameId: gameId),
+        _BroadcastAcplChart(controllerParams: controllerParams),
+        _GameSummaryTable(controllerParams: controllerParams),
       ],
     );
   }
 }
 
 class _BroadcastAcplChart extends ConsumerWidget {
-  const _BroadcastAcplChart({required this.roundId, required this.gameId});
+  const _BroadcastAcplChart({required this.controllerParams});
 
-  final BroadcastRoundId roundId;
-  final BroadcastGameId gameId;
+  final BroadcastAnalysisControllerParams controllerParams;
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
-    final ctrlProvider = broadcastAnalysisControllerProvider((roundId: roundId, gameId: gameId));
+    final ctrlProvider = broadcastAnalysisControllerProvider(controllerParams);
     final state = ref.watch(ctrlProvider).requireValue;
     final acplChartData = state.acplChartData;
 
@@ -64,14 +61,13 @@ class _BroadcastAcplChart extends ConsumerWidget {
 }
 
 class _GameSummaryTable extends ConsumerWidget {
-  const _GameSummaryTable({required this.roundId, required this.gameId});
+  const _GameSummaryTable({required this.controllerParams});
 
-  final BroadcastRoundId roundId;
-  final BroadcastGameId gameId;
+  final BroadcastAnalysisControllerParams controllerParams;
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
-    final ctrlProvider = broadcastAnalysisControllerProvider((roundId: roundId, gameId: gameId));
+    final ctrlProvider = broadcastAnalysisControllerProvider(controllerParams);
     final analysisState = ref.watch(ctrlProvider).requireValue;
 
     return GameSummaryTable(

--- a/test/view/broadcast/broadcast_game_screen_test.dart
+++ b/test/view/broadcast/broadcast_game_screen_test.dart
@@ -537,6 +537,7 @@ void main() {
       final ctrlProvider = broadcastAnalysisControllerProvider((
         roundId: _roundId,
         gameId: _gameId,
+        initialPov: Side.white,
       ));
 
       // Capture the sideline path, then promote it to mainline.

--- a/test/view/broadcast/broadcast_opening_test.dart
+++ b/test/view/broadcast/broadcast_opening_test.dart
@@ -60,7 +60,13 @@ void main() {
   BroadcastAnalysisState readState(WidgetTester tester) {
     final container = ProviderScope.containerOf(tester.element(find.byType(BroadcastGameScreen)));
     return container
-        .read(broadcastAnalysisControllerProvider((roundId: _roundId, gameId: _gameId)))
+        .read(
+          broadcastAnalysisControllerProvider((
+            roundId: _roundId,
+            gameId: _gameId,
+            initialPov: Side.white,
+          )),
+        )
         .requireValue;
   }
 


### PR DESCRIPTION
Send a notification to the user when:
    - a broadcast round he subscribed to starts
    - a FIDE player he follows begin a game in a broadcast

I have added a parameter to the BroadcastAnalysisController so that when the user taps the notification it opens with the pov of the player he follows. Because the controller is used in a lot of places in the code it requires passing the param in each widget. I wonder if there is another way to achieve this.

It will require https://github.com/lichess-org/lila/pull/20627