### PR TITLE
Refine analysis appbar header format for finished games

### DIFF
--- a/lib/src/view/analysis/analysis_screen.dart
+++ b/lib/src/view/analysis/analysis_screen.dart
@@ -123,17 +123,16 @@ class _AnalysisScreenState extends ConsumerState<_AnalysisScreen>
         Widget appBarTitle;
         if (value.archivedGame != null) {
           final meta = value.archivedGame!.meta;
-          final isStandardVariant =
-              value.variant == Variant.standard || value.variant == Variant.fromPosition;
+          // On mobile space is constrained, so unlike the web we omit the speed for standard chess
+          final isStandardVariant = value.variant == .standard || value.variant == .fromPosition;
           final ratedOrCasual = meta.rated ? context.l10n.rated : context.l10n.casual;
-          final trailingLabel = isStandardVariant
-              ? meta.speed.label(context.l10n)
-              : value.variant.label(context.l10n);
-          final title =
-              '${value.archivedGame!.data.clockDisplay(context.l10n)} • $ratedOrCasual • $trailingLabel';
+          final clockDisplay = value.archivedGame!.data.clockDisplay(context.l10n);
+          final title = isStandardVariant
+              ? '$clockDisplay • $ratedOrCasual'
+              : '$clockDisplay • $ratedOrCasual • ${value.variant.label(context.l10n)}';
           final icon = isStandardVariant ? meta.speed.icon : value.variant.icon;
           appBarTitle = Row(
-            mainAxisSize: MainAxisSize.min,
+            mainAxisSize: .min,
             children: [
               Icon(icon),
               const SizedBox(width: 5.0),

--- a/lib/src/view/analysis/analysis_screen.dart
+++ b/lib/src/view/analysis/analysis_screen.dart
@@ -41,6 +41,7 @@ import 'package:lichess_mobile/src/widgets/adaptive_choice_picker.dart';
 import 'package:lichess_mobile/src/widgets/bottom_bar.dart';
 import 'package:lichess_mobile/src/widgets/buttons.dart';
 import 'package:lichess_mobile/src/widgets/feedback.dart';
+import 'package:lichess_mobile/src/widgets/misc.dart';
 import 'package:lichess_mobile/src/widgets/platform_context_menu_button.dart';
 import 'package:lichess_mobile/src/widgets/user.dart';
 import 'package:lichess_mobile/src/widgets/variant_app_bar_title.dart';
@@ -121,9 +122,24 @@ class _AnalysisScreenState extends ConsumerState<_AnalysisScreen>
       case AsyncData(:final value):
         Widget appBarTitle;
         if (value.archivedGame != null) {
+          final meta = value.archivedGame!.meta;
+          final isStandardVariant =
+              value.variant == Variant.standard || value.variant == Variant.fromPosition;
+          final ratedOrCasual = meta.rated ? context.l10n.rated : context.l10n.casual;
+          final trailingLabel = isStandardVariant
+              ? meta.speed.label(context.l10n)
+              : value.variant.label(context.l10n);
           final title =
-              '${value.archivedGame!.data.clockDisplay(context.l10n)} • ${value.archivedGame!.meta.speed.label(context.l10n)} • ${value.archivedGame!.meta.rated ? context.l10n.rated : context.l10n.casual}';
-          appBarTitle = VariantAppBarTitle(variant: value.variant, title: title);
+              '${value.archivedGame!.data.clockDisplay(context.l10n)} • $ratedOrCasual • $trailingLabel';
+          final icon = isStandardVariant ? meta.speed.icon : value.variant.icon;
+          appBarTitle = Row(
+            mainAxisSize: MainAxisSize.min,
+            children: [
+              Icon(icon),
+              const SizedBox(width: 5.0),
+              Flexible(child: AppBarTitleText(title)),
+            ],
+          );
         } else {
           appBarTitle = VariantAppBarTitle(variant: value.variant, title: context.l10n.analysis);
         }

--- a/test/view/game/game_screen_test.dart
+++ b/test/view/game/game_screen_test.dart
@@ -1688,7 +1688,7 @@ void main() {
       await tester.tap(find.text('Analysis board'));
       await tester.pumpAndSettle(); // wait for analysis screen to open
       expect(
-        find.descendant(of: find.byType(AppBar), matching: find.text('2+1 • Rated • Bullet')),
+        find.descendant(of: find.byType(AppBar), matching: find.text('2+1 • Rated')),
         findsOneWidget,
       ); // analysis screen is now open
       expect(find.byType(Chessboard), findsOneWidget);

--- a/test/view/game/game_screen_test.dart
+++ b/test/view/game/game_screen_test.dart
@@ -1688,7 +1688,7 @@ void main() {
       await tester.tap(find.text('Analysis board'));
       await tester.pumpAndSettle(); // wait for analysis screen to open
       expect(
-        find.descendant(of: find.byType(AppBar), matching: find.textContaining('Rated')),
+        find.descendant(of: find.byType(AppBar), matching: find.text('2+1 • Rated • Bullet')),
         findsOneWidget,
       ); // analysis screen is now open
       expect(find.byType(Chessboard), findsOneWidget);


### PR DESCRIPTION
Fixes #3259.

Refine the analysis screen header for a finished game so the speed/variant icon leads the title and the rated/casual segment comes before any trailing variant label. On mobile space is constrained, so — unlike the web client — the speed label is omitted for standard chess; the leading icon and the time control already convey it.

Format:
- **Standard / from-position**: `{speed icon} {clockDisplay} • {Rated|Casual}` (e.g. `5+0 • Rated`). Previously standard games showed no leading icon at all.
- **Non-standard variants** (Chess960, Crazyhouse, …): keep the variant icon and append the variant label as the trailing segment (e.g. `5+0 • Rated • Chess960`); the time control is still shown so the duration is retained.

Previously the title was `{clock} • {speed} • {Rated|Casual}` for every game, and the variant icon was always used (so standard games had no leading icon).

## Changes
- `lib/src/view/analysis/analysis_screen.dart` — branch on `isStandardVariant`, pick the speed or variant icon/label accordingly, omit the speed label for standard games, reorder the rated/casual segment, and render the title as an icon + text `Row`.
- `test/view/game/game_screen_test.dart` — strengthen the analysis-from-finished-game test (was `find.textContaining("Rated")`) to assert the exact new text `2+1 • Rated`, locking in the format.

## Verification
```
flutter analyze lib/src/view/analysis/analysis_screen.dart test/view/game/game_screen_test.dart  # 0 issues
flutter test test/view/game/game_screen_test.dart  # all pass
```

Manual verification on a Pixel 10 emulator (lichess.dev, finished standard Rapid game):

| | App-bar header |
|---|---|
| BEFORE (`main`) | `10+0 • Rapid • Rated` (no leading icon) |
| AFTER (this PR) | `10+0 • Rated` (with leading speed icon, no speed label) |
