### PR TITLE
Fix crash in perf stats columns when a perf has zero games

### DIFF
--- a/lib/src/view/user/perf_stats_screen.dart
+++ b/lib/src/view/user/perf_stats_screen.dart
@@ -525,8 +525,8 @@ class _PercentageValueWidget extends StatelessWidget {
   const _PercentageValueWidget(this.value, this.denominator, {this.color, this.isShaded = false});
 
   String _getPercentageString(num numerator, num denominator) {
-    if (denominator == 0) return '0%';
-    return '${((numerator / denominator) * 100).round()}%';
+    final fraction = denominator == 0 ? 0 : numerator / denominator;
+    return NumberFormat.percentPattern().format(fraction);
   }
 
   @override

--- a/lib/src/view/user/perf_stats_screen.dart
+++ b/lib/src/view/user/perf_stats_screen.dart
@@ -525,6 +525,7 @@ class _PercentageValueWidget extends StatelessWidget {
   const _PercentageValueWidget(this.value, this.denominator, {this.color, this.isShaded = false});
 
   String _getPercentageString(num numerator, num denominator) {
+    if (denominator == 0) return '0%';
     return '${((numerator / denominator) * 100).round()}%';
   }
 

--- a/test/view/user/perf_stats_screen_test.dart
+++ b/test/view/user/perf_stats_screen_test.dart
@@ -20,6 +20,16 @@ final client = MockClient((request) {
   return mockResponse('', 404);
 });
 
+final zeroGamesClient = MockClient((request) {
+  if (request.url.path == '/api/user/${fakeUser.id}/perf/${testPerf.name}') {
+    return mockResponse(userPerfStatsZeroGamesResponse, 200);
+  }
+  if (request.url.path == '/api/user/${fakeUser.id}/rating-history') {
+    return mockResponse('[]', 200);
+  }
+  return mockResponse('', 404);
+});
+
 void main() {
   group('PerfStatsScreen', () {
     testWidgets('meets accessibility guidelines', (WidgetTester tester) async {
@@ -84,10 +94,63 @@ void main() {
         expect(find.widgetWithText(Card, val), findsAtLeastNWidgets(1));
       }
     }, variant: kPlatformVariant);
+
+    testWidgets('a perf with zero games does not crash the stat columns', (
+      WidgetTester tester,
+    ) async {
+      final app = await makeTestProviderScopeApp(
+        tester,
+        home: PerfStatsScreen(user: fakeUser, perf: testPerf),
+        overrides: {
+          lichessClientProvider: lichessClientProvider.overrideWith((ref) {
+            return LichessClient(zeroGamesClient, ref);
+          }),
+        },
+      );
+
+      await tester.pumpWidget(app);
+
+      // wait for auth state and perf stats
+      await tester.pump(const Duration(milliseconds: 50));
+
+      expect(tester.takeException(), isNull);
+      expect(find.byType(ErrorWidget), findsNothing);
+      expect(find.text('0%'), findsWidgets);
+    }, variant: kPlatformVariant);
   });
 }
 
 const testPerf = Perf.rapid;
+final userPerfStatsZeroGamesResponse =
+    '''
+{
+  "user": { "name": "${fakeUser.username}" },
+  "perf": {
+    "glicko": { "rating": 1837.0, "deviation": 215.18, "provisional": true },
+    "nb": 0,
+    "progress": 40
+  },
+  "rank": null,
+  "percentile": null,
+  "stat": {
+    "count": {
+      "berserk": 0, "win": 0, "all": 0, "seconds": 0,
+      "opAvg": null, "draw": 0, "tour": 0, "disconnects": 0,
+      "rated": 0, "loss": 0
+    },
+    "resultStreak": {
+      "win": { "cur": {"v": 0}, "max": {"v": 0} },
+      "loss": { "cur": {"v": 0}, "max": {"v": 0} }
+    },
+    "playStreak": {
+      "nb": { "cur": {"v": 0}, "max": {"v": 0} },
+      "time": { "cur": {"v": 0}, "max": {"v": 0} }
+    },
+    "worstLosses": { "results": [] },
+    "bestWins": { "results": [] }
+  }
+}
+''';
 final userPerfStatsResponse =
     '''
 {


### PR DESCRIPTION
## Problem

Fixes #1513.

On the perf stats screen, when a perf has a rating but **zero counted games** (`stat.count.all == 0`), the win/draw/loss percentage columns render as empty/grey boxes (error widgets).

The cause is a divide-by-zero in `_PercentageValueWidget`: the percentage is computed as `((numerator / denominator) * 100).round()`, and with `denominator == 0`, `0 / 0` is `NaN`. In Dart `NaN.round()` throws `Unsupported operation: Infinity or NaN toInt`, so each of the seven percentage cards (wins, draws, losses, rated, tournament, berserk, disconnections) throws during build and is replaced by an `ErrorWidget` (a grey box in release builds).

## Fix

Guard the division in `_getPercentageString` so it falls back to `0%` when the denominator is `0`.

## Test

Added a regression test that loads the screen for a perf with zero games and asserts no exception / no `ErrorWidget` is rendered. Verified the new test fails on the previous code (7 `NaN` exceptions) and passes with the fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)