### PR TITLE
Open patron page in external browser

### DIFF
--- a/lib/src/utils/launch.dart
+++ b/lib/src/utils/launch.dart
@@ -1,0 +1,13 @@
+import 'package:url_launcher/url_launcher.dart';
+
+const _patronUri = 'https://lichess.org/patron';
+
+typedef UrlLauncher = Future<bool> Function(Uri uri, LaunchMode mode);
+
+Future<bool> launchPatronPage({UrlLauncher? launcher}) {
+  return (launcher ?? _launchUrl)(Uri.parse(_patronUri), LaunchMode.externalApplication);
+}
+
+Future<bool> _launchUrl(Uri uri, LaunchMode mode) {
+  return launchUrl(uri, mode: mode);
+}

--- a/lib/src/view/account/account_menu.dart
+++ b/lib/src/view/account/account_menu.dart
@@ -14,6 +14,7 @@ import 'package:lichess_mobile/src/styles/lichess_icons.dart';
 import 'package:lichess_mobile/src/styles/styles.dart';
 import 'package:lichess_mobile/src/utils/http_network_image.dart';
 import 'package:lichess_mobile/src/utils/l10n_context.dart';
+import 'package:lichess_mobile/src/utils/launch.dart';
 import 'package:lichess_mobile/src/utils/lichess_assets.dart';
 import 'package:lichess_mobile/src/utils/navigation.dart';
 import 'package:lichess_mobile/src/view/account/profile_screen.dart';
@@ -237,7 +238,7 @@ class _AccountMenuScreenState extends ConsumerState<AccountMenuScreen> with Widg
                   ),
                   title: Text(context.l10n.patronDonate),
                   enabled: isOnline,
-                  onTap: () => launchUrl(Uri.parse('https://lichess.org/patron')),
+                  onTap: () => launchPatronPage(),
                 ),
               ListTile(
                 leading: const Icon(Icons.info_outline),

--- a/lib/src/view/home/home_tab_screen.dart
+++ b/lib/src/view/home/home_tab_screen.dart
@@ -32,6 +32,7 @@ import 'package:lichess_mobile/src/utils/focus_detector.dart';
 import 'package:lichess_mobile/src/utils/image.dart';
 import 'package:lichess_mobile/src/utils/l10n.dart';
 import 'package:lichess_mobile/src/utils/l10n_context.dart';
+import 'package:lichess_mobile/src/utils/launch.dart';
 import 'package:lichess_mobile/src/utils/navigation.dart';
 import 'package:lichess_mobile/src/utils/screen.dart';
 import 'package:lichess_mobile/src/view/account/account_menu.dart';
@@ -192,9 +193,7 @@ class _HomeScreenState extends ConsumerState<HomeTabScreen> {
                   (authUser == null || authUser.user.isPatron != true)) ...[
                 Center(
                   child: FilledButton.tonal(
-                    onPressed: () {
-                      launchUrl(Uri.parse('https://lichess.org/patron'));
-                    },
+                    onPressed: () => launchPatronPage(),
                     child: Text(context.l10n.patronDonate),
                   ),
                 ),

--- a/lib/src/view/more/more_tab_screen.dart
+++ b/lib/src/view/more/more_tab_screen.dart
@@ -12,6 +12,7 @@ import 'package:lichess_mobile/src/network/connectivity.dart';
 import 'package:lichess_mobile/src/styles/styles.dart';
 import 'package:lichess_mobile/src/tab_scaffold.dart';
 import 'package:lichess_mobile/src/utils/l10n_context.dart';
+import 'package:lichess_mobile/src/utils/launch.dart';
 import 'package:lichess_mobile/src/view/account/account_menu.dart';
 import 'package:lichess_mobile/src/view/account/profile_screen.dart';
 import 'package:lichess_mobile/src/view/analysis/analysis_screen.dart';
@@ -28,7 +29,6 @@ import 'package:lichess_mobile/src/widgets/misc.dart';
 import 'package:lichess_mobile/src/widgets/platform.dart';
 import 'package:lichess_mobile/src/widgets/settings.dart';
 import 'package:lichess_mobile/src/widgets/user.dart';
-import 'package:url_launcher/url_launcher.dart';
 
 class MoreTabScreen extends ConsumerWidget {
   const MoreTabScreen({super.key});
@@ -182,9 +182,7 @@ class _Body extends ConsumerWidget {
                   title: Text(context.l10n.patronDonate),
                   subtitle: Text(context.l10n.patronBecomePatron),
                   enabled: isOnline,
-                  onTap: () {
-                    launchUrl(Uri.parse('https://lichess.org/patron'));
-                  },
+                  onTap: () => launchPatronPage(),
                 ),
                 ListTile(
                   leading: const Icon(Icons.info_outline),

--- a/test/utils/launch_test.dart
+++ b/test/utils/launch_test.dart
@@ -1,0 +1,23 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:lichess_mobile/src/utils/launch.dart';
+import 'package:url_launcher/url_launcher.dart';
+
+void main() {
+  test('launchPatronPage opens the patron page externally', () async {
+    Uri? launchedUri;
+    LaunchMode? launchMode;
+
+    expect(
+      await launchPatronPage(
+        launcher: (uri, mode) async {
+          launchedUri = uri;
+          launchMode = mode;
+          return true;
+        },
+      ),
+      true,
+    );
+    expect(launchedUri, Uri.parse('https://lichess.org/patron'));
+    expect(launchMode, LaunchMode.externalApplication);
+  });
+}


### PR DESCRIPTION
## Summary
- Add a shared patron page launcher that requests the external application launch mode.
- Use it from the Android donation entry points so the donation thank-you page is not kept on top of the app task.

Fixes #3345

## Testing
- `flutter analyze lib/src/utils/launch.dart lib/src/view/home/home_tab_screen.dart lib/src/view/more/more_tab_screen.dart lib/src/view/account/account_menu.dart test/utils/launch_test.dart`
- `flutter test test/utils/launch_test.dart`