### PR TITLE
fix isTyping displaying if different user is typing

### DIFF
--- a/lib/src/model/message/conversation_controller.dart
+++ b/lib/src/model/message/conversation_controller.dart
@@ -127,17 +127,18 @@ class ConversationController extends AsyncNotifier<ConversationState> {
       case 'msgNew':
         _handleIncomingMessage(event.data as Map<String, dynamic>);
       case 'msgType':
-        _handleContactTyping();
+        _handleContactTyping(event.data);
     }
   }
 
   void _handleIncomingMessage(Map<String, dynamic> data) {
     final message = Message.fromServerJson(data);
+    if (message.userId != userId) {
+      return;
+    }
     final convo = state.requireValue.convo;
     final newMessages = convo.messages.insert(0, message);
-    if (message.userId == userId) {
-      markAsRead();
-    }
+    markAsRead();
     state = AsyncData(
       state.requireValue.copyWith(
         convo: convo.copyWith(messages: newMessages),
@@ -146,7 +147,10 @@ class ConversationController extends AsyncNotifier<ConversationState> {
     );
   }
 
-  void _handleContactTyping() {
+  void _handleContactTyping(dynamic data) {
+    if (data is! String || UserId(data) != userId) {
+      return;
+    }
     state = AsyncData(state.requireValue.copyWith(contactTyping: true));
 
     _contactTypingTimer?.cancel();

--- a/test/model/message/conversation_controller_test.dart
+++ b/test/model/message/conversation_controller_test.dart
@@ -170,4 +170,61 @@ void main() {
       expect(state.isBot, isFalse);
     });
   });
+
+  group('ConversationController socket events', () {
+    Future<ConversationState> loadState(ProviderContainer container) async {
+      container.listen(conversationControllerProvider(_userId), (_, _) {});
+      return container.read(conversationControllerProvider(_userId).future);
+    }
+
+    test('adds incoming message from open contact', () async {
+      final container = await _makeContainer(_inboxResponse, _userNotBlockedResponse);
+      await loadState(container);
+
+      sendServerSocketMessages(Uri(path: kDefaultSocketRoute), [
+        '{"t":"msgNew","d":{"user":"opponent","text":"hello","date":1621533013388}}',
+      ]);
+      await Future<void>.delayed(.zero);
+
+      final state = container.read(conversationControllerProvider(_userId)).requireValue;
+      expect(state.convo.messages.length, 1);
+      expect(state.convo.messages[0].text, 'hello');
+      expect(state.convo.messages[0].userId, _userId);
+    });
+
+    test('ignores incoming message from other contact', () async {
+      final container = await _makeContainer(_inboxResponse, _userNotBlockedResponse);
+      await loadState(container);
+
+      sendServerSocketMessages(Uri(path: kDefaultSocketRoute), [
+        '{"t":"msgNew","d":{"user":"other","text":"wrong thread","date":1621533013388}}',
+      ]);
+      await Future<void>.delayed(.zero);
+
+      final state = container.read(conversationControllerProvider(_userId)).requireValue;
+      expect(state.convo.messages, isEmpty);
+    });
+
+    test('shows typing indicator for open contact', () async {
+      final container = await _makeContainer(_inboxResponse, _userNotBlockedResponse);
+      await loadState(container);
+
+      sendServerSocketMessages(Uri(path: kDefaultSocketRoute), ['{"t":"msgType","d":"opponent"}']);
+      await Future<void>.delayed(.zero);
+
+      final state = container.read(conversationControllerProvider(_userId)).requireValue;
+      expect(state.contactTyping, isTrue);
+    });
+
+    test('ignores typing indicator from other contact', () async {
+      final container = await _makeContainer(_inboxResponse, _userNotBlockedResponse);
+      await loadState(container);
+
+      sendServerSocketMessages(Uri(path: kDefaultSocketRoute), ['{"t":"msgType","d":"other"}']);
+      await Future<void>.delayed(.zero);
+
+      final state = container.read(conversationControllerProvider(_userId)).requireValue;
+      expect(state.contactTyping, isNot(true));
+    });
+  });
 }


### PR DESCRIPTION
Currently when being in a chat `is typing` would be displayed even if a different user was typing and even worse the message from a different user would be displayed in the chat the user is viewing too. 

Added tests that fail before and pass now.
Also verified the fix on the app.