### PR TITLE
Fix OTB clock continuing to run after game-ending move

### DIFF
--- a/lib/src/view/over_the_board/over_the_board_screen.dart
+++ b/lib/src/view/over_the_board/over_the_board_screen.dart
@@ -267,9 +267,12 @@ class _BodyState extends ConsumerState<_Body> {
                       lastMove: gameState.lastMove,
                       onMove: (move, {viaDragAndDrop}) {
                         ref.read(overTheBoardGameControllerProvider.notifier).makeMove(move);
-                        ref
-                            .read(overTheBoardClockProvider.notifier)
-                            .onMove(newSideToMove: gameState.turn.opposite);
+                        // Don't restart the clock on a game-ending move, or it keeps running.
+                        if (!ref.read(overTheBoardGameControllerProvider).finished) {
+                          ref
+                              .read(overTheBoardClockProvider.notifier)
+                              .onMove(newSideToMove: gameState.turn.opposite);
+                        }
                       },
                     ),
                     moves: gameState.moves,

--- a/test/view/over_the_board/over_the_board_screen_test.dart
+++ b/test/view/over_the_board/over_the_board_screen_test.dart
@@ -84,6 +84,28 @@ void main() {
       expect(activeClock(tester), null);
     });
 
+    testWidgets('Clock stops after checkmate when dismissing the result dialog', (tester) async {
+      // Regression test for https://github.com/lichess-org/mobile/issues/3346
+      await initOverTheBoardGame(tester, const TimeIncrement(60, 5));
+
+      // Fool's mate: 1. f3 e6 2. g4 Qh4#
+      await playMove(tester, 'f2', 'f3');
+      await playMove(tester, 'e7', 'e6');
+      await playMove(tester, 'g2', 'g4');
+      await playMove(tester, 'd8', 'h4');
+
+      await tester.pumpAndSettle(const Duration(milliseconds: 600));
+      expect(find.text('Checkmate • Black is victorious'), findsOneWidget);
+      expect(activeClock(tester), null);
+
+      // Dismiss the dialog by tapping the barrier instead of using Rematch.
+      await tester.tapAt(const Offset(10, 10));
+      await tester.pumpAndSettle();
+
+      expect(find.text('Checkmate • Black is victorious'), findsNothing);
+      expect(activeClock(tester), null);
+    });
+
     testWidgets('Game ends when out of time', (tester) async {
       const time = Duration(seconds: 1);
       await initOverTheBoardGame(tester, TimeIncrement(time.inSeconds, 0));


### PR DESCRIPTION
## Problem

Fixes #3346

In over-the-board (pass-and-play) mode, the clock keeps running after a game ends by checkmate once the result dialog is dismissed by tapping outside it.

## Cause

The board's `onMove` handler restarted the clock on **every** move via `clock.onMove` → `switchSide()`, including the move that ends the game. `switchSide()` only guards against infinite time and a flagged clock — not against the game being finished — so the mating move re-started the stopwatch for the other side. The finished-game listener's `pause()` then raced that freshly-started stopwatch and lost, leaving the clock running.

## Fix

Skip restarting the clock when the move finishes the game, so the finished-game listener reliably freezes it. This also covers stalemate and variant-end, not just checkmate. The flag/out-of-time and threefold-repetition paths are unaffected (they don't go through `onMove`).

## Testing

[Screen_recording_20260617_165347.webm](https://github.com/user-attachments/assets/2055b65b-f4e1-4b67-b6a0-a8f9c0eb704b)

Added a regression test (`Clock stops after checkmate when dismissing the result dialog`) using `1. f3 e6 2. g4 Qh4#` that dismisses the dialog via the barrier and asserts the clock is no longer active. Verified it fails without the fix and passes with it; all OTB screen tests pass. Also manually verified on an Android emulator.

🤖 Generated with [Claude Code](https://claude.com/claude-code)