### PR TITLE
Remove flutter_secure_storage_linux override, fix is upstream

### DIFF
--- a/pubspec.lock
+++ b/pubspec.lock
@@ -660,14 +660,13 @@ packages:
     source: hosted
     version: "0.3.2"
   flutter_secure_storage_linux:
-    dependency: "direct overridden"
+    dependency: transitive
     description:
-      path: flutter_secure_storage_linux
-      ref: "v10.0.0-beta.4-literal_operator_fix"
-      resolved-ref: b24fada37569fc042b01205dfbb9cd46d837b4fc
-      url: "https://github.com/christianfl/flutter_secure_storage.git"
-    source: git
-    version: "2.0.0"
+      name: flutter_secure_storage_linux
+      sha256: a5f35ddab43cf5c8215d2feb4ce1957851f28c5c37e6f04335066a0602087bf5
+      url: "https://pub.dev"
+    source: hosted
+    version: "3.0.1"
   flutter_secure_storage_platform_interface:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -92,13 +92,6 @@ dev_dependencies:
   stream_channel: ^2.1.4
   wakelock_plus_platform_interface: ^1.5.1
 
-dependency_overrides:
-  flutter_secure_storage_linux:
-    git:
-      url: https://github.com/christianfl/flutter_secure_storage.git
-      path: flutter_secure_storage_linux
-      ref: v10.0.0-beta.4-literal_operator_fix
-
 flutter:
   # The following line ensures that the Material Icons font is
   # included with your application, so that you can use the icons in


### PR DESCRIPTION
The flutter_secure_storage_linux: 2.0.0 from the hosted pub.dev version already includes the literal operator fix (https://github.com/juliansteenbakker/flutter_secure_storage/pull/923/changes), so the git override to christianfl/flutter_secure_storage.git branch v10.0.0-beta.4-literal_operator_fix is no longer needed.