### PR TITLE
chore: update Flutter 3.44.3 & deps, use private named parameters

### DIFF
--- a/lib/src/model/engine/evaluation_service.dart
+++ b/lib/src/model/engine/evaluation_service.dart
@@ -62,8 +62,7 @@ final evaluationServiceProvider = Provider<EvaluationService>((Ref ref) {
 /// can run at a time - when a new evaluation is requested, it takes over from any
 /// previous one ("last caller wins").
 class EvaluationService {
-  EvaluationService({required this.maxMemory, required NnueService nnueService})
-    : _nnueService = nnueService {
+  EvaluationService({required this.maxMemory, required this._nnueService}) {
     _stdoutSubscription = _stockfish.stdout.listen(_protocol.received);
     _stockfish.state.addListener(_onStockfishStateChange);
     _protocol.isComputing.addListener(_onComputingChange);

--- a/lib/src/network/http.dart
+++ b/lib/src/network/http.dart
@@ -472,7 +472,7 @@ class LichessClient implements Client {
 /// * Sets the user-agent header with the app version, build number, and device info.
 /// * Logs all requests and responses with status code >= 400.
 class DefaultClient implements Client {
-  DefaultClient(this._inner, {required String userAgent}) : _userAgent = userAgent;
+  DefaultClient(this._inner, {required this._userAgent});
 
   final Client _inner;
   final String _userAgent;

--- a/lib/src/view/broadcast/broadcast_carousel.dart
+++ b/lib/src/view/broadcast/broadcast_carousel.dart
@@ -304,8 +304,7 @@ final Map<String, _CardColors?> _colorsCache = {};
 final _dateFormat = DateFormat.MMMd().add_jm();
 
 class _BroadcastCardContent extends StatelessWidget {
-  const _BroadcastCardContent({required this.broadcast, required _CardColors? cardColors})
-    : _cardColors = cardColors;
+  const _BroadcastCardContent({required this.broadcast, required this._cardColors});
 
   final Broadcast broadcast;
   final _CardColors? _cardColors;

--- a/lib/src/view/home/blog_carousel.dart
+++ b/lib/src/view/home/blog_carousel.dart
@@ -275,8 +275,7 @@ final Map<String, _CardColors?> _colorsCache = {};
 final _dateFormat = DateFormat.MMMd();
 
 class _BlogCardContent extends StatelessWidget {
-  const _BlogCardContent({required this.post, required _CardColors? cardColors})
-    : _cardColors = cardColors;
+  const _BlogCardContent({required this.post, required this._cardColors});
 
   final BlogPost post;
   final _CardColors? _cardColors;

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -253,10 +253,10 @@ packages:
     dependency: "direct main"
     description:
       name: cronet_http
-      sha256: "8e77bc6f203e0bc9126e6a9092508a3435dbcb04da3b53ed1a358909385c5e0e"
+      sha256: "9da9860b409d71e4b8259e3dee631176d499dee23e7cd45a3024ebd5181997d8"
       url: "https://pub.dev"
     source: hosted
-    version: "1.8.0"
+    version: "1.9.0"
   cross_file:
     dependency: transitive
     description:
@@ -485,10 +485,10 @@ packages:
     dependency: "direct main"
     description:
       name: firebase_messaging
-      sha256: f2d1734d167e07746949ada91a288a9b14a03be470eec89ee249ed90c8d4db44
+      sha256: ce21a510e5a9aed67a0404476981e19ec0361a0301eeba547dc93dc2e7dec99a
       url: "https://pub.dev"
     source: hosted
-    version: "16.4.0"
+    version: "16.4.1"
   firebase_messaging_platform_interface:
     dependency: transitive
     description:
@@ -639,10 +639,10 @@ packages:
     dependency: "direct main"
     description:
       name: flutter_riverpod
-      sha256: e2026c72738a925a60db30258ff1f29974e40716749f3c9850aabf34ffc1a14c
+      sha256: "4e166be88e1dbbaa34a280bdb744aeae73b7ef25fdf8db7a3bb776760a3648e2"
       url: "https://pub.dev"
     source: hosted
-    version: "3.2.1"
+    version: "3.3.1"
   flutter_secure_storage:
     dependency: "direct main"
     description:
@@ -914,10 +914,18 @@ packages:
     dependency: transitive
     description:
       name: jni
-      sha256: "8706a77e94c76fe9ec9315e18949cc9479cc03af97085ca9c1077b61323ea12d"
+      sha256: c2230682d5bc2362c1c9e8d3c7f406d9cbba23ab3f2e203a025dd47e0fb2e68f
       url: "https://pub.dev"
     source: hosted
-    version: "0.15.2"
+    version: "1.0.0"
+  jni_flutter:
+    dependency: transitive
+    description:
+      name: jni_flutter
+      sha256: "8b59e590786050b1cd866677dddaf76b1ade5e7bc751abe04b86e84d379d3ba6"
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.0.1"
   json_annotation:
     dependency: "direct main"
     description:
@@ -1154,10 +1162,10 @@ packages:
     dependency: transitive
     description:
       name: path_provider_android
-      sha256: "149441ca6e4f38193b2e004c0ca6376a3d11f51fa5a77552d8bd4d2b0c0912ba"
+      sha256: "69cbd515a62b94d32a7944f086b2f82b4ac40a1d45bebfc00813a430ab2dabcd"
       url: "https://pub.dev"
     source: hosted
-    version: "2.2.23"
+    version: "2.3.1"
   path_provider_foundation:
     dependency: transitive
     description:
@@ -1852,5 +1860,5 @@ packages:
     source: hosted
     version: "3.1.3"
 sdks:
-  dart: ">=3.12.0 <4.0.0"
-  flutter: ">=3.44.2"
+  dart: ">=3.12.2 <4.0.0"
+  flutter: "3.44.3"

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -5,9 +5,9 @@ publish_to: "none"
 version: 0.25.1+002501 # See README.md for details about versioning
 
 environment:
-  sdk: ^3.11.5
+  sdk: ^3.12.2
   # this should be updated with every new flutter stable release
-  flutter: 3.44.2
+  flutter: 3.44.3
 
 dependencies:
   app_links: ^7.1.2
@@ -18,7 +18,7 @@ dependencies:
   clock: ^1.1.2
   collection: ^1.19.1
   connectivity_plus: ^7.1.1
-  cronet_http: ^1.8.0
+  cronet_http: ^1.9.0
   crypto: ^3.0.7
   cupertino_http: ^3.0.2
   cupertino_icons: ^1.0.9
@@ -30,7 +30,7 @@ dependencies:
   file_picker: 12.0.0-beta.7 # pin because of 12.0.0-beta.7 build issue on android
   firebase_core: ^4.11.0
   firebase_crashlytics: ^5.2.4
-  firebase_messaging: ^16.4.0
+  firebase_messaging: ^16.4.1
   fl_chart: ^1.2.0
   flutter:
     sdk: flutter
@@ -43,7 +43,7 @@ dependencies:
     sdk: flutter
   flutter_markdown_plus: ^1.0.7
   flutter_native_splash: ^2.4.8
-  flutter_riverpod: 3.2.1 # current 3.3.2 version has a breaking change
+  flutter_riverpod: 3.3.1 # 3.3.2 version has a breaking change
   flutter_secure_storage: ^10.3.1
   flutter_slidable: ^4.0.3
   flutter_spinkit: ^5.2.2

--- a/test/view/more/import_pgn_screen_test.dart
+++ b/test/view/more/import_pgn_screen_test.dart
@@ -14,9 +14,8 @@ import '../../test_provider_scope.dart';
 /// A [PlatformFile] that overrides [readAsBytes] to return in-memory bytes,
 /// avoiding the need for a real file path in tests.
 class _FakePlatformFile extends PlatformFile {
-  _FakePlatformFile({required super.name, required super.size, required Uint8List fileBytes})
-    : _fileBytes = fileBytes,
-      super(path: '');
+  _FakePlatformFile({required super.name, required super.size, required this._fileBytes})
+    : super(path: '');
 
   final Uint8List _fileBytes;
 


### PR DESCRIPTION
- dart sdk to 3.12.2 & fix `Private named parameters` when linter find issues
- flutter to 3.44.3
- flutter_riverpod: 3.3.1, the regression occurs starting with version 3.3.2
- cronet_http to 1.9.0
- firebase_messaging to 16.4.1