### PR TITLE
Use refresh icon for New Streak button in puzzle streak

### DIFF
--- a/lib/src/view/puzzle/streak_screen.dart
+++ b/lib/src/view/puzzle/streak_screen.dart
@@ -555,7 +555,7 @@ class _BottomBar extends ConsumerWidget {
                 : null,
             highlighted: true,
             label: context.l10n.puzzleNewStreak,
-            icon: CupertinoIcons.play_arrow_solid,
+            icon: Icons.refresh,
           ),
       ],
     );


### PR DESCRIPTION
When using puzzle streak, I was really confused by the "Play" icon. I kept clicking it when I didn't mean to. I feel like a refresh icon would be less ambiguous that I am going to start a new session.

I've tested the change in Android Studio
