### PR TITLE
Polish app bar scroll behavior

### DIFF
--- a/lib/src/view/broadcast/broadcast_list_screen.dart
+++ b/lib/src/view/broadcast/broadcast_list_screen.dart
@@ -84,10 +84,14 @@ class _BroadcastListScreenState extends State<BroadcastListScreen> {
       ),
     );
 
+    final appBarBackground = ColorScheme.of(context).surfaceContainerHigh.withValues(alpha: 1);
+
     return Scaffold(
       body: _Body(filter),
       appBar: AppBar(
-        backgroundColor: ColorScheme.of(context).surfaceContainerHigh.withValues(alpha: 1),
+        backgroundColor: appBarBackground,
+        scrolledUnderElevation: 0,
+        surfaceTintColor: Colors.transparent,
         title: title,
         actions: [searchButton, filterButton],
       ),
@@ -136,6 +140,7 @@ class _Body extends ConsumerWidget {
                           backgroundColor: ColorScheme.of(
                             context,
                           ).surfaceContainerHigh.withValues(alpha: 1),
+                          scrolledUnderElevation: 0,
                           automaticallyImplyLeading: false,
                           primary: false,
                           title: AppBarTitleText(section.$2),

--- a/lib/src/view/settings/theme_settings_screen.dart
+++ b/lib/src/view/settings/theme_settings_screen.dart
@@ -28,7 +28,10 @@ class ThemeSettingsScreen extends ConsumerWidget {
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
-    return const Scaffold(body: _Body());
+    return Scaffold(
+      appBar: AppBar(title: Text(context.l10n.mobileTheme), animateColor: true),
+      body: const _Body(),
+    );
   }
 }
 
@@ -50,8 +53,6 @@ class _BodyState extends ConsumerState<_Body> {
   late double brightness;
   late double hue;
 
-  double headerOpacity = 0;
-
   bool openAdjustColorSection = false;
 
   @override
@@ -60,31 +61,6 @@ class _BodyState extends ConsumerState<_Body> {
     final boardPrefs = ref.read(boardPreferencesProvider);
     brightness = boardPrefs.brightness;
     hue = boardPrefs.hue;
-  }
-
-  bool handleScrollNotification(ScrollNotification notification) {
-    if (notification is ScrollUpdateNotification && notification.depth == 0) {
-      final ScrollMetrics metrics = notification.metrics;
-      double scrollExtent = 0.0;
-      switch (metrics.axisDirection) {
-        case AxisDirection.up:
-          scrollExtent = metrics.extentAfter;
-        case AxisDirection.down:
-          scrollExtent = metrics.extentBefore;
-        case AxisDirection.right:
-        case AxisDirection.left:
-          break;
-      }
-
-      final opacity = scrollExtent > 0.0 ? 1.0 : 0.0;
-
-      if (opacity != headerOpacity) {
-        setState(() {
-          headerOpacity = opacity;
-        });
-      }
-    }
-    return false;
   }
 
   @override
@@ -97,31 +73,21 @@ class _BodyState extends ConsumerState<_Body> {
 
     final boardSize = isTabletOrLarger(context) ? 350.0 : 200.0;
 
-    return NotificationListener(
-      onNotification: handleScrollNotification,
-      child: SafeArea(
-        child: CustomScrollView(
-          slivers: [
-            SliverAppBar(
-              backgroundColor: Theme.of(
-                context,
-              ).appBarTheme.backgroundColor?.withValues(alpha: headerOpacity),
-              pinned: true,
-              title: Text(context.l10n.mobileTheme),
-              bottom: PreferredSize(
-                preferredSize: Size.fromHeight(boardSize + 16.0),
-                child: Padding(
-                  padding: const EdgeInsets.symmetric(vertical: 16.0),
-                  child: _BoardPreview(
-                    size: boardSize,
-                    boardPrefs: boardPrefs,
-                    brightness: brightness,
-                    hue: hue,
-                  ),
-                ),
-              ),
+    return SafeArea(
+      top: false,
+      child: Column(
+        children: [
+          Padding(
+            padding: const EdgeInsets.symmetric(vertical: 16.0),
+            child: _BoardPreview(
+              size: boardSize,
+              boardPrefs: boardPrefs,
+              brightness: brightness,
+              hue: hue,
             ),
-            SliverList.list(
+          ),
+          Expanded(
+            child: ListView(
               children: [
                 ListSection(
                   hasLeading: true,
@@ -277,8 +243,8 @@ class _BodyState extends ConsumerState<_Body> {
                 ),
               ],
             ),
-          ],
-        ),
+          ),
+        ],
       ),
     );
   }

--- a/lib/src/widgets/platform.dart
+++ b/lib/src/widgets/platform.dart
@@ -143,6 +143,7 @@ class PlatformAppBar extends StatelessWidget implements PreferredSizeWidget {
       bottom: bottom,
       centerTitle: centerTitle,
       automaticallyImplyLeading: automaticallyImplyLeading,
+      animateColor: true,
     );
 
     return isIOS


### PR DESCRIPTION
## Summary

This PR smooths out app bar color transitions and makes a few scroll-related app bar behaviors more consistent.

## Changes

- Enables animated color transitions for regular app bars, so Material scrolled-under color changes no longer feel abrupt.
- Reworks the theme settings screen to use a regular `AppBar` with a fixed board preview area.
  - The board preview now stays on the page background instead of being part of a scrolling `SliverAppBar`.
  - This keeps the preview visually stable while the settings list scrolls underneath.
- Handles the broadcast list separately:
  - The page app bar and sticky section headers use the same background color.
  - The broadcast app bar does not change color on scroll, avoiding a distracting double state change between the page app bar and section headers.
  - Section headers keep their pinned `SliverAppBar` behavior, but do not apply additional scrolled-under elevation.
 

<table>
  <tr>
    <td>
      <video src="https://github.com/user-attachments/assets/32b421d3-05ec-4653-9904-98370f825368" width="300" controls></video>
    </td>
    <td>
      <video src="https://github.com/user-attachments/assets/e466983a-ff7a-4cf3-a111-010d59350057" width="300" controls></video>
    </td>
  </tr>
</table>


