### PR TITLE
Localize 'Good move, but there's better' verdict

### DIFF
--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -117,6 +117,7 @@
   "mobileChallengeCreated": "Challenge created: You will be notified when the game starts.\nYou can access it from the home tab.",
   "mobilePreviousPage": "Previous",
   "mobileOrImportPgnFile": "Or import a PGN file",
+  "mobileGoodMoveButThereIsBetter": "Good move, but there's better",
   "variantStandard": "Standard",
   "variantStandardTitle": "Standard rules of chess (FIDE)",
   "variantChess960": "Chess960",

--- a/lib/l10n/l10n.dart
+++ b/lib/l10n/l10n.dart
@@ -736,6 +736,12 @@ abstract class AppLocalizations {
   /// **'Or import a PGN file'**
   String get mobileOrImportPgnFile;
 
+  /// No description provided for @mobileGoodMoveButThereIsBetter.
+  ///
+  /// In en, this message translates to:
+  /// **'Good move, but there\'s better'**
+  String get mobileGoodMoveButThereIsBetter;
+
   /// No description provided for @variantStandard.
   ///
   /// In en, this message translates to:

--- a/lib/l10n/l10n_af.dart
+++ b/lib/l10n/l10n_af.dart
@@ -287,6 +287,9 @@ class AppLocalizationsAf extends AppLocalizations {
   String get mobileOrImportPgnFile => 'Or import a PGN file';
 
   @override
+  String get mobileGoodMoveButThereIsBetter => 'Good move, but there\'s better';
+
+  @override
   String get variantStandard => 'Standard';
 
   @override

--- a/lib/l10n/l10n_ar.dart
+++ b/lib/l10n/l10n_ar.dart
@@ -287,6 +287,9 @@ class AppLocalizationsAr extends AppLocalizations {
   String get mobileOrImportPgnFile => 'أو استيراد ملف PGN';
 
   @override
+  String get mobileGoodMoveButThereIsBetter => 'Good move, but there\'s better';
+
+  @override
   String get variantStandard => 'الأساسي';
 
   @override

--- a/lib/l10n/l10n_az.dart
+++ b/lib/l10n/l10n_az.dart
@@ -287,6 +287,9 @@ class AppLocalizationsAz extends AppLocalizations {
   String get mobileOrImportPgnFile => 'Or import a PGN file';
 
   @override
+  String get mobileGoodMoveButThereIsBetter => 'Good move, but there\'s better';
+
+  @override
   String get variantStandard => 'Standard';
 
   @override

--- a/lib/l10n/l10n_be.dart
+++ b/lib/l10n/l10n_be.dart
@@ -287,6 +287,9 @@ class AppLocalizationsBe extends AppLocalizations {
   String get mobileOrImportPgnFile => 'Or import a PGN file';
 
   @override
+  String get mobileGoodMoveButThereIsBetter => 'Good move, but there\'s better';
+
+  @override
   String get variantStandard => 'Звычайныя шахматы';
 
   @override

--- a/lib/l10n/l10n_bg.dart
+++ b/lib/l10n/l10n_bg.dart
@@ -287,6 +287,9 @@ class AppLocalizationsBg extends AppLocalizations {
   String get mobileOrImportPgnFile => 'Или зареди PGN файл';
 
   @override
+  String get mobileGoodMoveButThereIsBetter => 'Good move, but there\'s better';
+
+  @override
   String get variantStandard => 'Стандартен';
 
   @override

--- a/lib/l10n/l10n_bn.dart
+++ b/lib/l10n/l10n_bn.dart
@@ -287,6 +287,9 @@ class AppLocalizationsBn extends AppLocalizations {
   String get mobileOrImportPgnFile => 'Or import a PGN file';
 
   @override
+  String get mobileGoodMoveButThereIsBetter => 'Good move, but there\'s better';
+
+  @override
   String get variantStandard => 'Standard';
 
   @override

--- a/lib/l10n/l10n_bs.dart
+++ b/lib/l10n/l10n_bs.dart
@@ -287,6 +287,9 @@ class AppLocalizationsBs extends AppLocalizations {
   String get mobileOrImportPgnFile => 'Or import a PGN file';
 
   @override
+  String get mobileGoodMoveButThereIsBetter => 'Good move, but there\'s better';
+
+  @override
   String get variantStandard => 'Standardna';
 
   @override

--- a/lib/l10n/l10n_ca.dart
+++ b/lib/l10n/l10n_ca.dart
@@ -287,6 +287,9 @@ class AppLocalizationsCa extends AppLocalizations {
   String get mobileOrImportPgnFile => 'O importa un arxiu PGN';
 
   @override
+  String get mobileGoodMoveButThereIsBetter => 'Good move, but there\'s better';
+
+  @override
   String get variantStandard => 'Estàndard';
 
   @override

--- a/lib/l10n/l10n_cs.dart
+++ b/lib/l10n/l10n_cs.dart
@@ -287,6 +287,9 @@ class AppLocalizationsCs extends AppLocalizations {
   String get mobileOrImportPgnFile => 'Nebo nahrajte soubor PGN';
 
   @override
+  String get mobileGoodMoveButThereIsBetter => 'Good move, but there\'s better';
+
+  @override
   String get variantStandard => 'Standardní';
 
   @override

--- a/lib/l10n/l10n_da.dart
+++ b/lib/l10n/l10n_da.dart
@@ -287,6 +287,9 @@ class AppLocalizationsDa extends AppLocalizations {
   String get mobileOrImportPgnFile => 'Eller importer en PGN-fil';
 
   @override
+  String get mobileGoodMoveButThereIsBetter => 'Good move, but there\'s better';
+
+  @override
   String get variantStandard => 'Standard';
 
   @override

--- a/lib/l10n/l10n_de.dart
+++ b/lib/l10n/l10n_de.dart
@@ -287,6 +287,9 @@ class AppLocalizationsDe extends AppLocalizations {
   String get mobileOrImportPgnFile => 'Oder importiere eine PGN-Datei';
 
   @override
+  String get mobileGoodMoveButThereIsBetter => 'Good move, but there\'s better';
+
+  @override
   String get variantStandard => 'Standard';
 
   @override

--- a/lib/l10n/l10n_el.dart
+++ b/lib/l10n/l10n_el.dart
@@ -287,6 +287,9 @@ class AppLocalizationsEl extends AppLocalizations {
   String get mobileOrImportPgnFile => 'Ή μεταφορτώστε ένα αρχείο PGN';
 
   @override
+  String get mobileGoodMoveButThereIsBetter => 'Good move, but there\'s better';
+
+  @override
   String get variantStandard => 'Κανονικό';
 
   @override

--- a/lib/l10n/l10n_en.dart
+++ b/lib/l10n/l10n_en.dart
@@ -287,6 +287,9 @@ class AppLocalizationsEn extends AppLocalizations {
   String get mobileOrImportPgnFile => 'Or import a PGN file';
 
   @override
+  String get mobileGoodMoveButThereIsBetter => 'Good move, but there\'s better';
+
+  @override
   String get variantStandard => 'Standard';
 
   @override

--- a/lib/l10n/l10n_eo.dart
+++ b/lib/l10n/l10n_eo.dart
@@ -287,6 +287,9 @@ class AppLocalizationsEo extends AppLocalizations {
   String get mobileOrImportPgnFile => 'Or import a PGN file';
 
   @override
+  String get mobileGoodMoveButThereIsBetter => 'Good move, but there\'s better';
+
+  @override
   String get variantStandard => 'Normala';
 
   @override

--- a/lib/l10n/l10n_es.dart
+++ b/lib/l10n/l10n_es.dart
@@ -287,6 +287,9 @@ class AppLocalizationsEs extends AppLocalizations {
   String get mobileOrImportPgnFile => 'O importa un archivo PGN';
 
   @override
+  String get mobileGoodMoveButThereIsBetter => 'Good move, but there\'s better';
+
+  @override
   String get variantStandard => 'Estándar';
 
   @override

--- a/lib/l10n/l10n_et.dart
+++ b/lib/l10n/l10n_et.dart
@@ -287,6 +287,9 @@ class AppLocalizationsEt extends AppLocalizations {
   String get mobileOrImportPgnFile => 'Või importi PGN-fail';
 
   @override
+  String get mobileGoodMoveButThereIsBetter => 'Good move, but there\'s better';
+
+  @override
   String get variantStandard => 'Tavaline';
 
   @override

--- a/lib/l10n/l10n_eu.dart
+++ b/lib/l10n/l10n_eu.dart
@@ -287,6 +287,9 @@ class AppLocalizationsEu extends AppLocalizations {
   String get mobileOrImportPgnFile => 'Edo inportatu PGN fitxategi bat';
 
   @override
+  String get mobileGoodMoveButThereIsBetter => 'Good move, but there\'s better';
+
+  @override
   String get variantStandard => 'Ohikoa';
 
   @override

--- a/lib/l10n/l10n_fa.dart
+++ b/lib/l10n/l10n_fa.dart
@@ -287,6 +287,9 @@ class AppLocalizationsFa extends AppLocalizations {
   String get mobileOrImportPgnFile => 'یا درونبُردِ یک پَروَنِ PGN';
 
   @override
+  String get mobileGoodMoveButThereIsBetter => 'Good move, but there\'s better';
+
+  @override
   String get variantStandard => 'اِستانده';
 
   @override

--- a/lib/l10n/l10n_fi.dart
+++ b/lib/l10n/l10n_fi.dart
@@ -287,6 +287,9 @@ class AppLocalizationsFi extends AppLocalizations {
   String get mobileOrImportPgnFile => 'Tai tuo PGN-tiedosto';
 
   @override
+  String get mobileGoodMoveButThereIsBetter => 'Good move, but there\'s better';
+
+  @override
   String get variantStandard => 'Normaali';
 
   @override

--- a/lib/l10n/l10n_fr.dart
+++ b/lib/l10n/l10n_fr.dart
@@ -287,6 +287,9 @@ class AppLocalizationsFr extends AppLocalizations {
   String get mobileOrImportPgnFile => 'Importer un fichier PGN';
 
   @override
+  String get mobileGoodMoveButThereIsBetter => 'Good move, but there\'s better';
+
+  @override
   String get variantStandard => 'Standard';
 
   @override

--- a/lib/l10n/l10n_gl.dart
+++ b/lib/l10n/l10n_gl.dart
@@ -287,6 +287,9 @@ class AppLocalizationsGl extends AppLocalizations {
   String get mobileOrImportPgnFile => 'Ou importa un arquivo PGN';
 
   @override
+  String get mobileGoodMoveButThereIsBetter => 'Good move, but there\'s better';
+
+  @override
   String get variantStandard => 'Estándar';
 
   @override

--- a/lib/l10n/l10n_gsw.dart
+++ b/lib/l10n/l10n_gsw.dart
@@ -287,6 +287,9 @@ class AppLocalizationsGsw extends AppLocalizations {
   String get mobileOrImportPgnFile => 'Oder lad e PGN-Datei ufe';
 
   @override
+  String get mobileGoodMoveButThereIsBetter => 'Good move, but there\'s better';
+
+  @override
   String get variantStandard => 'Schtandard';
 
   @override

--- a/lib/l10n/l10n_he.dart
+++ b/lib/l10n/l10n_he.dart
@@ -287,6 +287,9 @@ class AppLocalizationsHe extends AppLocalizations {
   String get mobileOrImportPgnFile => 'Or import a PGN file';
 
   @override
+  String get mobileGoodMoveButThereIsBetter => 'Good move, but there\'s better';
+
+  @override
   String get variantStandard => 'רגיל';
 
   @override

--- a/lib/l10n/l10n_hi.dart
+++ b/lib/l10n/l10n_hi.dart
@@ -287,6 +287,9 @@ class AppLocalizationsHi extends AppLocalizations {
   String get mobileOrImportPgnFile => 'Or import a PGN file';
 
   @override
+  String get mobileGoodMoveButThereIsBetter => 'Good move, but there\'s better';
+
+  @override
   String get variantStandard => 'Standard';
 
   @override

--- a/lib/l10n/l10n_hr.dart
+++ b/lib/l10n/l10n_hr.dart
@@ -287,6 +287,9 @@ class AppLocalizationsHr extends AppLocalizations {
   String get mobileOrImportPgnFile => 'Or import a PGN file';
 
   @override
+  String get mobileGoodMoveButThereIsBetter => 'Good move, but there\'s better';
+
+  @override
   String get variantStandard => 'Standard';
 
   @override

--- a/lib/l10n/l10n_hu.dart
+++ b/lib/l10n/l10n_hu.dart
@@ -287,6 +287,9 @@ class AppLocalizationsHu extends AppLocalizations {
   String get mobileOrImportPgnFile => 'Vagy PGN fájl importálása';
 
   @override
+  String get mobileGoodMoveButThereIsBetter => 'Good move, but there\'s better';
+
+  @override
   String get variantStandard => 'Normál';
 
   @override

--- a/lib/l10n/l10n_hy.dart
+++ b/lib/l10n/l10n_hy.dart
@@ -287,6 +287,9 @@ class AppLocalizationsHy extends AppLocalizations {
   String get mobileOrImportPgnFile => 'Or import a PGN file';
 
   @override
+  String get mobileGoodMoveButThereIsBetter => 'Good move, but there\'s better';
+
+  @override
   String get variantStandard => 'Standard';
 
   @override

--- a/lib/l10n/l10n_id.dart
+++ b/lib/l10n/l10n_id.dart
@@ -287,6 +287,9 @@ class AppLocalizationsId extends AppLocalizations {
   String get mobileOrImportPgnFile => 'Or import a PGN file';
 
   @override
+  String get mobileGoodMoveButThereIsBetter => 'Good move, but there\'s better';
+
+  @override
   String get variantStandard => 'Standar';
 
   @override

--- a/lib/l10n/l10n_it.dart
+++ b/lib/l10n/l10n_it.dart
@@ -287,6 +287,9 @@ class AppLocalizationsIt extends AppLocalizations {
   String get mobileOrImportPgnFile => 'O importa un file PGN';
 
   @override
+  String get mobileGoodMoveButThereIsBetter => 'Good move, but there\'s better';
+
+  @override
   String get variantStandard => 'Standard';
 
   @override

--- a/lib/l10n/l10n_ja.dart
+++ b/lib/l10n/l10n_ja.dart
@@ -287,6 +287,9 @@ class AppLocalizationsJa extends AppLocalizations {
   String get mobileOrImportPgnFile => 'または PGN ファイルをインポート';
 
   @override
+  String get mobileGoodMoveButThereIsBetter => 'Good move, but there\'s better';
+
+  @override
   String get variantStandard => 'スタンダード';
 
   @override

--- a/lib/l10n/l10n_kk.dart
+++ b/lib/l10n/l10n_kk.dart
@@ -287,6 +287,9 @@ class AppLocalizationsKk extends AppLocalizations {
   String get mobileOrImportPgnFile => 'Or import a PGN file';
 
   @override
+  String get mobileGoodMoveButThereIsBetter => 'Good move, but there\'s better';
+
+  @override
   String get variantStandard => 'Standard';
 
   @override

--- a/lib/l10n/l10n_ko.dart
+++ b/lib/l10n/l10n_ko.dart
@@ -287,6 +287,9 @@ class AppLocalizationsKo extends AppLocalizations {
   String get mobileOrImportPgnFile => '또는 PGN 파일 가져오기';
 
   @override
+  String get mobileGoodMoveButThereIsBetter => 'Good move, but there\'s better';
+
+  @override
   String get variantStandard => '스탠다드';
 
   @override

--- a/lib/l10n/l10n_lt.dart
+++ b/lib/l10n/l10n_lt.dart
@@ -287,6 +287,9 @@ class AppLocalizationsLt extends AppLocalizations {
   String get mobileOrImportPgnFile => 'Or import a PGN file';
 
   @override
+  String get mobileGoodMoveButThereIsBetter => 'Good move, but there\'s better';
+
+  @override
   String get variantStandard => 'Standard';
 
   @override

--- a/lib/l10n/l10n_lv.dart
+++ b/lib/l10n/l10n_lv.dart
@@ -287,6 +287,9 @@ class AppLocalizationsLv extends AppLocalizations {
   String get mobileOrImportPgnFile => 'Or import a PGN file';
 
   @override
+  String get mobileGoodMoveButThereIsBetter => 'Good move, but there\'s better';
+
+  @override
   String get variantStandard => 'Standard';
 
   @override

--- a/lib/l10n/l10n_mk.dart
+++ b/lib/l10n/l10n_mk.dart
@@ -287,6 +287,9 @@ class AppLocalizationsMk extends AppLocalizations {
   String get mobileOrImportPgnFile => 'Or import a PGN file';
 
   @override
+  String get mobileGoodMoveButThereIsBetter => 'Good move, but there\'s better';
+
+  @override
   String get variantStandard => 'Standard';
 
   @override

--- a/lib/l10n/l10n_nb.dart
+++ b/lib/l10n/l10n_nb.dart
@@ -287,6 +287,9 @@ class AppLocalizationsNb extends AppLocalizations {
   String get mobileOrImportPgnFile => 'Eller importer en PGN-fil';
 
   @override
+  String get mobileGoodMoveButThereIsBetter => 'Good move, but there\'s better';
+
+  @override
   String get variantStandard => 'Standard';
 
   @override

--- a/lib/l10n/l10n_nl.dart
+++ b/lib/l10n/l10n_nl.dart
@@ -287,6 +287,9 @@ class AppLocalizationsNl extends AppLocalizations {
   String get mobileOrImportPgnFile => 'Of importeer een PGN-bestand';
 
   @override
+  String get mobileGoodMoveButThereIsBetter => 'Good move, but there\'s better';
+
+  @override
   String get variantStandard => 'Standaard';
 
   @override

--- a/lib/l10n/l10n_pl.dart
+++ b/lib/l10n/l10n_pl.dart
@@ -287,6 +287,9 @@ class AppLocalizationsPl extends AppLocalizations {
   String get mobileOrImportPgnFile => 'Lub zaimportuj plik PGN';
 
   @override
+  String get mobileGoodMoveButThereIsBetter => 'Good move, but there\'s better';
+
+  @override
   String get variantStandard => 'Standardowe';
 
   @override

--- a/lib/l10n/l10n_pt.dart
+++ b/lib/l10n/l10n_pt.dart
@@ -287,6 +287,9 @@ class AppLocalizationsPt extends AppLocalizations {
   String get mobileOrImportPgnFile => 'Or import a PGN file';
 
   @override
+  String get mobileGoodMoveButThereIsBetter => 'Good move, but there\'s better';
+
+  @override
   String get variantStandard => 'Padrão';
 
   @override

--- a/lib/l10n/l10n_ro.dart
+++ b/lib/l10n/l10n_ro.dart
@@ -287,6 +287,9 @@ class AppLocalizationsRo extends AppLocalizations {
   String get mobileOrImportPgnFile => 'Sau încarcă un fișier PGN';
 
   @override
+  String get mobileGoodMoveButThereIsBetter => 'Good move, but there\'s better';
+
+  @override
   String get variantStandard => 'Standard';
 
   @override

--- a/lib/l10n/l10n_ru.dart
+++ b/lib/l10n/l10n_ru.dart
@@ -287,6 +287,9 @@ class AppLocalizationsRu extends AppLocalizations {
   String get mobileOrImportPgnFile => 'Или импортировать в PGN файл';
 
   @override
+  String get mobileGoodMoveButThereIsBetter => 'Good move, but there\'s better';
+
+  @override
   String get variantStandard => 'Шахматы';
 
   @override

--- a/lib/l10n/l10n_sk.dart
+++ b/lib/l10n/l10n_sk.dart
@@ -287,6 +287,9 @@ class AppLocalizationsSk extends AppLocalizations {
   String get mobileOrImportPgnFile => 'Or import a PGN file';
 
   @override
+  String get mobileGoodMoveButThereIsBetter => 'Good move, but there\'s better';
+
+  @override
   String get variantStandard => 'Štandard';
 
   @override

--- a/lib/l10n/l10n_sl.dart
+++ b/lib/l10n/l10n_sl.dart
@@ -287,6 +287,9 @@ class AppLocalizationsSl extends AppLocalizations {
   String get mobileOrImportPgnFile => 'Ali uvozite datoteko PGN';
 
   @override
+  String get mobileGoodMoveButThereIsBetter => 'Good move, but there\'s better';
+
+  @override
   String get variantStandard => 'Običajno';
 
   @override

--- a/lib/l10n/l10n_sq.dart
+++ b/lib/l10n/l10n_sq.dart
@@ -287,6 +287,9 @@ class AppLocalizationsSq extends AppLocalizations {
   String get mobileOrImportPgnFile => 'Ose importoni një kartelë PNG';
 
   @override
+  String get mobileGoodMoveButThereIsBetter => 'Good move, but there\'s better';
+
+  @override
   String get variantStandard => 'Standard';
 
   @override

--- a/lib/l10n/l10n_sr.dart
+++ b/lib/l10n/l10n_sr.dart
@@ -287,6 +287,9 @@ class AppLocalizationsSr extends AppLocalizations {
   String get mobileOrImportPgnFile => 'Or import a PGN file';
 
   @override
+  String get mobileGoodMoveButThereIsBetter => 'Good move, but there\'s better';
+
+  @override
   String get variantStandard => 'Standard';
 
   @override

--- a/lib/l10n/l10n_sv.dart
+++ b/lib/l10n/l10n_sv.dart
@@ -287,6 +287,9 @@ class AppLocalizationsSv extends AppLocalizations {
   String get mobileOrImportPgnFile => 'Or import a PGN file';
 
   @override
+  String get mobileGoodMoveButThereIsBetter => 'Good move, but there\'s better';
+
+  @override
   String get variantStandard => 'Standard';
 
   @override

--- a/lib/l10n/l10n_tr.dart
+++ b/lib/l10n/l10n_tr.dart
@@ -287,6 +287,9 @@ class AppLocalizationsTr extends AppLocalizations {
   String get mobileOrImportPgnFile => 'Veya bir PGN dosyası aktar';
 
   @override
+  String get mobileGoodMoveButThereIsBetter => 'Good move, but there\'s better';
+
+  @override
   String get variantStandard => 'Standart';
 
   @override

--- a/lib/l10n/l10n_uk.dart
+++ b/lib/l10n/l10n_uk.dart
@@ -287,6 +287,9 @@ class AppLocalizationsUk extends AppLocalizations {
   String get mobileOrImportPgnFile => 'Чи завантажте файл PGN';
 
   @override
+  String get mobileGoodMoveButThereIsBetter => 'Good move, but there\'s better';
+
+  @override
   String get variantStandard => 'Стандартні шахи';
 
   @override

--- a/lib/l10n/l10n_uz.dart
+++ b/lib/l10n/l10n_uz.dart
@@ -287,6 +287,9 @@ class AppLocalizationsUz extends AppLocalizations {
   String get mobileOrImportPgnFile => 'Yoki PGN faylini import qiling';
 
   @override
+  String get mobileGoodMoveButThereIsBetter => 'Good move, but there\'s better';
+
+  @override
   String get variantStandard => 'Standart';
 
   @override

--- a/lib/l10n/l10n_vi.dart
+++ b/lib/l10n/l10n_vi.dart
@@ -287,6 +287,9 @@ class AppLocalizationsVi extends AppLocalizations {
   String get mobileOrImportPgnFile => 'Hoặc nhập một tệp PGN';
 
   @override
+  String get mobileGoodMoveButThereIsBetter => 'Good move, but there\'s better';
+
+  @override
   String get variantStandard => 'Tiêu chuẩn';
 
   @override

--- a/lib/l10n/l10n_zh.dart
+++ b/lib/l10n/l10n_zh.dart
@@ -287,6 +287,9 @@ class AppLocalizationsZh extends AppLocalizations {
   String get mobileOrImportPgnFile => '或者导入 PGN 文件';
 
   @override
+  String get mobileGoodMoveButThereIsBetter => 'Good move, but there\'s better';
+
+  @override
   String get variantStandard => '标准';
 
   @override

--- a/lib/src/view/offline_computer/offline_computer_game_screen.dart
+++ b/lib/src/view/offline_computer/offline_computer_game_screen.dart
@@ -611,7 +611,7 @@ class _PracticeCommentCardState extends ConsumerState<_PracticeCommentCard> {
 
       final verdictText = switch (verdict) {
         MoveVerdict.goodMove => context.l10n.studyGoodMove,
-        MoveVerdict.notBest => "Good, but there's better",
+        MoveVerdict.notBest => context.l10n.mobileGoodMoveButThereIsBetter,
         MoveVerdict.inaccuracy => context.l10n.inaccuracy,
         MoveVerdict.mistake => context.l10n.mistake,
         MoveVerdict.blunder => context.l10n.blunder,

--- a/test/view/offline_computer/offline_computer_game_screen_test.dart
+++ b/test/view/offline_computer/offline_computer_game_screen_test.dart
@@ -1430,9 +1430,9 @@ void main() {
       expect(find.text('Good move'), findsOneWidget);
     });
 
-    testWidgets('notBest shows "Good, but there\'s better" label', (tester) async {
+    testWidgets('notBest shows "Good move, but there\'s better" label', (tester) async {
       await pumpWithComment(tester, makeComment(.notBest));
-      expect(find.text("Good, but there's better"), findsOneWidget);
+      expect(find.text("Good move, but there's better"), findsOneWidget);
     });
 
     testWidgets('inaccuracy shows "Inaccuracy" label', (tester) async {

--- a/translation/source/mobile.xml
+++ b/translation/source/mobile.xml
@@ -90,4 +90,5 @@
   <string name="challengeCreated" comment="Shown as a bottom banner when another player has been challenged.">Challenge created: You will be notified when the game starts.\nYou can access it from the home tab.</string>
   <string name="previousPage" comment="Shows the previous page, e.g. in tournament standings">Previous</string>
   <string name="orImportPgnFile" comment="Button text to import a PGN file from the device">Or import a PGN file</string>
+  <string name="goodMoveButThereIsBetter" comment="Verdict shown in the offline computer game when the player's move is good but not the best move available.">Good move, but there's better</string>
 </resources>


### PR DESCRIPTION
  Fixes #3179.

  `MoveVerdict.notBest` in the offline computer practice screen was the
  only verdict still hard-coded in English (every other verdict —
  `goodMove`, `inaccuracy`, `mistake`, `blunder` — goes through
  `context.l10n`).

  **Changes**
  - `translation/source/mobile.xml` — add `goodMoveButThereIsBetter` mobile string.
  - `lib/src/view/offline_computer/offline_computer_game_screen.dart` — replace the literal with `context.l10n.mobileGoodMoveButThereIsBetter`.
  - Regenerated via `./scripts/gen-translations.sh` (touches `lib/l10n/app_*.arb`, `lib/l10n/l10n_*.dart`, `ios/LichessWidgets/Localizable.xcstrings`).

  No manual edits to generated files — only the source `mobile.xml` was hand-edited.