### PR TITLE
[codex] Fix manual iOS build workflow

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -7,7 +7,7 @@ permissions: read-all
 jobs:
   build:
     name: Build ${{ matrix.target }}
-    runs-on: macos-latest
+    runs-on: macos-26
     strategy:
       fail-fast: false
       matrix:

--- a/ios/Runner.xcodeproj/project.pbxproj
+++ b/ios/Runner.xcodeproj/project.pbxproj
@@ -455,7 +455,7 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
-			shellScript = "if [[ \"$PLATFORM_NAME\" == *simulator* ]]; then\n  echo \"Skipping Crashlytics upload for simulator build\"\n  exit 0\nfi\n\"$PODS_ROOT/FirebaseCrashlytics/upload-symbols\" --flutter-project \"$PROJECT_DIR/firebase_app_id_file.json\" ";
+			shellScript = "if [[ \"$PLATFORM_NAME\" == *simulator* ]]; then\n  echo \"Skipping Crashlytics upload for simulator build\"\n  exit 0\nfi\nUPLOAD_SYMBOLS=\"$PODS_ROOT/FirebaseCrashlytics/upload-symbols\"\nif [[ ! -x \"$UPLOAD_SYMBOLS\" ]]; then\n  echo \"Skipping Crashlytics upload; upload-symbols not found at $UPLOAD_SYMBOLS\"\n  exit 0\nfi\n\"$UPLOAD_SYMBOLS\" --flutter-project \"$PROJECT_DIR/firebase_app_id_file.json\" ";
 		};
 		87319253AF8B73E944EEC4D0 /* [CP] Check Pods Manifest.lock */ = {
 			isa = PBXShellScriptBuildPhase;


### PR DESCRIPTION
## Summary

Fix the manual `Builds` workflow so `flutter build ios --no-codesign` passes on GitHub-hosted macOS runners again.

## Motivation

A manual baseline run against clean upstream `main` reproduced the current iOS build failure before this change:

- Baseline run: https://github.com/MichaelSpece/mobile/actions/runs/27955673530
- Failure: `connectivity_plus-7.1.1` references `NWPath.isUltraConstrained`, which is unavailable on the `macos-latest` runner image used by the workflow.

This is separate from #3316 and from the requested installable Android artifact work in #3337. It makes the existing manual build workflow healthy first, so #3337 can later add APK artifact upload without being mixed with an iOS runner repair.

## Changes

- Run the manual `Builds` workflow on `macos-26`.
- Guard the Crashlytics upload-symbols phase so no-codesign/manual CI builds skip symbol upload when the helper script is absent.

## Validation

Validation run on this branch: https://github.com/MichaelSpece/mobile/actions/runs/27959590265

- `Build ios --no-codesign`: passed
- `Build appbundle --debug`: passed
