### PR TITLE
fix list length when lichess account is filtered out

### DIFF
--- a/lib/src/view/home/following_carousel.dart
+++ b/lib/src/view/home/following_carousel.dart
@@ -109,7 +109,7 @@ class _FollowingWidgetState extends ConsumerState<FollowingCarousel> {
                 child: ListView.separated(
                   scrollDirection: Axis.horizontal,
                   padding: const EdgeInsets.symmetric(horizontal: 16.0, vertical: 3.0),
-                  itemCount: users.length,
+                  itemCount: sortedUsers.length,
                   separatorBuilder: (context, index) => const SizedBox(width: 10),
                   itemBuilder: (context, index) {
                     final friend = sortedUsers[index];


### PR DESCRIPTION
calculates the item count correctly when the lichess user is filtered out.