### PR TITLE
Add new "Move on release" board setting

### DIFF
--- a/lib/src/model/settings/board_preferences.dart
+++ b/lib/src/model/settings/board_preferences.dart
@@ -56,6 +56,10 @@ class BoardPreferences extends Notifier<BoardPrefs> with PreferencesStorage<Boar
     await save(state.copyWith(pieceShiftMethod: pieceShiftMethod));
   }
 
+  Future<void> toggleMoveOnRelease() async {
+    await save(state.copyWith(moveOnRelease: !state.moveOnRelease));
+  }
+
   Future<void> setCastlingMethod(CastlingMethod castlingMethod) {
     return save(state.copyWith(castlingMethod: castlingMethod));
   }
@@ -157,6 +161,7 @@ sealed class BoardPrefs with _$BoardPrefs implements Serializable {
     required LandscapeBoardPosition landscapeBoardPosition,
     @JsonKey(defaultValue: PieceShiftMethod.either, unknownEnumValue: PieceShiftMethod.either)
     required PieceShiftMethod pieceShiftMethod,
+    @JsonKey(defaultValue: false) required bool moveOnRelease,
     @JsonKey(
       defaultValue: CastlingMethod.kingOverRook,
       unknownEnumValue: CastlingMethod.kingOverRook,
@@ -194,6 +199,7 @@ sealed class BoardPrefs with _$BoardPrefs implements Serializable {
     premoves: true,
     confirmResignAndDraw: true,
     pieceShiftMethod: PieceShiftMethod.either,
+    moveOnRelease: false,
     castlingMethod: CastlingMethod.kingOverRook,
     enableShapeDrawings: true,
     magnifyDraggedPiece: true,
@@ -224,6 +230,7 @@ sealed class BoardPrefs with _$BoardPrefs implements Serializable {
       dragFeedbackOffset: Offset(0.0, magnifyDraggedPiece ? -1.0 : 0.0),
       dragTargetKind: dragTargetKind,
       pieceShiftMethod: pieceShiftMethod,
+      moveOnRelease: moveOnRelease,
       drawShape: DrawShapeOptions(enable: enableShapeDrawings, newShapeColor: shapeColor.color),
       enableDrops: variant == Variant.crazyhouse,
       canPromoteToKing: variant == Variant.antichess,

--- a/lib/src/view/settings/board_settings_screen.dart
+++ b/lib/src/view/settings/board_settings_screen.dart
@@ -233,6 +233,19 @@ class _Body extends ConsumerWidget {
                 );
               },
             ),
+            SwitchSettingTile(
+              // TODO l10n
+              title: const Text('Move on release'),
+              subtitle: const Text(
+                'When moving a piece by tapping, the move is made when you lift '
+                'your finger, letting you slide to change the destination square.',
+                maxLines: 5,
+              ),
+              value: boardPrefs.moveOnRelease,
+              onChanged: (value) {
+                ref.read(boardPreferencesProvider.notifier).toggleMoveOnRelease();
+              },
+            ),
             SettingsListTile(
               settingsLabel: Text(
                 context.l10n.preferencesCastleByMovingTheKingTwoSquaresOrOntoTheRook,


### PR DESCRIPTION
This pull request introduces a new "Move on release" setting to the board preferences, allowing users to control whether a chess move is made immediately on tap or only when they release their finger, providing more flexibility in move input.

* Added a `SwitchSettingTile` to the board settings screen, allowing users to enable or disable the "Move on release" feature with an explanatory subtitle.