### PR TITLE
Link usernames in the analysis summary table to user profiles

### DIFF
--- a/lib/src/view/analysis/analysis_screen.dart
+++ b/lib/src/view/analysis/analysis_screen.dart
@@ -344,6 +344,8 @@ class _Body extends ConsumerWidget {
               serverAnalysisSource: analysisState.serverAnalysisSource,
               playersAnalysis: analysisState.playersAnalysis,
               pgnHeaders: analysisState.pgnHeaders,
+              whiteUser: analysisState.archivedGame?.white.user,
+              blackUser: analysisState.archivedGame?.black.user,
               acplChartParams: analysisState.acplChartData != null
                   ? (
                       acplChartData: analysisState.acplChartData!,

--- a/lib/src/view/analysis/server_analysis.dart
+++ b/lib/src/view/analysis/server_analysis.dart
@@ -5,6 +5,7 @@ import 'package:lichess_mobile/src/model/analysis/analysis_preferences.dart';
 import 'package:lichess_mobile/src/model/analysis/server_analysis_service.dart';
 import 'package:lichess_mobile/src/model/auth/auth_controller.dart';
 import 'package:lichess_mobile/src/model/game/player.dart';
+import 'package:lichess_mobile/src/model/user/user.dart';
 import 'package:lichess_mobile/src/utils/l10n_context.dart';
 import 'package:lichess_mobile/src/widgets/acpl_chart.dart';
 import 'package:lichess_mobile/src/widgets/feedback.dart';
@@ -17,6 +18,8 @@ class ServerAnalysisSummary extends ConsumerWidget {
     required this.pgnHeaders,
     required this.acplChartParams,
     required this.onRequestServerAnalysis,
+    this.whiteUser,
+    this.blackUser,
     super.key,
   });
 
@@ -25,6 +28,10 @@ class ServerAnalysisSummary extends ConsumerWidget {
   final PlayersAnalysis? playersAnalysis;
 
   final IMap<String, String> pgnHeaders;
+
+  final LightUser? whiteUser;
+
+  final LightUser? blackUser;
 
   final AcplChartParams? acplChartParams;
 
@@ -70,7 +77,12 @@ class ServerAnalysisSummary extends ConsumerWidget {
                 ),
 
               if (acplChartParams != null) AcplChart(params: acplChartParams!),
-              GameSummaryTable(pgnHeaders: pgnHeaders, playersAnalysis: playersAnalysis!),
+              GameSummaryTable(
+                pgnHeaders: pgnHeaders,
+                playersAnalysis: playersAnalysis!,
+                whiteUser: whiteUser,
+                blackUser: blackUser,
+              ),
             ],
           )
         : Column(

--- a/lib/src/widgets/game_summary_table.dart
+++ b/lib/src/widgets/game_summary_table.dart
@@ -5,8 +5,10 @@ import 'package:fast_immutable_collections/fast_immutable_collections.dart';
 import 'package:flutter/cupertino.dart';
 import 'package:flutter/material.dart';
 import 'package:lichess_mobile/src/model/game/player.dart';
+import 'package:lichess_mobile/src/model/user/user.dart';
 import 'package:lichess_mobile/src/styles/styles.dart';
 import 'package:lichess_mobile/src/utils/l10n_context.dart';
+import 'package:lichess_mobile/src/view/user/user_or_profile_screen.dart';
 import 'package:url_launcher/url_launcher.dart';
 
 /// A reusable table displaying game summary with player names, result, and analysis statistics.
@@ -14,13 +16,25 @@ import 'package:url_launcher/url_launcher.dart';
 /// Shows player names, game result, accuracy, inaccuracies, mistakes, blunders, and ACPL
 /// in a formatted table layout.
 class GameSummaryTable extends StatelessWidget {
-  const GameSummaryTable({required this.pgnHeaders, required this.playersAnalysis, super.key});
+  const GameSummaryTable({
+    required this.pgnHeaders,
+    required this.playersAnalysis,
+    this.whiteUser,
+    this.blackUser,
+    super.key,
+  });
 
   /// PGN headers containing player names, titles, and result
   final IMap<String, String> pgnHeaders;
 
   /// White and Black player's analysis summary
   final PlayersAnalysis playersAnalysis;
+
+  /// White player's lichess user, when known
+  final LightUser? whiteUser;
+
+  /// Black player's lichess user, when known
+  final LightUser? blackUser;
 
   @override
   Widget build(BuildContext context) {
@@ -47,11 +61,11 @@ class GameSummaryTable extends StatelessWidget {
                   border: Border(bottom: BorderSide(color: Colors.grey)),
                 ),
                 children: [
-                  _SummaryPlayerName(.white, pgnHeaders),
+                  _SummaryPlayerName(.white, pgnHeaders, whiteUser),
                   Center(
                     child: Text(result, style: const TextStyle(fontWeight: .bold)),
                   ),
-                  _SummaryPlayerName(.black, pgnHeaders),
+                  _SummaryPlayerName(.black, pgnHeaders, blackUser),
                 ],
               ),
 
@@ -147,9 +161,10 @@ class _SummaryNumber extends StatelessWidget {
 }
 
 class _SummaryPlayerName extends StatelessWidget {
-  const _SummaryPlayerName(this.side, this.pgnHeaders);
+  const _SummaryPlayerName(this.side, this.pgnHeaders, this.user);
   final Side side;
   final IMap<String, String> pgnHeaders;
+  final LightUser? user;
 
   @override
   Widget build(BuildContext context) {
@@ -161,6 +176,29 @@ class _SummaryPlayerName extends StatelessWidget {
         : pgnHeaders.get('Black') ?? context.l10n.black;
 
     final brightness = Theme.of(context).brightness;
+
+    final nameText = Text.rich(
+      TextSpan(
+        children: [
+          if (playerTitle != null)
+            TextSpan(
+              text: '$playerTitle ',
+              style: TextStyle(
+                fontWeight: .bold,
+                color: playerTitle == 'BOT'
+                    ? context.lichessColors.fancy
+                    : context.lichessColors.brag,
+              ),
+            ),
+          TextSpan(
+            text: playerName,
+            style: const TextStyle(fontWeight: .bold),
+          ),
+        ],
+      ),
+      textAlign: .center,
+      softWrap: true,
+    );
 
     return TableCell(
       verticalAlignment: .top,
@@ -179,28 +217,13 @@ class _SummaryPlayerName extends StatelessWidget {
                     : CupertinoIcons.circle,
                 size: 14,
               ),
-              Text.rich(
-                TextSpan(
-                  children: [
-                    if (playerTitle != null)
-                      TextSpan(
-                        text: '$playerTitle ',
-                        style: TextStyle(
-                          fontWeight: .bold,
-                          color: playerTitle == 'BOT'
-                              ? context.lichessColors.fancy
-                              : context.lichessColors.brag,
-                        ),
-                      ),
-                    TextSpan(
-                      text: playerName,
-                      style: const TextStyle(fontWeight: .bold),
-                    ),
-                  ],
-                ),
-                textAlign: .center,
-                softWrap: true,
-              ),
+              if (user != null)
+                GestureDetector(
+                  onTap: () => Navigator.of(context).push(UserOrProfileScreen.buildRoute(user!)),
+                  child: nameText,
+                )
+              else
+                nameText,
             ],
           ),
         ),


### PR DESCRIPTION
## Problem

On the analysis board's **Analysis tab**, the two player usernames at the top of the summary table (Accuracy / Inaccuracies / Mistakes / Blunders) are rendered as plain text. The usernames shown above and below the board are links to the user's profile page, so the summary-table names should behave the same way.

Fixes #1547 (see [this comment](https://github.com/lichess-org/mobile/issues/1547#issuecomment-4710951805)).

## Changes

- **`game_summary_table.dart`**: added optional `whiteUser` / `blackUser` (`LightUser?`) params. When a side's user is known, its name is wrapped in a `GestureDetector` that pushes `UserOrProfileScreen.buildRoute(user)` — the same navigation used by the board header/footer `_PlayerWidget`. When the user is null, the name renders as plain text exactly as before.
- **`server_analysis.dart`**: threads `whiteUser` / `blackUser` through `ServerAnalysisSummary` into the table.
- **`analysis_screen.dart`**: passes `archivedGame?.white.user` / `archivedGame?.black.user` into `ServerAnalysisSummary`.

## Notes

- Links use the authoritative `LightUser` from the archived game (the same source the board header/footer uses), rather than reconstructing one from the PGN name string. So links appear only for real lichess accounts — anonymous/AI players stay as plain text, consistent with the board header/footer.
- The broadcast summary table reuses `GameSummaryTable` but passes no users, so its (often non-lichess FIDE) player names correctly remain plain text.
- `flutter analyze` and `dart format` are clean.

## Demo

[Screen_recording_20260615_172757.webm](https://github.com/user-attachments/assets/204925d2-70c8-4a18-9a6d-a7c6c9b9d683)


🤖 Generated with [Claude Code](https://claude.com/claude-code)