### PR TITLE
Add clock delay option to the over-the-board clock tool

### DIFF
--- a/lib/src/model/clock/chess_clock.dart
+++ b/lib/src/model/clock/chess_clock.dart
@@ -116,8 +116,6 @@ class ChessClock {
   ///
   /// Trying to start an already running clock on the same side is a no-op.
   ///
-  /// The [delay] parameter can be used to add a delay before the clock starts counting down. This is useful for lag compensation.
-  ///
   /// Returns the think time of the active side before switching or `null` if the clock is not running.
   Duration? startSide(Side side, {Duration? delay}) {
     if (isRunning && _activeSide == side) {
@@ -131,23 +129,39 @@ class ChessClock {
 
   /// Starts the clock.
   ///
-  /// The [delay] parameter can be used to add a delay before the clock starts counting down. This is useful for lag compensation.
+  /// The [delay] parameter holds the main clock for that long before it starts
+  /// counting down (used for clock delay, and for lag compensation).
   void start({Duration? delay}) {
-    _lastStarted = clock.now().add(delay ?? Duration.zero);
+    final delayDuration = delay ?? Duration.zero;
+    _lastStarted = clock.now().add(delayDuration);
     _startDelayTimer?.cancel();
-    _startDelayTimer = Timer(delay ?? Duration.zero, _scheduleTick);
+    // Cancel any in-progress main tick so it doesn't run during the start delay.
+    _timer?.cancel();
+    _startDelayTimer = Timer(delayDuration, _scheduleTick);
   }
 
-  /// Pauses the clock.
+  /// Stops the clock, discarding any in-progress start delay.
   ///
   /// Returns the current think time for the active side.
   Duration stop() {
+    final thinkTime = _thinkTime ?? Duration.zero;
+    _halt();
+    return thinkTime;
+  }
+
+  /// Pauses the clock, returning any remaining start delay so it can be carried
+  /// over on resume.
+  Duration pause() {
+    final remaining = _lastStarted != null ? _lastStarted!.difference(clock.now()) : Duration.zero;
+    _halt();
+    return remaining > Duration.zero ? remaining : Duration.zero;
+  }
+
+  void _halt() {
     _stopwatch.stop();
     _startDelayTimer?.cancel();
     _timer?.cancel();
-    final thinkTime = _thinkTime ?? Duration.zero;
     _lastStarted = null;
-    return thinkTime;
   }
 
   void dispose() {

--- a/lib/src/model/clock/clock_tool_controller.dart
+++ b/lib/src/model/clock/clock_tool_controller.dart
@@ -31,6 +31,9 @@ class ClockToolController extends Notifier<ClockState> {
   };
   late Duration _emergencyThreshold;
 
+  /// Start delay remaining from the last pause, carried over on [resume].
+  Duration _pausedDelay = Duration.zero;
+
   @override
   ClockState build() {
     const time = Duration(minutes: 10);
@@ -111,7 +114,10 @@ class ClockToolController extends Notifier<ClockState> {
     final bool hasNewActiveMoved =
         (playerType.opposite == ClockSide.top ? state.topMoves : state.bottomMoves) > 0;
     if (initialOfNewActive.inMilliseconds != 0 || hasNewActiveMoved) {
-      _clock.startSide(playerType.opposite.chessClockSide);
+      _clock.startSide(
+        playerType.opposite.chessClockSide,
+        delay: state.options.getDelay(playerType.opposite),
+      );
     } else {
       _clock.stop();
     }
@@ -153,6 +159,10 @@ class ClockToolController extends Notifier<ClockState> {
       bottomIncrement: player == ClockSide.bottom
           ? Duration(seconds: clock.increment)
           : state.options.bottomIncrement,
+      topDelay: player == ClockSide.top ? Duration(seconds: clock.delay) : state.options.topDelay,
+      bottomDelay: player == ClockSide.bottom
+          ? Duration(seconds: clock.delay)
+          : state.options.bottomDelay,
     );
     _clock.setTimes(blackTime: options.topTime, whiteTime: options.bottomTime);
     state = ClockState(
@@ -192,12 +202,16 @@ class ClockToolController extends Notifier<ClockState> {
     if (initialOfStartingPlayer.inMilliseconds == 0) {
       _clock.stop();
     } else {
-      _clock.startSide(playerType.opposite.chessClockSide);
+      _clock.startSide(
+        playerType.opposite.chessClockSide,
+        delay: state.options.getDelay(playerType.opposite),
+      );
     }
   }
 
   void pause() {
-    _clock.stop();
+    // Preserve any remaining start delay so it carries over on resume.
+    _pausedDelay = _clock.pause();
     state = state.copyWith(paused: true);
   }
 
@@ -213,8 +227,10 @@ class ClockToolController extends Notifier<ClockState> {
         : state.bottomMoves > 0;
 
     if (active != null && (initialOfActive.inMilliseconds != 0 || hasActiveMoved)) {
-      _clock.start();
+      // Carry over any delay left from when we paused; otherwise resume immediately.
+      _clock.start(delay: _pausedDelay > Duration.zero ? _pausedDelay : null);
     }
+    _pausedDelay = Duration.zero;
     state = state.copyWith(paused: false);
   }
 
@@ -232,6 +248,8 @@ sealed class ClockOptions with _$ClockOptions {
     required Duration bottomTime,
     required Duration topIncrement,
     required Duration bottomIncrement,
+    @Default(Duration.zero) Duration topDelay,
+    @Default(Duration.zero) Duration bottomDelay,
   }) = _ClockOptions;
 
   factory ClockOptions.fromTimeIncrement(TimeIncrement timeIncrement) => ClockOptions(
@@ -239,6 +257,8 @@ sealed class ClockOptions with _$ClockOptions {
     bottomTime: Duration(seconds: timeIncrement.time),
     topIncrement: Duration(seconds: timeIncrement.increment),
     bottomIncrement: Duration(seconds: timeIncrement.increment),
+    topDelay: Duration(seconds: timeIncrement.delay),
+    bottomDelay: Duration(seconds: timeIncrement.delay),
   );
 
   factory ClockOptions.fromSeparateTimeIncrements(
@@ -249,6 +269,8 @@ sealed class ClockOptions with _$ClockOptions {
     bottomTime: Duration(seconds: playerBottom.time),
     topIncrement: Duration(seconds: playerTop.increment),
     bottomIncrement: Duration(seconds: playerBottom.increment),
+    topDelay: Duration(seconds: playerTop.delay),
+    bottomDelay: Duration(seconds: playerBottom.delay),
   );
 
   int getIncrement(ClockSide playerType) {
@@ -257,6 +279,14 @@ sealed class ClockOptions with _$ClockOptions {
 
   bool hasIncrement(ClockSide playerType) {
     return getIncrement(playerType) > 0;
+  }
+
+  Duration getDelay(ClockSide playerType) {
+    return playerType == ClockSide.top ? topDelay : bottomDelay;
+  }
+
+  bool hasDelay(ClockSide playerType) {
+    return getDelay(playerType) > Duration.zero;
   }
 }
 

--- a/lib/src/model/common/time_increment.dart
+++ b/lib/src/model/common/time_increment.dart
@@ -5,14 +5,16 @@ import 'package:lichess_mobile/src/model/common/speed.dart';
 /// A pair of time and increment in seconds used as game clock
 @immutable
 class TimeIncrement implements Comparable<TimeIncrement> {
-  const TimeIncrement(this.time, this.increment) : assert(time >= 0 && increment >= 0);
+  const TimeIncrement(this.time, this.increment, {this.delay = 0})
+    : assert(time >= 0 && increment >= 0 && delay >= 0);
 
-  TimeIncrement.fromDurations(Duration time, Duration increment)
+  TimeIncrement.fromDurations(Duration time, Duration increment, {Duration delay = Duration.zero})
     : time = time.inSeconds,
       increment = increment.inSeconds,
-      assert(time >= Duration.zero && increment >= Duration.zero);
+      delay = delay.inSeconds,
+      assert(time >= Duration.zero && increment >= Duration.zero && delay >= Duration.zero);
 
-  const TimeIncrement.infinite() : time = 0, increment = 0;
+  const TimeIncrement.infinite() : time = 0, increment = 0, delay = 0;
 
   /// Clock initial time in seconds
   final int time;
@@ -20,11 +22,16 @@ class TimeIncrement implements Comparable<TimeIncrement> {
   /// Clock increment in seconds
   final int increment;
 
+  /// Clock simple (US) delay in seconds. Only used by the local clock tool:
+  /// lichess online play does not support delay.
+  final int delay;
+
   TimeIncrement.fromJson(Map<String, dynamic> json)
     : time = json['time'] as int,
-      increment = json['increment'] as int;
+      increment = json['increment'] as int,
+      delay = json['delay'] as int? ?? 0;
 
-  Map<String, dynamic> toJson() => {'time': time, 'increment': increment};
+  Map<String, dynamic> toJson() => {'time': time, 'increment': increment, 'delay': delay};
 
   /// Returns the estimated duration of the game, with increment * 40 added to
   /// the initial time.
@@ -50,13 +57,14 @@ class TimeIncrement implements Comparable<TimeIncrement> {
       other is TimeIncrement &&
           runtimeType == other.runtimeType &&
           time == other.time &&
-          increment == other.increment;
+          increment == other.increment &&
+          delay == other.delay;
 
   @override
-  int get hashCode => Object.hash(time, increment);
+  int get hashCode => Object.hash(time, increment, delay);
 
   @override
-  String toString() => 'TimeIncrement($time+$increment)';
+  String toString() => 'TimeIncrement($time+$increment${delay > 0 ? ' d$delay' : ''})';
 
   @override
   int compareTo(TimeIncrement other) {

--- a/lib/src/view/clock/clock_settings.dart
+++ b/lib/src/view/clock/clock_settings.dart
@@ -70,9 +70,11 @@ class ClockSettings extends ConsumerWidget {
                           );
                           return TimeControlModal(
                             excludeUltraBullet: true,
+                            showDelay: true,
                             timeIncrement: TimeIncrement(
                               options.bottomTime.inSeconds,
                               options.bottomIncrement.inSeconds,
+                              delay: options.bottomDelay.inSeconds,
                             ),
                             onSelected: (choice) {
                               ref.read(clockToolControllerProvider.notifier).updateOptions(choice);

--- a/lib/src/view/clock/clock_settings.dart
+++ b/lib/src/view/clock/clock_settings.dart
@@ -62,6 +62,7 @@ class ClockSettings extends ConsumerWidget {
                       showModalBottomSheet<void>(
                         context: context,
                         isScrollControlled: true,
+                        clipBehavior: Clip.antiAlias,
                         constraints: BoxConstraints(maxHeight: screenHeight - (screenHeight / 10)),
                         builder: (BuildContext context) {
                           final options = ref.watch(

--- a/lib/src/view/clock/clock_tool_screen.dart
+++ b/lib/src/view/clock/clock_tool_screen.dart
@@ -310,10 +310,12 @@ class _ClockTileState extends ConsumerState<ClockTile> with SingleTickerProvider
                                           ? TimeIncrement.fromDurations(
                                               clockState.options.topTime,
                                               clockState.options.topIncrement,
+                                              delay: clockState.options.topDelay,
                                             )
                                           : TimeIncrement.fromDurations(
                                               clockState.options.bottomTime,
                                               clockState.options.bottomIncrement,
+                                              delay: clockState.options.bottomDelay,
                                             ),
                                       onSubmit: (ClockSide player, TimeIncrement clock) {
                                         Navigator.of(context).pop();
@@ -328,6 +330,13 @@ class _ClockTileState extends ConsumerState<ClockTile> with SingleTickerProvider
                             const SizedBox(width: 8),
                             Text(
                               '+${clockState.options.getIncrement(playerType)}',
+                              style: TextStyle(fontSize: 28, color: clockStyle.textColor),
+                            ),
+                          ],
+                          if (clockState.options.hasDelay(playerType)) ...[
+                            const SizedBox(width: 8),
+                            Text(
+                              'd${clockState.options.getDelay(playerType).inSeconds}',
                               style: TextStyle(fontSize: 28, color: clockStyle.textColor),
                             ),
                           ],

--- a/lib/src/view/clock/custom_clock_settings.dart
+++ b/lib/src/view/clock/custom_clock_settings.dart
@@ -67,35 +67,21 @@ class _PlayerTimeSlider extends StatelessWidget {
   Widget build(BuildContext context) {
     return ListSection(
       children: [
-        ListTile(
+        NonLinearSliderTile(
           title: Text(
             '${context.l10n.time}: ${clock.time < 60 ? context.l10n.nbSeconds(clock.time) : context.l10n.nbMinutes(_secToMin(clock.time))}',
           ),
-          subtitle: NonLinearSlider(
-            value: clock.time,
-            values: kAvailableTimesInSeconds,
-            labelBuilder: _clockTimeLabel,
-            onChange: (num value) {
-              updateTime(value.toInt());
-            },
-            onChangeEnd: (num value) {
-              updateTime(value.toInt());
-            },
-          ),
+          value: clock.time,
+          values: kAvailableTimesInSeconds,
+          labelBuilder: _clockTimeLabel,
+          onChanged: updateTime,
         ),
-        ListTile(
+        NonLinearSliderTile(
           title: Text('${context.l10n.increment}: ${context.l10n.nbSeconds(clock.increment)}'),
-          subtitle: NonLinearSlider(
-            value: clock.increment,
-            values: kAvailableIncrementsInSeconds,
-            labelBuilder: (num sec) => sec.toString(),
-            onChange: (num value) {
-              updateIncrement(value.toInt());
-            },
-            onChangeEnd: (num value) {
-              updateIncrement(value.toInt());
-            },
-          ),
+          value: clock.increment,
+          values: kAvailableIncrementsInSeconds,
+          labelBuilder: (num sec) => sec.toString(),
+          onChanged: updateIncrement,
         ),
       ],
     );

--- a/lib/src/view/clock/custom_clock_settings.dart
+++ b/lib/src/view/clock/custom_clock_settings.dart
@@ -22,11 +22,13 @@ class CustomClockSettings extends StatefulWidget {
 class _CustomClockSettingsState extends State<CustomClockSettings> {
   late int time;
   late int increment;
+  late int delay;
 
   @override
   void initState() {
     time = widget.clock.time;
     increment = widget.clock.increment;
+    delay = widget.clock.delay;
     super.initState();
   }
 
@@ -36,15 +38,17 @@ class _CustomClockSettingsState extends State<CustomClockSettings> {
       padding: const EdgeInsets.symmetric(vertical: 16.0, horizontal: 8.0),
       children: [
         _PlayerTimeSlider(
-          clock: TimeIncrement(time, increment),
+          clock: TimeIncrement(time, increment, delay: delay),
           updateTime: (int t) => setState(() => time = t),
           updateIncrement: (int inc) => setState(() => increment = inc),
+          updateDelay: (int d) => setState(() => delay = d),
         ),
         Padding(
           padding: Styles.horizontalBodyPadding,
           child: FilledButton(
             child: Text(context.l10n.apply),
-            onPressed: () => widget.onSubmit(widget.player, TimeIncrement(time, increment)),
+            onPressed: () =>
+                widget.onSubmit(widget.player, TimeIncrement(time, increment, delay: delay)),
           ),
         ),
       ],
@@ -57,11 +61,13 @@ class _PlayerTimeSlider extends StatelessWidget {
     required this.clock,
     required this.updateTime,
     required this.updateIncrement,
+    required this.updateDelay,
   });
 
   final TimeIncrement clock;
   final void Function(int time) updateTime;
   final void Function(int time) updateIncrement;
+  final void Function(int delay) updateDelay;
 
   @override
   Widget build(BuildContext context) {
@@ -82,6 +88,13 @@ class _PlayerTimeSlider extends StatelessWidget {
           values: kAvailableIncrementsInSeconds,
           labelBuilder: (num sec) => sec.toString(),
           onChanged: updateIncrement,
+        ),
+        NonLinearSliderTile(
+          title: Text('Delay: ${context.l10n.nbSeconds(clock.delay)}'),
+          value: clock.delay,
+          values: kAvailableIncrementsInSeconds,
+          labelBuilder: (num sec) => sec.toString(),
+          onChanged: updateDelay,
         ),
       ],
     );

--- a/lib/src/view/play/create_game_widget.dart
+++ b/lib/src/view/play/create_game_widget.dart
@@ -59,6 +59,7 @@ class CreateGameWidget extends ConsumerWidget {
                       showModalBottomSheet<void>(
                         context: context,
                         isScrollControlled: true,
+                        clipBehavior: Clip.antiAlias,
                         constraints: BoxConstraints(maxHeight: screenHeight - (screenHeight / 10)),
                         builder: (BuildContext context) {
                           return TimeControlModal(

--- a/lib/src/view/play/time_control_modal.dart
+++ b/lib/src/view/play/time_control_modal.dart
@@ -145,68 +145,34 @@ class TimeControlModal extends StatelessWidget {
                         builder: (context, setState) {
                           return Column(
                             children: [
-                              ListTile(
+                              NonLinearSliderTile(
                                 contentPadding: EdgeInsets.zero,
-                                title: Text.rich(
-                                  TextSpan(
-                                    text: '${context.l10n.minutesPerSide}: ',
-                                    children: [
-                                      TextSpan(
-                                        style: const TextStyle(
-                                          fontWeight: FontWeight.bold,
-                                          fontSize: 18,
-                                        ),
-                                        text: clockLabelInMinutes(custom.time),
-                                      ),
-                                    ],
-                                  ),
+                                title: _SliderValueTitle(
+                                  '${context.l10n.minutesPerSide}: ',
+                                  clockLabelInMinutes(custom.time),
                                 ),
-                                subtitle: NonLinearSlider(
-                                  value: custom.time,
-                                  values: kAvailableTimesInSeconds,
-                                  labelBuilder: clockLabelInMinutes,
-                                  onChange: (num value) {
-                                    setState(() {
-                                      custom = TimeIncrement(value.toInt(), custom.increment);
-                                    });
-                                  },
-                                  onChangeEnd: (num value) {
-                                    setState(() {
-                                      custom = TimeIncrement(value.toInt(), custom.increment);
-                                    });
-                                  },
-                                ),
+                                value: custom.time,
+                                values: kAvailableTimesInSeconds,
+                                labelBuilder: clockLabelInMinutes,
+                                onChanged: (value) {
+                                  setState(() {
+                                    custom = TimeIncrement(value, custom.increment);
+                                  });
+                                },
                               ),
-                              ListTile(
+                              NonLinearSliderTile(
                                 contentPadding: EdgeInsets.zero,
-                                title: Text.rich(
-                                  TextSpan(
-                                    text: '${context.l10n.incrementInSeconds}: ',
-                                    children: [
-                                      TextSpan(
-                                        style: const TextStyle(
-                                          fontWeight: FontWeight.bold,
-                                          fontSize: 18,
-                                        ),
-                                        text: custom.increment.toString(),
-                                      ),
-                                    ],
-                                  ),
+                                title: _SliderValueTitle(
+                                  '${context.l10n.incrementInSeconds}: ',
+                                  custom.increment.toString(),
                                 ),
-                                subtitle: NonLinearSlider(
-                                  value: custom.increment,
-                                  values: kAvailableIncrementsInSeconds,
-                                  onChange: (num value) {
-                                    setState(() {
-                                      custom = TimeIncrement(custom.time, value.toInt());
-                                    });
-                                  },
-                                  onChangeEnd: (num value) {
-                                    setState(() {
-                                      custom = TimeIncrement(custom.time, value.toInt());
-                                    });
-                                  },
-                                ),
+                                value: custom.increment,
+                                values: kAvailableIncrementsInSeconds,
+                                onChanged: (value) {
+                                  setState(() {
+                                    custom = TimeIncrement(custom.time, value);
+                                  });
+                                },
                               ),
                               FilledButton(
                                 onPressed: custom.isInfinite ? null : () => onSelected(custom),
@@ -329,6 +295,29 @@ class _ChoiceChip extends StatelessWidget {
             ),
           ),
         ),
+      ),
+    );
+  }
+}
+
+/// A slider label of the form "`label`**`value`**" (bold value).
+class _SliderValueTitle extends StatelessWidget {
+  const _SliderValueTitle(this.label, this.value);
+
+  final String label;
+  final String value;
+
+  @override
+  Widget build(BuildContext context) {
+    return Text.rich(
+      TextSpan(
+        text: label,
+        children: [
+          TextSpan(
+            style: const TextStyle(fontWeight: FontWeight.bold, fontSize: 18),
+            text: value,
+          ),
+        ],
       ),
     );
   }

--- a/lib/src/view/play/time_control_modal.dart
+++ b/lib/src/view/play/time_control_modal.dart
@@ -14,6 +14,7 @@ class TimeControlModal extends StatelessWidget {
     required this.timeIncrement,
     required this.onSelected,
     this.excludeUltraBullet = false,
+    this.showDelay = false,
     super.key,
   });
 
@@ -21,6 +22,12 @@ class TimeControlModal extends StatelessWidget {
   final ValueSetter<TimeIncrement> onSelected;
 
   final bool excludeUltraBullet;
+
+  /// Whether to show a clock delay slider in the custom section.
+  ///
+  /// Only enabled for the local clock tool: lichess online play does not
+  /// support clock delay.
+  final bool showDelay;
 
   static const _horizontalPadding = EdgeInsets.symmetric(horizontal: 16.0);
   static const _sectionSpacing = SizedBox(height: 16.0);
@@ -156,7 +163,11 @@ class TimeControlModal extends StatelessWidget {
                                 labelBuilder: clockLabelInMinutes,
                                 onChanged: (value) {
                                   setState(() {
-                                    custom = TimeIncrement(value, custom.increment);
+                                    custom = TimeIncrement(
+                                      value,
+                                      custom.increment,
+                                      delay: custom.delay,
+                                    );
                                   });
                                 },
                               ),
@@ -170,10 +181,29 @@ class TimeControlModal extends StatelessWidget {
                                 values: kAvailableIncrementsInSeconds,
                                 onChanged: (value) {
                                   setState(() {
-                                    custom = TimeIncrement(custom.time, value);
+                                    custom = TimeIncrement(custom.time, value, delay: custom.delay);
                                   });
                                 },
                               ),
+                              if (showDelay)
+                                NonLinearSliderTile(
+                                  contentPadding: EdgeInsets.zero,
+                                  title: _SliderValueTitle(
+                                    'Delay in seconds: ',
+                                    custom.delay.toString(),
+                                  ),
+                                  value: custom.delay,
+                                  values: kAvailableIncrementsInSeconds,
+                                  onChanged: (value) {
+                                    setState(() {
+                                      custom = TimeIncrement(
+                                        custom.time,
+                                        custom.increment,
+                                        delay: value,
+                                      );
+                                    });
+                                  },
+                                ),
                               FilledButton(
                                 onPressed: custom.isInfinite ? null : () => onSelected(custom),
                                 child: Text(context.l10n.mobileOkButton, style: Styles.bold),

--- a/lib/src/widgets/non_linear_slider.dart
+++ b/lib/src/widgets/non_linear_slider.dart
@@ -1,5 +1,45 @@
 import 'package:flutter/material.dart';
 
+/// A [ListTile] pairing a [title] with a [NonLinearSlider] whose drag and
+/// drag-end callbacks both invoke [onChanged] with the selected value as an
+/// `int`.
+///
+/// Used by the time-control and clock settings sheets, where every slider
+/// updates its value identically on change and change-end.
+class NonLinearSliderTile extends StatelessWidget {
+  const NonLinearSliderTile({
+    required this.title,
+    required this.value,
+    required this.values,
+    required this.onChanged,
+    this.labelBuilder,
+    this.contentPadding,
+    super.key,
+  });
+
+  final Widget title;
+  final num value;
+  final List<num> values;
+  final ValueChanged<int> onChanged;
+  final String Function(num)? labelBuilder;
+  final EdgeInsetsGeometry? contentPadding;
+
+  @override
+  Widget build(BuildContext context) {
+    return ListTile(
+      contentPadding: contentPadding,
+      title: title,
+      subtitle: NonLinearSlider(
+        value: value,
+        values: values,
+        labelBuilder: labelBuilder,
+        onChange: (num value) => onChanged(value.toInt()),
+        onChangeEnd: (num value) => onChanged(value.toInt()),
+      ),
+    );
+  }
+}
+
 /// Platform adaptive slider that allows for non-linear values.
 class NonLinearSlider extends StatefulWidget {
   NonLinearSlider({

--- a/test/model/clock/chess_clock_test.dart
+++ b/test/model/clock/chess_clock_test.dart
@@ -140,6 +140,95 @@ void main() {
     });
   });
 
+  test('start delay holds the main clock until it elapses', () {
+    fakeAsync((async) {
+      final clock = ChessClock(
+        whiteTime: const Duration(seconds: 5),
+        blackTime: const Duration(seconds: 5),
+      );
+
+      clock.start(delay: const Duration(seconds: 3));
+      // The main clock is untouched during the delay window.
+      async.elapse(const Duration(milliseconds: 1500));
+      expect(clock.whiteTime.value, const Duration(seconds: 5));
+
+      // Once the delay elapses the main clock begins ticking down.
+      async.elapse(const Duration(seconds: 2));
+      expect(clock.whiteTime.value, lessThan(const Duration(seconds: 5)));
+
+      clock.stop();
+    });
+  });
+
+  test('switching sides into a new delay does not keep ticking the main clock', () {
+    fakeAsync((async) {
+      final clock = ChessClock(
+        whiteTime: const Duration(seconds: 60),
+        blackTime: const Duration(seconds: 60),
+      );
+
+      // First side plays through its delay and ticks the main clock a bit.
+      clock.startSide(Side.white, delay: const Duration(seconds: 3));
+      async.elapse(const Duration(seconds: 4)); // 3s delay + 1s of ticking
+      expect(clock.whiteTime.value, const Duration(seconds: 59));
+
+      // Switch to black with a fresh delay. During black's delay window the
+      // main clock (now black) must stay frozen and white must be untouched.
+      clock.startSide(Side.black, delay: const Duration(seconds: 3));
+      async.elapse(const Duration(seconds: 2)); // still within black's delay
+      expect(clock.blackTime.value, const Duration(seconds: 60));
+      expect(clock.whiteTime.value, const Duration(seconds: 59));
+
+      // After the delay elapses, only black ticks down.
+      async.elapse(const Duration(seconds: 2));
+      expect(clock.blackTime.value, lessThan(const Duration(seconds: 60)));
+      expect(clock.whiteTime.value, const Duration(seconds: 59));
+
+      clock.stop();
+    });
+  });
+
+  test('does not flag while the start delay is counting down', () {
+    fakeAsync((async) {
+      int flagCount = 0;
+      final clock = ChessClock(
+        whiteTime: const Duration(seconds: 1),
+        blackTime: const Duration(seconds: 1),
+        onFlag: () => flagCount++,
+      );
+      clock.start(delay: const Duration(seconds: 3));
+
+      // During the delay the (tiny) main clock is frozen and must not flag.
+      async.elapse(const Duration(seconds: 2));
+      expect(flagCount, 0);
+      expect(clock.whiteTime.value, const Duration(seconds: 1));
+
+      // Once the delay elapses, the main clock runs out and flags.
+      async.elapse(const Duration(seconds: 2));
+      expect(flagCount, greaterThan(0));
+
+      clock.stop();
+    });
+  });
+
+  test('pause() returns the remaining delay', () {
+    fakeAsync((async) {
+      final clock = ChessClock(
+        whiteTime: const Duration(seconds: 60),
+        blackTime: const Duration(seconds: 60),
+      );
+      clock.start(delay: const Duration(seconds: 3));
+      async.elapse(const Duration(seconds: 1));
+
+      // 2s of the 3s delay remain; the main clock is untouched and frozen.
+      final kept = clock.pause();
+      expect(kept, const Duration(seconds: 2));
+      expect(clock.whiteTime.value, const Duration(seconds: 60));
+      async.elapse(const Duration(seconds: 5));
+      expect(clock.whiteTime.value, const Duration(seconds: 60));
+    });
+  });
+
   test('increment times', () {
     fakeAsync((async) {
       final clock = ChessClock(

--- a/test/model/clock/clock_tool_controller_test.dart
+++ b/test/model/clock/clock_tool_controller_test.dart
@@ -1,0 +1,222 @@
+import 'package:fake_async/fake_async.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:lichess_mobile/src/model/clock/clock_tool_controller.dart';
+import 'package:lichess_mobile/src/model/common/time_increment.dart';
+
+import '../../test_container.dart';
+
+void main() {
+  group('ClockToolController options', () {
+    test('updateOptions applies delay to both sides', () async {
+      final container = await makeContainer();
+      // Keep the autoDispose provider alive for the duration of the test.
+      container.listen(clockToolControllerProvider, (_, _) {});
+      final controller = container.read(clockToolControllerProvider.notifier);
+
+      controller.updateOptions(const TimeIncrement(60, 0, delay: 3));
+
+      final options = container.read(clockToolControllerProvider).options;
+      expect(options.topDelay, const Duration(seconds: 3));
+      expect(options.bottomDelay, const Duration(seconds: 3));
+      expect(options.hasDelay(ClockSide.top), true);
+      expect(options.hasDelay(ClockSide.bottom), true);
+      expect(options.getDelay(ClockSide.top), const Duration(seconds: 3));
+    });
+
+    test('updateOptions with no delay reports no delay', () async {
+      final container = await makeContainer();
+      container.listen(clockToolControllerProvider, (_, _) {});
+      final controller = container.read(clockToolControllerProvider.notifier);
+
+      controller.updateOptions(const TimeIncrement(60, 0));
+
+      final options = container.read(clockToolControllerProvider).options;
+      expect(options.topDelay, Duration.zero);
+      expect(options.bottomDelay, Duration.zero);
+      expect(options.hasDelay(ClockSide.top), false);
+    });
+
+    test('updateOptionsCustom sets delay for only the given side', () async {
+      final container = await makeContainer();
+      container.listen(clockToolControllerProvider, (_, _) {});
+      final controller = container.read(clockToolControllerProvider.notifier);
+
+      controller.updateOptionsCustom(const TimeIncrement(60, 0, delay: 5), ClockSide.top);
+
+      final options = container.read(clockToolControllerProvider).options;
+      expect(options.topDelay, const Duration(seconds: 5));
+      expect(options.bottomDelay, Duration.zero);
+    });
+  });
+
+  group('ClockToolController delay behavior', () {
+    test('start defers the countdown by the configured delay', () async {
+      final container = await makeContainer();
+      fakeAsync((async) {
+        // Build the controller (and its ChessClock) inside the fake zone, and
+        // keep it alive so autoDispose doesn't cancel the clock on microtask flush.
+        container.listen(clockToolControllerProvider, (_, _) {});
+        final controller = container.read(clockToolControllerProvider.notifier);
+        controller.updateOptions(const TimeIncrement(60, 0, delay: 3));
+
+        // start(top) makes the bottom side active and starts its clock.
+        controller.start(ClockSide.top);
+
+        final state = container.read(clockToolControllerProvider);
+        // Within the 3s delay window the active clock must not tick down.
+        async.elapse(const Duration(seconds: 2));
+        expect(state.bottomTime.value, const Duration(seconds: 60));
+
+        // After the delay elapses the clock starts counting: at 4s total,
+        // ~1s has been consumed past the 3s delay.
+        async.elapse(const Duration(seconds: 2));
+        expect(state.bottomTime.value, const Duration(seconds: 59));
+
+        controller.pause();
+      });
+    });
+
+    test('without delay the countdown starts immediately', () async {
+      final container = await makeContainer();
+      fakeAsync((async) {
+        container.listen(clockToolControllerProvider, (_, _) {});
+        final controller = container.read(clockToolControllerProvider.notifier);
+        controller.updateOptions(const TimeIncrement(60, 0));
+
+        controller.start(ClockSide.top);
+
+        final state = container.read(clockToolControllerProvider);
+        async.elapse(const Duration(seconds: 2));
+        expect(state.bottomTime.value, const Duration(seconds: 58));
+
+        controller.pause();
+      });
+    });
+
+    test('resume after the delay has elapsed does not re-grant it', () async {
+      final container = await makeContainer();
+      fakeAsync((async) {
+        container.listen(clockToolControllerProvider, (_, _) {});
+        final controller = container.read(clockToolControllerProvider.notifier);
+        controller.updateOptions(const TimeIncrement(60, 0, delay: 3));
+
+        // Start and let the delay fully elapse so the main clock is ticking.
+        controller.start(ClockSide.top);
+        async.elapse(const Duration(seconds: 4));
+        final state = container.read(clockToolControllerProvider);
+        expect(state.bottomTime.value, const Duration(seconds: 59));
+
+        // Pause then resume: no fresh delay should be granted, and the main
+        // clock should keep counting immediately.
+        controller.pause();
+        controller.resume();
+
+        async.elapse(const Duration(seconds: 1));
+        expect(state.bottomTime.value, const Duration(seconds: 58));
+
+        controller.pause();
+      });
+    });
+
+    test('pausing mid-delay preserves and resumes the remaining delay', () async {
+      final container = await makeContainer();
+      fakeAsync((async) {
+        container.listen(clockToolControllerProvider, (_, _) {});
+        final controller = container.read(clockToolControllerProvider.notifier);
+        controller.updateOptions(const TimeIncrement(60, 0, delay: 3));
+
+        controller.start(ClockSide.top); // bottom becomes active, 3s delay
+        final state = container.read(clockToolControllerProvider);
+
+        // 1s into the delay (~2s remain), main clock untouched.
+        async.elapse(const Duration(seconds: 1));
+        expect(state.bottomTime.value, const Duration(seconds: 60));
+
+        // While paused, elapsing wall time does not move the main clock.
+        controller.pause();
+        async.elapse(const Duration(seconds: 5));
+        expect(state.bottomTime.value, const Duration(seconds: 60));
+
+        controller.resume();
+        // The remaining ~2s of delay must still pass before the main clock moves.
+        async.elapse(const Duration(seconds: 1));
+        expect(state.bottomTime.value, const Duration(seconds: 60));
+
+        // After the remaining delay elapses, the main clock finally ticks.
+        async.elapse(const Duration(seconds: 2));
+        expect(state.bottomTime.value, lessThan(const Duration(seconds: 60)));
+
+        controller.pause();
+      });
+    });
+
+    test('reset during a delay stops the clock', () async {
+      final container = await makeContainer();
+      fakeAsync((async) {
+        container.listen(clockToolControllerProvider, (_, _) {});
+        final controller = container.read(clockToolControllerProvider.notifier);
+        controller.updateOptions(const TimeIncrement(60, 0, delay: 3));
+
+        controller.start(ClockSide.top);
+        async.elapse(const Duration(seconds: 1));
+
+        controller.reset();
+        final resetState = container.read(clockToolControllerProvider);
+        expect(resetState.activeSide, isNull);
+
+        // The clock is stopped and back to full time.
+        async.elapse(const Duration(seconds: 2));
+        expect(resetState.bottomTime.value, const Duration(seconds: 60));
+      });
+    });
+
+    test('each side gets its own delay (asymmetric)', () async {
+      final container = await makeContainer();
+      fakeAsync((async) {
+        container.listen(clockToolControllerProvider, (_, _) {});
+        final controller = container.read(clockToolControllerProvider.notifier);
+        // Top has a 3s delay, bottom has none.
+        controller.updateOptionsCustom(const TimeIncrement(60, 0, delay: 3), ClockSide.top);
+        controller.updateOptionsCustom(const TimeIncrement(60, 0), ClockSide.bottom);
+
+        // start(top) makes the bottom side active: no delay, so it ticks at once.
+        controller.start(ClockSide.top);
+        final state = container.read(clockToolControllerProvider);
+        async.elapse(const Duration(seconds: 1));
+        expect(state.bottomTime.value, const Duration(seconds: 59));
+
+        // Tapping bottom hands over to top, which has a 3s delay: top is frozen.
+        controller.onTap(ClockSide.bottom);
+        async.elapse(const Duration(seconds: 2));
+        expect(state.topTime.value, const Duration(seconds: 60));
+
+        // After top's delay elapses it starts ticking.
+        async.elapse(const Duration(seconds: 2));
+        expect(state.topTime.value, lessThan(const Duration(seconds: 60)));
+
+        controller.pause();
+      });
+    });
+
+    test('onTap applies the delay to the newly active side', () async {
+      final container = await makeContainer();
+      fakeAsync((async) {
+        container.listen(clockToolControllerProvider, (_, _) {});
+        final controller = container.read(clockToolControllerProvider.notifier);
+        controller.updateOptions(const TimeIncrement(60, 0, delay: 3));
+
+        // Tapping the bottom player passes the turn: the top side becomes active.
+        controller.onTap(ClockSide.bottom);
+
+        final state = container.read(clockToolControllerProvider);
+        async.elapse(const Duration(seconds: 2));
+        expect(state.topTime.value, const Duration(seconds: 60));
+
+        async.elapse(const Duration(seconds: 2));
+        expect(state.topTime.value, const Duration(seconds: 59));
+
+        controller.pause();
+      });
+    });
+  });
+}

--- a/test/model/common/time_increment_test.dart
+++ b/test/model/common/time_increment_test.dart
@@ -7,16 +7,46 @@ void main() {
       const timeIncrement = TimeIncrement(300, 5);
       expect(timeIncrement.time, 300);
       expect(timeIncrement.increment, 5);
+      // delay defaults to 0 when omitted
+      expect(timeIncrement.delay, 0);
+    });
+
+    test('Initialization with delay', () {
+      const timeIncrement = TimeIncrement(300, 5, delay: 3);
+      expect(timeIncrement.time, 300);
+      expect(timeIncrement.increment, 5);
+      expect(timeIncrement.delay, 3);
+    });
+
+    test('fromDurations with delay', () {
+      final timeIncrement = TimeIncrement.fromDurations(
+        const Duration(minutes: 5),
+        const Duration(seconds: 5),
+        delay: const Duration(seconds: 3),
+      );
+      expect(timeIncrement.time, 300);
+      expect(timeIncrement.increment, 5);
+      expect(timeIncrement.delay, 3);
     });
 
     test('JSON Serialization', () {
-      final json = const TimeIncrement(300, 5).toJson();
+      final json = const TimeIncrement(300, 5, delay: 3).toJson();
       expect(json['time'], 300);
       expect(json['increment'], 5);
+      expect(json['delay'], 3);
 
       final newTimeIncrement = TimeIncrement.fromJson(json);
       expect(newTimeIncrement.time, 300);
       expect(newTimeIncrement.increment, 5);
+      expect(newTimeIncrement.delay, 3);
+    });
+
+    test('JSON deserialization is backward compatible (no delay key)', () {
+      // Persisted prefs from before the delay feature won't have a 'delay' key.
+      final timeIncrement = TimeIncrement.fromJson(const {'time': 300, 'increment': 5});
+      expect(timeIncrement.time, 300);
+      expect(timeIncrement.increment, 5);
+      expect(timeIncrement.delay, 0);
     });
 
     test('Display Strings', () {
@@ -42,6 +72,22 @@ void main() {
       expect(timeIncrement1, timeIncrement2);
       expect(timeIncrement1.hashCode, timeIncrement2.hashCode);
       expect(timeIncrement1, isNot(timeIncrement3));
+    });
+
+    test('Equality and HashCode account for delay', () {
+      const noDelay = TimeIncrement(300, 5);
+      const withDelay = TimeIncrement(300, 5, delay: 3);
+      const sameDelay = TimeIncrement(300, 5, delay: 3);
+
+      expect(noDelay.delay, 0);
+      expect(withDelay, isNot(noDelay));
+      expect(withDelay, sameDelay);
+      expect(withDelay.hashCode, sameDelay.hashCode);
+    });
+
+    test('toString includes delay only when non-zero', () {
+      expect(const TimeIncrement(300, 5).toString(), 'TimeIncrement(300+5)');
+      expect(const TimeIncrement(300, 5, delay: 3).toString(), 'TimeIncrement(300+5 d3)');
     });
 
     test('clockLabelInMinutes Function', () {

--- a/test/view/clock/clock_tool_screen_test.dart
+++ b/test/view/clock/clock_tool_screen_test.dart
@@ -1,0 +1,51 @@
+import 'package:flutter/widgets.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:lichess_mobile/src/model/clock/clock_tool_controller.dart';
+import 'package:lichess_mobile/src/model/common/time_increment.dart';
+import 'package:lichess_mobile/src/view/clock/clock_tool_screen.dart';
+
+import '../../test_provider_scope.dart';
+
+void main() {
+  group('ClockToolScreen delay chip', () {
+    testWidgets('shows a d{n} chip for each side when a delay is configured', (tester) async {
+      final app = await makeTestProviderScopeApp(tester, home: const ClockToolScreen());
+      await tester.pumpWidget(app);
+      await tester.pumpAndSettle();
+
+      // No delay by default.
+      expect(find.text('d5'), findsNothing);
+
+      final container = ProviderScope.containerOf(tester.element(find.byType(ClockToolScreen)));
+      container
+          .read(clockToolControllerProvider.notifier)
+          .updateOptions(const TimeIncrement(60, 0, delay: 5));
+      await tester.pumpAndSettle();
+
+      // One static chip per player tile (top and bottom).
+      expect(find.text('d5'), findsNWidgets(2));
+    });
+
+    testWidgets('shows no delay chip when only an increment is set', (tester) async {
+      final app = await makeTestProviderScopeApp(tester, home: const ClockToolScreen());
+      await tester.pumpWidget(app);
+      await tester.pumpAndSettle();
+
+      final container = ProviderScope.containerOf(tester.element(find.byType(ClockToolScreen)));
+      container
+          .read(clockToolControllerProvider.notifier)
+          .updateOptions(const TimeIncrement(60, 3));
+      await tester.pumpAndSettle();
+
+      // No 'd{n}' delay chip is rendered at all (only the '+3' increment chip).
+      expect(
+        find.byWidgetPredicate(
+          (w) => w is Text && w.data != null && RegExp(r'^d\d+$').hasMatch(w.data!),
+        ),
+        findsNothing,
+      );
+      expect(find.text('+3'), findsNWidgets(2));
+    });
+  });
+}

--- a/test/view/play/time_control_modal_test.dart
+++ b/test/view/play/time_control_modal_test.dart
@@ -1,0 +1,87 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:lichess_mobile/src/model/common/time_increment.dart';
+import 'package:lichess_mobile/src/view/play/time_control_modal.dart';
+import 'package:lichess_mobile/src/widgets/non_linear_slider.dart';
+
+import '../../test_provider_scope.dart';
+
+void main() {
+  group('TimeControlModal delay slider', () {
+    testWidgets('is hidden when showDelay is false', (tester) async {
+      // A non-preset time control keeps the custom section expanded.
+      final app = await makeTestProviderScopeApp(
+        tester,
+        home: Scaffold(
+          body: TimeControlModal(timeIncrement: const TimeIncrement(120, 4), onSelected: (_) {}),
+        ),
+      );
+      await tester.pumpWidget(app);
+      await tester.pumpAndSettle();
+
+      // Only the minutes and increment sliders, no delay slider.
+      expect(find.byType(NonLinearSlider), findsNWidgets(2));
+      expect(find.textContaining('Delay in seconds'), findsNothing);
+    });
+
+    testWidgets('is shown when showDelay is true', (tester) async {
+      final app = await makeTestProviderScopeApp(
+        tester,
+        home: Scaffold(
+          body: TimeControlModal(
+            timeIncrement: const TimeIncrement(600, 0, delay: 5),
+            showDelay: true,
+            onSelected: (_) {},
+          ),
+        ),
+      );
+      await tester.pumpWidget(app);
+      await tester.pumpAndSettle();
+
+      // Minutes, increment and delay sliders.
+      expect(find.byType(NonLinearSlider), findsNWidgets(3));
+      expect(find.textContaining('Delay in seconds'), findsOneWidget);
+    });
+
+    testWidgets('custom OK returns the configured delay', (tester) async {
+      TimeIncrement? selected;
+      final app = await makeTestProviderScopeApp(
+        tester,
+        home: Scaffold(
+          body: Builder(
+            builder: (context) => Center(
+              child: ElevatedButton(
+                onPressed: () => showModalBottomSheet<void>(
+                  context: context,
+                  isScrollControlled: true,
+                  builder: (_) => TimeControlModal(
+                    timeIncrement: const TimeIncrement(600, 0, delay: 5),
+                    showDelay: true,
+                    onSelected: (choice) => selected = choice,
+                  ),
+                ),
+                child: const Text('open'),
+              ),
+            ),
+          ),
+        ),
+      );
+      await tester.pumpWidget(app);
+      await tester.tap(find.text('open'));
+      await tester.pumpAndSettle();
+
+      // The custom section's only FilledButton is the confirm/OK button (avoid
+      // coupling to the translated label).
+      final okButton = find.byType(FilledButton);
+      await tester.ensureVisible(okButton);
+      await tester.pumpAndSettle();
+      await tester.tap(okButton);
+      await tester.pumpAndSettle();
+
+      expect(selected, isNotNull);
+      expect(selected!.time, 600);
+      expect(selected!.increment, 0);
+      expect(selected!.delay, 5);
+    });
+  });
+}


### PR DESCRIPTION
## Summary

Adds a **clock delay** (simple/US delay) option to the over-the-board clock tool. Each side can be given a delay that holds its main clock for that long before it starts counting down — so a move played within the delay window costs no time.

Delay is only offered in the **local clock tool**; lichess online play does not support it, so the time-control modal gates the delay slider behind a `showDelay` flag and online flows (lobby/challenge) are unaffected.

## What's included

- **Per-side delay**, configurable from each player's tune sheet, and **for both sides at once** via the shared time-control modal's Custom section (new "Delay in seconds" slider).
- A static **`d{n}` chip** shown before the game starts, indicating the configured delay.
- Delay **behaviour**: the active side's main clock is held for the delay before ticking; **pause/resume carries over** the remaining delay rather than restarting or discarding it.
- `TimeIncrement` gains a named `delay` field; `ChessClock` gains a `pause()` (split from `stop()`) that returns the remaining delay for carry-over.

## Incidental cleanup (separate commits)

- `fix(clock)`: clip the time-control bottom sheets to their rounded corners (scrolled content was bleeding past the corners).
- `refactor`: extract a shared `NonLinearSliderTile` widget to de-duplicate the time-control sliders.

## Testing

- Unit tests: `ChessClock` holding the main clock for the start delay, not flagging during the delay, and `pause()` returning the remaining delay; `ClockToolController` applying delay across start/onTap/resume/reset and per side.
- Widget tests: the time-control modal delay slider (shown only when enabled, OK carries the delay) and the clock-tool `d{n}` chip.
- `flutter analyze` and `dart format` clean.

## Demo

https://github.com/user-attachments/assets/48f6f380-adb8-46fc-8233-2aeb699dfa36

🤖 Generated with [Claude Code](https://claude.com/claude-code)
