### PR TITLE
Add board editor deep link support

### DIFF
--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -123,6 +123,10 @@
                 <data android:pathPattern="/broadcast/.*/.*/........" />
                 <data android:pathPattern="/broadcast/.*/.*/......../........" />
 
+                <!-- Board editor: bare /editor and /editor/<fen> (FEN ranks contain '/'). -->
+                <data android:pathPattern="/editor" />
+                <data android:pathPattern="/editor/.*" />
+
                 <!--
                   Game or challenge link: any 8-char path (e.g. /abcd1234).
                   pathPattern cannot exclude known static 8-char routes (e.g. /analysis,

--- a/lib/src/app_links_service.dart
+++ b/lib/src/app_links_service.dart
@@ -58,28 +58,33 @@ class AppLinksService {
   StreamSubscription<Uri>? _linkSubscription;
 
   Future<void> start() async {
-    // Handle the link that cold-started the app (if any) after the first frame
-    // so the navigator is ready. Push without animation — the user launched the
-    // app via this link so the target screen should just be there.
-    WidgetsBinding.instance.addPostFrameCallback((_) async {
-      try {
-        final initialUri = await _appLinks.getInitialLink();
-        if (initialUri != null) {
-          await _handleUri(initialUri, animated: false);
-        }
-      } catch (e, st) {
-        _logger.severe('Error handling initial app link: $e\n$st');
+    // app_links' uriLinkStream emits the link that cold-started the app as its
+    // first event, followed by any links received while the app is running, so a
+    // single subscription covers both. (Also calling getInitialLink() would
+    // deliver the cold-start link a second time, running its side effects twice.)
+    var isColdStart = true;
+    _linkSubscription = _appLinks.uriLinkStream.listen((uri) {
+      if (isColdStart) {
+        isColdStart = false;
+        // The cold-start link can arrive before the first frame, so defer until
+        // the navigator is ready. Push without a transition — the user launched
+        // the app via this link so the target screen should just be there.
+        WidgetsBinding.instance.addPostFrameCallback((_) {
+          unawaited(_handleUriLogged(uri, animated: false));
+        });
+      } else {
+        // Links received while the app is already running get a normal transition.
+        unawaited(_handleUriLogged(uri, animated: true));
       }
     });
+  }
 
-    // Links received while the app is already running get a normal transition.
-    _linkSubscription = _appLinks.uriLinkStream.listen((uri) async {
-      try {
-        await _handleUri(uri, animated: true);
-      } catch (e, st) {
-        _logger.severe('Error handling app link: $e\n$st');
-      }
-    });
+  Future<void> _handleUriLogged(Uri uri, {required bool animated}) async {
+    try {
+      await _handleUri(uri, animated: animated);
+    } catch (e, st) {
+      _logger.severe('Error handling app link: $e\n$st');
+    }
   }
 
   Future<void> _handleUri(Uri uri, {required bool animated}) async {

--- a/lib/src/app_links_service.dart
+++ b/lib/src/app_links_service.dart
@@ -9,6 +9,7 @@ import 'package:lichess_mobile/src/constants.dart';
 import 'package:lichess_mobile/src/model/analysis/analysis_controller.dart';
 import 'package:lichess_mobile/src/model/challenge/challenge_repository.dart';
 import 'package:lichess_mobile/src/model/challenge/challenge_service.dart';
+import 'package:lichess_mobile/src/model/common/chess.dart';
 import 'package:lichess_mobile/src/model/common/id.dart';
 import 'package:lichess_mobile/src/model/game/game_repository.dart';
 import 'package:lichess_mobile/src/model/puzzle/puzzle.dart';
@@ -21,6 +22,7 @@ import 'package:lichess_mobile/src/model/user/user_repository.dart';
 import 'package:lichess_mobile/src/tab_scaffold.dart';
 import 'package:lichess_mobile/src/utils/navigation.dart';
 import 'package:lichess_mobile/src/view/analysis/analysis_screen.dart';
+import 'package:lichess_mobile/src/view/board_editor/board_editor_screen.dart';
 import 'package:lichess_mobile/src/view/broadcast/broadcast_game_screen.dart';
 import 'package:lichess_mobile/src/view/broadcast/broadcast_player_results_screen.dart';
 import 'package:lichess_mobile/src/view/broadcast/broadcast_round_screen.dart';
@@ -162,6 +164,29 @@ class AppLinksService {
       case 'training':
         final id = appLinkUri.pathSegments[1];
         return [PuzzleScreen.buildRoute(angle: PuzzleAngle.fromKey('mix'), puzzleId: PuzzleId(id))];
+      case 'editor':
+        final orientation = appLinkUri.queryParameters['color'] == 'black'
+            ? Side.black
+            : Side.white;
+        final fen = appLinkUri.pathSegments.sublist(1).join('/').replaceAll('_', ' ').trim();
+        String? initialFen;
+        if (fen.isNotEmpty) {
+          try {
+            Setup.parseFen(fen);
+            initialFen = fen;
+          } catch (_) {
+            if (context.mounted) {
+              showSnackBar(context, 'Invalid FEN: $fen', type: SnackBarType.error);
+            }
+          }
+        }
+        return [
+          BoardEditorScreen.buildRoute((
+            initialVariant: Variant.standard,
+            initialFen: initialFen,
+            initialOrientation: orientation,
+          )),
+        ];
       case 'tv':
         if (appLinkUri.pathSegments.length < 2) return null;
         final channel = TvChannel.nameMap.entryOrNull(appLinkUri.pathSegments[1]);

--- a/lib/src/app_links_service.dart
+++ b/lib/src/app_links_service.dart
@@ -50,11 +50,13 @@ final appLinksServiceProvider = Provider<AppLinksService>((ref) {
 });
 
 class AppLinksService {
-  AppLinksService(this.ref);
+  /// Creates the service. [appLinks] is injectable so tests can supply a fake
+  /// in place of the real (singleton, platform-channel backed) [AppLinks].
+  AppLinksService(this.ref, {AppLinks? appLinks}) : _appLinks = appLinks ?? AppLinks();
 
   final Ref ref;
 
-  final _appLinks = AppLinks();
+  final AppLinks _appLinks;
   StreamSubscription<Uri>? _linkSubscription;
 
   Future<void> start() async {

--- a/lib/src/model/board_editor/board_editor_controller.dart
+++ b/lib/src/model/board_editor/board_editor_controller.dart
@@ -8,7 +8,11 @@ import 'package:lichess_mobile/src/model/common/chess960.dart';
 
 part 'board_editor_controller.freezed.dart';
 
-typedef BoardEditorControllerParams = ({Variant initialVariant, String? initialFen});
+typedef BoardEditorControllerParams = ({
+  Variant initialVariant,
+  String? initialFen,
+  Side? initialOrientation,
+});
 
 /// A provider for [BoardEditorController].
 final boardEditorControllerProvider = NotifierProvider.autoDispose
@@ -32,7 +36,7 @@ class BoardEditorController extends Notifier<BoardEditorState> {
     final pieces = readFen(fen).lock;
 
     return BoardEditorState(
-      orientation: Side.white,
+      orientation: params?.initialOrientation ?? Side.white,
       sideToPlay: setup.turn,
       variant: variant,
       pieces: pieces,

--- a/lib/src/view/analysis/analysis_screen.dart
+++ b/lib/src/view/analysis/analysis_screen.dart
@@ -638,6 +638,7 @@ class _BottomBar extends ConsumerWidget {
                 BoardEditorScreen.buildRoute((
                   initialVariant: analysisState.variant,
                   initialFen: boardFen,
+                  initialOrientation: null,
                 )),
               );
             },

--- a/lib/src/view/more/more_tab_screen.dart
+++ b/lib/src/view/more/more_tab_screen.dart
@@ -127,6 +127,7 @@ class _Body extends ConsumerWidget {
                   BoardEditorScreen.buildRoute((
                     initialVariant: Variant.standard,
                     initialFen: null,
+                    initialOrientation: null,
                   )),
                 ),
               ),

--- a/test/app_links_service_test.dart
+++ b/test/app_links_service_test.dart
@@ -1,5 +1,6 @@
 import 'dart:async';
 
+import 'package:app_links/app_links.dart';
 import 'package:dartchess/dartchess.dart';
 import 'package:fast_immutable_collections/fast_immutable_collections.dart';
 import 'package:flutter/material.dart';
@@ -8,6 +9,7 @@ import 'package:flutter_riverpod/misc.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:http/http.dart' as http;
 import 'package:http/testing.dart';
+import 'package:lichess_mobile/l10n/l10n.dart';
 import 'package:lichess_mobile/src/app_links_service.dart';
 import 'package:lichess_mobile/src/model/challenge/challenge.dart';
 import 'package:lichess_mobile/src/model/challenge/challenge_repository.dart';
@@ -23,6 +25,7 @@ import 'package:lichess_mobile/src/model/tv/tv_channel.dart';
 import 'package:lichess_mobile/src/model/user/user.dart';
 import 'package:lichess_mobile/src/model/user/user_repository.dart';
 import 'package:lichess_mobile/src/network/http.dart';
+import 'package:lichess_mobile/src/tab_scaffold.dart';
 import 'package:lichess_mobile/src/view/analysis/analysis_screen.dart';
 import 'package:lichess_mobile/src/view/board_editor/board_editor_screen.dart';
 import 'package:lichess_mobile/src/view/broadcast/broadcast_game_screen.dart';
@@ -48,6 +51,8 @@ final _mockStalePuzzleJson = mockDailyPuzzleResponse.trim().replaceFirst(
   '"id":"0XqV2"',
   '"id":"stale1"',
 );
+
+class MockAppLinks extends Mock implements AppLinks {}
 
 class MockGameRepository extends Mock implements GameRepository {}
 
@@ -86,6 +91,25 @@ class _TestWidget extends ConsumerWidget {
       child: const Text('test link'),
     );
   }
+}
+
+/// Starts the [AppLinksService] when mounted, as the real app does at launch.
+class _ColdStartLauncher extends ConsumerStatefulWidget {
+  const _ColdStartLauncher();
+
+  @override
+  ConsumerState<_ColdStartLauncher> createState() => _ColdStartLauncherState();
+}
+
+class _ColdStartLauncherState extends ConsumerState<_ColdStartLauncher> {
+  @override
+  void initState() {
+    super.initState();
+    ref.read(appLinksServiceProvider).start();
+  }
+
+  @override
+  Widget build(BuildContext context) => const Scaffold(body: SizedBox.shrink());
 }
 
 Future<void> triggerAppLink(
@@ -861,6 +885,51 @@ void main() {
 
       expect(find.byType(TvScreen), findsNothing);
       expect(find.text('Invalid TV channel: not-a-real-channel'), findsOneWidget);
+    });
+  });
+
+  group('start (deep link subscription)', () {
+    testWidgets('a cold-start link is handled exactly once', (tester) async {
+      // An invalid-FEN editor link shows a snackbar, and snackbars queue rather
+      // than dedup, so a double-handled link surfaces as a duplicate.
+      final coldStartUri = Uri.parse('https://lichess.org/editor/not-a-valid-fen');
+      final navigatorKey = GlobalKey<NavigatorState>();
+
+      final mockAppLinks = MockAppLinks();
+      // The stream emits the cold-start link as its first (and only) event.
+      when(() => mockAppLinks.uriLinkStream).thenAnswer((_) => Stream.value(coldStartUri));
+      // getInitialLink() also returns it, so handling it too would duplicate.
+      when(() => mockAppLinks.getInitialLink()).thenAnswer((_) async => coldStartUri);
+
+      final app = await makeTestProviderScope(
+        tester,
+        overrides: {
+          currentNavigatorKeyProvider: currentNavigatorKeyProvider.overrideWithValue(navigatorKey),
+          appLinksServiceProvider: appLinksServiceProvider.overrideWith((ref) {
+            final service = AppLinksService(ref, appLinks: mockAppLinks);
+            ref.onDispose(service.dispose);
+            return service;
+          }),
+        },
+        child: MaterialApp(
+          navigatorKey: navigatorKey,
+          localizationsDelegates: AppLocalizations.localizationsDelegates,
+          home: const _ColdStartLauncher(),
+        ),
+      );
+      await tester.pumpWidget(app);
+      await tester.pumpAndSettle();
+
+      expect(find.byType(BoardEditorScreen), findsOneWidget);
+      expect(find.textContaining('Invalid FEN'), findsOneWidget);
+      verifyNever(() => mockAppLinks.getInitialLink());
+
+      // Dismiss the current snackbar; a duplicate would surface behind it.
+      tester
+          .firstState<ScaffoldMessengerState>(find.byType(ScaffoldMessenger))
+          .removeCurrentSnackBar();
+      await tester.pumpAndSettle();
+      expect(find.textContaining('Invalid FEN'), findsNothing);
     });
   });
 }

--- a/test/app_links_service_test.dart
+++ b/test/app_links_service_test.dart
@@ -24,6 +24,7 @@ import 'package:lichess_mobile/src/model/user/user.dart';
 import 'package:lichess_mobile/src/model/user/user_repository.dart';
 import 'package:lichess_mobile/src/network/http.dart';
 import 'package:lichess_mobile/src/view/analysis/analysis_screen.dart';
+import 'package:lichess_mobile/src/view/board_editor/board_editor_screen.dart';
 import 'package:lichess_mobile/src/view/broadcast/broadcast_game_screen.dart';
 import 'package:lichess_mobile/src/view/broadcast/broadcast_player_results_screen.dart';
 import 'package:lichess_mobile/src/view/broadcast/broadcast_round_screen.dart';
@@ -287,6 +288,90 @@ void main() {
         isA<PuzzleScreen>().having((s) => s.puzzleId, 'id', '61044'),
       );
     });
+
+    testWidgets('resolves bare /editor to BoardEditorScreen with default position', (
+      WidgetTester tester,
+    ) async {
+      final uri = Uri.parse('https://lichess.org/editor');
+      await triggerAppLink(tester, uri);
+      await tester.pumpAndSettle();
+      expect(
+        tester.widget(find.byType(BoardEditorScreen)),
+        isA<BoardEditorScreen>()
+            .having((s) => s.params?.initialFen, 'initialFen', isNull)
+            .having((s) => s.params?.initialOrientation, 'orientation', Side.white),
+      );
+    });
+
+    testWidgets('resolves trailing-slash /editor/ to BoardEditorScreen with default position', (
+      WidgetTester tester,
+    ) async {
+      // /editor/ parses to an empty trailing path segment, so the reconstructed FEN is
+      // empty: it must fall back to the default position rather than fail validation.
+      final uri = Uri.parse('https://lichess.org/editor/?color=black');
+      await triggerAppLink(tester, uri);
+      await tester.pumpAndSettle();
+      expect(find.textContaining('Invalid FEN'), findsNothing);
+      expect(
+        tester.widget(find.byType(BoardEditorScreen)),
+        isA<BoardEditorScreen>()
+            .having((s) => s.params?.initialFen, 'initialFen', isNull)
+            .having((s) => s.params?.initialOrientation, 'orientation', Side.black),
+      );
+    });
+
+    testWidgets('resolves /editor/{fen} reconstructing the FEN from path segments', (
+      WidgetTester tester,
+    ) async {
+      // Ranks are split by '/' and metadata spaces are encoded as '_'.
+      final uri = Uri.parse(
+        'https://lichess.org/editor/rnbqkbnr/pppppppp/8/8/4P3/8/PPPP1PPP/RNBQKBNR_w_KQkq_-_0_1',
+      );
+      await triggerAppLink(tester, uri);
+      await tester.pumpAndSettle();
+      expect(
+        tester.widget(find.byType(BoardEditorScreen)),
+        isA<BoardEditorScreen>()
+            .having(
+              (s) => s.params?.initialFen,
+              'initialFen',
+              'rnbqkbnr/pppppppp/8/8/4P3/8/PPPP1PPP/RNBQKBNR w KQkq - 0 1',
+            )
+            .having((s) => s.params?.initialOrientation, 'orientation', Side.white),
+      );
+    });
+
+    testWidgets('resolves /editor/{fen}?color=black with black orientation', (
+      WidgetTester tester,
+    ) async {
+      final uri = Uri.parse(
+        'https://lichess.org/editor/rnbqkbnr/pppppppp/8/8/4P3/8/PPPP1PPP/RNBQKBNR_w_KQkq_-_0_1?color=black',
+      );
+      await triggerAppLink(tester, uri);
+      await tester.pumpAndSettle();
+      expect(
+        tester.widget(find.byType(BoardEditorScreen)),
+        isA<BoardEditorScreen>().having(
+          (s) => s.params?.initialOrientation,
+          'orientation',
+          Side.black,
+        ),
+      );
+    });
+
+    testWidgets(
+      'shows error snackbar but still opens editor with default position for invalid FEN',
+      (WidgetTester tester) async {
+        final uri = Uri.parse('https://lichess.org/editor/not-a-valid-fen');
+        await triggerAppLink(tester, uri);
+        await tester.pumpAndSettle();
+        expect(find.textContaining('Invalid FEN'), findsOneWidget);
+        expect(
+          tester.widget(find.byType(BoardEditorScreen)),
+          isA<BoardEditorScreen>().having((s) => s.params?.initialFen, 'initialFen', isNull),
+        );
+      },
+    );
 
     testWidgets('resolves /tournament/{id} to TournamentScreen route', (WidgetTester tester) async {
       final uri = Uri.parse('https://lichess.org/tournament/61044');

--- a/test/view/board_editor/board_editor_screen_test.dart
+++ b/test/view/board_editor/board_editor_screen_test.dart
@@ -44,7 +44,9 @@ void main() {
     testWidgets('Opening with variant loads its starting position', (tester) async {
       final app = await makeTestProviderScopeApp(
         tester,
-        home: const BoardEditorScreen(params: (initialVariant: Variant.horde, initialFen: null)),
+        home: const BoardEditorScreen(
+          params: (initialVariant: Variant.horde, initialFen: null, initialOrientation: null),
+        ),
       );
       await tester.pumpWidget(app);
 


### PR DESCRIPTION
part of https://github.com/lichess-org/mobile/issues/2988

## What

Adds deep link support for the board editor, matching lichess.org URLs:

- `lichess.org/editor` → opens the editor at the default starting position
- `lichess.org/editor/<fen>?color=<side>` → opens the editor at the given position and orientation

For example, `https://lichess.org/editor/rnbqkbnr/pppppppp/8/8/4P3/8/PPPP1PPP/RNBQKBNR_w_KQkq_-_0_1?color=black`.

## How

- **`app_links_service.dart`** — new `case 'editor'` in `resolveAppLinkUri`. A FEN's rank separators (`/`) and metadata spaces are encoded in the lichess URL as path separators and `_` respectively, so the handler rejoins `pathSegments[1..]` with `/` and restores the spaces to reconstruct the FEN. `?color=black` sets the orientation (anything else → white).
- **`board_editor_controller.dart`** — adds an `initialOrientation` field to `BoardEditorControllerParams`; `build()` uses it (defaulting to white).
- **`AndroidManifest.xml`** — registers `/editor` and `/editor/.*` App Links path patterns.

### Edge cases
- **Empty FEN** (bare `/editor`, or a trailing-slash `/editor/`) → default starting position, no error.
- **Invalid FEN** (e.g. `/editor/not-a-valid-fen`) → opens the editor at the default position **and** shows an `Invalid FEN` snackbar, rather than failing silently or refusing to navigate.

### Also fixes a pre-existing bug
A link that **cold-starts** the app was handled twice — `getInitialLink()` and the first event of `uriLinkStream` both delivered it. This was masked for navigation by `_pushDeepLinkRoute`'s same-screen dedup, but the new invalid-FEN snackbar (snackbars queue rather than dedup) surfaced it as a duplicate. Fixed by following [app_links' documented pattern](https://pub.dev/packages/app_links#getting-started) of subscribing to `uriLinkStream` alone (it already emits the cold-start link as its first event), instead of also calling `getInitialLink()`.

## Server-side dependency

App Links/universal-link verification for `/editor` lives in the `.well-known` files served from `lichess-org/lichess-org.github.io`. Companion PR: **lichess-org/lichess-org.github.io#6** (adds `/editor` to `apple-app-site-association` and `assetlinks.json`). Until that merges, `/editor` links open the app on Android ≤14 only; iOS and Android 15+ fall back to the browser.

## Testing

- Unit tests in `app_links_service_test.dart` cover: bare `/editor`, trailing slash, FEN reconstruction, `?color=black`, and invalid FEN.
- Verified on an Android emulator (API 36) by firing each link: correct position, orientation, the invalid-FEN snackbar, and — on cold start — the editor opening with a single (no longer duplicated) snackbar.

### Demo

https://github.com/user-attachments/assets/071253b9-140a-4124-abe4-54338d871fa8

🤖 Generated with [Claude Code](https://claude.com/claude-code)
