### PR TITLE
Guard async callbacks with ref.mounted to prevent use-after-dispose

### DIFF
--- a/lib/src/model/analysis/analysis_controller.dart
+++ b/lib/src/model/analysis/analysis_controller.dart
@@ -297,6 +297,7 @@ class AnalysisController extends AsyncNotifier<AnalysisState>
         .then((hasOpening) {
           if (hasOpening) {
             scheduleMicrotask(() {
+              if (!ref.mounted) return;
               _setPath(state.requireValue.currentPath);
             });
           }
@@ -379,6 +380,7 @@ class AnalysisController extends AsyncNotifier<AnalysisState>
         .timeout(const Duration(seconds: 3))
         .onError((_, _) {})
         .whenComplete(() {
+          if (!ref.mounted) return;
           if (state.requireValue.isEngineAvailable(evaluationPrefs)) {
             requestEval();
           } else if (options case ActiveCorrespondenceGame(:final gameFullId)) {
@@ -724,6 +726,7 @@ class AnalysisController extends AsyncNotifier<AnalysisState>
 
       if (currentNode.opening == null && currentNode.position.ply <= 30) {
         _fetchOpening(currentNode.position.fen, path).then((value) {
+          if (!ref.mounted) return;
           if (value != null) {
             final (path, opening) = value;
             _updateOpening(path, opening);

--- a/lib/src/model/analysis/retro_controller.dart
+++ b/lib/src/model/analysis/retro_controller.dart
@@ -168,6 +168,7 @@ class RetroController extends AsyncNotifier<RetroState>
     state = AsyncData(await _computeMistakes(options.initialSide));
 
     socketClient.firstConnection.then((_) {
+      if (!ref.mounted) return;
       requestEval();
     });
 

--- a/lib/src/model/game/game_controller.dart
+++ b/lib/src/model/game/game_controller.dart
@@ -754,6 +754,7 @@ class GameController extends AsyncNotifier<GameState> {
 
         if (curState.game.lastPosition.fullmoves > 1) {
           Timer(const Duration(milliseconds: 500), () {
+            if (!ref.mounted) return;
             ref.read(soundServiceProvider).play(Sound.dong);
           });
         }
@@ -768,6 +769,7 @@ class GameController extends AsyncNotifier<GameState> {
         if (!newState.game.aborted) {
           _getPostGameData()
               .then((data) {
+                if (!ref.mounted) return;
                 final game = _mergePostGameData(state.requireValue.game, data);
                 state = AsyncValue.data(state.requireValue.copyWith(game: game));
                 _storeGame(game);

--- a/lib/src/model/puzzle/storm_controller.dart
+++ b/lib/src/model/puzzle/storm_controller.dart
@@ -215,6 +215,7 @@ class StormController extends Notifier<StormState> {
       ),
     );
     Future<void>.delayed(userMove ? Duration.zero : const Duration(milliseconds: 250), () {
+      if (!ref.mounted) return;
       if (pos.board.pieceAt(move.to) != null) {
         ref
             .read(moveFeedbackServiceProvider)

--- a/lib/src/model/study/study_controller.dart
+++ b/lib/src/model/study/study_controller.dart
@@ -206,6 +206,7 @@ class StudyController extends AsyncNotifier<StudyState>
 
     if (state.requireValue.isEngineAvailable(evaluationPrefs)) {
       socketClient.firstConnection.then((_) {
+        if (!ref.mounted) return;
         requestEval();
       });
     }


### PR DESCRIPTION
## What

Several fire-and-forget async callbacks in Riverpod notifiers can run after their notifier has been disposed and then access `state`/`ref`, throwing an unhandled `Cannot use the Ref of ... after it has been disposed`. This happens when the user leaves a screen while a non-cancellable async operation (socket `firstConnection`, an opening fetch, a post-game-data fetch, or a delayed/timer callback) is still in flight.

This adds the project's existing `if (!ref.mounted) return;` guard to the callbacks that lacked it:

- **`analysis_controller`** — socket `firstConnection.whenComplete` (→ `requestEval`), the opening-fetch result microtask (→ `_setPath`), and `_fetchOpening().then` (→ `_updateOpening`)
- **`study_controller` / `retro_controller`** — socket `firstConnection.then` (→ `requestEval`)
- **`game_controller`** — the post-game-data `.then` (→ `state`) and the end-of-game dong-sound `Timer` (→ `ref.read(soundServiceProvider)`)
- **`storm_controller`** — the move-feedback `Future.delayed` (→ `ref.read` + `state`)

Timers and stream subscriptions that are already cancelled in `onDispose` cannot fire after disposal and are left unchanged.

## Why

This matches the guard convention already used elsewhere in the codebase (e.g. `evaluation_mixin.dart`, `broadcast_analysis_controller.dart`, `online_friends.dart`) and aligns with Riverpod's documented `Ref.mounted` usage.

## Testing

- `flutter analyze` clean, `dart format` clean.
- Relevant widget tests pass (analysis, retro, storm, study, board editor, opening).
- Reproduced the exception live on an Android emulator (board editor → analyze → leave quickly), then verified the guard eliminates it: with the device offline the analysis socket `firstConnection` stays pending until its 3s timeout, so `whenComplete` fires after the controller is disposed on every cycle — 0 `Cannot use the Ref` / `Unhandled Exception` across the runs after the fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)