### PR TITLE
Clamp displayed centipawn evaluations to +/-99 pawns

### DIFF
--- a/lib/src/model/common/eval.dart
+++ b/lib/src/model/common/eval.dart
@@ -324,9 +324,17 @@ double _rawWinningChances(num cp) {
   return 2 / (1 + math.exp(multiplier * cp)) - 1;
 }
 
+/// Maximum absolute centipawn value displayed in evaluations.
+///
+/// Values above this magnitude (e.g. tablebase scores like +200) are clamped
+/// to +/-99 pawns when rendered, since such large advantages have little
+/// practical value for human consumption. Mate scores are unaffected.
+const int _maxDisplayedCp = 9900;
+
 String _evalString(int? cp, int? mate) {
   if (cp != null) {
-    final e = cpToPawns(cp);
+    final clamped = cp.clamp(-_maxDisplayedCp, _maxDisplayedCp);
+    final e = cpToPawns(clamped);
     final s = e.toStringAsFixed(1);
     if (s == '0.0' || s == '-0.0') {
       return '0.0';

--- a/test/model/common/eval_test.dart
+++ b/test/model/common/eval_test.dart
@@ -1,0 +1,45 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:lichess_mobile/src/model/common/eval.dart';
+
+void main() {
+  group('Eval.evalString (centipawn formatting)', () {
+    test('formats small positive cp with sign', () {
+      expect(const ExternalEval(cp: 50, mate: null).evalString, '+0.5');
+    });
+
+    test('formats small negative cp with sign', () {
+      expect(const ExternalEval(cp: -120, mate: null).evalString, '-1.2');
+    });
+
+    test('formats zero cp without sign', () {
+      expect(const ExternalEval(cp: 0, mate: null).evalString, '0.0');
+    });
+
+    test('returns "-" when both cp and mate are null', () {
+      expect(const ExternalEval(cp: null, mate: null).evalString, '-');
+    });
+
+    test('formats mate with leading #', () {
+      expect(const ExternalEval(cp: null, mate: 3).evalString, '#3');
+      expect(const ExternalEval(cp: null, mate: -2).evalString, '#-2');
+    });
+
+    test('clamps very large positive cp to +99.0', () {
+      expect(const ExternalEval(cp: 20000, mate: null).evalString, '+99.0');
+    });
+
+    test('clamps very large negative cp to -99.0', () {
+      expect(const ExternalEval(cp: -20000, mate: null).evalString, '-99.0');
+    });
+
+    test('does not clamp cp at exactly +/-9900 boundary', () {
+      expect(const ExternalEval(cp: 9900, mate: null).evalString, '+99.0');
+      expect(const ExternalEval(cp: -9900, mate: null).evalString, '-99.0');
+    });
+
+    test('clamping does not affect mate scores', () {
+      expect(const ExternalEval(cp: null, mate: 200).evalString, '#200');
+      expect(const ExternalEval(cp: null, mate: -150).evalString, '#-150');
+    });
+  });
+}


### PR DESCRIPTION
  Fixes #3222.

  Tablebase / extreme engine scores currently render as values like
  `+200.0` in the analysis gauge and move list, which has no practical
  meaning for humans. Mirror the web behaviour by clamping the
  centipawn value to `[-9900, 9900]` inside `_evalString` before
  converting to pawns. Mate scores are unaffected (`#3`, `#-2`, …).

  **Changes**
  - `lib/src/model/common/eval.dart` — clamp `cp` to `±9900` in `_evalString`.
  - `test/model/common/eval_test.dart` — new unit tests covering small / negative / zero / mate / and the new clamp boundaries.