### PR TITLE
Show opening name in broadcast and study opening explorer

### DIFF
--- a/lib/src/model/analysis/analysis_controller.dart
+++ b/lib/src/model/analysis/analysis_controller.dart
@@ -12,7 +12,7 @@ import 'package:lichess_mobile/src/model/analysis/analysis_player.dart';
 import 'package:lichess_mobile/src/model/analysis/analysis_preferences.dart';
 import 'package:lichess_mobile/src/model/analysis/common_analysis_state.dart';
 import 'package:lichess_mobile/src/model/analysis/forecast.dart';
-import 'package:lichess_mobile/src/model/analysis/opening_service.dart';
+import 'package:lichess_mobile/src/model/analysis/opening_explorer_mixin.dart';
 import 'package:lichess_mobile/src/model/analysis/server_analysis_mixin.dart';
 import 'package:lichess_mobile/src/model/analysis/server_analysis_service.dart';
 import 'package:lichess_mobile/src/model/common/chess.dart';
@@ -127,7 +127,10 @@ void clearSavedStandaloneAnalysis() {
 }
 
 class AnalysisController extends AsyncNotifier<AnalysisState>
-    with EngineEvaluationMixin, ServerAnalysisMixin<AnalysisState>
+    with
+        EngineEvaluationMixin,
+        ServerAnalysisMixin<AnalysisState>,
+        OpeningExplorerMixin<AnalysisState>
     implements PgnTreeNotifier {
   AnalysisController(this.options);
 
@@ -273,34 +276,17 @@ class AnalysisController extends AsyncNotifier<AnalysisState>
           }
           if (isMainline) {
             mainlinePath = mainlinePath + branch.id;
-            if (branch.position.ply <= 30) {
-              openingFutures.add(_fetchOpening(branch.position.fen, mainlinePath));
+            final openingFuture = fetchMainlineOpening(branch, mainlinePath);
+            if (openingFuture != null) {
+              openingFutures.add(openingFuture);
             }
           }
         },
       ),
     };
 
-    // wait for the opening to be fetched to recompute the branch opening
-    Future.wait(openingFutures)
-        .then((list) {
-          bool hasOpening = false;
-          for (final updated in list) {
-            if (updated != null) {
-              hasOpening = true;
-              final (path, opening) = updated;
-              _root.updateAt(path, (node) => node.opening = opening);
-            }
-          }
-          return hasOpening;
-        })
-        .then((hasOpening) {
-          if (hasOpening) {
-            scheduleMicrotask(() {
-              _setPath(state.requireValue.currentPath);
-            });
-          }
-        });
+    // wait for the openings to be fetched to recompute the branch opening
+    applyFetchedOpenings(openingFutures);
 
     final currentPath = switch (options) {
       Standalone() when _savedStandalone != null => _savedStandalone!.path,
@@ -635,15 +621,15 @@ class AnalysisController extends AsyncNotifier<AnalysisState>
     state = AsyncData(state.requireValue.copyWith(pgnHeaders: headers));
   }
 
-  /// Gets the node and maybe the associated branch opening at the given path.
-  (Node, Opening?) _nodeOpeningAt(Node node, UciPath path, [Opening? opening]) {
-    if (path.isEmpty) return (node, opening);
-    final child = node.childById(path.head!);
-    if (child != null) {
-      return _nodeOpeningAt(child, path.tail, child.opening ?? opening);
-    } else {
-      return (node, opening);
-    }
+  @override
+  void refreshCurrentBranchOpening() {
+    final curState = state.requireValue;
+    state = AsyncData(
+      curState.copyWith(
+        currentNode: AnalysisCurrentNode.fromNode(_root.nodeAt(curState.currentPath)),
+        currentBranchOpening: currentBranchOpeningAt(curState.currentPath),
+      ),
+    );
   }
 
   /// Makes a full PGN string (including headers and comments) of the current game state.
@@ -685,7 +671,7 @@ class AnalysisController extends AsyncNotifier<AnalysisState>
     _currentPath = path;
     final curState = state.requireValue;
     final pathChange = curState.currentPath != path;
-    final (currentNode, opening) = _nodeOpeningAt(_root, path);
+    final (currentNode, opening) = nodeOpeningAt(_root, path);
 
     // always show variation if the user plays a move
     if (shouldForceShowVariation && currentNode is Branch && currentNode.isCollapsed) {
@@ -722,14 +708,7 @@ class AnalysisController extends AsyncNotifier<AnalysisState>
         }
       }
 
-      if (currentNode.opening == null && currentNode.position.ply <= 30) {
-        _fetchOpening(currentNode.position.fen, path).then((value) {
-          if (value != null) {
-            final (path, opening) = value;
-            _updateOpening(path, opening);
-          }
-        });
-      }
+      maybeFetchOpeningAt(currentNode, path);
 
       state = AsyncData(
         curState.copyWith(
@@ -765,30 +744,6 @@ class AnalysisController extends AsyncNotifier<AnalysisState>
     super.requestServerAnalysis(side ?? options.orientation);
   }
 
-  Future<(UciPath, FullOpening)?> _fetchOpening(String fen, UciPath path) async {
-    if (!kOpeningAllowedVariants.contains(_variant)) return null;
-
-    final opening = await ref.read(openingServiceProvider).fetchFromFen(fen);
-    if (opening != null) {
-      return (path, opening);
-    }
-    return null;
-  }
-
-  void _updateOpening(UciPath path, FullOpening opening) {
-    _root.updateAt(path, (node) => node.opening = opening);
-
-    final curState = state.requireValue;
-    if (curState.currentPath == path) {
-      _refreshCurrentNode();
-    } else {
-      final (_, newOpening) = _nodeOpeningAt(_root, curState.currentPath);
-      if (newOpening != null && newOpening != curState.currentBranchOpening) {
-        state = AsyncData(curState.copyWith(currentBranchOpening: newOpening));
-      }
-    }
-  }
-
   @override
   Future<void> onServerAnalysisEvent(ServerEvalEvent event) async {
     state = AsyncData(
@@ -809,7 +764,8 @@ sealed class AnalysisState
         _$AnalysisState,
         AnalysisExplosionMixin,
         EvaluationMixinState<AnalysisState>,
-        ServerAnalysisMixinState
+        ServerAnalysisMixinState,
+        OpeningExplorerMixinState
     implements CommonAnalysisState {
   const AnalysisState._();
 

--- a/lib/src/model/analysis/analysis_controller.dart
+++ b/lib/src/model/analysis/analysis_controller.dart
@@ -227,7 +227,6 @@ class AnalysisController extends AsyncNotifier<AnalysisState>
     }
 
     UciPath path = UciPath.empty;
-    UciPath mainlinePath = UciPath.empty;
     Move? lastMove;
 
     final game = PgnGame.parsePgn(
@@ -260,8 +259,6 @@ class AnalysisController extends AsyncNotifier<AnalysisState>
       ActiveCorrespondenceGame() => false,
     };
 
-    final List<Future<(UciPath, FullOpening)?>> openingFutures = [];
-
     _root = switch (options) {
       Standalone() when _savedStandalone != null => _savedStandalone!.root,
       _ => Root.fromPgnGame(
@@ -274,19 +271,9 @@ class AnalysisController extends AsyncNotifier<AnalysisState>
             path = path + branch.id;
             lastMove = branch.sanMove.move;
           }
-          if (isMainline) {
-            mainlinePath = mainlinePath + branch.id;
-            final openingFuture = fetchMainlineOpening(branch, mainlinePath);
-            if (openingFuture != null) {
-              openingFutures.add(openingFuture);
-            }
-          }
         },
       ),
     };
-
-    // wait for the openings to be fetched to recompute the branch opening
-    applyFetchedOpenings(openingFutures);
 
     final currentPath = switch (options) {
       Standalone() when _savedStandalone != null => _savedStandalone!.path,

--- a/lib/src/model/analysis/opening_explorer_mixin.dart
+++ b/lib/src/model/analysis/opening_explorer_mixin.dart
@@ -35,12 +35,17 @@ mixin OpeningExplorerMixinState {
 /// [OpeningExplorerMixinState.currentBranchOpening] is recomputed whenever the
 /// current path changes or a new opening is fetched.
 ///
+/// The build-time mainline opening fetch is centralized here: this mixin
+/// overrides [runBuild] to schedule [initMainlineOpenings] once the initial
+/// state has been built. Controllers therefore do not need to fetch the
+/// mainline openings themselves.
+///
 /// The parent must implement:
 /// - [positionTree] to provide the tree where openings are stored.
 /// - [refreshCurrentBranchOpening] to recompute its state from the tree at the
 ///   current path (i.e. rebuild `currentNode` and update `currentBranchOpening`)
 ///   after an opening has been fetched.
-mixin OpeningExplorerMixin<T extends OpeningExplorerMixinState> on AnyNotifier<AsyncValue<T>, T> {
+mixin OpeningExplorerMixin<T extends OpeningExplorerMixinState> on AsyncNotifier<T> {
   /// The tree where openings are stored.
   Root get positionTree;
 
@@ -51,6 +56,46 @@ mixin OpeningExplorerMixin<T extends OpeningExplorerMixinState> on AnyNotifier<A
   /// freshly fetched opening on the current node is reflected) and update
   /// `currentBranchOpening` with [currentBranchOpeningAt] for the current path.
   void refreshCurrentBranchOpening();
+
+  /// Whether the [positionTree] is available and openings can be fetched for it.
+  ///
+  /// Defaults to `true`. Implementations whose [positionTree] may be
+  /// unavailable (e.g. studies with an illegal starting position) should
+  /// override this to return `false` in that case.
+  bool get canFetchMainlineOpenings => true;
+
+  @override
+  void runBuild() {
+    super.runBuild();
+    // Fetch the openings of the mainline once the initial state has been built.
+    // [future] resolves with the first non-loading state, which is exactly when
+    // [positionTree] has been populated and [state] has a value. This is
+    // fire-and-forget: it must not block the build, since openings are a
+    // non-critical enhancement.
+    future
+        .then((_) {
+          if (ref.mounted && state.hasValue) initMainlineOpenings();
+        })
+        // If the build fails, there is nothing to fetch openings for; swallow
+        // the error so it does not surface as an unhandled async error.
+        .ignore();
+  }
+
+  /// Walks the mainline of [positionTree], fetches the opening for each branch
+  /// (up to [_kMaxOpeningPly]), stores them on the tree, and refreshes the
+  /// current branch opening once they resolve.
+  void initMainlineOpenings() {
+    if (!canFetchMainlineOpenings) return;
+    final openingFutures = <Future<(UciPath, FullOpening)?>>[];
+    UciPath mainlinePath = UciPath.empty;
+    for (final branch in positionTree.mainline) {
+      mainlinePath = mainlinePath + branch.id;
+      final openingFuture = _fetchMainlineOpening(branch, mainlinePath);
+      if (openingFuture == null) break;
+      openingFutures.add(openingFuture);
+    }
+    _applyFetchedOpenings(openingFutures);
+  }
 
   /// Walks the tree from [node] down to [path], returning the node at [path]
   /// and the deepest opening found along the way.
@@ -74,10 +119,8 @@ mixin OpeningExplorerMixin<T extends OpeningExplorerMixinState> on AnyNotifier<A
   /// Returns a future that fetches the opening for the mainline [branch] at
   /// [mainlinePath], or `null` if the position is too deep to have an opening.
   ///
-  /// Should be called during the build of the notifier while iterating over the
-  /// mainline. The returned futures should be collected and then awaited with
-  /// [applyFetchedOpenings].
-  Future<(UciPath, FullOpening)?>? fetchMainlineOpening(Branch branch, UciPath mainlinePath) {
+  /// Called by [initMainlineOpenings] while iterating over the mainline.
+  Future<(UciPath, FullOpening)?>? _fetchMainlineOpening(Branch branch, UciPath mainlinePath) {
     if (branch.position.ply > _kMaxOpeningPly) return null;
     return fetchOpening(branch.position.fen, mainlinePath);
   }
@@ -88,7 +131,7 @@ mixin OpeningExplorerMixin<T extends OpeningExplorerMixinState> on AnyNotifier<A
   ///
   /// This is fire-and-forget: it must not block the build, since openings are a
   /// non-critical enhancement.
-  void applyFetchedOpenings(List<Future<(UciPath, FullOpening)?>> openingFutures) {
+  void _applyFetchedOpenings(List<Future<(UciPath, FullOpening)?>> openingFutures) {
     Future.wait(openingFutures).then((list) {
       var hasOpening = false;
       for (final updated in list) {

--- a/lib/src/model/analysis/opening_explorer_mixin.dart
+++ b/lib/src/model/analysis/opening_explorer_mixin.dart
@@ -6,84 +6,48 @@ import 'package:lichess_mobile/src/model/common/chess.dart';
 import 'package:lichess_mobile/src/model/common/node.dart';
 import 'package:lichess_mobile/src/model/common/uci.dart';
 
-/// The maximum ply up to which openings are looked up.
-///
-/// Openings only exist for the first moves of a game, so there is no point in
-/// querying the opening database for positions deeper than this.
+/// Openings only exist for the first moves, so we don't look them up beyond this ply.
 const _kMaxOpeningPly = 30;
 
 /// Interface for a Notifier state that uses [OpeningExplorerMixin].
 mixin OpeningExplorerMixinState {
-  /// The variant of the analysis, used to determine whether openings should be
-  /// looked up (see [kOpeningAllowedVariants]).
   Variant get variant;
-
-  /// The path to the current node in the analysis view.
   UciPath get currentPath;
 
-  /// The opening associated with the current branch, if any.
-  ///
-  /// This is the opening of the deepest ancestor of the current node (including
-  /// the current node itself) that has an opening.
+  /// The opening of the deepest ancestor of the current node (including itself).
   Opening? get currentBranchOpening;
 }
 
-/// A mixin to provide opening name lookup to an [AsyncNotifier] backing an
-/// analysis-like screen (analysis, broadcast, study).
+/// Provides opening name lookup to an [AsyncNotifier] backing an analysis-like
+/// screen (analysis, broadcast, study).
 ///
-/// Openings are stored on the tree [Node]s themselves and the
-/// [OpeningExplorerMixinState.currentBranchOpening] is recomputed whenever the
-/// current path changes or a new opening is fetched.
-///
-/// The build-time mainline opening fetch is centralized here: this mixin
-/// overrides [runBuild] to schedule [initMainlineOpenings] once the initial
-/// state has been built. Controllers therefore do not need to fetch the
-/// mainline openings themselves.
-///
-/// The parent must implement:
-/// - [positionTree] to provide the tree where openings are stored.
-/// - [refreshCurrentBranchOpening] to recompute its state from the tree at the
-///   current path (i.e. rebuild `currentNode` and update `currentBranchOpening`)
-///   after an opening has been fetched.
+/// Openings are stored on the tree [Node]s. The build-time mainline fetch is
+/// centralized here via [runBuild]; controllers only implement [positionTree]
+/// and [refreshCurrentBranchOpening].
 mixin OpeningExplorerMixin<T extends OpeningExplorerMixinState> on AsyncNotifier<T> {
   /// The tree where openings are stored.
   Root get positionTree;
 
   /// Recomputes the state from the tree at the current path after an opening
   /// has been stored on a node.
-  ///
-  /// Implementations should rebuild their `currentNode` from the tree (so a
-  /// freshly fetched opening on the current node is reflected) and update
-  /// `currentBranchOpening` with [currentBranchOpeningAt] for the current path.
   void refreshCurrentBranchOpening();
 
-  /// Whether the [positionTree] is available and openings can be fetched for it.
-  ///
-  /// Defaults to `true`. Implementations whose [positionTree] may be
-  /// unavailable (e.g. studies with an illegal starting position) should
-  /// override this to return `false` in that case.
+  /// Whether openings can be fetched. Studies with an illegal starting position
+  /// have no tree and should override this to return `false`.
   bool get canFetchMainlineOpenings => true;
 
   @override
   void runBuild() {
     super.runBuild();
-    // Fetch the openings of the mainline once the initial state has been built.
-    // [future] resolves with the first non-loading state, which is exactly when
-    // [positionTree] has been populated and [state] has a value. This is
-    // fire-and-forget: it must not block the build, since openings are a
-    // non-critical enhancement.
-    future
-        .then((_) {
-          if (ref.mounted && state.hasValue) initMainlineOpenings();
-        })
-        // If the build fails, there is nothing to fetch openings for; swallow
-        // the error so it does not surface as an unhandled async error.
-        .ignore();
+    // [future] resolves with the first non-loading state, i.e. once [positionTree]
+    // is populated. Fire-and-forget: openings are a non-critical enhancement.
+    future.then((_) {
+      if (ref.mounted && state.hasValue) initMainlineOpenings();
+    }).ignore();
   }
 
-  /// Walks the mainline of [positionTree], fetches the opening for each branch
-  /// (up to [_kMaxOpeningPly]), stores them on the tree, and refreshes the
-  /// current branch opening once they resolve.
+  /// Fetches the opening for each mainline branch (up to [_kMaxOpeningPly]),
+  /// stores them on the tree, and refreshes the current branch opening.
   void initMainlineOpenings() {
     if (!canFetchMainlineOpenings) return;
     final openingFutures = <Future<(UciPath, FullOpening)?>>[];
@@ -109,28 +73,17 @@ mixin OpeningExplorerMixin<T extends OpeningExplorerMixinState> on AsyncNotifier
     }
   }
 
-  /// The opening associated with the current branch given [path], i.e. the
-  /// deepest opening found while walking the tree down to [path].
+  /// The deepest opening found while walking the tree down to [path].
   Opening? currentBranchOpeningAt(UciPath path) {
     final (_, opening) = nodeOpeningAt(positionTree, path);
     return opening;
   }
 
-  /// Returns a future that fetches the opening for the mainline [branch] at
-  /// [mainlinePath], or `null` if the position is too deep to have an opening.
-  ///
-  /// Called by [initMainlineOpenings] while iterating over the mainline.
   Future<(UciPath, FullOpening)?>? _fetchMainlineOpening(Branch branch, UciPath mainlinePath) {
     if (branch.position.ply > _kMaxOpeningPly) return null;
     return fetchOpening(branch.position.fen, mainlinePath);
   }
 
-  /// Awaits the [openingFutures] collected during build, stores the fetched
-  /// openings on the tree, and refreshes the current branch opening if any
-  /// opening was found.
-  ///
-  /// This is fire-and-forget: it must not block the build, since openings are a
-  /// non-critical enhancement.
   void _applyFetchedOpenings(List<Future<(UciPath, FullOpening)?>> openingFutures) {
     Future.wait(openingFutures).then((list) {
       var hasOpening = false;
@@ -150,11 +103,8 @@ mixin OpeningExplorerMixin<T extends OpeningExplorerMixinState> on AsyncNotifier
     });
   }
 
-  /// If [currentNode] is a [Branch] without an opening yet (and shallow enough),
-  /// fetches its opening asynchronously, stores it on the tree, then refreshes
-  /// the current branch opening.
-  ///
-  /// Should be called from the controller's `_setPath` when the path changes.
+  /// Fetches [currentNode]'s opening if it is a shallow [Branch] without one yet,
+  /// then refreshes the current branch opening. Call from the controller's `_setPath`.
   void maybeFetchOpeningAt(Node currentNode, UciPath path) {
     if (currentNode is Branch &&
         currentNode.opening == null &&
@@ -170,8 +120,8 @@ mixin OpeningExplorerMixin<T extends OpeningExplorerMixinState> on AsyncNotifier
     }
   }
 
-  /// Fetches the opening for [fen] from the opening database, returning it
-  /// together with [path] if found and the variant allows openings.
+  /// Fetches the opening for [fen], returning it with [path] if found and the
+  /// variant allows openings.
   Future<(UciPath, FullOpening)?> fetchOpening(String fen, UciPath path) async {
     if (!kOpeningAllowedVariants.contains(state.value?.variant ?? Variant.standard)) {
       return null;

--- a/lib/src/model/analysis/opening_explorer_mixin.dart
+++ b/lib/src/model/analysis/opening_explorer_mixin.dart
@@ -135,10 +135,11 @@ mixin OpeningExplorerMixin<T extends OpeningExplorerMixinState> on AsyncNotifier
     if (!kOpeningAllowedVariants.contains(state.value?.variant ?? Variant.standard)) {
       return null;
     }
-    final opening = await ref.read(openingServiceProvider).fetchFromFen(fen);
-    if (opening != null) {
-      return (path, opening);
+    try {
+      final opening = await ref.read(openingServiceProvider).fetchFromFen(fen);
+      return opening != null ? (path, opening) : null;
+    } catch (_) {
+      return null;
     }
-    return null;
   }
 }

--- a/lib/src/model/analysis/opening_explorer_mixin.dart
+++ b/lib/src/model/analysis/opening_explorer_mixin.dart
@@ -5,6 +5,7 @@ import 'package:lichess_mobile/src/model/analysis/opening_service.dart';
 import 'package:lichess_mobile/src/model/common/chess.dart';
 import 'package:lichess_mobile/src/model/common/node.dart';
 import 'package:lichess_mobile/src/model/common/uci.dart';
+import 'package:meta/meta.dart';
 
 /// Openings only exist for the first moves, so we don't look them up beyond this ply.
 const _kMaxOpeningPly = 30;
@@ -26,14 +27,17 @@ mixin OpeningExplorerMixinState {
 /// and [refreshCurrentBranchOpening].
 mixin OpeningExplorerMixin<T extends OpeningExplorerMixinState> on AsyncNotifier<T> {
   /// The tree where openings are stored.
+  @protected
   Root get positionTree;
 
   /// Recomputes the state from the tree at the current path after an opening
   /// has been stored on a node.
+  @protected
   void refreshCurrentBranchOpening();
 
   /// Whether openings can be fetched. Studies with an illegal starting position
   /// have no tree and should override this to return `false`.
+  @protected
   bool get canFetchMainlineOpenings => true;
 
   @override
@@ -48,6 +52,7 @@ mixin OpeningExplorerMixin<T extends OpeningExplorerMixinState> on AsyncNotifier
 
   /// Fetches the opening for each mainline branch (up to [_kMaxOpeningPly]),
   /// stores them on the tree, and refreshes the current branch opening.
+  @protected
   void initMainlineOpenings() {
     if (!canFetchMainlineOpenings) return;
     final openingFutures = <Future<(UciPath, FullOpening)?>>[];
@@ -63,6 +68,7 @@ mixin OpeningExplorerMixin<T extends OpeningExplorerMixinState> on AsyncNotifier
 
   /// Walks the tree from [node] down to [path], returning the node at [path]
   /// and the deepest opening found along the way.
+  @protected
   (Node, Opening?) nodeOpeningAt(Node node, UciPath path, [Opening? opening]) {
     if (path.isEmpty) return (node, opening);
     final child = node.childById(path.head!);
@@ -74,6 +80,7 @@ mixin OpeningExplorerMixin<T extends OpeningExplorerMixinState> on AsyncNotifier
   }
 
   /// The deepest opening found while walking the tree down to [path].
+  @protected
   Opening? currentBranchOpeningAt(UciPath path) {
     final (_, opening) = nodeOpeningAt(positionTree, path);
     return opening;
@@ -105,6 +112,7 @@ mixin OpeningExplorerMixin<T extends OpeningExplorerMixinState> on AsyncNotifier
 
   /// Fetches [currentNode]'s opening if it is a shallow [Branch] without one yet,
   /// then refreshes the current branch opening. Call from the controller's `_setPath`.
+  @protected
   void maybeFetchOpeningAt(Node currentNode, UciPath path) {
     if (currentNode is Branch &&
         currentNode.opening == null &&
@@ -122,6 +130,7 @@ mixin OpeningExplorerMixin<T extends OpeningExplorerMixinState> on AsyncNotifier
 
   /// Fetches the opening for [fen], returning it with [path] if found and the
   /// variant allows openings.
+  @protected
   Future<(UciPath, FullOpening)?> fetchOpening(String fen, UciPath path) async {
     if (!kOpeningAllowedVariants.contains(state.value?.variant ?? Variant.standard)) {
       return null;

--- a/lib/src/model/analysis/opening_explorer_mixin.dart
+++ b/lib/src/model/analysis/opening_explorer_mixin.dart
@@ -1,0 +1,142 @@
+import 'dart:async';
+
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:lichess_mobile/src/model/analysis/opening_service.dart';
+import 'package:lichess_mobile/src/model/common/chess.dart';
+import 'package:lichess_mobile/src/model/common/node.dart';
+import 'package:lichess_mobile/src/model/common/uci.dart';
+
+/// The maximum ply up to which openings are looked up.
+///
+/// Openings only exist for the first moves of a game, so there is no point in
+/// querying the opening database for positions deeper than this.
+const _kMaxOpeningPly = 30;
+
+/// Interface for a Notifier state that uses [OpeningExplorerMixin].
+mixin OpeningExplorerMixinState {
+  /// The variant of the analysis, used to determine whether openings should be
+  /// looked up (see [kOpeningAllowedVariants]).
+  Variant get variant;
+
+  /// The path to the current node in the analysis view.
+  UciPath get currentPath;
+
+  /// The opening associated with the current branch, if any.
+  ///
+  /// This is the opening of the deepest ancestor of the current node (including
+  /// the current node itself) that has an opening.
+  Opening? get currentBranchOpening;
+}
+
+/// A mixin to provide opening name lookup to an [AsyncNotifier] backing an
+/// analysis-like screen (analysis, broadcast, study).
+///
+/// Openings are stored on the tree [Node]s themselves and the
+/// [OpeningExplorerMixinState.currentBranchOpening] is recomputed whenever the
+/// current path changes or a new opening is fetched.
+///
+/// The parent must implement:
+/// - [positionTree] to provide the tree where openings are stored.
+/// - [refreshCurrentBranchOpening] to recompute its state from the tree at the
+///   current path (i.e. rebuild `currentNode` and update `currentBranchOpening`)
+///   after an opening has been fetched.
+mixin OpeningExplorerMixin<T extends OpeningExplorerMixinState> on AnyNotifier<AsyncValue<T>, T> {
+  /// The tree where openings are stored.
+  Root get positionTree;
+
+  /// Recomputes the state from the tree at the current path after an opening
+  /// has been stored on a node.
+  ///
+  /// Implementations should rebuild their `currentNode` from the tree (so a
+  /// freshly fetched opening on the current node is reflected) and update
+  /// `currentBranchOpening` with [currentBranchOpeningAt] for the current path.
+  void refreshCurrentBranchOpening();
+
+  /// Walks the tree from [node] down to [path], returning the node at [path]
+  /// and the deepest opening found along the way.
+  (Node, Opening?) nodeOpeningAt(Node node, UciPath path, [Opening? opening]) {
+    if (path.isEmpty) return (node, opening);
+    final child = node.childById(path.head!);
+    if (child != null) {
+      return nodeOpeningAt(child, path.tail, child.opening ?? opening);
+    } else {
+      return (node, opening);
+    }
+  }
+
+  /// The opening associated with the current branch given [path], i.e. the
+  /// deepest opening found while walking the tree down to [path].
+  Opening? currentBranchOpeningAt(UciPath path) {
+    final (_, opening) = nodeOpeningAt(positionTree, path);
+    return opening;
+  }
+
+  /// Returns a future that fetches the opening for the mainline [branch] at
+  /// [mainlinePath], or `null` if the position is too deep to have an opening.
+  ///
+  /// Should be called during the build of the notifier while iterating over the
+  /// mainline. The returned futures should be collected and then awaited with
+  /// [applyFetchedOpenings].
+  Future<(UciPath, FullOpening)?>? fetchMainlineOpening(Branch branch, UciPath mainlinePath) {
+    if (branch.position.ply > _kMaxOpeningPly) return null;
+    return fetchOpening(branch.position.fen, mainlinePath);
+  }
+
+  /// Awaits the [openingFutures] collected during build, stores the fetched
+  /// openings on the tree, and refreshes the current branch opening if any
+  /// opening was found.
+  ///
+  /// This is fire-and-forget: it must not block the build, since openings are a
+  /// non-critical enhancement.
+  void applyFetchedOpenings(List<Future<(UciPath, FullOpening)?>> openingFutures) {
+    Future.wait(openingFutures).then((list) {
+      var hasOpening = false;
+      for (final updated in list) {
+        if (updated != null) {
+          hasOpening = true;
+          final (path, opening) = updated;
+          positionTree.updateAt(path, (node) => node.opening = opening);
+        }
+      }
+      if (hasOpening && ref.mounted && state.hasValue) {
+        scheduleMicrotask(() {
+          if (!ref.mounted || !state.hasValue) return;
+          refreshCurrentBranchOpening();
+        });
+      }
+    });
+  }
+
+  /// If [currentNode] is a [Branch] without an opening yet (and shallow enough),
+  /// fetches its opening asynchronously, stores it on the tree, then refreshes
+  /// the current branch opening.
+  ///
+  /// Should be called from the controller's `_setPath` when the path changes.
+  void maybeFetchOpeningAt(Node currentNode, UciPath path) {
+    if (currentNode is Branch &&
+        currentNode.opening == null &&
+        currentNode.position.ply <= _kMaxOpeningPly) {
+      fetchOpening(currentNode.position.fen, path).then((value) {
+        if (value != null) {
+          positionTree.updateAt(value.$1, (node) => node.opening = value.$2);
+          if (ref.mounted && state.hasValue) {
+            refreshCurrentBranchOpening();
+          }
+        }
+      });
+    }
+  }
+
+  /// Fetches the opening for [fen] from the opening database, returning it
+  /// together with [path] if found and the variant allows openings.
+  Future<(UciPath, FullOpening)?> fetchOpening(String fen, UciPath path) async {
+    if (!kOpeningAllowedVariants.contains(state.value?.variant ?? Variant.standard)) {
+      return null;
+    }
+    final opening = await ref.read(openingServiceProvider).fetchFromFen(fen);
+    if (opening != null) {
+      return (path, opening);
+    }
+    return null;
+  }
+}

--- a/lib/src/model/broadcast/broadcast_analysis_controller.dart
+++ b/lib/src/model/broadcast/broadcast_analysis_controller.dart
@@ -125,17 +125,6 @@ class BroadcastAnalysisController extends AsyncNotifier<BroadcastAnalysisState>
     final currentNode = _root.nodeAt(currentPath);
     final lastMove = _root.branchAt(_root.mainlinePath)?.sanMove.move;
 
-    final openingFutures = <Future<(UciPath, FullOpening)?>>[];
-    {
-      UciPath mainlinePath = UciPath.empty;
-      for (final branch in _root.mainline) {
-        mainlinePath = mainlinePath + branch.id;
-        final openingFuture = fetchMainlineOpening(branch, mainlinePath);
-        if (openingFuture == null) break;
-        openingFutures.add(openingFuture);
-      }
-    }
-
     // don't use ref.watch here: we don't want to invalidate state when the
     // analysis preferences change
     final prefs = ref.read(broadcastPreferencesProvider);
@@ -163,8 +152,6 @@ class BroadcastAnalysisController extends AsyncNotifier<BroadcastAnalysisState>
     // We need to define the state value in the build method because `sendEvalGetEvent` and
     // `debouncedStartEngineEval` require the state to have a value.
     state = AsyncData(broadcastState);
-
-    applyFetchedOpenings(openingFutures);
 
     if (state.requireValue.isEngineAvailable(evaluationPrefs)) {
       requestEval();

--- a/lib/src/model/broadcast/broadcast_analysis_controller.dart
+++ b/lib/src/model/broadcast/broadcast_analysis_controller.dart
@@ -10,7 +10,7 @@ import 'package:freezed_annotation/freezed_annotation.dart';
 import 'package:lichess_mobile/src/model/analysis/analysis_controller.dart';
 import 'package:lichess_mobile/src/model/analysis/analysis_summary.dart';
 import 'package:lichess_mobile/src/model/analysis/common_analysis_state.dart';
-import 'package:lichess_mobile/src/model/analysis/opening_service.dart';
+import 'package:lichess_mobile/src/model/analysis/opening_explorer_mixin.dart';
 import 'package:lichess_mobile/src/model/broadcast/broadcast.dart';
 import 'package:lichess_mobile/src/model/broadcast/broadcast_preferences.dart';
 import 'package:lichess_mobile/src/model/broadcast/broadcast_repository.dart';
@@ -46,7 +46,7 @@ final broadcastAnalysisControllerProvider = AsyncNotifierProvider.autoDispose
     );
 
 class BroadcastAnalysisController extends AsyncNotifier<BroadcastAnalysisState>
-    with EngineEvaluationMixin
+    with EngineEvaluationMixin, OpeningExplorerMixin<BroadcastAnalysisState>
     implements PgnTreeNotifier {
   BroadcastAnalysisController(this.params);
 
@@ -130,8 +130,9 @@ class BroadcastAnalysisController extends AsyncNotifier<BroadcastAnalysisState>
       UciPath mainlinePath = UciPath.empty;
       for (final branch in _root.mainline) {
         mainlinePath = mainlinePath + branch.id;
-        if (branch.position.ply > 30) break;
-        openingFutures.add(_fetchOpening(branch.position.fen, mainlinePath));
+        final openingFuture = fetchMainlineOpening(branch, mainlinePath);
+        if (openingFuture == null) break;
+        openingFutures.add(openingFuture);
       }
     }
 
@@ -139,7 +140,7 @@ class BroadcastAnalysisController extends AsyncNotifier<BroadcastAnalysisState>
     // analysis preferences change
     final prefs = ref.read(broadcastPreferencesProvider);
 
-    final (_, initialBranchOpening) = _nodeOpeningAt(_root, currentPath);
+    final initialBranchOpening = currentBranchOpeningAt(currentPath);
 
     final broadcastState = BroadcastAnalysisState(
       id: params.gameId,
@@ -163,26 +164,7 @@ class BroadcastAnalysisController extends AsyncNotifier<BroadcastAnalysisState>
     // `debouncedStartEngineEval` require the state to have a value.
     state = AsyncData(broadcastState);
 
-    Future.wait(openingFutures)
-        .then((list) {
-          bool hasOpening = false;
-          for (final updated in list) {
-            if (updated != null) {
-              hasOpening = true;
-              final (path, opening) = updated;
-              _root.updateAt(path, (node) => node.opening = opening);
-            }
-          }
-          return hasOpening;
-        })
-        .then((hasOpening) {
-          if (hasOpening && ref.mounted && state.hasValue) {
-            scheduleMicrotask(() {
-              if (!ref.mounted || !state.hasValue) return;
-              _setPath(state.requireValue.currentPath);
-            });
-          }
-        });
+    applyFetchedOpenings(openingFutures);
 
     if (state.requireValue.isEngineAvailable(evaluationPrefs)) {
       requestEval();
@@ -466,7 +448,7 @@ class BroadcastAnalysisController extends AsyncNotifier<BroadcastAnalysisState>
         : state.requireValue.root;
 
     final isForward = path.size > state.requireValue.currentPath.size;
-    final (_, branchOpening) = _nodeOpeningAt(_root, path);
+    final branchOpening = currentBranchOpeningAt(path);
     if (currentNode is Branch) {
       // normal move feedback
       if (!isNavigating && isForward) {
@@ -489,13 +471,7 @@ class BroadcastAnalysisController extends AsyncNotifier<BroadcastAnalysisState>
         }
       }
 
-      if (currentNode.opening == null && currentNode.position.ply <= 30) {
-        _fetchOpening(currentNode.position.fen, path).then((value) {
-          if (value != null) {
-            _updateOpening(value.$1, value.$2);
-          }
-        });
-      }
+      maybeFetchOpeningAt(currentNode, path);
 
       state = AsyncData(
         state.requireValue.copyWith(
@@ -530,45 +506,15 @@ class BroadcastAnalysisController extends AsyncNotifier<BroadcastAnalysisState>
     }
   }
 
-  (Node, Opening?) _nodeOpeningAt(Node node, UciPath path, [Opening? opening]) {
-    if (path.isEmpty) return (node, opening);
-    final child = node.childById(path.head!);
-    if (child != null) {
-      return _nodeOpeningAt(child, path.tail, child.opening ?? opening);
-    } else {
-      return (node, opening);
-    }
-  }
-
-  Future<(UciPath, FullOpening)?> _fetchOpening(String fen, UciPath path) async {
-    if (!kOpeningAllowedVariants.contains(state.value?.variant ?? Variant.standard)) {
-      return null;
-    }
-    final opening = await ref.read(openingServiceProvider).fetchFromFen(fen);
-    if (opening != null) {
-      return (path, opening);
-    }
-    return null;
-  }
-
-  void _updateOpening(UciPath path, FullOpening opening) {
-    _root.updateAt(path, (node) => node.opening = opening);
-
-    if (!state.hasValue) return;
+  @override
+  void refreshCurrentBranchOpening() {
     final curState = state.requireValue;
-    if (curState.currentPath == path) {
-      state = AsyncData(
-        curState.copyWith(
-          currentNode: AnalysisCurrentNode.fromNode(_root.nodeAt(path)),
-          currentBranchOpening: opening,
-        ),
-      );
-    } else {
-      final (_, newOpening) = _nodeOpeningAt(_root, curState.currentPath);
-      if (newOpening != null && newOpening != curState.currentBranchOpening) {
-        state = AsyncData(curState.copyWith(currentBranchOpening: newOpening));
-      }
-    }
+    state = AsyncData(
+      curState.copyWith(
+        currentNode: AnalysisCurrentNode.fromNode(_root.nodeAt(curState.currentPath)),
+        currentBranchOpening: currentBranchOpeningAt(curState.currentPath),
+      ),
+    );
   }
 
   ({Duration? parentClock, Duration? clock}) _getClocks(UciPath path) {
@@ -621,7 +567,8 @@ sealed class BroadcastAnalysisState
     with
         _$BroadcastAnalysisState,
         AnalysisExplosionMixin,
-        EvaluationMixinState<BroadcastAnalysisState>
+        EvaluationMixinState<BroadcastAnalysisState>,
+        OpeningExplorerMixinState
     implements CommonAnalysisState {
   const BroadcastAnalysisState._();
 

--- a/lib/src/model/broadcast/broadcast_analysis_controller.dart
+++ b/lib/src/model/broadcast/broadcast_analysis_controller.dart
@@ -10,6 +10,7 @@ import 'package:freezed_annotation/freezed_annotation.dart';
 import 'package:lichess_mobile/src/model/analysis/analysis_controller.dart';
 import 'package:lichess_mobile/src/model/analysis/analysis_summary.dart';
 import 'package:lichess_mobile/src/model/analysis/common_analysis_state.dart';
+import 'package:lichess_mobile/src/model/analysis/opening_service.dart';
 import 'package:lichess_mobile/src/model/broadcast/broadcast.dart';
 import 'package:lichess_mobile/src/model/broadcast/broadcast_preferences.dart';
 import 'package:lichess_mobile/src/model/broadcast/broadcast_repository.dart';
@@ -124,9 +125,21 @@ class BroadcastAnalysisController extends AsyncNotifier<BroadcastAnalysisState>
     final currentNode = _root.nodeAt(currentPath);
     final lastMove = _root.branchAt(_root.mainlinePath)?.sanMove.move;
 
+    final openingFutures = <Future<(UciPath, FullOpening)?>>[];
+    {
+      UciPath mainlinePath = UciPath.empty;
+      for (final branch in _root.mainline) {
+        mainlinePath = mainlinePath + branch.id;
+        if (branch.position.ply > 30) break;
+        openingFutures.add(_fetchOpening(branch.position.fen, mainlinePath));
+      }
+    }
+
     // don't use ref.watch here: we don't want to invalidate state when the
     // analysis preferences change
     final prefs = ref.read(broadcastPreferencesProvider);
+
+    final (_, initialBranchOpening) = _nodeOpeningAt(_root, currentPath);
 
     final broadcastState = BroadcastAnalysisState(
       id: params.gameId,
@@ -135,6 +148,7 @@ class BroadcastAnalysisController extends AsyncNotifier<BroadcastAnalysisState>
       isOnMainline: _root.isOnMainline(currentPath),
       root: _root.view,
       currentNode: AnalysisCurrentNode.fromNode(currentNode),
+      currentBranchOpening: initialBranchOpening,
       pgnHeaders: pgnHeaders,
       pgnRootComments: rootComments,
       lastMove: lastMove,
@@ -148,6 +162,27 @@ class BroadcastAnalysisController extends AsyncNotifier<BroadcastAnalysisState>
     // We need to define the state value in the build method because `sendEvalGetEvent` and
     // `debouncedStartEngineEval` require the state to have a value.
     state = AsyncData(broadcastState);
+
+    Future.wait(openingFutures)
+        .then((list) {
+          bool hasOpening = false;
+          for (final updated in list) {
+            if (updated != null) {
+              hasOpening = true;
+              final (path, opening) = updated;
+              _root.updateAt(path, (node) => node.opening = opening);
+            }
+          }
+          return hasOpening;
+        })
+        .then((hasOpening) {
+          if (hasOpening && ref.mounted && state.hasValue) {
+            scheduleMicrotask(() {
+              if (!ref.mounted || !state.hasValue) return;
+              _setPath(state.requireValue.currentPath);
+            });
+          }
+        });
 
     if (state.requireValue.isEngineAvailable(evaluationPrefs)) {
       requestEval();
@@ -431,6 +466,7 @@ class BroadcastAnalysisController extends AsyncNotifier<BroadcastAnalysisState>
         : state.requireValue.root;
 
     final isForward = path.size > state.requireValue.currentPath.size;
+    final (_, branchOpening) = _nodeOpeningAt(_root, path);
     if (currentNode is Branch) {
       // normal move feedback
       if (!isNavigating && isForward) {
@@ -452,12 +488,22 @@ class BroadcastAnalysisController extends AsyncNotifier<BroadcastAnalysisState>
           soundService.play(Sound.move);
         }
       }
+
+      if (currentNode.opening == null && currentNode.position.ply <= 30) {
+        _fetchOpening(currentNode.position.fen, path).then((value) {
+          if (value != null) {
+            _updateOpening(value.$1, value.$2);
+          }
+        });
+      }
+
       state = AsyncData(
         state.requireValue.copyWith(
           currentPath: path,
           broadcastPath: broadcastPath ?? state.requireValue.broadcastPath,
           isOnMainline: _root.isOnMainline(path),
           currentNode: AnalysisCurrentNode.fromNode(currentNode),
+          currentBranchOpening: branchOpening,
           lastMove: currentNode.sanMove.move,
           root: rootView,
           clocks: _getClocks(path),
@@ -470,6 +516,7 @@ class BroadcastAnalysisController extends AsyncNotifier<BroadcastAnalysisState>
           broadcastPath: broadcastPath ?? state.requireValue.broadcastPath,
           isOnMainline: _root.isOnMainline(path),
           currentNode: AnalysisCurrentNode.fromNode(currentNode),
+          currentBranchOpening: branchOpening,
           lastMove: null,
           root: rootView,
           clocks: _getClocks(path),
@@ -480,6 +527,47 @@ class BroadcastAnalysisController extends AsyncNotifier<BroadcastAnalysisState>
     if (pathChange) {
       state = AsyncData(state.requireValue.copyWith(engineInThreatMode: false));
       requestEval();
+    }
+  }
+
+  (Node, Opening?) _nodeOpeningAt(Node node, UciPath path, [Opening? opening]) {
+    if (path.isEmpty) return (node, opening);
+    final child = node.childById(path.head!);
+    if (child != null) {
+      return _nodeOpeningAt(child, path.tail, child.opening ?? opening);
+    } else {
+      return (node, opening);
+    }
+  }
+
+  Future<(UciPath, FullOpening)?> _fetchOpening(String fen, UciPath path) async {
+    if (!kOpeningAllowedVariants.contains(state.value?.variant ?? Variant.standard)) {
+      return null;
+    }
+    final opening = await ref.read(openingServiceProvider).fetchFromFen(fen);
+    if (opening != null) {
+      return (path, opening);
+    }
+    return null;
+  }
+
+  void _updateOpening(UciPath path, FullOpening opening) {
+    _root.updateAt(path, (node) => node.opening = opening);
+
+    if (!state.hasValue) return;
+    final curState = state.requireValue;
+    if (curState.currentPath == path) {
+      state = AsyncData(
+        curState.copyWith(
+          currentNode: AnalysisCurrentNode.fromNode(_root.nodeAt(path)),
+          currentBranchOpening: opening,
+        ),
+      );
+    } else {
+      final (_, newOpening) = _nodeOpeningAt(_root, curState.currentPath);
+      if (newOpening != null && newOpening != curState.currentBranchOpening) {
+        state = AsyncData(curState.copyWith(currentBranchOpening: newOpening));
+      }
     }
   }
 
@@ -593,6 +681,8 @@ sealed class BroadcastAnalysisState
     /// The analysis summary sent by the server.
     /// Contains the Accuracy, ACPL, Mistakes, Blunders, Inaccuracies of White and Black.
     AnalysisSummary? analysisSummary,
+
+    Opening? currentBranchOpening,
 
     @Default(false) bool engineInThreatMode,
   }) = _BroadcastGameState;

--- a/lib/src/model/broadcast/broadcast_analysis_controller.dart
+++ b/lib/src/model/broadcast/broadcast_analysis_controller.dart
@@ -418,7 +418,7 @@ class BroadcastAnalysisController extends AsyncNotifier<BroadcastAnalysisState>
     if (!state.hasValue) return;
 
     final pathChange = state.requireValue.currentPath != path;
-    final currentNode = _root.nodeAt(path);
+    final (currentNode, branchOpening) = nodeOpeningAt(_root, path);
 
     // always show variation if the user plays a move
     if (shouldForceShowVariation && currentNode is Branch && currentNode.isCollapsed) {
@@ -435,7 +435,6 @@ class BroadcastAnalysisController extends AsyncNotifier<BroadcastAnalysisState>
         : state.requireValue.root;
 
     final isForward = path.size > state.requireValue.currentPath.size;
-    final branchOpening = currentBranchOpeningAt(path);
     if (currentNode is Branch) {
       // normal move feedback
       if (!isNavigating && isForward) {

--- a/lib/src/model/study/study_controller.dart
+++ b/lib/src/model/study/study_controller.dart
@@ -9,6 +9,7 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:freezed_annotation/freezed_annotation.dart';
 import 'package:lichess_mobile/src/model/analysis/analysis_summary.dart';
 import 'package:lichess_mobile/src/model/analysis/common_analysis_state.dart';
+import 'package:lichess_mobile/src/model/analysis/opening_explorer_mixin.dart';
 import 'package:lichess_mobile/src/model/analysis/server_analysis_mixin.dart';
 import 'package:lichess_mobile/src/model/analysis/server_analysis_service.dart';
 import 'package:lichess_mobile/src/model/auth/auth_controller.dart';
@@ -44,7 +45,7 @@ final studyControllerProvider = AsyncNotifierProvider.autoDispose
 enum ChapterServerAnalysisStatus { canRequest, notEnoughMoves, notWriteable, available }
 
 class StudyController extends AsyncNotifier<StudyState>
-    with EngineEvaluationMixin, ServerAnalysisMixin
+    with EngineEvaluationMixin, ServerAnalysisMixin, OpeningExplorerMixin<StudyState>
     implements PgnTreeNotifier {
   StudyController(this.options);
 
@@ -95,6 +96,17 @@ class StudyController extends AsyncNotifier<StudyState>
       state.requireValue.copyWith(
         root: recomputeRootView ? _root.view : state.requireValue.root,
         currentNode: StudyCurrentNode.fromNode(_root.nodeAt(state.requireValue.currentPath)),
+      ),
+    );
+  }
+
+  @override
+  void refreshCurrentBranchOpening() {
+    final curState = state.requireValue;
+    state = AsyncData(
+      curState.copyWith(
+        currentNode: StudyCurrentNode.fromNode(_root.nodeAt(curState.currentPath)),
+        currentBranchOpening: currentBranchOpeningAt(curState.currentPath),
       ),
     );
   }
@@ -176,6 +188,17 @@ class StudyController extends AsyncNotifier<StudyState>
     const currentPath = UciPath.empty;
     Move? lastMove;
 
+    final openingFutures = <Future<(UciPath, FullOpening)?>>[];
+    {
+      UciPath mainlinePath = UciPath.empty;
+      for (final branch in _root.mainline) {
+        mainlinePath = mainlinePath + branch.id;
+        final openingFuture = fetchMainlineOpening(branch, mainlinePath);
+        if (openingFuture == null) break;
+        openingFutures.add(openingFuture);
+      }
+    }
+
     final studyState = StudyState(
       myId: me,
       variant: variant,
@@ -184,6 +207,7 @@ class StudyController extends AsyncNotifier<StudyState>
       isOnMainline: true,
       root: _root.view,
       currentNode: StudyCurrentNode.fromNode(_root),
+      currentBranchOpening: currentBranchOpeningAt(currentPath),
       evaluationContext: EvaluationContext(
         id: study.chapter.id,
         variant: variant,
@@ -203,6 +227,10 @@ class StudyController extends AsyncNotifier<StudyState>
     // We need to define the state value in the build method because `requestEval` require the state
     // to have a value.
     state = AsyncData(studyState);
+
+    // Fetch openings for the mainline asynchronously and refresh the branch
+    // opening once they resolve.
+    applyFetchedOpenings(openingFutures);
 
     if (state.requireValue.isEngineAvailable(evaluationPrefs)) {
       socketClient.firstConnection.then((_) {
@@ -456,6 +484,7 @@ class StudyController extends AsyncNotifier<StudyState>
     final rootView = shouldForceShowVariation || shouldRecomputeRootView ? _root.view : state.root;
 
     final isForward = path.size > state.currentPath.size;
+    final branchOpening = currentBranchOpeningAt(path);
     if (currentNode is Branch) {
       // normal move feedback
       if (!isNavigating && isForward) {
@@ -476,11 +505,14 @@ class StudyController extends AsyncNotifier<StudyState>
         }
       }
 
+      maybeFetchOpeningAt(currentNode, path);
+
       this.state = AsyncValue.data(
         state.copyWith(
           currentPath: path,
           isOnMainline: _root.isOnMainline(path),
           currentNode: StudyCurrentNode.fromNode(currentNode),
+          currentBranchOpening: branchOpening,
           lastMove: currentNode.sanMove.move,
           root: rootView,
         ),
@@ -491,6 +523,7 @@ class StudyController extends AsyncNotifier<StudyState>
           currentPath: path,
           isOnMainline: _root.isOnMainline(path),
           currentNode: StudyCurrentNode.fromNode(currentNode),
+          currentBranchOpening: branchOpening,
           lastMove: null,
           root: rootView,
         ),
@@ -531,7 +564,8 @@ sealed class StudyState
         _$StudyState,
         AnalysisExplosionMixin,
         EvaluationMixinState<StudyState>,
-        ServerAnalysisMixinState
+        ServerAnalysisMixinState,
+        OpeningExplorerMixinState
     implements CommonAnalysisState {
   const StudyState._();
 
@@ -584,6 +618,9 @@ sealed class StudyState
 
     /// The last move played.
     Move? lastMove,
+
+    /// The opening of the current branch, if any.
+    Opening? currentBranchOpening,
 
     /// The PGN root comments of the study
     IList<PgnComment>? pgnRootComments,
@@ -723,6 +760,7 @@ sealed class StudyCurrentNode with _$StudyCurrentNode implements AnalysisCurrent
     required List<Move> children,
     required bool isRoot,
     SanMove? sanMove,
+    Opening? opening,
     IList<PgnComment>? startingComments,
     IList<PgnComment>? comments,
     IList<int>? nags,
@@ -742,6 +780,7 @@ sealed class StudyCurrentNode with _$StudyCurrentNode implements AnalysisCurrent
         isRoot: false,
         children: children,
         eval: node.eval,
+        opening: node.opening,
         startingComments: IList(node.startingComments),
         comments: IList(node.comments),
         nags: IList(node.nags),
@@ -751,6 +790,7 @@ sealed class StudyCurrentNode with _$StudyCurrentNode implements AnalysisCurrent
         position: node.position,
         children: children,
         eval: node.eval,
+        opening: node.opening,
         isRoot: true,
       );
     }

--- a/lib/src/model/study/study_controller.dart
+++ b/lib/src/model/study/study_controller.dart
@@ -462,7 +462,7 @@ class StudyController extends AsyncNotifier<StudyState>
     if (state == null) return;
 
     final pathChange = state.currentPath != path;
-    final currentNode = _root.nodeAt(path);
+    final (currentNode, branchOpening) = nodeOpeningAt(_root, path);
 
     // always show variation if the user plays a move
     if (shouldForceShowVariation && currentNode is Branch && currentNode.isCollapsed) {
@@ -477,7 +477,6 @@ class StudyController extends AsyncNotifier<StudyState>
     final rootView = shouldForceShowVariation || shouldRecomputeRootView ? _root.view : state.root;
 
     final isForward = path.size > state.currentPath.size;
-    final branchOpening = currentBranchOpeningAt(path);
     if (currentNode is Branch) {
       // normal move feedback
       if (!isNavigating && isForward) {

--- a/lib/src/model/study/study_controller.dart
+++ b/lib/src/model/study/study_controller.dart
@@ -67,6 +67,11 @@ class StudyController extends AsyncNotifier<StudyState>
   @protected
   Root get positionTree => _root;
 
+  // Studies with an illegal starting position do not build a position tree, so
+  // there is nothing to fetch openings for in that case.
+  @override
+  bool get canFetchMainlineOpenings => state.value?.root != null;
+
   @override
   Future<StudyState> build() async {
     ref.onDispose(() {
@@ -123,6 +128,9 @@ class StudyController extends AsyncNotifier<StudyState>
 
   Future<void> goToChapter(StudyChapterId chapterId) async {
     await _fetchChapter(state.requireValue.study.id, chapterId: chapterId);
+    // Switching chapters does not re-run [runBuild], so fetch the new mainline's
+    // openings explicitly here.
+    if (state.hasValue) initMainlineOpenings();
     _ensureItsOurTurnIfGamebook();
   }
 
@@ -188,17 +196,6 @@ class StudyController extends AsyncNotifier<StudyState>
     const currentPath = UciPath.empty;
     Move? lastMove;
 
-    final openingFutures = <Future<(UciPath, FullOpening)?>>[];
-    {
-      UciPath mainlinePath = UciPath.empty;
-      for (final branch in _root.mainline) {
-        mainlinePath = mainlinePath + branch.id;
-        final openingFuture = fetchMainlineOpening(branch, mainlinePath);
-        if (openingFuture == null) break;
-        openingFutures.add(openingFuture);
-      }
-    }
-
     final studyState = StudyState(
       myId: me,
       variant: variant,
@@ -227,10 +224,6 @@ class StudyController extends AsyncNotifier<StudyState>
     // We need to define the state value in the build method because `requestEval` require the state
     // to have a value.
     state = AsyncData(studyState);
-
-    // Fetch openings for the mainline asynchronously and refresh the branch
-    // opening once they resolve.
-    applyFetchedOpenings(openingFutures);
 
     if (state.requireValue.isEngineAvailable(evaluationPrefs)) {
       socketClient.firstConnection.then((_) {

--- a/lib/src/view/analysis/analysis_screen.dart
+++ b/lib/src/view/analysis/analysis_screen.dart
@@ -5,7 +5,6 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:lichess_mobile/src/model/analysis/analysis_controller.dart';
 import 'package:lichess_mobile/src/model/analysis/analysis_player.dart';
 import 'package:lichess_mobile/src/model/analysis/analysis_preferences.dart';
-import 'package:lichess_mobile/src/model/analysis/opening_service.dart';
 import 'package:lichess_mobile/src/model/auth/auth_controller.dart';
 import 'package:lichess_mobile/src/model/common/chess.dart';
 import 'package:lichess_mobile/src/model/engine/evaluation_preferences.dart';
@@ -329,11 +328,13 @@ class _Body extends ConsumerWidget {
             pov: pov,
             isComputerAnalysisAllowed: analysisState.isComputerAnalysisAllowed,
             position: currentNode.position,
-            opening: kOpeningAllowedVariants.contains(analysisState.variant)
-                ? analysisState.currentNode.isRoot
-                      ? LightOpening(eco: '', name: context.l10n.startPosition)
-                      : analysisState.currentNode.opening ?? analysisState.currentBranchOpening
-                : null,
+            opening: explorerOpening(
+              context,
+              variant: analysisState.variant,
+              isRootNode: analysisState.currentNode.isRoot,
+              nodeOpening: analysisState.currentNode.opening,
+              branchOpening: analysisState.currentBranchOpening,
+            ),
             onMoveSelected: (move) {
               ref.read(ctrlProvider.notifier).onUserMove(move);
             },

--- a/lib/src/view/broadcast/broadcast_game_screen.dart
+++ b/lib/src/view/broadcast/broadcast_game_screen.dart
@@ -4,10 +4,12 @@ import 'package:flutter/gestures.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:lichess_mobile/src/constants.dart';
+import 'package:lichess_mobile/src/model/analysis/opening_service.dart';
 import 'package:lichess_mobile/src/model/broadcast/broadcast.dart';
 import 'package:lichess_mobile/src/model/broadcast/broadcast_analysis_controller.dart';
 import 'package:lichess_mobile/src/model/broadcast/broadcast_preferences.dart';
 import 'package:lichess_mobile/src/model/broadcast/broadcast_repository.dart';
+import 'package:lichess_mobile/src/model/common/chess.dart';
 import 'package:lichess_mobile/src/model/common/id.dart';
 import 'package:lichess_mobile/src/model/engine/evaluation_preferences.dart';
 import 'package:lichess_mobile/src/model/engine/evaluation_service.dart';
@@ -493,9 +495,16 @@ class _OpeningExplorerTab extends ConsumerWidget {
     final ctrlProvider = broadcastAnalysisControllerProvider((roundId: roundId, gameId: gameId));
     final state = ref.watch(ctrlProvider).requireValue;
 
+    final opening = kOpeningAllowedVariants.contains(state.variant)
+        ? state.currentNode.isRoot
+              ? LightOpening(eco: '', name: context.l10n.startPosition)
+              : state.currentNode.opening ?? state.currentBranchOpening
+        : null;
+
     return ExplorerView(
       pov: state.pov,
       position: state.currentNode.position,
+      opening: opening,
       onMoveSelected: ref.read(ctrlProvider.notifier).onUserMove,
       isComputerAnalysisAllowed: true,
     );

--- a/lib/src/view/broadcast/broadcast_game_screen.dart
+++ b/lib/src/view/broadcast/broadcast_game_screen.dart
@@ -4,12 +4,10 @@ import 'package:flutter/gestures.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:lichess_mobile/src/constants.dart';
-import 'package:lichess_mobile/src/model/analysis/opening_service.dart';
 import 'package:lichess_mobile/src/model/broadcast/broadcast.dart';
 import 'package:lichess_mobile/src/model/broadcast/broadcast_analysis_controller.dart';
 import 'package:lichess_mobile/src/model/broadcast/broadcast_preferences.dart';
 import 'package:lichess_mobile/src/model/broadcast/broadcast_repository.dart';
-import 'package:lichess_mobile/src/model/common/chess.dart';
 import 'package:lichess_mobile/src/model/common/id.dart';
 import 'package:lichess_mobile/src/model/engine/evaluation_preferences.dart';
 import 'package:lichess_mobile/src/model/engine/evaluation_service.dart';
@@ -495,16 +493,16 @@ class _OpeningExplorerTab extends ConsumerWidget {
     final ctrlProvider = broadcastAnalysisControllerProvider((roundId: roundId, gameId: gameId));
     final state = ref.watch(ctrlProvider).requireValue;
 
-    final opening = kOpeningAllowedVariants.contains(state.variant)
-        ? state.currentNode.isRoot
-              ? LightOpening(eco: '', name: context.l10n.startPosition)
-              : state.currentNode.opening ?? state.currentBranchOpening
-        : null;
-
     return ExplorerView(
       pov: state.pov,
       position: state.currentNode.position,
-      opening: opening,
+      opening: explorerOpening(
+        context,
+        variant: state.variant,
+        isRootNode: state.currentNode.isRoot,
+        nodeOpening: state.currentNode.opening,
+        branchOpening: state.currentBranchOpening,
+      ),
       onMoveSelected: ref.read(ctrlProvider.notifier).onUserMove,
       isComputerAnalysisAllowed: true,
     );

--- a/lib/src/view/explorer/explorer_view.dart
+++ b/lib/src/view/explorer/explorer_view.dart
@@ -1,6 +1,7 @@
 import 'package:dartchess/dartchess.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:lichess_mobile/src/model/analysis/opening_service.dart';
 import 'package:lichess_mobile/src/model/auth/auth_controller.dart';
 import 'package:lichess_mobile/src/model/common/chess.dart';
 import 'package:lichess_mobile/src/model/explorer/tablebase.dart';
@@ -26,6 +27,25 @@ Color whiteBoxColor(BuildContext context) => Theme.of(context).brightness == Bri
 Color blackBoxColor(BuildContext context) => Theme.of(context).brightness == Brightness.light
     ? Colors.black.withValues(alpha: 0.7)
     : Colors.black;
+
+/// Resolves the [Opening] to display in the opening explorer, or `null` when
+/// the variant has no opening book.
+///
+/// Falls back to the deepest ancestor opening ([branchOpening]) when the current
+/// node has no opening of its own.
+Opening? explorerOpening(
+  BuildContext context, {
+  required Variant variant,
+  required bool isRootNode,
+  required Opening? nodeOpening,
+  required Opening? branchOpening,
+}) {
+  if (!kOpeningAllowedVariants.contains(variant)) return null;
+  if (isRootNode) {
+    return LightOpening(eco: '', name: context.l10n.startPosition);
+  }
+  return nodeOpening ?? branchOpening;
+}
 
 class ExplorerView extends ConsumerWidget {
   const ExplorerView({

--- a/lib/src/view/study/study_screen.dart
+++ b/lib/src/view/study/study_screen.dart
@@ -7,7 +7,6 @@ import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:lichess_mobile/src/constants.dart';
 import 'package:lichess_mobile/src/model/account/account_repository.dart';
-import 'package:lichess_mobile/src/model/analysis/opening_service.dart';
 import 'package:lichess_mobile/src/model/auth/auth_controller.dart';
 import 'package:lichess_mobile/src/model/chat/chat_controller.dart';
 import 'package:lichess_mobile/src/model/common/chess.dart';
@@ -503,15 +502,16 @@ class _Body extends ConsumerWidget {
         switch (tab) {
           case AnalysisTab.explorer:
             if (studyState.isOpeningExplorerAvailable && studyState.currentNode.position != null) {
-              final opening = kOpeningAllowedVariants.contains(studyState.variant)
-                  ? studyState.currentNode.isRoot
-                        ? LightOpening(eco: '', name: context.l10n.startPosition)
-                        : studyState.currentNode.opening ?? studyState.currentBranchOpening
-                  : null;
               return ExplorerView(
                 pov: pov,
                 position: studyState.currentNode.position!,
-                opening: opening,
+                opening: explorerOpening(
+                  context,
+                  variant: studyState.variant,
+                  isRootNode: studyState.currentNode.isRoot,
+                  nodeOpening: studyState.currentNode.opening,
+                  branchOpening: studyState.currentBranchOpening,
+                ),
                 onMoveSelected: (move) {
                   ref.read(studyControllerProvider(options).notifier).onUserMove(move);
                 },

--- a/lib/src/view/study/study_screen.dart
+++ b/lib/src/view/study/study_screen.dart
@@ -7,6 +7,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:lichess_mobile/src/constants.dart';
 import 'package:lichess_mobile/src/model/account/account_repository.dart';
+import 'package:lichess_mobile/src/model/analysis/opening_service.dart';
 import 'package:lichess_mobile/src/model/auth/auth_controller.dart';
 import 'package:lichess_mobile/src/model/chat/chat_controller.dart';
 import 'package:lichess_mobile/src/model/common/chess.dart';
@@ -502,9 +503,15 @@ class _Body extends ConsumerWidget {
         switch (tab) {
           case AnalysisTab.explorer:
             if (studyState.isOpeningExplorerAvailable && studyState.currentNode.position != null) {
+              final opening = kOpeningAllowedVariants.contains(studyState.variant)
+                  ? studyState.currentNode.isRoot
+                        ? LightOpening(eco: '', name: context.l10n.startPosition)
+                        : studyState.currentNode.opening ?? studyState.currentBranchOpening
+                  : null;
               return ExplorerView(
                 pov: pov,
                 position: studyState.currentNode.position!,
+                opening: opening,
                 onMoveSelected: (move) {
                   ref.read(studyControllerProvider(options).notifier).onUserMove(move);
                 },

--- a/test/view/broadcast/broadcast_opening_test.dart
+++ b/test/view/broadcast/broadcast_opening_test.dart
@@ -1,0 +1,132 @@
+import 'package:dartchess/dartchess.dart';
+import 'package:flutter/widgets.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:http/testing.dart';
+import 'package:lichess_mobile/src/model/analysis/opening_service.dart';
+import 'package:lichess_mobile/src/model/broadcast/broadcast_analysis_controller.dart';
+import 'package:lichess_mobile/src/model/common/chess.dart';
+import 'package:lichess_mobile/src/model/common/id.dart';
+import 'package:lichess_mobile/src/network/http.dart';
+import 'package:lichess_mobile/src/view/broadcast/broadcast_game_screen.dart';
+
+import '../../model/analysis/fake_opening_service.dart';
+import '../../model/broadcast/example_data.dart';
+import '../../test_helpers.dart';
+import '../../test_provider_scope.dart';
+
+const _tournamentId = BroadcastTournamentId('RAIoMC7L');
+const _roundId = BroadcastRoundId('6VuqTjes');
+const _gameId = BroadcastGameId('OpeningTest');
+
+String _epd(Position pos) => pos.fen.split(' ').take(4).join(' ');
+
+const _kingsPawnGame = FullOpening(
+  eco: 'C20',
+  name: "King's Pawn Game",
+  fen: 'rnbqkbnr/pppppppp/8/8/4P3/8/PPPP1PPP/RNBQKBNR b KQkq e3',
+  pgnMoves: 'e4',
+  uciMoves: 'e2e4',
+);
+
+const _openGame = FullOpening(
+  eco: 'C20',
+  name: 'Open Game',
+  fen: 'rnbqkbnr/pppp1ppp/8/4p3/4P3/8/PPPP1PPP/RNBQKBNR w KQkq e6',
+  pgnMoves: 'e4 e5',
+  uciMoves: 'e2e4 e7e5',
+);
+
+MockClient _client(String pgn) => MockClient((request) async {
+  if (request.url.path == '/api/broadcast/-/-/$_roundId') {
+    return mockResponse(
+      broadcastRoundMockResponses[(_tournamentId, _roundId)]!,
+      200,
+      headers: {'content-type': 'application/json; charset=utf-8'},
+    );
+  }
+  if (request.url.path == '/api/study/$_roundId/$_gameId.pgn') {
+    return mockResponse(pgn, 200, headers: {'content-type': 'application/x-chess-pgn'});
+  }
+  return mockResponse('', 404);
+});
+
+void main() {
+  final afterE4Epd = _epd(Chess.initial.playUnchecked(Move.parse('e2e4')!));
+  final afterE5Epd = _epd(
+    Chess.initial.playUnchecked(Move.parse('e2e4')!).playUnchecked(Move.parse('e7e5')!),
+  );
+
+  BroadcastAnalysisState readState(WidgetTester tester) {
+    final container = ProviderScope.containerOf(tester.element(find.byType(BroadcastGameScreen)));
+    return container
+        .read(broadcastAnalysisControllerProvider((roundId: _roundId, gameId: _gameId)))
+        .requireValue;
+  }
+
+  group('Broadcast opening detection', () {
+    testWidgets('opening is set when navigating to a mainline position', (tester) async {
+      final app = await makeTestProviderScopeApp(
+        tester,
+        home: const BroadcastGameScreen(
+          tournamentId: _tournamentId,
+          roundId: _roundId,
+          gameId: _gameId,
+        ),
+        overrides: {
+          lichessClientProvider: lichessClientProvider.overrideWith(
+            (ref) => LichessClient(_client('1. e4 e5 2. Nf3'), ref),
+          ),
+          openingServiceProvider: openingServiceProvider.overrideWithValue(
+            FakeOpeningService(openings: {afterE4Epd: _kingsPawnGame, afterE5Epd: _openGame}),
+          ),
+        },
+      );
+
+      await tester.pumpWidget(app);
+      await tester.pumpAndSettle();
+
+      // Broadcast starts at the end of the mainline (after Nf3). Navigate back to e5.
+      await tester.tap(find.byKey(const ValueKey('goto-previous')));
+      await tester.pumpAndSettle();
+      expect(readState(tester).currentBranchOpening?.name, 'Open Game');
+
+      // Navigate back to e4.
+      await tester.tap(find.byKey(const ValueKey('goto-previous')));
+      await tester.pumpAndSettle();
+      expect(readState(tester).currentBranchOpening?.name, "King's Pawn Game");
+    });
+
+    testWidgets('ancestor opening is used when current node has no direct opening', (tester) async {
+      final app = await makeTestProviderScopeApp(
+        tester,
+        home: const BroadcastGameScreen(
+          tournamentId: _tournamentId,
+          roundId: _roundId,
+          gameId: _gameId,
+        ),
+        overrides: {
+          lichessClientProvider: lichessClientProvider.overrideWith(
+            (ref) => LichessClient(_client('1. e4 e5 2. Nf3'), ref),
+          ),
+          openingServiceProvider: openingServiceProvider.overrideWithValue(
+            FakeOpeningService(
+              openings: {
+                afterE4Epd: _kingsPawnGame,
+                afterE5Epd: _openGame,
+                // No opening for the Nf3 position — intentionally omitted.
+              },
+            ),
+          ),
+        },
+      );
+
+      await tester.pumpWidget(app);
+      await tester.pumpAndSettle();
+
+      // At end of mainline (after Nf3): no direct opening, but the e5 ancestor
+      // has 'Open Game'.
+      expect(readState(tester).currentBranchOpening?.name, 'Open Game');
+    });
+  });
+}

--- a/test/view/broadcast/broadcast_opening_test.dart
+++ b/test/view/broadcast/broadcast_opening_test.dart
@@ -37,7 +37,7 @@ const _openGame = FullOpening(
   uciMoves: 'e2e4 e7e5',
 );
 
-MockClient _client(String pgn) => MockClient((request) async {
+MockClient _client(String pgn) => MockClient((request) {
   if (request.url.path == '/api/broadcast/-/-/$_roundId') {
     return mockResponse(
       broadcastRoundMockResponses[(_tournamentId, _roundId)]!,

--- a/test/view/study/study_opening_test.dart
+++ b/test/view/study/study_opening_test.dart
@@ -1,0 +1,158 @@
+import 'package:dartchess/dartchess.dart';
+import 'package:fast_immutable_collections/fast_immutable_collections.dart';
+import 'package:flutter/widgets.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:lichess_mobile/src/model/analysis/opening_service.dart';
+import 'package:lichess_mobile/src/model/common/chess.dart';
+import 'package:lichess_mobile/src/model/common/id.dart';
+import 'package:lichess_mobile/src/model/study/study.dart';
+import 'package:lichess_mobile/src/model/study/study_controller.dart';
+import 'package:lichess_mobile/src/model/study/study_repository.dart';
+import 'package:lichess_mobile/src/model/user/user.dart';
+import 'package:lichess_mobile/src/view/study/study_screen.dart';
+import 'package:mocktail/mocktail.dart';
+
+import '../../model/analysis/fake_opening_service.dart';
+import '../../test_provider_scope.dart';
+
+class MockStudyRepository extends Mock implements StudyRepository {}
+
+const _testId = StudyId('test-id');
+
+String _epd(Position pos) => pos.fen.split(' ').take(4).join(' ');
+
+const _kingsPawnGame = FullOpening(
+  eco: 'C20',
+  name: "King's Pawn Game",
+  fen: 'rnbqkbnr/pppppppp/8/8/4P3/8/PPPP1PPP/RNBQKBNR b KQkq e3',
+  pgnMoves: 'e4',
+  uciMoves: 'e2e4',
+);
+
+const _openGame = FullOpening(
+  eco: 'C20',
+  name: 'Open Game',
+  fen: 'rnbqkbnr/pppp1ppp/8/4p3/4P3/8/PPPP1PPP/RNBQKBNR w KQkq e6',
+  pgnMoves: 'e4 e5',
+  uciMoves: 'e2e4 e7e5',
+);
+
+Study _makeStudy() {
+  const chapter = StudyChapter(
+    id: StudyChapterId('1'),
+    setup: StudyChapterSetup(
+      id: null,
+      orientation: Side.white,
+      variant: Variant.standard,
+      fromFen: null,
+    ),
+    conceal: null,
+    features: (computer: true, explorer: true),
+    gamebook: false,
+    practise: false,
+  );
+  return Study(
+    id: _testId,
+    name: '',
+    liked: false,
+    likes: 0,
+    ownerId: null,
+    features: (cloneable: false, chat: false, sticky: false),
+    topics: const IList.empty(),
+    chapters: IList(const [StudyChapterMeta(id: StudyChapterId('1'), name: '', fen: null)]),
+    chapter: chapter,
+    members: IMap(const {
+      UserId(''): StudyMember(
+        user: LightUser(id: UserId(''), name: ''),
+        role: '',
+      ),
+    }),
+    hints: const IList.empty(),
+    deviationComments: const IList.empty(),
+  );
+}
+
+void main() {
+  final afterE4Epd = _epd(Chess.initial.playUnchecked(Move.parse('e2e4')!));
+  final afterE5Epd = _epd(
+    Chess.initial.playUnchecked(Move.parse('e2e4')!).playUnchecked(Move.parse('e7e5')!),
+  );
+
+  const options = (id: _testId, initialChapter: null);
+
+  StudyState readState(WidgetTester tester) {
+    final container = ProviderScope.containerOf(tester.element(find.byType(StudyScreen)));
+    return container.read(studyControllerProvider(options)).requireValue;
+  }
+
+  group('Study opening detection', () {
+    testWidgets('opening is set when navigating to a mainline position', (tester) async {
+      final mockRepository = MockStudyRepository();
+      when(
+        () => mockRepository.getStudy(id: _testId),
+      ).thenAnswer((_) async => (_makeStudy(), null, '1. e4 e5 2. Nf3'));
+
+      final app = await makeTestProviderScopeApp(
+        tester,
+        home: const StudyScreen(options: options),
+        overrides: {
+          studyRepositoryProvider: studyRepositoryProvider.overrideWith((ref) => mockRepository),
+          openingServiceProvider: openingServiceProvider.overrideWithValue(
+            FakeOpeningService(openings: {afterE4Epd: _kingsPawnGame, afterE5Epd: _openGame}),
+          ),
+        },
+      );
+
+      await tester.pumpWidget(app);
+      await tester.pumpAndSettle();
+
+      // Starts at the start of the chapter. Navigate forward to e4 then e5.
+      await tester.tap(find.byKey(const Key('goto-next')));
+      await tester.pumpAndSettle();
+      expect(readState(tester).currentBranchOpening?.name, "King's Pawn Game");
+
+      await tester.tap(find.byKey(const Key('goto-next')));
+      await tester.pumpAndSettle();
+      expect(readState(tester).currentBranchOpening?.name, 'Open Game');
+    });
+
+    testWidgets('ancestor opening is used when current node has no direct opening', (tester) async {
+      final mockRepository = MockStudyRepository();
+      when(
+        () => mockRepository.getStudy(id: _testId),
+      ).thenAnswer((_) async => (_makeStudy(), null, '1. e4 e5 2. Nf3'));
+
+      final app = await makeTestProviderScopeApp(
+        tester,
+        home: const StudyScreen(options: options),
+        overrides: {
+          studyRepositoryProvider: studyRepositoryProvider.overrideWith((ref) => mockRepository),
+          openingServiceProvider: openingServiceProvider.overrideWithValue(
+            FakeOpeningService(
+              openings: {
+                afterE4Epd: _kingsPawnGame,
+                afterE5Epd: _openGame,
+                // No opening for the Nf3 position — intentionally omitted.
+              },
+            ),
+          ),
+        },
+      );
+
+      await tester.pumpWidget(app);
+      await tester.pumpAndSettle();
+
+      // Navigate to the last mainline move (Nf3): no direct opening, but the e5
+      // ancestor has 'Open Game'.
+      await tester.tap(find.byKey(const Key('goto-next')));
+      await tester.pumpAndSettle();
+      await tester.tap(find.byKey(const Key('goto-next')));
+      await tester.pumpAndSettle();
+      await tester.tap(find.byKey(const Key('goto-next')));
+      await tester.pumpAndSettle();
+
+      expect(readState(tester).currentBranchOpening?.name, 'Open Game');
+    });
+  });
+}


### PR DESCRIPTION
Fixes #3190.

The Opening Explorer tab inside a broadcast game now shows the opening name (`OpeningNameHeader`) above the move table, matching the behaviour of regular analysis and study game analysis. Previously only an unnamed move table was rendered.

### Changes
- `BroadcastAnalysisState` gains `currentBranchOpening`, the last named opening reached on the current branch (used as a fallback when the active node is not itself an opening transposition).
- `BroadcastAnalysisController` looks up openings via the local sqflite opening DB:
  - Prefetches openings for the mainline (first 30 plies) at build time.
  - On every `_setPath` it walks the active branch to find the most recent named opening and triggers a per-node fetch for the new node.
- `_OpeningExplorerTab` now passes the resolved opening to `ExplorerView`, gated on `kOpeningAllowedVariants` so the header is hidden for variants where the explorer is not applicable.

No network calls were added; opening lookups go through the existing `OpeningService` against the bundled openings DB.

### Testing
- `flutter test test/view/broadcast/` (24 tests, all pass)
- `flutter test test/model/broadcast/` 
- Manual verification on a local lila-docker broadcast (Sicilian Taimanov position): explorer tab now displays `B47 Sicilian Defense: Taimanov Variation, Bastrikov Variation` above the move table; on `main` the same position renders no header.

| Before | After |
| --- | --- |
| <img width="1080" height="2424" alt="BEFORE-lila" src="https://github.com/user-attachments/assets/4483eac8-c2e8-4c83-86ad-6e871989dd76" /> | <img width="1080" height="2424" alt="AFTER" src="https://github.com/user-attachments/assets/eeed187b-a7ed-4251-8999-48e531278530" /> |

