### PR TITLE
Handle 400 from /api/challenge instead of crashing

### DIFF
--- a/lib/src/view/game/game_loading_board.dart
+++ b/lib/src/view/game/game_loading_board.dart
@@ -15,6 +15,7 @@ import 'package:lichess_mobile/src/model/game/game_board_params.dart';
 import 'package:lichess_mobile/src/model/lobby/game_seek.dart';
 import 'package:lichess_mobile/src/model/lobby/lobby_numbers.dart';
 import 'package:lichess_mobile/src/model/settings/brightness.dart';
+import 'package:lichess_mobile/src/network/http.dart';
 import 'package:lichess_mobile/src/utils/l10n_context.dart';
 import 'package:lichess_mobile/src/utils/navigation.dart';
 import 'package:lichess_mobile/src/utils/share.dart';
@@ -314,9 +315,24 @@ class _OpenChallengeLoadingContentState extends ConsumerState<OpenChallengeLoadi
                                   (route) => route is! ScreenRoute || route.screen is! GameScreen,
                                 );
                               } else {
-                                await ref
-                                    .read(challengeRepositoryProvider)
-                                    .create(directedChallengeReq);
+                                try {
+                                  await ref
+                                      .read(challengeRepositoryProvider)
+                                      .create(directedChallengeReq);
+                                } catch (e) {
+                                  // The server can reject the challenge with a 400, e.g. when the
+                                  // rating is too far from the opponent's, or the opponent does not
+                                  // accept challenges. Surface the error instead of crashing.
+                                  if (!context.mounted) return;
+                                  showSnackBar(
+                                    context,
+                                    e is ServerException && e.statusCode == 400
+                                        ? '${e.jsonError?['error'] ?? 'Could not create the challenge.'}'
+                                        : 'Could not create the challenge. Please try again later.',
+                                    type: SnackBarType.error,
+                                  );
+                                  return;
+                                }
                                 if (!context.mounted) return;
                                 ScaffoldMessenger.of(context).showSnackBar(
                                   SnackBar(

--- a/lib/src/view/game/game_screen.dart
+++ b/lib/src/view/game/game_screen.dart
@@ -116,7 +116,17 @@ class _GameScreenState extends ConsumerState<GameScreen> {
   Widget build(BuildContext context) {
     final boardPreferences = ref.watch(boardPreferencesProvider);
 
-    switch (ref.watch(gameScreenLoaderProvider(widget.source))) {
+    final loaderState = ref.watch(gameScreenLoaderProvider(widget.source));
+
+    // An error raised in the loader's `build` can be attached to an
+    // `AsyncLoading` state (Riverpod keeps the previous state on rebuild), in
+    // which case it would not match the `AsyncError` case below and the screen
+    // would stay stuck on the loading board. Handle any error here first.
+    if (loaderState case AsyncValue(hasError: true, :final error, :final stackTrace)) {
+      return _buildErrorScaffold(context, error!, stackTrace);
+    }
+
+    switch (loaderState) {
       case AsyncData(value: SeekCancelledState()):
         return Scaffold(
           resizeToAvoidBottomInset: false,
@@ -246,29 +256,6 @@ class _GameScreenState extends ConsumerState<GameScreen> {
             ),
           ),
         );
-      case AsyncError(error: final e, stackTrace: final s):
-        debugPrint('SEVERE: [GameScreen] could not create game; $e\n$s');
-
-        // lichess sends a 400 response if user has not allowed challenges
-        final message = e is ServerException && e.statusCode == 400
-            ? LoadGameError('Could not create the game: ${e.jsonError?['error']}')
-            : const LoadGameError('Sorry, we could not create the game. Please try again later.');
-
-        return Scaffold(
-          resizeToAvoidBottomInset: false,
-          appBar: AppBar(
-            leading: const SocketPingRatingIcon(),
-            title: switch (widget.source) {
-              LobbySource(:final seek) => _GameTitle(_LobbyTitleVariant(seek), monitorSocket: true),
-              UserChallengeSource(:final challengeRequest) => _GameTitle(
-                _ChallengeTitleVariant(challengeRequest),
-                monitorSocket: true,
-              ),
-              _ => null,
-            },
-          ),
-          body: PopScope(child: message),
-        );
       case _:
         final loadingBoard = switch (widget.source) {
           LobbySource(:final seek) => LobbyScreenLoadingContent(
@@ -299,6 +286,31 @@ class _GameScreenState extends ConsumerState<GameScreen> {
           body: PopScope(canPop: false, child: WakelockWidget(child: loadingBoard)),
         );
     }
+  }
+
+  Widget _buildErrorScaffold(BuildContext context, Object error, StackTrace? stackTrace) {
+    debugPrint('SEVERE: [GameScreen] could not create game; $error\n$stackTrace');
+
+    // lichess sends a 400 response if user has not allowed challenges
+    final message = error is ServerException && error.statusCode == 400
+        ? LoadGameError('Could not create the game: ${error.jsonError?['error']}')
+        : const LoadGameError('Sorry, we could not create the game. Please try again later.');
+
+    return Scaffold(
+      resizeToAvoidBottomInset: false,
+      appBar: AppBar(
+        leading: const SocketPingRatingIcon(),
+        title: switch (widget.source) {
+          LobbySource(:final seek) => _GameTitle(_LobbyTitleVariant(seek), monitorSocket: true),
+          UserChallengeSource(:final challengeRequest) => _GameTitle(
+            _ChallengeTitleVariant(challengeRequest),
+            monitorSocket: true,
+          ),
+          _ => null,
+        },
+      ),
+      body: PopScope(child: message),
+    );
   }
 }
 

--- a/test/view/game/game_screen_test.dart
+++ b/test/view/game/game_screen_test.dart
@@ -503,6 +503,47 @@ void main() {
       expect(find.text('3+2 • Rated'), findsOneWidget);
     });
 
+    testWidgets('challenge rejected with a 400 shows an error instead of crashing', (
+      WidgetTester tester,
+    ) async {
+      final challengeRequest = ChallengeRequest(
+        destUser: LightUser(id: UserId.fromUserName('YoBot_v2'), name: 'YoBot_v2'),
+        variant: Variant.standard,
+        timeControl: ChallengeTimeControlType.clock,
+        clock: (time: const Duration(minutes: 3), increment: const Duration(seconds: 2)),
+        rated: true,
+        sideChoice: .random,
+      );
+      final createGameService = MockCreateGameService();
+      when(() => createGameService.newOpenOrRealTimeChallenge(any())).thenAnswer(
+        (_) async => throw ServerException(
+          400,
+          'Request to /api/challenge/yobot_v2 failed with status 400',
+          Uri(path: '/api/challenge/yobot_v2'),
+          const {'error': 'Your Blitz rating is too far from BOT YoBot_v2.'},
+        ),
+      );
+
+      final app = await makeTestProviderScopeApp(
+        tester,
+        home: GameScreen(source: UserChallengeSource(challengeRequest)),
+        overrides: {
+          createGameServiceProvider: createGameServiceProvider.overrideWith(
+            (_) => createGameService,
+          ),
+        },
+      );
+      await tester.pumpWidget(app);
+      await tester.pumpAndSettle();
+
+      // The 400 must be surfaced as an error, not crash or hang on the loading board.
+      expect(tester.takeException(), isNull);
+      expect(
+        find.textContaining('Your Blitz rating is too far from BOT YoBot_v2.'),
+        findsOneWidget,
+      );
+    });
+
     testWidgets('open challenge shows challenge time control and mode', (
       WidgetTester tester,
     ) async {


### PR DESCRIPTION
Fixes #1123.

## Problem

Creating a challenge that the server rejects with a **400** (e.g. _"Your Blitz rating is too far from BOT YoBot_v2"_, or the opponent doesn't accept challenges) was not handled:

- **Hard crash** (the Crashlytics report in #1123): the open-challenge _"Invite a Lichess user"_ flow called `challengeRepository.create()` directly in the button callback with **no try/catch**, so the `ServerException` propagated as a fatal `Unhandled Exception`.
- **Stuck on "Waiting for opponent"**: a 400 raised in the game-screen loader's `build()` can be attached to an `AsyncLoading` state (Riverpod keeps the previous state on rebuild), so the old `case AsyncError` never matched and the screen hung on the loading board forever.

## Fix

- **`game_loading_board.dart`** — wrap the direct `challengeRepository.create()` call in try/catch and surface the error via a snackbar instead of crashing.
- **`game_screen.dart`** — add a pre-`switch` `hasError` guard that renders the error board whenever the loader state carries an error (even on `AsyncLoading`), extracted into `_buildErrorScaffold`.
- **Test** — regression test asserting a rejected 400 shows an error instead of crashing or hanging.

## Verification

The new regression test fails on the old code and passes with the fix.

Reproduced on an Android emulator against a local lila-docker server, with a too-far-rated player (Mary) challenging a rating-restricted account (Ana):

### Before — old code crashes (issue #1123)

Open correspondence challenge → _"Invite a Lichess user"_ → Ana. The 400 is unhandled and fatal:

```
E flutter : Unhandled Exception: ClientException: Request to /api/challenge/ana
  failed with status 400: Your Correspondence rating is too far from WCM Ana., uri=/api/challenge/ana
E flutter : #2  ChallengeRepository.create (challenge_repository.dart:48:23)
E flutter : #3  _OpenChallengeLoadingContentState.build...(game_loading_board.dart:317:33)
```

The user is left with no feedback — the challenge silently fails. In release mode the uncaught async error is routed to `PlatformDispatcher.instance.onError` (`binding.dart`), which reports it to Crashlytics (the report in #1123) and returns `true`, so the app keeps running rather than surfacing anything. (The `game_loading_board.dart` snackbar replaces this silent failure with a visible error.)

<img width="1080" height="2340" alt="before_oldcode_after_crash" src="https://github.com/user-attachments/assets/6327d520-7883-4d10-99b5-7be9a7de24b9" />

### After — error is handled gracefully

The same 400 is now caught — **no `Unhandled Exception`**, the app stays alive and surfaces the server's reason instead of crashing or hanging on the loading board:

```
I flutter : [HttpClient] POST .../api/challenge/ana responded with status 400 Bad Request
I flutter : SEVERE: [GameScreen] could not create game; ClientException: ... 400:
            Your Rapid rating is too far from WCM Ana.
```

<img width="1080" height="2340" alt="after_fixed_graceful_error" src="https://github.com/user-attachments/assets/98a1fd6d-70df-4fb8-a682-9232bad3e468" />

> Note: the literal "stuck on Waiting for opponent" state (the `game_screen.dart` half) is a Riverpod rebuild race that the regression test reproduces deterministically, but it does not surface as a live screenshot against the local server, which returns the 400 as a clean `AsyncError` that even the old code rendered as an error board.
