### PR TITLE
Show player age relative to the broadcast tournament date

### DIFF
--- a/lib/src/view/broadcast/broadcast_player_results_screen.dart
+++ b/lib/src/view/broadcast/broadcast_player_results_screen.dart
@@ -30,6 +30,18 @@ final broadcastTournamentIdProvider = FutureProvider.autoDispose
       return (await ref.watch(broadcastRoundProvider(roundId).future)).tournament.id;
     }, name: 'BroadcastTournamentIdProvider');
 
+/// Returns the year that should be used as the reference point for the
+/// player's age display, matching lichess.org behaviour: the year the
+/// tournament took place (preferring its end date when known, otherwise its
+/// start date). Falls back to the current year only if no dates are known.
+int tournamentReferenceYear(BroadcastTournament tournament) {
+  final dates = tournament.data.information.dates;
+  if (dates == null) {
+    return DateTime.now().year;
+  }
+  return (dates.endsAt ?? dates.startsAt).year;
+}
+
 class BroadcastPlayerResultsScreenLoading extends ConsumerWidget {
   final BroadcastRoundId roundId;
   final BroadcastPlayer? player;
@@ -334,7 +346,7 @@ class _OverallStatPlayer extends StatelessWidget {
                           SizedBox(width: 100, child: Text(context.l10n.broadcastAge)),
                           Expanded(
                             child: Text(
-                              (DateTime.now().year - birthYear).toString(),
+                              (tournamentReferenceYear(tournament) - birthYear).toString(),
                               style: Theme.of(context).textTheme.bodyLarge,
                             ),
                           ),

--- a/test/view/broadcast/broadcast_player_results_screen_test.dart
+++ b/test/view/broadcast/broadcast_player_results_screen_test.dart
@@ -1,6 +1,8 @@
+import 'package:fast_immutable_collections/fast_immutable_collections.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:http/testing.dart';
+import 'package:lichess_mobile/src/model/broadcast/broadcast.dart';
 import 'package:lichess_mobile/src/model/common/id.dart';
 import 'package:lichess_mobile/src/network/http.dart';
 import 'package:lichess_mobile/src/view/broadcast/broadcast_player_results_screen.dart';
@@ -170,6 +172,50 @@ void main() {
         await pumpPlayerResultsScreen(tester, points: '0', customPoints: 0.0);
         expectGameTileShows('0');
       });
+    });
+  });
+
+  group('tournamentReferenceYear', () {
+    BroadcastTournament makeTournament({DateTime? startsAt, DateTime? endsAt}) {
+      return BroadcastTournament(
+        data: BroadcastTournamentData(
+          id: const BroadcastTournamentId('t'),
+          name: 'Test',
+          slug: 'test',
+          imageUrl: null,
+          description: null,
+          information: (
+            format: null,
+            timeControl: null,
+            players: null,
+            location: null,
+            dates: startsAt == null ? null : (startsAt: startsAt, endsAt: endsAt),
+            website: null,
+            standings: null,
+          ),
+        ),
+        rounds: const IListConst([]),
+        defaultRoundId: const BroadcastRoundId('r'),
+        group: null,
+      );
+    }
+
+    test('uses end year when the tournament has ended', () {
+      final tournament = makeTournament(
+        startsAt: DateTime.utc(2021, 1, 10),
+        endsAt: DateTime.utc(2021, 12, 20),
+      );
+      expect(tournamentReferenceYear(tournament), 2021);
+    });
+
+    test('uses start year when no end date is set', () {
+      final tournament = makeTournament(startsAt: DateTime.utc(2018, 6, 5));
+      expect(tournamentReferenceYear(tournament), 2018);
+    });
+
+    test('falls back to current year when no dates are available', () {
+      final tournament = makeTournament();
+      expect(tournamentReferenceYear(tournament), DateTime.now().year);
     });
   });
 }


### PR DESCRIPTION
Fixes #3252.

  When opening a player's profile from a broadcast, the Age row used
  `DateTime.now().year`, so a player who was 14 during a 2018 broadcast
  would now be shown as 21. Lichess web shows the age relative to the
  tournament itself.

  Add a `tournamentReferenceYear` helper that prefers
  `BroadcastTournament`'s end date when known, falls back to its start
  date, and finally to the current year if no dates are available. Use
  it instead of `DateTime.now().year` when computing the age.

  **Changes**
  - `lib/src/view/broadcast/broadcast_player_results_screen.dart`
  - `test/view/broadcast/broadcast_player_results_screen_test.dart` — three new unit tests covering the three branches.

  **Note for reviewer — audit of other "dynamic" fields:** the issue mentions "would make sense to confirm if there are other fields that are also dynamic like this." I audited every visible field on `BroadcastPlayerResultsScreen` and adjacent broadcast views.

  **Conclusion: Age was the only truly buggy field.** Every other display value already comes from the lila broadcast snapshot.

  **Bug fixed (only one):**
  - Age — was `DateTime.now().year - birthYear` → now `tournamentReferenceYear(tournament) - birthYear`.

  **Tournament-snapshotted (already correct, no change needed):**
  - Player name, title (GM/IM/…), federation flag — `BroadcastPlayer` from `/broadcast/<t>/players/<p>`.
  - Team affiliation — `BroadcastPlayerWithOverallResult.team`.
  - Photo — `tournament.photos.get(fideId)` (per-tournament manifest).
  - Score / played / rank / tie-breaks / performances / rating diffs — all on `BroadcastPlayerWithOverallResult`.
  - Per-game opponent (title / federation / rating shown in each row of the games list) — comes from `BroadcastPlayerGameResult.opponent`, snapshotted per game.
  - App-bar player title widget and `BroadcastPlayerWidget` rows on adjacent screens (`broadcast_team_screen.dart`, `broadcast_players_tab.dart`, broadcast game tiles) — same snapshot source.

  **Intentionally "live" (matches lichess.org behaviour — out of scope):**
  - `fideData.ratings` in the rating stat-cards is the *current* FIDE rating per time control, not the rating during the tournament. Lichess web does the same. Strictly snapshotting this would require lila to store FIDE rating per tournament, so it's a server-side ask, not a mobile fix.

  **Other `DateTime.now()` usages in broadcast code (all legitimate, kept as-is):**
  - `broadcast_carousel.dart:317` — "round starts in X minutes" countdown.
  - `broadcast_round_screen.dart:444` — "round within last 30 days" filter.
  - `broadcast_round_controller.dart:166, 225` — clock event timestamps.
  - `broadcast_player_results_screen.dart:40` — fallback inside `tournamentReferenceYear` when tournament dates are unknown.