### PR TITLE
Mirror lila's translateDuration for toDaysHoursMinutes

### DIFF
--- a/lib/src/utils/duration.dart
+++ b/lib/src/utils/duration.dart
@@ -13,47 +13,32 @@ extension DurationExtensions on Duration {
     }
   }
 
+  /// Returns the duration formatted as a comma-separated list of localised
+  /// day / hour / minute parts, matching lila's `translateDuration` in
+  /// `modules/coreI18n/src/main/i18n.scala`.
   String toDaysHoursMinutes(AppLocalizations l10n) {
     final days = inDays;
     final hours = inHours.remainder(24);
     final minutes = inMinutes.remainder(60);
 
-    String daysString = days == 0 ? '' : l10n.nbDays(days);
-    String hoursString = hours == 0 ? '' : l10n.nbHours(hours);
-    final String minutesString = minutes == 0 ? '' : l10n.nbMinutes(minutes);
+    final slots = <({String text, bool dropIfZero, int value})>[
+      (text: l10n.nbDays(days), dropIfZero: true, value: days),
+      (text: l10n.nbHours(hours), dropIfZero: true, value: hours),
+      if (days == 0) (text: l10n.nbMinutes(minutes), dropIfZero: false, value: minutes),
+    ];
 
-    int valueCount = 0;
-    for (final value in [days, hours, minutes]) {
-      if (value != 0) {
-        ++valueCount;
-      }
+    final parts = <String>[];
+    var droppingLeading = true;
+    for (final slot in slots) {
+      if (droppingLeading && slot.dropIfZero && slot.value == 0) continue;
+      droppingLeading = false;
+      parts.add(slot.text);
     }
 
-    if (valueCount == 0) {
+    if (parts.isEmpty) {
       return l10n.nbMinutes(0);
     }
 
-    // Add comma and space if all values are nonzero,
-    // add only space if 'daysString' is not the only value.
-    if (days != 0 && hours != 0 && minutes != 0) {
-      daysString = '$daysString, ';
-    } else if (days != 0 && valueCount != 1) {
-      daysString = '$daysString ';
-    }
-
-    final String and = valueCount > 1 ? 'and ' : '';
-
-    // Avoid case where 'and' is printed after days and hours.
-    if (minutes == 0) {
-      return '$daysString$and$hoursString';
-    }
-
-    // Since we know hoursString either is either the only string, or it goes
-    // before 'minutesString', we add a space after it, if it's not the only value.
-    if (hours != 0 && valueCount != 1) {
-      hoursString = '$hoursString ';
-    }
-
-    return '$daysString$hoursString$and$minutesString';
+    return parts.join(', ');
   }
 }

--- a/test/utils/duration_test.dart
+++ b/test/utils/duration_test.dart
@@ -9,57 +9,54 @@ void main() {
   final mockAppLocalizations = MockAppLocalizations();
 
   setUpAll(() {
-    when(() => mockAppLocalizations.nbDays(2)).thenReturn('2 days');
-    when(() => mockAppLocalizations.nbDays(1)).thenReturn('1 day');
-    when(() => mockAppLocalizations.nbDays(0)).thenReturn('0 days');
-
-    when(() => mockAppLocalizations.nbHours(2)).thenReturn('2 hours');
-    when(() => mockAppLocalizations.nbHours(1)).thenReturn('1 hour');
-    when(() => mockAppLocalizations.nbHours(0)).thenReturn('0 hours');
-
-    when(() => mockAppLocalizations.nbMinutes(2)).thenReturn('2 minutes');
-    when(() => mockAppLocalizations.nbMinutes(1)).thenReturn('1 minute');
-    when(() => mockAppLocalizations.nbMinutes(0)).thenReturn('0 minutes');
+    for (final n in [0, 1, 2, 3, 5, 18, 24]) {
+      when(() => mockAppLocalizations.nbDays(n)).thenReturn('$n day${n == 1 ? '' : 's'}');
+      when(() => mockAppLocalizations.nbHours(n)).thenReturn('$n hour${n == 1 ? '' : 's'}');
+      when(() => mockAppLocalizations.nbMinutes(n)).thenReturn('$n minute${n == 1 ? '' : 's'}');
+    }
   });
 
   group('DurationExtensions.toDaysHoursMinutes()', () {
-    test('all values nonzero, plural', () {
-      testTimeStr(mockAppLocalizations, 2, 2, 2, '2 days, 2 hours and 2 minutes');
+    // Mirrors lila's `translateDuration` in
+    // `modules/coreI18n/src/main/i18n.scala`.
+
+    test('hours+minutes are joined with ", " and minutes shown when no days', () {
+      testTimeStr(mockAppLocalizations, 0, 2, 2, '2 hours, 2 minutes');
     });
 
-    test('all values nonzero, plural', () {
-      testTimeStr(mockAppLocalizations, 2, 2, 2, '2 days, 2 hours and 2 minutes');
+    test('minutes are omitted when there is at least one day', () {
+      testTimeStr(mockAppLocalizations, 3, 18, 24, '3 days, 18 hours');
     });
 
-    test('all values nonzero, single', () {
-      testTimeStr(mockAppLocalizations, 1, 1, 1, '1 day, 1 hour and 1 minute');
+    test('singular labels are respected', () {
+      testTimeStr(mockAppLocalizations, 1, 1, 1, '1 day, 1 hour');
     });
 
-    test('no days', () {
-      testTimeStr(mockAppLocalizations, 0, 2, 2, '2 hours and 2 minutes');
+    test('middle zero hours are preserved when days are nonzero', () {
+      testTimeStr(mockAppLocalizations, 2, 0, 5, '2 days, 0 hours');
     });
 
-    test('no hours', () {
-      testTimeStr(mockAppLocalizations, 2, 0, 2, '2 days and 2 minutes');
+    test('leading zero days are dropped', () {
+      testTimeStr(mockAppLocalizations, 0, 2, 2, '2 hours, 2 minutes');
     });
 
-    test('no minutes', () {
-      testTimeStr(mockAppLocalizations, 2, 2, 0, '2 days and 2 hours');
-    });
-
-    test('only days', () {
-      testTimeStr(mockAppLocalizations, 2, 0, 0, '2 days');
-    });
-
-    test('only hours', () {
-      testTimeStr(mockAppLocalizations, 0, 2, 0, '2 hours');
-    });
-
-    test('only minutes', () {
+    test('leading zero days and hours are dropped', () {
       testTimeStr(mockAppLocalizations, 0, 0, 2, '2 minutes');
     });
 
-    test('all values zero', () {
+    test('only days', () {
+      testTimeStr(mockAppLocalizations, 2, 0, 0, '2 days, 0 hours');
+    });
+
+    test('only hours', () {
+      testTimeStr(mockAppLocalizations, 0, 2, 0, '2 hours, 0 minutes');
+    });
+
+    test('one day no hours no minutes -> "1 day, 0 hours"', () {
+      testTimeStr(mockAppLocalizations, 1, 0, 0, '1 day, 0 hours');
+    });
+
+    test('all values zero -> "0 minutes"', () {
       testTimeStr(mockAppLocalizations, 0, 0, 0, '0 minutes');
     });
   });


### PR DESCRIPTION
Fixes #3227.

The duration formatter in `lib/src/utils/duration.dart` joined the last two parts with a hard-coded English `'and '`, which both diverged from the web client and made the string impossible to translate via Crowdin (it lived in source code, not in `mobile.xml`).

Port the rules from lila's [`translateDuration`](https://github.com/lichess-org/lila/blob/master/modules/coreI18n/src/main/i18n.scala):

- Day / hour / minute parts joined with `', '`.
- Minutes are only included when the duration is less than one day, so `3 days, 18 hours` instead of `3 days, 18 hours, 24 minutes` (matching what's shown on the website).
- Only leading zero parts are dropped; a zero hour between days and minutes is preserved (e.g. `2 days, 0 hours`).
- When the whole duration is zero, falls back to `0 minutes`.

Plural / singular handling continues to go through the already-translated `nbDays` / `nbHours` / `nbMinutes` Crowdin strings, so no source text remains in `duration.dart`.

## Changes
- `lib/src/utils/duration.dart` — rewrite `toDaysHoursMinutes`; link the lila reference.
- `test/utils/duration_test.dart` — rewritten unit tests (10 cases) covering each rule including the no-minutes-when-days-present rule and middle-zero preservation.

## Verification
```
flutter test test/utils/duration_test.dart   # 14/14 pass
flutter analyze lib/src/utils/duration.dart test/utils/duration_test.dart   # 0 issues
```

Existing call sites (`perf_stats_screen.dart` x2, `user_profile.dart`) all render the "Time played" total — exactly the use-case lila's `translateDuration` was built for, so the new format matches what those screens look like on the website.