### PR TITLE
[codex] Upload debug APK from manual builds

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -19,12 +19,14 @@ jobs:
           java-version: 17
           distribution: temurin
 
-      - name: Install Flutter
-        uses: subosito/flutter-action@1a449444c387b1966244ae4d4f8c696479add0b2 # v2.23.0
-      - run: flutter doctor -v
-
       - name: Checkout mobile code
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+
+      - name: Install Flutter
+        uses: subosito/flutter-action@1a449444c387b1966244ae4d4f8c696479add0b2 # v2.23.0
+        with:
+          flutter-version-file: pubspec.yaml
+      - run: flutter doctor -v
 
       - name: Install dependencies
         run: flutter pub get

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -11,7 +11,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        target: ["appbundle --debug", "ios --no-codesign"]
+        target: ["appbundle --debug", "ios --no-codesign", "apk --debug"]
     steps:
       - name: Set up JDK 17
         uses: actions/setup-java@be666c2fcd27ec809703dec50e508c2fdc7f6654 # v5.2.0
@@ -33,3 +33,12 @@ jobs:
         run: dart run build_runner build
 
       - run: flutter build ${{ matrix.target }}
+
+      - name: Upload debug APK
+        if: matrix.target == 'apk --debug'
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: lichess-mobile-debug-apk
+          path: build/app/outputs/flutter-apk/app-debug.apk
+          if-no-files-found: error
+          retention-days: 7


### PR DESCRIPTION
## Summary

- add `apk --debug` to the manual Builds workflow matrix
- upload `build/app/outputs/flutter-apk/app-debug.apk` as the `lichess-mobile-debug-apk` artifact with 7-day retention
- make the manual Builds workflow install the Flutter version from `pubspec.yaml`, matching the existing test and Play Store workflows

Closes #3337.

## Validation

- `git diff --check`
- parsed `.github/workflows/build.yml` with Ruby YAML
- fork workflow run passed: https://github.com/MichaelSpece/mobile/actions/runs/28192926297
- verified artifact download from that run: `app-debug.apk`, 369,124,845 bytes, SHA-256 `a429d8e959dd0826cc56980ace104b5905a9bc18a11f981c59fa5f3531356166`
