### PR TITLE
Show a toast when a user does not accept challenges

### DIFF
--- a/lib/src/view/user/user_context_menu.dart
+++ b/lib/src/view/user/user_context_menu.dart
@@ -13,6 +13,7 @@ import 'package:lichess_mobile/src/view/user/user_or_profile_screen.dart';
 import 'package:lichess_mobile/src/view/user/user_screen.dart';
 import 'package:lichess_mobile/src/view/watch/tv_screen.dart';
 import 'package:lichess_mobile/src/widgets/adaptive_bottom_sheet.dart';
+import 'package:lichess_mobile/src/widgets/feedback.dart';
 import 'package:lichess_mobile/src/widgets/list.dart';
 import 'package:lichess_mobile/src/widgets/user.dart';
 
@@ -77,9 +78,17 @@ class UserContextMenu extends ConsumerWidget {
                   },
                   child: Text(context.l10n.watchGames),
                 ),
-                if (authUser != null && value.canChallenge == true)
+                if (authUser != null && value.canChallenge != null)
                   BottomSheetContextMenuAction(
-                    onPressed: () => UserScreen.challengeUser(value, context: context, ref: ref),
+                    onPressed: value.canChallenge == true
+                        ? () => UserScreen.challengeUser(value, context: context, ref: ref)
+                        : () {
+                            Navigator.of(context).pop();
+                            showSnackBar(
+                              context,
+                              context.l10n.challengeXDoesNotAcceptChallenges(value.username),
+                            );
+                          },
                     icon: LichessIcons.crossed_swords,
                     child: Text(context.l10n.challengeChallengeToPlay),
                   ),

--- a/lib/src/view/user/user_screen.dart
+++ b/lib/src/view/user/user_screen.dart
@@ -236,11 +236,16 @@ class _UserProfileListView extends ConsumerWidget {
                 },
               ),
               if (authUser != null) ...[
-                if (user.canChallenge == true)
+                if (user.canChallenge != null)
                   ListTile(
                     title: Text(context.l10n.challengeChallengeToPlay),
                     leading: const Icon(LichessIcons.crossed_swords),
-                    onTap: () => UserScreen.challengeUser(user, context: context, ref: ref),
+                    onTap: user.canChallenge == true
+                        ? () => UserScreen.challengeUser(user, context: context, ref: ref)
+                        : () => showSnackBar(
+                            context,
+                            context.l10n.challengeXDoesNotAcceptChallenges(user.username),
+                          ),
                   ),
 
                 if (user.blocking != true && !user.isBot && kidMode.value == false)

--- a/test/view/user/user_screen_test.dart
+++ b/test/view/user/user_screen_test.dart
@@ -1,3 +1,4 @@
+import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:http/testing.dart';
 import 'package:lichess_mobile/src/model/common/id.dart';
@@ -5,12 +6,27 @@ import 'package:lichess_mobile/src/model/user/user.dart';
 import 'package:lichess_mobile/src/network/http.dart';
 import 'package:lichess_mobile/src/view/user/user_screen.dart';
 
+import '../../model/auth/fake_auth_storage.dart';
 import '../../test_helpers.dart';
 import '../../test_provider_scope.dart';
 
 final client = MockClient((request) {
   if (request.url.path == '/api/mobile/profile/$testUserId') {
     return mockResponse(userProfileResponse, 200);
+  }
+  return mockResponse('', 404);
+});
+
+final clientCannotChallenge = MockClient((request) {
+  if (request.url.path == '/api/mobile/profile/$testUserId') {
+    return mockResponse(userProfileResponseCannotChallenge, 200);
+  }
+  return mockResponse('', 404);
+});
+
+final clientCanChallenge = MockClient((request) {
+  if (request.url.path == '/api/mobile/profile/$testUserId') {
+    return mockResponse(userProfileResponseCanChallenge, 200);
   }
   return mockResponse('', 404);
 });
@@ -41,6 +57,80 @@ void main() {
 
       expect(find.text('Activity'), findsOneWidget);
     }, variant: kPlatformVariant);
+
+    testWidgets('Challenge action is hidden when canChallenge is null (own profile case)', (
+      WidgetTester tester,
+    ) async {
+      final app = await makeTestProviderScopeApp(
+        tester,
+        home: const UserScreen(user: testUser),
+        authUser: fakeAuthUser,
+        overrides: {
+          lichessClientProvider: lichessClientProvider.overrideWith(
+            (ref) => LichessClient(client, ref),
+          ),
+        },
+      );
+
+      await tester.pumpWidget(app);
+      await tester.pump(const Duration(milliseconds: 100));
+
+      expect(find.text('Challenge'), findsNothing);
+    });
+
+    testWidgets(
+      'Challenge action shown when canChallenge is true, and triggers the challenge flow',
+      (WidgetTester tester) async {
+        final app = await makeTestProviderScopeApp(
+          tester,
+          home: const UserScreen(user: testUser),
+          authUser: fakeAuthUser,
+          overrides: {
+            lichessClientProvider: lichessClientProvider.overrideWith(
+              (ref) => LichessClient(clientCanChallenge, ref),
+            ),
+          },
+        );
+
+        await tester.pumpWidget(app);
+        await tester.pump(const Duration(milliseconds: 100));
+
+        expect(find.text('Challenge'), findsOneWidget);
+      },
+    );
+
+    testWidgets(
+      'Challenge action is visible but shows a toast when the user does not accept challenges',
+      (WidgetTester tester) async {
+        final app = await makeTestProviderScopeApp(
+          tester,
+          home: const UserScreen(user: testUser),
+          authUser: fakeAuthUser,
+          overrides: {
+            lichessClientProvider: lichessClientProvider.overrideWith(
+              (ref) => LichessClient(clientCannotChallenge, ref),
+            ),
+          },
+        );
+
+        await tester.pumpWidget(app);
+        await tester.pump(const Duration(milliseconds: 100));
+
+        // Button stays visible (web parity) so the reason can be explained.
+        expect(find.text('Challenge'), findsOneWidget);
+
+        await tester.tap(find.text('Challenge'));
+        await tester.pump();
+
+        expect(
+          find.descendant(
+            of: find.byType(SnackBar),
+            matching: find.text('$testUserName does not accept challenges.'),
+          ),
+          findsOneWidget,
+        );
+      },
+    );
   });
 }
 
@@ -985,3 +1075,19 @@ const userProfileResponse =
     }
 }
 ''';
+
+/// Same as [userProfileResponse] but with the user's `canChallenge` flag set
+/// to `true`, as the server returns when viewing a profile of someone you can
+/// challenge to a game.
+final userProfileResponseCanChallenge = userProfileResponse.replaceFirst(
+  '"verified": true',
+  '"verified": true,\n        "canChallenge": true',
+);
+
+/// Same as [userProfileResponse] but with the user's `canChallenge` flag set
+/// to `false`, as the server returns for users who have opted out of
+/// receiving challenges (e.g. accept challenges only from friends).
+final userProfileResponseCannotChallenge = userProfileResponse.replaceFirst(
+  '"verified": true',
+  '"verified": true,\n        "canChallenge": false',
+);


### PR DESCRIPTION
Fixes #3243.

When viewing a user profile, the **Challenge** action was previously hidden whenever the server returned `canChallenge != true`. The action then silently came and went depending on each user's challenge preference, which (as the reporter noted) is confusing — users had no way to know *why* the button was missing.

Match the web behaviour:

- Show the Challenge action whenever `canChallenge` is **non-null** (i.e. the server is informing us about the challengeability state). On the user's own profile `canChallenge` is null, so the action stays hidden as before.
- When the user has opted out (`canChallenge == false`), tapping the action now shows a snackbar using the already-translated `challengeXDoesNotAcceptChallenges` string instead of triggering the challenge flow.
- Same logic applied to the user context-menu bottom sheet.

## Changes

- `lib/src/view/user/user_screen.dart`
- `lib/src/view/user/user_context_menu.dart`
- `test/view/user/user_screen_test.dart` — three new widget tests (`canChallenge` null / true / false), including asserting that the toast appears with the localized message.

## Verification

```
flutter analyze lib/src/view/user/user_screen.dart lib/src/view/user/user_context_menu.dart test/view/user/user_screen_test.dart  # 0 issues
flutter test test/view/user/user_screen_test.dart  # 5/5 pass
```

Also verified manually on an Android emulator (Pixel 10 / API 36) against `lichess.dev`:

1. Signed in as `CD-Test-1`.
2. Set `CD-Test-2`'s "Let other players challenge you" preference to **Nobody** on the website.
3. Opened `CD-Test-2`'s profile in the app:
   - Challenge action is **visible** (the new behaviour).
4. Tapped Challenge:
   - Snackbar appears reading **"CD-Test-2 does not accept challenges."** instead of opening the challenge composer.

UI accessibility-tree dump after tap confirms the snackbar text:

```
content-desc="CD-Test-2 does not accept challenges."
```

Screenshots attached in a follow-up comment.