### PR TITLE
Sort language picker by native name

### DIFF
--- a/lib/src/utils/l10n.dart
+++ b/lib/src/utils/l10n.dart
@@ -191,3 +191,11 @@ String localeToLocalizedName(Locale locale) => switch (locale) {
   Locale(languageCode: 'zu') => 'isiZulu',
   _ => locale.toString(),
 };
+
+/// Returns the given [locales] sorted alphabetically by their localized
+/// (native) name, following Unicode ordering.
+///
+/// This groups locales written in the same script together, instead of the
+/// default ordering by language code.
+List<Locale> localesSortedByLocalizedName(Iterable<Locale> locales) =>
+    [...locales]..sort((a, b) => localeToLocalizedName(a).compareTo(localeToLocalizedName(b)));

--- a/lib/src/view/settings/settings_screen.dart
+++ b/lib/src/view/settings/settings_screen.dart
@@ -148,7 +148,7 @@ class SettingsScreen extends ConsumerWidget {
                   if (Theme.of(context).platform == TargetPlatform.android) {
                     showChoicePicker<Locale>(
                       context,
-                      choices: AppLocalizations.supportedLocales,
+                      choices: localesSortedByLocalizedName(AppLocalizations.supportedLocales),
                       selectedItem: generalPrefs.locale ?? Localizations.localeOf(context),
                       labelBuilder: (t) => Text(localeToLocalizedName(t)),
                       onSelectedItemChanged: (Locale? locale) =>

--- a/test/utils/l10n_test.dart
+++ b/test/utils/l10n_test.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/widgets.dart';
 import 'package:flutter_test/flutter_test.dart';
 
+import 'package:lichess_mobile/l10n/l10n.dart';
 import 'package:lichess_mobile/src/utils/l10n.dart';
 
 void main() {
@@ -47,6 +48,43 @@ void main() {
       expect((children[0] as TextSpan).style?.fontWeight, FontWeight.bold);
       expect((children[1] as WidgetSpan).child, widget);
       expect((children[2] as TextSpan).style?.fontWeight, FontWeight.bold);
+    });
+  });
+
+  group('localesSortedByLocalizedName', () {
+    test('sorts by native name, grouping scripts together', () {
+      const locales = [
+        Locale('ru'), // русский язык (Cyrillic)
+        Locale('en'), // English (Latin)
+        Locale('ko'), // 한국어 (Hangul)
+        Locale('fr'), // Français (Latin)
+        Locale('ar'), // العربية (Arabic)
+      ];
+
+      final sorted = localesSortedByLocalizedName(locales);
+
+      // Unicode ordering: Latin, then Cyrillic (U+04xx), Arabic (U+06xx), Hangul.
+      expect(sorted.map(localeToLocalizedName).toList(), [
+        'English',
+        'Français',
+        'русский язык',
+        'العربية',
+        '한국어',
+      ]);
+    });
+
+    test('does not mutate the input list', () {
+      const locales = [Locale('ru'), Locale('en')];
+      localesSortedByLocalizedName(locales);
+      expect(locales, const [Locale('ru'), Locale('en')]);
+    });
+
+    test('all supported locales are sorted by their localized name', () {
+      final sorted = localesSortedByLocalizedName(AppLocalizations.supportedLocales);
+      final names = sorted.map(localeToLocalizedName).toList();
+      final expected = [...names]..sort();
+      expect(names, expected);
+      expect(sorted.length, AppLocalizations.supportedLocales.length);
     });
   });
 }


### PR DESCRIPTION
## What

Sorts the language selector (Settings → Language) by each locale's **native display name** using Unicode ordering, instead of the current ordering by two-letter language code.

## Why

Closes #3341.

Ordering by language code interleaves different scripts (Latin, Cyrillic, Arabic, CJK), making languages hard to find. Sorting by native name groups similar scripts together and is far easier to scan. This mirrors the website's behavior from lichess-org/lila#20660, where the language list is ordered by native name.

## How

- Added `localesSortedByLocalizedName(...)` next to `localeToLocalizedName` in `lib/src/utils/l10n.dart`, which sorts locales by their localized name with a plain `String.compareTo` (Unicode/code-unit order — no ICU collator needed, matching the issue's request).
- The Android language picker in `settings_screen.dart` now feeds the sorted list into `showChoicePicker`. (iOS opens the system locale settings, so there's no in-app list to sort there.)

## Tests

Added unit tests in `test/utils/l10n_test.dart` covering: native-name ordering across scripts, that the input list is not mutated, and that all supported locales come back in sorted order.

[language ordering.webm](https://github.com/user-attachments/assets/16fd170d-2c3b-4252-9eab-c42a6eb88cb8)

🤖 Generated with [Claude Code](https://claude.com/claude-code)