### PR TITLE
Puzzle streak: offline & previous puzzles

### DIFF
--- a/lib/src/app.dart
+++ b/lib/src/app.dart
@@ -22,6 +22,7 @@ import 'package:lichess_mobile/src/model/correspondence/correspondence_service.d
 import 'package:lichess_mobile/src/model/log/app_log_service.dart';
 import 'package:lichess_mobile/src/model/message/message_service.dart';
 import 'package:lichess_mobile/src/model/notifications/notification_service.dart';
+import 'package:lichess_mobile/src/model/puzzle/streak_score_sync.dart';
 import 'package:lichess_mobile/src/model/settings/board_preferences.dart';
 import 'package:lichess_mobile/src/model/settings/general_preferences.dart';
 import 'package:lichess_mobile/src/model/study/study_preferences.dart';
@@ -182,6 +183,11 @@ class _AppState extends ConsumerState<Application> {
     ref.listenManual(connectivityChangesProvider, (prev, current) async {
       final prevWasOffline = prev?.value?.isOnline == false;
       final currentIsOnline = current.value?.isOnline == true;
+
+      // Post a streak score queued while offline, on reconnect or on the first online check.
+      if (currentIsOnline && (prevWasOffline || !_firstTimeOnlineCheck)) {
+        ref.read(streakScoreSyncProvider).flushCurrentUser().ignore();
+      }
 
       // Play registered moves whenever the app comes back online.
       if (prevWasOffline && currentIsOnline) {

--- a/lib/src/model/puzzle/puzzle_controller.dart
+++ b/lib/src/model/puzzle/puzzle_controller.dart
@@ -86,14 +86,10 @@ class PuzzleController extends Notifier<PuzzleState> {
     // update puzzles that are remaining in replay
     _replayRemaining = context.replayRemaining;
 
-    // play first move after 1 second
-    _firstMoveTimer = Timer(const Duration(seconds: 1), () {
-      _setPath(state.initialPath, firstMove: true);
-    });
-
     final initialPath = UciPath.fromId(_gameTree.children.first.id);
+    final initialNode = _gameTree.branchAt(initialPath);
 
-    return PuzzleState(
+    final loaded = PuzzleState(
       puzzle: context.puzzle,
       glicko: context.glicko,
       mode: PuzzleMode.load,
@@ -102,18 +98,41 @@ class PuzzleController extends Notifier<PuzzleState> {
       initialPath: initialPath,
       currentPath: UciPath.empty,
       node: _gameTree.view,
-      pov: _gameTree.nodeAt(initialPath).position.ply.isEven ? Side.white : Side.black,
+      pov: initialNode.position.ply.isEven ? Side.white : Side.black,
       hintShown: false,
       resultSent: false,
       isChangingDifficulty: false,
       shouldBlinkNextArrow: false,
     );
+
+    if (context.isReview) {
+      // Already solved and reported: opens on the solution, with no first move to play.
+      _mergeSolution(initialPath, context.puzzle.puzzle.solution);
+      return loaded.copyWith(
+        mode: PuzzleMode.replay,
+        root: _gameTree.view,
+        currentPath: initialPath,
+        node: initialNode.view,
+        lastMove: initialNode.sanMove.move,
+        result: PuzzleResult.win,
+        resultSent: true,
+      );
+    }
+
+    // play first move after 1 second
+    _firstMoveTimer = Timer(const Duration(seconds: 1), () {
+      _setPath(state.initialPath, firstMove: true);
+    });
+    return loaded;
   }
 
   Future<void> onUserMove(Move move) async {
-    _addMove(move);
+    // A replay may walk into a move already in the tree, e.g. the one that lost the streak.
+    final isNewMove = _addMove(move);
 
-    if (state.mode == PuzzleMode.play) {
+    // Read once: a wrong move switches a streak puzzle to replay below.
+    final replaying = state.mode == PuzzleMode.replay;
+    if (state.mode == PuzzleMode.play || replaying) {
       state = state.copyWith(hintSquare: null);
       final nodeList = _gameTree.branchesOn(state.currentPath).toList();
       final movesToTest = nodeList.sublist(state.initialPath.size).map((e) => e.sanMove);
@@ -132,6 +151,7 @@ class PuzzleController extends Notifier<PuzzleState> {
         else if (nextUci != null) {
           final correctPath = state.currentPath;
           await Future<void>.delayed(const Duration(milliseconds: 500));
+          if (!ref.mounted) return;
           final (nextPath, _) = _gameTree.addMoveAt(correctPath, Move.parse(nextUci)!);
           if (nextPath != null) {
             _setPath(nextPath, isNavigating: true);
@@ -143,11 +163,17 @@ class PuzzleController extends Notifier<PuzzleState> {
         }
       } else {
         state = state.copyWith(feedback: PuzzleFeedback.bad);
-        _onFailOrWin(PuzzleResult.lose);
-        if (initialContext.isPuzzleStreak != true) {
+        if (replaying) {
+          ref.read(soundServiceProvider).play(Sound.error);
+        } else {
+          _onFailOrWin(PuzzleResult.lose);
+        }
+        // A wrong move that ends a live streak stays on the board; any other is taken back.
+        if (initialContext.isPuzzleStreak != true || replaying) {
           final wrongPath = state.currentPath;
           await Future<void>.delayed(const Duration(milliseconds: 500));
-          _gameTree.deleteAt(wrongPath);
+          if (!ref.mounted) return;
+          if (isNewMove) _gameTree.deleteAt(wrongPath);
           _setPath(wrongPath.penultimate);
         }
       }
@@ -167,7 +193,7 @@ class PuzzleController extends Notifier<PuzzleState> {
   void viewSolution() {
     if (state.mode == PuzzleMode.view) return;
 
-    _mergeSolution();
+    _mergeSolution(state.initialPath, state.puzzle.puzzle.solution);
 
     state = state.copyWith(root: _gameTree.view, node: _gameTree.branchAt(state.currentPath).view);
 
@@ -261,9 +287,13 @@ class PuzzleController extends Notifier<PuzzleState> {
   }
 
   Future<void> _completePuzzle() async {
-    state = state.copyWith(mode: PuzzleMode.view);
+    state = state.copyWith(mode: _doneMode);
     await _onFailOrWin(state.result ?? PuzzleResult.win);
   }
+
+  /// Once over, a streak puzzle stays playable against its solution; the others open up.
+  PuzzleMode get _doneMode =>
+      initialContext.isPuzzleStreak == true ? PuzzleMode.replay : PuzzleMode.view;
 
   Future<void> _onFailOrWin(PuzzleResult result) async {
     if (state.resultSent) return;
@@ -277,12 +307,15 @@ class PuzzleController extends Notifier<PuzzleState> {
       if (result == PuzzleResult.lose) {
         soundService.play(Sound.error);
         await Future<void>.delayed(const Duration(milliseconds: 500));
+        if (!ref.mounted) return;
         _setPath(state.currentPath.penultimate);
-        _mergeSolution();
+        _mergeSolution(state.initialPath, state.puzzle.puzzle.solution);
         state = state.copyWith(
-          mode: PuzzleMode.view,
+          mode: PuzzleMode.replay,
           root: _gameTree.view,
           node: _gameTree.branchAt(state.currentPath).view,
+          // The losing move was taken back; feedback now tracks the replay.
+          feedback: null,
         );
       }
     } else {
@@ -407,8 +440,10 @@ class PuzzleController extends Notifier<PuzzleState> {
     return pgn;
   }
 
-  void _addMove(Move move) {
-    final (newPath, _) = _gameTree.addMoveAt(
+  /// Plays [move] from the current position, and returns whether it added a node to the tree
+  /// (false when the move was already there).
+  bool _addMove(Move move) {
+    final (newPath, isNewNode) = _gameTree.addMoveAt(
       state.currentPath,
       move,
       prepend: state.mode == PuzzleMode.play,
@@ -416,28 +451,41 @@ class PuzzleController extends Notifier<PuzzleState> {
     if (newPath != null) {
       _setPath(newPath);
     }
+    return isNewNode;
   }
 
-  void _mergeSolution() {
-    final initialNode = _gameTree.nodeAt(state.initialPath);
-    final (_, newNodes) = state.puzzle.puzzle.solution.foldIndexed(
-      (initialNode.position, IList<Branch>(const [])),
-      (index, previous, uci) {
-        final moveObj = Move.parse(uci)!;
-        final (pos, nodes) = previous;
-        final normalizedMove = _gameTree.normalizeMove(pos, moveObj);
-        final (newPos, newSan) = pos.makeSan(normalizedMove);
-        return (
-          newPos,
-          nodes.add(Branch(position: newPos, sanMove: SanMove(newSan, normalizedMove))),
-        );
-      },
-    );
-    _gameTree.addNodesAt(state.initialPath, newNodes, prepend: true);
+  /// Adds [solution] to the game tree at [initialPath], ahead of any move already played there.
+  void _mergeSolution(UciPath initialPath, IList<String> solution) {
+    final initialNode = _gameTree.nodeAt(initialPath);
+    final (_, newNodes) = solution.foldIndexed((initialNode.position, IList<Branch>(const [])), (
+      index,
+      previous,
+      uci,
+    ) {
+      final moveObj = Move.parse(uci)!;
+      final (pos, nodes) = previous;
+      final normalizedMove = _gameTree.normalizeMove(pos, moveObj);
+      final (newPos, newSan) = pos.makeSan(normalizedMove);
+      return (
+        newPos,
+        nodes.add(Branch(position: newPos, sanMove: SanMove(newSan, normalizedMove))),
+      );
+    });
+    _gameTree.addNodesAt(initialPath, newNodes, prepend: true);
   }
 }
 
-enum PuzzleMode { load, play, view }
+enum PuzzleMode {
+  load,
+  play,
+
+  /// The puzzle is over and the board is free for analysis.
+  view,
+
+  /// The puzzle is over and reported, but moves are still checked against the solution: a wrong
+  /// one is taken back, a right one answered. Streak puzzles end up here.
+  replay,
+}
 
 enum PuzzleResult { win, lose }
 

--- a/lib/src/model/puzzle/puzzle_providers.dart
+++ b/lib/src/model/puzzle/puzzle_providers.dart
@@ -9,7 +9,6 @@ import 'package:lichess_mobile/src/model/puzzle/puzzle_opening.dart';
 import 'package:lichess_mobile/src/model/puzzle/puzzle_preferences.dart';
 import 'package:lichess_mobile/src/model/puzzle/puzzle_repository.dart';
 import 'package:lichess_mobile/src/model/puzzle/puzzle_service.dart';
-import 'package:lichess_mobile/src/model/puzzle/puzzle_storage.dart';
 import 'package:lichess_mobile/src/model/puzzle/puzzle_theme.dart';
 import 'package:lichess_mobile/src/model/puzzle/storm.dart';
 import 'package:lichess_mobile/src/network/http.dart';
@@ -103,10 +102,10 @@ final puzzleProvider = FutureProvider.autoDispose.family<Puzzle, PuzzleId>((
   Ref ref,
   PuzzleId id,
 ) async {
-  final puzzleStorage = await ref.watch(puzzleStorageProvider.future);
-  final puzzle = await puzzleStorage.fetch(puzzleId: id);
-  if (puzzle != null) return puzzle;
-  return ref.read(puzzleRepositoryProvider).fetch(id);
+  // Read, not watch: the service rebuilds on a preference change, which must not restart a
+  // puzzle in play.
+  final service = await ref.read(puzzleServiceProvider.future);
+  return service.loadPuzzle(id);
 }, name: 'PuzzleProvider');
 
 /// Fetches the daily puzzle.

--- a/lib/src/model/puzzle/puzzle_repository.dart
+++ b/lib/src/model/puzzle/puzzle_repository.dart
@@ -21,6 +21,10 @@ import 'package:lichess_mobile/src/utils/json.dart';
 
 part 'puzzle_repository.freezed.dart';
 
+/// Maximum number of puzzles `/api/puzzle/many` serves in one request, whatever the number of
+/// ids asked for (`ids.take(50)` in lila's `Puzzle` controller).
+const kServerPuzzleManyCap = 50;
+
 /// A provider for the [PuzzleRepository].
 final puzzleRepositoryProvider = Provider<PuzzleRepository>((ref) {
   final client = ref.watch(lichessClientProvider);
@@ -67,6 +71,21 @@ class PuzzleRepository {
 
   Future<Puzzle> fetch(PuzzleId id) {
     return client.readJson(Uri(path: '/api/puzzle/$id'), mapper: _puzzleFromJson);
+  }
+
+  /// Fetches up to [kServerPuzzleManyCap] puzzles by id in one `/api/puzzle/many` request.
+  ///
+  /// Meant for prefetching: the endpoint is rate limited per IP, on a budget shared with
+  /// `/api/puzzle/batch/`, whereas [fetch] is not. It drops any id it cannot serve, so the result
+  /// may be shorter than [ids].
+  Future<IList<Puzzle>> fetchMany(IList<PuzzleId> ids) async {
+    assert(ids.isNotEmpty, '/api/puzzle/many charges for a request with no ids');
+    assert(ids.length <= kServerPuzzleManyCap, 'ids beyond $kServerPuzzleManyCap are ignored');
+    final response = await client.readJson(
+      Uri(path: '/api/puzzle/many', queryParameters: {'ids': ids.join(',')}),
+      mapper: _decodeBatchResponse,
+    );
+    return response.puzzles;
   }
 
   Future<PuzzleStreakResponse> streak() {

--- a/lib/src/model/puzzle/puzzle_service.dart
+++ b/lib/src/model/puzzle/puzzle_service.dart
@@ -83,6 +83,31 @@ class PuzzleService {
   final PuzzleStorage puzzleStorage;
   final Logger _log = Logger('PuzzleService');
 
+  /// Loads a puzzle from the local storage, or from the server on a miss, saving it locally.
+  ///
+  /// An unreadable local copy is ignored and fetched again.
+  Future<Puzzle> loadPuzzle(PuzzleId id) async {
+    try {
+      final cached = await puzzleStorage.fetch(puzzleId: id);
+      if (cached != null) return cached;
+    } catch (e) {
+      _log.info('Ignoring an unreadable cached puzzle $id', e);
+    }
+    final puzzle = await _ref.read(puzzleRepositoryProvider).fetch(id);
+    await cachePuzzle(puzzle);
+    return puzzle;
+  }
+
+  /// Saves [puzzle] to the local storage, so that [loadPuzzle] serves it offline. Best-effort: a
+  /// failed write is logged, not thrown.
+  Future<void> cachePuzzle(Puzzle puzzle) async {
+    try {
+      await puzzleStorage.save(puzzle: puzzle);
+    } catch (e) {
+      _log.warning('Could not cache puzzle ${puzzle.puzzle.id}', e);
+    }
+  }
+
   /// Loads the next puzzle from database and the glicko rating if available.
   ///
   /// Will sync with server if necessary.
@@ -116,7 +141,7 @@ class PuzzleService {
     required Puzzle puzzle,
     PuzzleAngle angle = const PuzzleTheme(PuzzleThemeKey.mix),
   }) async {
-    puzzleStorage.save(puzzle: puzzle);
+    cachePuzzle(puzzle);
     const emptyBatch = PuzzleBatch(solved: IListConst([]), unsolved: IListConst([]));
     final data = await batchStorage.fetch(userId: userId, angle: angle) ?? emptyBatch;
     await batchStorage.save(

--- a/lib/src/model/puzzle/puzzle_service.dart
+++ b/lib/src/model/puzzle/puzzle_service.dart
@@ -66,6 +66,9 @@ sealed class PuzzleContext with _$PuzzleContext {
 
     /// Remaining puzzle IDs to replay after the current one.
     IList<PuzzleId>? replayRemaining,
+
+    /// If true, the puzzle was already solved and opens on its solution, to be replayed.
+    @Default(false) bool isReview,
   }) = _PuzzleContext;
 }
 

--- a/lib/src/model/puzzle/puzzle_storage.dart
+++ b/lib/src/model/puzzle/puzzle_storage.dart
@@ -1,5 +1,6 @@
 import 'dart:convert';
 
+import 'package:fast_immutable_collections/fast_immutable_collections.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:lichess_mobile/src/db/database.dart';
 import 'package:lichess_mobile/src/model/common/id.dart';
@@ -40,11 +41,39 @@ class PuzzleStorage {
     return null;
   }
 
-  Future<void> save({required Puzzle puzzle}) async {
-    await _db.insert(_tableName, {
-      'puzzleId': puzzle.puzzle.id.toString(),
-      'lastModified': DateTime.now().toIso8601String(),
-      'data': jsonEncode(puzzle.toJson()),
-    }, conflictAlgorithm: ConflictAlgorithm.replace);
+  /// Returns which of [ids] are stored.
+  Future<ISet<PuzzleId>> cachedPuzzleIds({required IList<PuzzleId> ids}) async {
+    if (ids.isEmpty) return const ISetConst({});
+    final rows = await _db.query(
+      _tableName,
+      columns: ['puzzleId'],
+      where: 'puzzleId IN (${List.filled(ids.length, '?').join(', ')})',
+      whereArgs: [for (final id in ids) id.toString()],
+    );
+    return ISet(rows.map((row) => PuzzleId(row['puzzleId']! as String)));
   }
+
+  Future<void> save({required Puzzle puzzle}) async {
+    await _db.insert(
+      _tableName,
+      _row(puzzle, DateTime.now().toIso8601String()),
+      conflictAlgorithm: .replace,
+    );
+  }
+
+  /// Saves [puzzles] in a single transaction.
+  Future<void> saveAll({required IList<Puzzle> puzzles}) async {
+    final batch = _db.batch();
+    final lastModified = DateTime.now().toIso8601String();
+    for (final puzzle in puzzles) {
+      batch.insert(_tableName, _row(puzzle, lastModified), conflictAlgorithm: .replace);
+    }
+    await batch.commit(noResult: true);
+  }
+
+  Map<String, Object?> _row(Puzzle puzzle, String lastModified) => {
+    'puzzleId': puzzle.puzzle.id.toString(),
+    'lastModified': lastModified,
+    'data': jsonEncode(puzzle.toJson()),
+  };
 }

--- a/lib/src/model/puzzle/puzzle_streak.dart
+++ b/lib/src/model/puzzle/puzzle_streak.dart
@@ -17,9 +17,16 @@ sealed class PuzzleStreak with _$PuzzleStreak {
     required bool hasSkipped,
     required bool finished,
     required DateTime timestamp,
+
+    /// Set when the puzzle at [index] was solved but the next one was not available offline, so
+    /// the next load or reconnect completes the advance instead of replaying the puzzle.
+    @Default(false) bool advancePending,
   }) = _PuzzleStreak;
 
   PuzzleId? get nextId => streak.getOrNull(index + 1);
+
+  /// Puzzles solved in this run, counting a solve that could not advance yet.
+  int get score => advancePending ? index + 1 : index;
 
   factory PuzzleStreak.fromJson(Map<String, dynamic> json) => _$PuzzleStreakFromJson(json);
 }

--- a/lib/src/model/puzzle/puzzle_streak_controller.dart
+++ b/lib/src/model/puzzle/puzzle_streak_controller.dart
@@ -1,15 +1,38 @@
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:lichess_mobile/src/model/auth/auth_controller.dart';
+import 'package:lichess_mobile/src/model/common/id.dart';
 import 'package:lichess_mobile/src/model/common/service/sound_service.dart';
 import 'package:lichess_mobile/src/model/puzzle/puzzle.dart';
 import 'package:lichess_mobile/src/model/puzzle/puzzle_repository.dart';
+import 'package:lichess_mobile/src/model/puzzle/puzzle_service.dart';
+import 'package:lichess_mobile/src/model/puzzle/puzzle_storage.dart';
 import 'package:lichess_mobile/src/model/puzzle/puzzle_streak.dart';
+import 'package:lichess_mobile/src/model/puzzle/streak_lookahead.dart';
+import 'package:lichess_mobile/src/model/puzzle/streak_score_sync.dart';
 import 'package:lichess_mobile/src/model/puzzle/streak_storage.dart';
-import 'package:lichess_mobile/src/tab_navigation.dart' show currentNavigatorKeyProvider;
-import 'package:lichess_mobile/src/widgets/feedback.dart';
+import 'package:lichess_mobile/src/network/connectivity.dart';
+import 'package:lichess_mobile/src/network/http.dart';
+import 'package:logging/logging.dart';
+
+final _logger = Logger('PuzzleStreakController');
 
 /// [PuzzleStreak] with its current [Puzzle].
-typedef StreakState = ({PuzzleStreak streak, Puzzle puzzle, Puzzle? nextPuzzle});
+typedef StreakState = ({PuzzleStreak streak, Puzzle puzzle});
+
+/// Outcome of [PuzzleStreakController.next].
+enum StreakAdvance {
+  advanced,
+
+  /// The next puzzle could not be loaded (e.g. offline with nothing cached). The streak stays on
+  /// the solved puzzle and moves on by itself once back online.
+  unavailable,
+
+  /// The streak has no puzzle left, moved on or was disposed while the next puzzle was loading.
+  aborted,
+
+  /// The server refuses the next puzzle for good, so the run ended here, with the solve counted.
+  ended,
+}
 
 final puzzleStreakControllerProvider =
     AsyncNotifierProvider.autoDispose<PuzzleStreakController, StreakState>(
@@ -17,110 +40,173 @@ final puzzleStreakControllerProvider =
       name: 'PuzzleStreakControllerProvider',
     );
 
+/// Plays a streak run from the local puzzle cache, so that it goes on offline.
+///
+/// Puzzles are loaded cache-first through [PuzzleService.loadPuzzle], and a [StreakLookahead]
+/// keeps the coming ones cached. A solve whose next puzzle cannot be loaded is kept as
+/// [PuzzleStreak.advancePending] and completed on reconnect; a run that ends offline queues its
+/// score for [StreakScoreSync] to post.
 class PuzzleStreakController extends AsyncNotifier<StreakState> {
+  late StreakStorage _storage;
+  UserId? _userId;
+  late StreakLookahead _lookahead;
+
+  /// The run being played, or null while a new one is loading or the last load failed.
+  StreakState? get _current => switch (state) {
+    AsyncData(:final value, isLoading: false) => value,
+    _ => null,
+  };
+
+  Future<PuzzleService> get _service => ref.read(puzzleServiceProvider.future);
+
   @override
   Future<StreakState> build() async {
-    final authUser = ref.watch(authControllerProvider);
-    final streakStorage = ref.watch(streakStorageProvider(authUser?.user.id));
-    final activeStreak = await streakStorage.loadActiveStreak();
-    final repository = ref.read(puzzleRepositoryProvider);
-    if (activeStreak != null) {
-      final [puzzle, nextPuzzle] = await Future.wait([
-        repository.fetch(activeStreak.streak[activeStreak.index]),
-        if (activeStreak.nextId != null)
-          repository.fetch(activeStreak.nextId!)
-        else
-          Future.value(null),
-      ]);
+    _userId = ref.watch(authControllerProvider)?.user.id;
+    _storage = ref.watch(streakStorageProvider(_userId));
 
-      return (streak: activeStreak, puzzle: puzzle!, nextPuzzle: nextPuzzle);
+    ref.read(streakScoreSyncProvider).flush(_userId).ignore();
+
+    ref.listen(connectivityChangesProvider, (previous, now) {
+      if (previous?.value?.isOnline != false || now.value?.isOnline != true) return;
+      if (state is AsyncError) {
+        // A load that failed offline, e.g. a solve stranded with nothing cached.
+        ref.invalidateSelf();
+      } else if (_current?.streak.advancePending ?? false) {
+        // A solve stranded offline. Should this fail too, the screen offers a retry.
+        next().ignore();
+      }
+    });
+
+    final saved = await _storage.loadActiveStreak();
+    if (saved == null) return _newRun();
+
+    // A solve stranded offline counts, and is never replayed.
+    final active = saved.copyWith(index: saved.score, advancePending: false);
+    final Puzzle puzzle;
+    try {
+      puzzle = await (await _service).loadPuzzle(active.streak[active.index]);
+    } catch (e) {
+      if (!isPermanentFailure(e)) rethrow;
+      // The server will never serve this puzzle: end the run with the score it has, rather than
+      // failing on every visit until the user gives up on the feature.
+      _logger.warning('Ending a streak whose puzzle the server refuses', e);
+      await _endRun(active.score);
+      return _newRun();
     }
+    if (active != saved) await _storage.saveActiveStreak(active);
+    return _start(active, puzzle);
+  }
 
-    final newStreak = await repository.streak();
-    final nextPuzzle = await repository.fetch(newStreak.streak[1]);
-
-    return (
-      streak: PuzzleStreak(
-        streak: newStreak.streak,
-        index: 0,
-        hasSkipped: false,
-        finished: false,
-        timestamp: newStreak.timestamp,
-      ),
-      puzzle: newStreak.puzzle,
-      nextPuzzle: nextPuzzle,
+  Future<StreakState> _newRun() async {
+    final response = await ref.read(puzzleRepositoryProvider).streak();
+    final streak = PuzzleStreak(
+      streak: response.streak,
+      index: 0,
+      hasSkipped: false,
+      finished: false,
+      timestamp: response.timestamp,
     );
+    // The first puzzle comes embedded in the response; the others are loaded by id.
+    await ((await _service).cachePuzzle(response.puzzle), _storage.saveActiveStreak(streak)).wait;
+    return _start(streak, response.puzzle);
+  }
+
+  Future<StreakState> _start(PuzzleStreak streak, Puzzle puzzle) async {
+    _lookahead = StreakLookahead(
+      streak.streak,
+      storage: await ref.read(puzzleStorageProvider.future),
+      repository: ref.read(puzzleRepositoryProvider),
+    );
+    _lookahead.refill(streak.index).ignore();
+    return (streak: streak, puzzle: puzzle);
+  }
+
+  /// The run being played if it is still on the solve at [index] of [run], or null once the
+  /// notifier was disposed, a new run started or another advance went through.
+  StreakState? _sameSolve(Streak run, int index) {
+    if (!ref.mounted) return null;
+    final current = _current;
+    if (current == null || current.streak.streak != run || current.streak.index != index) {
+      return null;
+    }
+    return current;
   }
 
   void skipMove() {
-    if (!state.hasValue) return;
-
-    state = AsyncData((
-      streak: state.requireValue.streak.copyWith(hasSkipped: true),
-      puzzle: state.requireValue.puzzle,
-      nextPuzzle: state.requireValue.nextPuzzle,
-    ));
-
-    ref
-        .read(streakStorageProvider(ref.read(authControllerProvider)?.user.id))
-        .saveActiveStreak(state.requireValue.streak);
+    final current = _current;
+    if (current == null) return;
+    final skipped = current.streak.copyWith(hasSkipped: true);
+    state = AsyncData((streak: skipped, puzzle: current.puzzle));
+    _storage.saveActiveStreak(skipped);
   }
 
-  /// Advance the streak to the next puzzle.
-  Future<void> next() async {
-    if (!state.hasValue || state.requireValue.nextPuzzle == null) {
-      return;
+  /// Advances the streak to the next puzzle. Offline with nothing cached, the streak stays on the
+  /// solved puzzle with [PuzzleStreak.advancePending] set, and completes the advance on reconnect.
+  Future<StreakAdvance> next() async {
+    var solved = _current;
+    if (solved == null) return .aborted;
+    final nextId = solved.streak.nextId;
+    if (nextId == null) return .aborted;
+    final run = solved.streak.streak;
+    final index = solved.streak.index;
+
+    if (!solved.streak.advancePending) {
+      // The solve counts from now on: cut short (screen left, app killed) or failed, the run
+      // resumes on the next puzzle rather than replaying this one.
+      final pending = solved.streak.copyWith(advancePending: true);
+      state = AsyncData((streak: pending, puzzle: solved.puzzle));
+      await _storage.saveActiveStreak(pending);
     }
+
+    Puzzle? puzzle;
+    try {
+      puzzle = await (await _service).loadPuzzle(nextId);
+    } catch (e) {
+      if (isPermanentFailure(e)) {
+        // The server will never serve it, so the run ends here, with the solve counted.
+        _logger.warning('Ending a streak whose next puzzle the server refuses', e);
+        solved = _sameSolve(run, index);
+        if (solved == null) return .aborted;
+        await _finish(solved);
+        return .ended;
+      }
+      _logger.info('Could not load puzzle $nextId', e);
+    }
+    solved = _sameSolve(run, index);
+    if (solved == null) return .aborted;
+    if (puzzle == null) return .unavailable;
+
     ref.read(soundServiceProvider).play(Sound.confirmation);
-
-    state = AsyncData((
-      streak: state.requireValue.streak.copyWith(index: state.requireValue.streak.index + 1),
-      puzzle: state.requireValue.nextPuzzle!,
-      nextPuzzle: null,
-    ));
-
-    final nextId = state.requireValue.streak.nextId;
-    if (nextId != null) {
-      ref
-          .read(puzzleRepositoryProvider)
-          .fetch(nextId)
-          .then((puzzle) {
-            state = AsyncData((
-              streak: state.requireValue.streak,
-              puzzle: state.requireValue.puzzle,
-              nextPuzzle: puzzle,
-            ));
-          })
-          .catchError((_) {
-            final currentContext = ref.read(currentNavigatorKeyProvider).currentContext;
-            if (currentContext != null && currentContext.mounted) {
-              showSnackBar(currentContext, 'Error loading next puzzle', type: SnackBarType.error);
-            }
-          });
-    }
-
-    ref
-        .read(streakStorageProvider(ref.read(authControllerProvider)?.user.id))
-        .saveActiveStreak(state.requireValue.streak);
+    final advanced = solved.streak.copyWith(index: index + 1, advancePending: false);
+    state = AsyncData((streak: advanced, puzzle: puzzle));
+    _lookahead.refill(advanced.index).ignore();
+    await _storage.saveActiveStreak(advanced);
+    return .advanced;
   }
 
   Future<void> gameOver() async {
-    if (!state.hasValue) return;
+    final current = _current;
+    if (current == null || current.streak.finished) return;
+    await _finish(current);
+  }
 
-    state = AsyncData((
-      streak: state.requireValue.streak.copyWith(finished: true),
-      puzzle: state.requireValue.puzzle,
-      nextPuzzle: state.requireValue.nextPuzzle,
-    ));
+  Future<void> _finish(StreakState current) async {
+    final finished = current.streak.copyWith(finished: true);
+    state = AsyncData((streak: finished, puzzle: current.puzzle));
+    await _endRun(finished.score);
+  }
 
-    final userId = ref.read(authControllerProvider)?.user.id;
-    ref.read(streakStorageProvider(userId)).clearActiveStreak();
-
-    if (userId != null) {
-      final streak = state.requireValue.streak.index;
-      if (streak > 0) {
-        await ref.read(puzzleRepositoryProvider).postStreakRun(streak);
-      }
-    }
+  /// Clears the run and posts [score], queued first so that a post that fails now is retried
+  /// later. Reads what it needs up front, as the screen may be left (disposing the notifier)
+  /// during the awaits.
+  Future<void> _endRun(int score) async {
+    final storage = _storage;
+    final userId = _userId;
+    final scoreSync = ref.read(streakScoreSyncProvider);
+    final posting = userId != null && score > 0;
+    // Issued together: both hit the preferences cache synchronously, so a 'New streak' tap during
+    // the disk writes cannot load the run back.
+    await Future.wait([if (posting) storage.savePendingScore(score), storage.clearActiveStreak()]);
+    if (posting) await scoreSync.flush(userId);
   }
 }

--- a/lib/src/model/puzzle/streak_lookahead.dart
+++ b/lib/src/model/puzzle/streak_lookahead.dart
@@ -1,0 +1,73 @@
+import 'dart:math';
+
+import 'package:fast_immutable_collections/fast_immutable_collections.dart';
+import 'package:lichess_mobile/src/model/puzzle/puzzle_repository.dart';
+import 'package:lichess_mobile/src/model/puzzle/puzzle_storage.dart';
+import 'package:lichess_mobile/src/model/puzzle/puzzle_streak.dart';
+import 'package:lichess_mobile/src/network/http.dart';
+import 'package:logging/logging.dart';
+
+final _logger = Logger('StreakLookahead');
+
+/// How many puzzles one refill fetches, in a single `/api/puzzle/many` request.
+const _windowSize = 30;
+
+/// Refill once fewer than this many puzzles are cached past the one being played.
+const _margin = 10;
+
+/// How many advances to wait before retrying a refill that failed.
+const _retryAfter = 5;
+
+/// Keeps the puzzles of one streak run cached ahead of the one being played, so that the run goes
+/// on offline.
+///
+/// Refills are best-effort: the streak loads each puzzle on its own when it is due, so a failed
+/// refill only costs the offline play. One instance serves one run.
+class StreakLookahead {
+  StreakLookahead(this.run, {required this.storage, required this.repository})
+    : assert(_windowSize <= kServerPuzzleManyCap);
+
+  final Streak run;
+  final PuzzleStorage storage;
+  final PuzzleRepository repository;
+
+  /// Exclusive end of the range of [run] known to be cached.
+  int _cachedUpTo = 0;
+
+  /// Refills for an index before this one are skipped: the back-off after a failed refill.
+  int _retryFrom = 0;
+
+  bool _refilling = false;
+
+  /// Caches the next [_windowSize] puzzles once fewer than [_margin] are cached past [index], the
+  /// one being played. Never throws.
+  Future<void> refill(int index) async {
+    final from = index + 1;
+    if (_refilling || from < _retryFrom || _cachedUpTo >= from + _margin) return;
+    // Start past what is cached, so that the windows do not overlap.
+    final start = max(from, _cachedUpTo);
+    final to = min(start + _windowSize, run.length);
+    if (start >= to) return;
+
+    _refilling = true;
+    try {
+      final window = run.sublist(start, to);
+      final cached = await storage.cachedPuzzleIds(ids: window);
+      final missing = window.where((id) => !cached.contains(id)).toIList();
+      if (missing.isNotEmpty) {
+        await storage.saveAll(puzzles: await repository.fetchMany(missing));
+      }
+      // The whole window counts as cached, even if the server dropped an id: the streak fetches
+      // such a puzzle on its own and fails the same way, so asking again is pointless.
+      _cachedUpTo = max(_cachedUpTo, to);
+    } catch (e) {
+      // A 429 means the hourly puzzle budget is spent, and any other 4xx is final: stop asking
+      // for this run. Play goes on from `/api/puzzle/{id}`, which is not rate limited.
+      final refused = e is ServerException && e.statusCode < 500;
+      _retryFrom = refused ? run.length : from + _retryAfter;
+      _logger.info('Streak look-ahead refill failed', e);
+    } finally {
+      _refilling = false;
+    }
+  }
+}

--- a/lib/src/model/puzzle/streak_score_sync.dart
+++ b/lib/src/model/puzzle/streak_score_sync.dart
@@ -1,0 +1,58 @@
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:lichess_mobile/src/model/auth/auth_controller.dart';
+import 'package:lichess_mobile/src/model/common/id.dart';
+import 'package:lichess_mobile/src/model/puzzle/puzzle_repository.dart';
+import 'package:lichess_mobile/src/model/puzzle/streak_storage.dart';
+import 'package:lichess_mobile/src/network/http.dart';
+import 'package:logging/logging.dart';
+
+final _logger = Logger('StreakScoreSync');
+
+final streakScoreSyncProvider = Provider<StreakScoreSync>(
+  StreakScoreSync.new,
+  name: 'StreakScoreSyncProvider',
+);
+
+/// Posts the pending streak score of a user: a run that ended but could not be posted yet.
+///
+/// Lives outside the streak controller, which is disposed with its screen, so that a score can be
+/// posted on reconnect or on the next app start.
+class StreakScoreSync {
+  StreakScoreSync(this._ref);
+
+  final Ref _ref;
+
+  /// The last flush per user. A new one queues behind it, as the running one may have loaded the
+  /// pending score before it was updated.
+  final Map<UserId, Future<void>> _flushes = {};
+
+  /// Posts the pending score of the signed-in user, if any.
+  Future<void> flushCurrentUser() => flush(_ref.read(authControllerProvider)?.user.id);
+
+  /// Posts [userId]'s pending score, if any. A failure worth retrying leaves it for the next
+  /// attempt; one the server has rejected for good drops it.
+  Future<void> flush(UserId? userId) {
+    if (userId == null) return Future.value();
+    return _flushes[userId] = (_flushes[userId] ?? Future.value()).then((_) => _flush(userId));
+  }
+
+  Future<void> _flush(UserId userId) async {
+    try {
+      final storage = _ref.read(streakStorageProvider(userId));
+      final pending = await storage.loadPendingScore();
+      if (pending == null) return;
+      try {
+        await _ref.read(puzzleRepositoryProvider).postStreakRun(pending);
+      } catch (e) {
+        if (!isPermanentFailure(e)) {
+          _logger.info('Could not post the pending streak score', e);
+          return;
+        }
+        _logger.warning('Dropping a streak score the server rejected', e);
+      }
+      await storage.clearPendingScoreIfAtMost(pending);
+    } catch (e) {
+      _logger.info('Could not flush the pending streak score', e);
+    }
+  }
+}

--- a/lib/src/model/puzzle/streak_storage.dart
+++ b/lib/src/model/puzzle/streak_storage.dart
@@ -1,17 +1,18 @@
 import 'dart:convert';
+import 'dart:math';
 
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:lichess_mobile/src/binding.dart';
 import 'package:lichess_mobile/src/model/auth/auth_controller.dart';
 import 'package:lichess_mobile/src/model/common/id.dart';
 import 'package:lichess_mobile/src/model/puzzle/puzzle_streak.dart';
+import 'package:logging/logging.dart';
 import 'package:shared_preferences/shared_preferences.dart';
 
+final _logger = Logger('StreakStorage');
+
 /// Provider for the streak storage for a given user.
-final streakStorageProvider = Provider.autoDispose.family<StreakStorage, UserId?>((
-  Ref ref,
-  UserId? userId,
-) {
+final streakStorageProvider = Provider.family<StreakStorage, UserId?>((Ref ref, UserId? userId) {
   return StreakStorage(ref, userId);
 });
 
@@ -22,7 +23,7 @@ final savedStreakScoreProvider = FutureProvider.autoDispose<int?>((Ref ref) asyn
   // as we invalidate this provider in the storage saveActiveStreak and clearActiveStreak methods
   final streakStorage = ref.read(streakStorageProvider(authUser?.user.id));
   final streak = await streakStorage.loadActiveStreak();
-  return streak?.index;
+  return streak?.score;
 });
 
 /// Local storage for the current puzzle streak.
@@ -37,7 +38,13 @@ class StreakStorage {
       return null;
     }
 
-    return PuzzleStreak.fromJson(jsonDecode(stored) as Map<String, dynamic>);
+    try {
+      return PuzzleStreak.fromJson(jsonDecode(stored) as Map<String, dynamic>);
+    } catch (e) {
+      // Written by another version of the app. The next run overwrites it.
+      _logger.warning('Ignoring an unreadable saved streak', e);
+      return null;
+    }
   }
 
   Future<void> saveActiveStreak(PuzzleStreak streak) async {
@@ -50,7 +57,27 @@ class StreakStorage {
     ref.invalidate(savedStreakScoreProvider);
   }
 
+  /// The score of a run that has ended but has not been posted yet.
+  Future<int?> loadPendingScore() async => _store.getInt(_pendingScoreKey);
+
+  /// Queues [score] to be posted. Only the best pending score is kept: the server keeps the best
+  /// score anyway, so several runs that ended before a post went through count as one.
+  Future<void> savePendingScore(int score) async {
+    final existing = _store.getInt(_pendingScoreKey);
+    await _store.setInt(_pendingScoreKey, existing == null ? score : max(existing, score));
+  }
+
+  /// Clears the pending score unless it beats [score], the one that has just been posted.
+  Future<void> clearPendingScoreIfAtMost(int score) async {
+    final pending = _store.getInt(_pendingScoreKey);
+    if (pending == null || pending <= score) {
+      await _store.remove(_pendingScoreKey);
+    }
+  }
+
   SharedPreferencesWithCache get _store => LichessBinding.instance.sharedPreferences;
 
   String get _storageKey => 'puzzle_streak.${userId ?? '**anon**'}';
+
+  String get _pendingScoreKey => 'puzzle_streak.pending_score.${userId ?? '**anon**'}';
 }

--- a/lib/src/network/http.dart
+++ b/lib/src/network/http.dart
@@ -171,22 +171,37 @@ final lichessClientProvider = Provider<LichessClient>((Ref ref) {
 
 /// Whether a response should be retried once by [lichessClientProvider].
 ///
-/// Retries on 429 Too Many Requests, except for the puzzle batch endpoints (`/api/puzzle/batch/…`),
-/// which are rate-limited deliberately:
-/// - solve submissions (`POST`) are handled with a back-off by `PuzzleSolveLimiter`, so retrying
-///   here only burns a request and delays arming the back-off;
-/// - batch downloads (`GET`) are issued once per puzzle angle, so a retry doubles an already large
-///   burst against an endpoint that has just said it is receiving too many requests.
+/// Retries on 429 Too Many Requests, except for the puzzle fetch endpoints, which are
+/// rate-limited deliberately and share a per-IP budget on the server:
+/// - solve submissions (`POST /api/puzzle/batch/…`) are handled with a back-off by
+///   `PuzzleSolveLimiter`, so retrying here only burns a request and delays arming the back-off;
+/// - batch downloads (`GET /api/puzzle/batch/…`) are issued once per puzzle angle, so a retry
+///   doubles an already large burst;
+/// - streak prefetches (`GET /api/puzzle/many`) are best-effort, and the streak plays on without
+///   them.
 @visibleForTesting
 bool shouldRetryOn429(BaseResponse response) {
   if (response.statusCode != 429) return false;
   final request = response.request;
-  final isPuzzleBatch = request != null && request.url.path.startsWith('/api/puzzle/batch/');
-  return !isPuzzleBatch;
+  if (request == null) return true;
+  final path = request.url.path;
+  final isPuzzleFetch = path.startsWith('/api/puzzle/batch/') || path == '/api/puzzle/many';
+  return !isPuzzleFetch;
 }
 
 Duration _defaultDelay(int retryCount) =>
     const Duration(milliseconds: 900) * math.pow(1.5, retryCount);
+
+/// Whether [error] is the server's final answer, so that repeating the same request is pointless
+/// and work queued for a later retry should be dropped.
+///
+/// True for a 4xx, except 429 Too Many Requests (passes once the rate limit resets) and 401
+/// Unauthorized (passes once the session is renewed). A network error or a 5xx may succeed later.
+bool isPermanentFailure(Object error) =>
+    error is ServerException &&
+    error.statusCode != 401 &&
+    error.statusCode != 429 &&
+    error.statusCode < 500;
 
 final userAgentProvider = Provider<String>((Ref ref) {
   final authUser = ref.watch(authControllerProvider);

--- a/lib/src/view/puzzle/puzzle_feedback_widget.dart
+++ b/lib/src/view/puzzle/puzzle_feedback_widget.dart
@@ -11,16 +11,25 @@ import 'package:lichess_mobile/src/view/account/rating_pref_aware.dart';
 import 'package:material_ui/material_ui.dart';
 
 class PuzzleFeedbackWidget extends ConsumerWidget {
-  const PuzzleFeedbackWidget({required this.puzzle, required this.state, required this.onStreak});
+  const PuzzleFeedbackWidget({
+    required this.puzzle,
+    required this.state,
+    required this.onStreak,
+    this.streakAdvanceNotice,
+  });
 
   final Puzzle puzzle;
   final PuzzleState state;
   final bool onStreak;
 
+  /// Shown in place of the puzzle stats while a solved streak puzzle cannot advance, e.g. offline.
+  final String? streakAdvanceNotice;
+
   @override
   Widget build(BuildContext context, WidgetRef ref) {
     switch (state.mode) {
       case PuzzleMode.view:
+        final notice = streakAdvanceNotice;
         final puzzleRating = context.l10n.puzzleRatingX(puzzle.puzzle.rating.toString());
         final playedXTimes = context.l10n.puzzlePlayedXTimes(puzzle.puzzle.plays).localizeNumbers();
         return FeedbackTile(
@@ -42,6 +51,8 @@ class PuzzleFeedbackWidget extends ConsumerWidget {
                 ),
           subtitle: onStreak && state.result == PuzzleResult.lose
               ? null
+              : notice != null
+              ? Text(notice, overflow: TextOverflow.ellipsis, maxLines: 2)
               : RatingPrefAware(
                   orElse: Text('$playedXTimes.', overflow: TextOverflow.ellipsis, maxLines: 2),
                   child: Text(

--- a/lib/src/view/puzzle/puzzle_feedback_widget.dart
+++ b/lib/src/view/puzzle/puzzle_feedback_widget.dart
@@ -15,6 +15,7 @@ class PuzzleFeedbackWidget extends ConsumerWidget {
     required this.puzzle,
     required this.state,
     required this.onStreak,
+    this.streakReview,
     this.streakAdvanceNotice,
   });
 
@@ -25,13 +26,39 @@ class PuzzleFeedbackWidget extends ConsumerWidget {
   /// Shown in place of the puzzle stats while a solved streak puzzle cannot advance, e.g. offline.
   final String? streakAdvanceNotice;
 
+  /// Set while a solved streak puzzle is reviewed: its index in the run and the solved count.
+  final ({int index, int total})? streakReview;
+
   @override
   Widget build(BuildContext context, WidgetRef ref) {
+    final replayFeedback = switch (state.feedback) {
+      PuzzleFeedback.good => Text(context.l10n.puzzleBestMove, overflow: TextOverflow.ellipsis),
+      PuzzleFeedback.bad => Text(
+        context.l10n.puzzleTrySomethingElse,
+        overflow: TextOverflow.ellipsis,
+      ),
+      null => null,
+    };
+
+    final review = streakReview;
+    if (review != null) {
+      return FeedbackTile(
+        leading: switch (state.feedback) {
+          PuzzleFeedback.good => Icon(Icons.check, size: 36, color: context.lichessColors.good),
+          PuzzleFeedback.bad => Icon(Icons.close, size: 36, color: context.lichessColors.error),
+          null => SideToPlayPiece(side: state.pov),
+        },
+        title: Text(
+          'Solved puzzle ${review.index + 1} of ${review.total}',
+          overflow: TextOverflow.ellipsis,
+        ),
+        subtitle: replayFeedback ?? _PuzzleStats(puzzle: puzzle),
+      );
+    }
+
     switch (state.mode) {
-      case PuzzleMode.view:
+      case PuzzleMode.view || PuzzleMode.replay:
         final notice = streakAdvanceNotice;
-        final puzzleRating = context.l10n.puzzleRatingX(puzzle.puzzle.rating.toString());
-        final playedXTimes = context.l10n.puzzlePlayedXTimes(puzzle.puzzle.plays).localizeNumbers();
         return FeedbackTile(
           leading: state.result == PuzzleResult.win
               ? Icon(Icons.check, size: 36, color: context.lichessColors.good)
@@ -50,17 +77,10 @@ class PuzzleFeedbackWidget extends ConsumerWidget {
                   overflow: TextOverflow.ellipsis,
                 ),
           subtitle: onStreak && state.result == PuzzleResult.lose
-              ? null
+              ? replayFeedback
               : notice != null
               ? Text(notice, overflow: TextOverflow.ellipsis, maxLines: 2)
-              : RatingPrefAware(
-                  orElse: Text('$playedXTimes.', overflow: TextOverflow.ellipsis, maxLines: 2),
-                  child: Text(
-                    '$puzzleRating. $playedXTimes.',
-                    overflow: TextOverflow.ellipsis,
-                    maxLines: 2,
-                  ),
-                ),
+              : _PuzzleStats(puzzle: puzzle),
         );
       case PuzzleMode.load:
       case PuzzleMode.play:
@@ -94,6 +114,22 @@ class PuzzleFeedbackWidget extends ConsumerWidget {
           );
         }
     }
+  }
+}
+
+class _PuzzleStats extends StatelessWidget {
+  const _PuzzleStats({required this.puzzle});
+
+  final Puzzle puzzle;
+
+  @override
+  Widget build(BuildContext context) {
+    final rating = context.l10n.puzzleRatingX(puzzle.puzzle.rating.toString());
+    final playedXTimes = context.l10n.puzzlePlayedXTimes(puzzle.puzzle.plays).localizeNumbers();
+    return RatingPrefAware(
+      orElse: Text('$playedXTimes.', overflow: TextOverflow.ellipsis, maxLines: 2),
+      child: Text('$rating. $playedXTimes.', overflow: TextOverflow.ellipsis, maxLines: 2),
+    );
   }
 }
 

--- a/lib/src/view/puzzle/puzzle_tab_screen.dart
+++ b/lib/src/view/puzzle/puzzle_tab_screen.dart
@@ -273,6 +273,10 @@ class _PuzzleMenu extends ConsumerWidget {
     final isOnline = ref.watch(isDeviceOnlineProvider);
     final authUser = ref.watch(authControllerProvider);
 
+    final savedStreakScore = ref.watch(savedStreakScoreProvider);
+    // A saved streak resumes offline from the cache; only a new one needs the network.
+    final canPlayStreak = isOnline || savedStreakScore.value != null;
+
     return ListSection(
       hasLeading: true,
       children: [
@@ -285,11 +289,11 @@ class _PuzzleMenu extends ConsumerWidget {
           },
         ),
         _PuzzleMenuListTile(
-          enabled: isOnline,
+          enabled: canPlayStreak,
           icon: LichessIcons.streak,
           title: 'Puzzle Streak',
-          badgeLabel: switch (ref.watch(savedStreakScoreProvider)) {
-            AsyncData(:final value?) => value.toString(),
+          badgeLabel: switch (savedStreakScore) {
+            AsyncData(:final value?) when value > 0 => value.toString(),
             _ => null,
           },
           subtitle:
@@ -297,7 +301,7 @@ class _PuzzleMenu extends ConsumerWidget {
                   .takeWhile((c) => c != '.')
                   .toString() +
               (context.l10n.puzzleStreakDescription.contains('.') ? '.' : ''),
-          onTap: isOnline
+          onTap: canPlayStreak
               ? () {
                   Navigator.of(context, rootNavigator: true).push(StreakScreen.buildRoute());
                 }

--- a/lib/src/view/puzzle/streak_screen.dart
+++ b/lib/src/view/puzzle/streak_screen.dart
@@ -13,6 +13,7 @@ import 'package:lichess_mobile/src/model/puzzle/puzzle_streak.dart';
 import 'package:lichess_mobile/src/model/puzzle/puzzle_streak_controller.dart';
 import 'package:lichess_mobile/src/model/puzzle/puzzle_theme.dart';
 import 'package:lichess_mobile/src/model/settings/board_preferences.dart';
+import 'package:lichess_mobile/src/network/connectivity.dart';
 import 'package:lichess_mobile/src/network/http.dart';
 import 'package:lichess_mobile/src/styles/lichess_icons.dart';
 import 'package:lichess_mobile/src/styles/styles.dart';
@@ -28,6 +29,7 @@ import 'package:lichess_mobile/src/view/puzzle/puzzle_feedback_widget.dart';
 import 'package:lichess_mobile/src/view/settings/toggle_sound_button.dart';
 import 'package:lichess_mobile/src/widgets/board.dart';
 import 'package:lichess_mobile/src/widgets/bottom_bar.dart';
+import 'package:lichess_mobile/src/widgets/feedback.dart';
 import 'package:lichess_mobile/src/widgets/pgn.dart';
 import 'package:lichess_mobile/src/widgets/platform_alert_dialog.dart';
 import 'package:lichess_mobile/src/widgets/yes_no_dialog.dart';
@@ -63,7 +65,11 @@ class _Load extends ConsumerWidget {
     switch (streak) {
       case AsyncValue(:final error?, :final stackTrace):
         debugPrint('SEVERE: [StreakScreen] could not load streak; $error\n$stackTrace');
-        return PuzzleErrorBoardWidget(errorMessage: error.toString());
+        return PuzzleErrorBoardWidget(
+          errorMessage: ref.watch(isDeviceOnlineProvider)
+              ? error.toString()
+              : 'Go online to start or continue your streak.',
+        );
       case AsyncValue(:final value?):
         return _Body(
           initialPuzzleContext: PuzzleContext(
@@ -93,6 +99,9 @@ class _Body extends ConsumerStatefulWidget {
 class _BodyState extends ConsumerState<_Body> {
   final _boardKey = GlobalKey(debugLabel: 'boardOnPuzzleStreakScreen');
   late final ChessboardController _controller;
+
+  /// Set once the solved live puzzle could not advance, until the next attempt.
+  bool _advanceFailed = false;
 
   @override
   void initState() {
@@ -140,6 +149,37 @@ class _BodyState extends ConsumerState<_Body> {
     );
   }
 
+  /// Moves the streak on to the next puzzle, and tells the user when it cannot.
+  Future<void> _advance() async {
+    if (_advanceFailed) {
+      setState(() {
+        _advanceFailed = false;
+      });
+    }
+    final result = await ref.read(puzzleStreakControllerProvider.notifier).next();
+    if (!mounted) return;
+    switch (result) {
+      case .advanced || .aborted:
+        return;
+      case .ended:
+        showSnackBar(context, 'The next puzzle is no longer available, so your streak ends here.');
+      case .unavailable:
+        // The feedback tile says what is wrong, and the bottom bar offers a retry while online.
+        setState(() {
+          _advanceFailed = true;
+        });
+        if (!ref.read(isDeviceOnlineProvider)) {
+          showSnackBar(context, "You're offline. Your streak will continue when you reconnect.");
+        }
+    }
+  }
+
+  /// What the feedback tile says while the solved live puzzle waits for the next one.
+  String? _advanceNotice({required bool isOnline}) {
+    if (!isOnline) return 'Waiting for connection to load the next puzzle.';
+    return _advanceFailed ? 'Could not load the next puzzle.' : null;
+  }
+
   /// Pushes the latest puzzle position to the board controller without rebuilding it.
   void _applyBoardUpdate() {
     _controller.updatePosition(_buildGameData());
@@ -150,6 +190,25 @@ class _BodyState extends ConsumerState<_Body> {
     final boardPreferences = ref.watch(boardPreferencesProvider);
     final ctrlProvider = puzzleControllerProvider(widget.initialPuzzleContext);
     final puzzleState = ref.watch(ctrlProvider);
+
+    // Set while the live puzzle is solved and its successor not there yet. Connectivity is only
+    // watched then, so that it does not rebuild the screen during play.
+    final pendingAdvance = widget.streak.advancePending;
+    final isOnline = !pendingAdvance || ref.watch(isDeviceOnlineProvider);
+
+    // Shared by the portrait and landscape layouts.
+    final feedback = PuzzleFeedbackWidget(
+      puzzle: puzzleState.puzzle,
+      state: puzzleState,
+      onStreak: true,
+      streakAdvanceNotice: pendingAdvance ? _advanceNotice(isOnline: isOnline) : null,
+    );
+    final bottomBar = _BottomBar(
+      initialPuzzleContext: widget.initialPuzzleContext,
+      streak: widget.streak,
+      // Offline, the streak controller retries by itself on reconnect.
+      onRetryAdvance: pendingAdvance && _advanceFailed && isOnline ? _advance : null,
+    );
 
     // fix for #1951 : when failing the first puzzle, need to do
     // an explicit check when restarting, or else the puzzle will be in a bugged state
@@ -176,7 +235,7 @@ class _BodyState extends ConsumerState<_Body> {
       if (previous?.result != PuzzleResult.lose && next.result == PuzzleResult.lose) {
         ref.read(puzzleStreakControllerProvider.notifier).gameOver();
       } else if (previous?.result != PuzzleResult.win && next.result == PuzzleResult.win) {
-        ref.read(puzzleStreakControllerProvider.notifier).next();
+        _advance();
       }
     });
 
@@ -193,7 +252,7 @@ class _BodyState extends ConsumerState<_Body> {
     );
 
     final content = PopScope(
-      canPop: widget.streak.index == 0 || widget.streak.finished,
+      canPop: widget.streak.score == 0 || widget.streak.finished,
       onPopInvokedWithResult: (bool didPop, _) async {
         if (didPop) {
           return;
@@ -272,13 +331,7 @@ class _BodyState extends ConsumerState<_Body> {
                                       child: Row(
                                         mainAxisAlignment: MainAxisAlignment.spaceAround,
                                         children: [
-                                          Expanded(
-                                            child: PuzzleFeedbackWidget(
-                                              puzzle: puzzleState.puzzle,
-                                              state: puzzleState,
-                                              onStreak: true,
-                                            ),
-                                          ),
+                                          Expanded(child: feedback),
                                           Text(
                                             context.l10n.puzzleRatingX(
                                               puzzleState.puzzle.puzzle.rating.toString(),
@@ -307,7 +360,7 @@ class _BodyState extends ConsumerState<_Body> {
                                                 ),
                                                 const SizedBox(width: 8.0),
                                                 Text(
-                                                  widget.streak.index.toString(),
+                                                  widget.streak.score.toString(),
                                                   style: TextStyle(
                                                     fontSize: 90.0,
                                                     fontWeight: FontWeight.bold,
@@ -342,10 +395,7 @@ class _BodyState extends ConsumerState<_Body> {
                                         ),
                                       ),
                                     ),
-                                    _BottomBar(
-                                      initialPuzzleContext: widget.initialPuzzleContext,
-                                      streak: widget.streak,
-                                    ),
+                                    bottomBar,
                                   ],
                                 ),
                               ),
@@ -370,11 +420,7 @@ class _BodyState extends ConsumerState<_Body> {
                                 child: Center(
                                   child: Padding(
                                     padding: const EdgeInsets.symmetric(horizontal: 10.0),
-                                    child: PuzzleFeedbackWidget(
-                                      puzzle: puzzleState.puzzle,
-                                      state: puzzleState,
-                                      onStreak: true,
-                                    ),
+                                    child: feedback,
                                   ),
                                 ),
                               ),
@@ -422,7 +468,7 @@ class _BodyState extends ConsumerState<_Body> {
                                               ),
                                               const SizedBox(width: 8.0),
                                               Text(
-                                                widget.streak.index.toString(),
+                                                widget.streak.score.toString(),
                                                 style: TextStyle(
                                                   fontSize: 30.0,
                                                   fontWeight: FontWeight.bold,
@@ -443,10 +489,7 @@ class _BodyState extends ConsumerState<_Body> {
                                 ),
                               ),
                             ),
-                            _BottomBar(
-                              initialPuzzleContext: widget.initialPuzzleContext,
-                              streak: widget.streak,
-                            ),
+                            bottomBar,
                           ],
                         );
                       }
@@ -472,10 +515,17 @@ class _BodyState extends ConsumerState<_Body> {
 }
 
 class _BottomBar extends ConsumerWidget {
-  const _BottomBar({required this.initialPuzzleContext, required this.streak});
+  const _BottomBar({
+    required this.initialPuzzleContext,
+    required this.streak,
+    required this.onRetryAdvance,
+  });
 
   final PuzzleContext initialPuzzleContext;
   final PuzzleStreak streak;
+
+  /// Set while the solved live puzzle could not advance: tries again to load the next puzzle.
+  final VoidCallback? onRetryAdvance;
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
@@ -491,18 +541,29 @@ class _BottomBar extends ConsumerWidget {
             showLabel: true,
             onTap: () => _streakInfoDialogBuilder(context),
           ),
+        // A solved puzzle cannot be skipped, so a retry takes the button's place when needed.
         if (!streak.finished)
-          BottomBarButton(
-            icon: Icons.skip_next,
-            label: context.l10n.skipThisMove,
-            showLabel: true,
-            onTap: streak.hasSkipped || puzzleState.mode == PuzzleMode.view
-                ? null
-                : () {
-                    ref.read(ctrlProvider.notifier).skipMove();
-                    ref.read(puzzleStreakControllerProvider.notifier).skipMove();
-                  },
-          ),
+          if (onRetryAdvance case final retry?)
+            BottomBarButton(
+              key: const ValueKey('retry-advance'),
+              icon: Icons.refresh,
+              label: context.l10n.retry,
+              showLabel: true,
+              onTap: retry,
+            )
+          else
+            BottomBarButton(
+              key: const ValueKey('skip'),
+              icon: Icons.skip_next,
+              label: context.l10n.skipThisMove,
+              showLabel: true,
+              onTap: streak.hasSkipped || puzzleState.mode == PuzzleMode.view
+                  ? null
+                  : () {
+                      ref.read(ctrlProvider.notifier).skipMove();
+                      ref.read(puzzleStreakControllerProvider.notifier).skipMove();
+                    },
+            ),
         if (streak.finished)
           BottomBarButton(
             onTap: () {
@@ -551,9 +612,17 @@ class _BottomBar extends ConsumerWidget {
           ),
         if (streak.finished)
           BottomBarButton(
-            onTap: ref.read(puzzleStreakControllerProvider).isLoading == false
-                ? () => ref.invalidate(puzzleStreakControllerProvider)
-                : null,
+            key: const ValueKey('new-streak'),
+            // Stays tappable offline, so that it can say why a new streak needs the network.
+            onTap: ref.watch(puzzleStreakControllerProvider.select((s) => s.isLoading))
+                ? null
+                : () {
+                    if (!ref.read(isDeviceOnlineProvider)) {
+                      showSnackBar(context, "You're offline. Go online to start a new streak.");
+                      return;
+                    }
+                    ref.invalidate(puzzleStreakControllerProvider);
+                  },
             highlighted: true,
             label: context.l10n.puzzleNewStreak,
             icon: Icons.refresh,

--- a/lib/src/view/puzzle/streak_screen.dart
+++ b/lib/src/view/puzzle/streak_screen.dart
@@ -3,9 +3,9 @@ import 'package:cupertino_ui/cupertino_ui.dart';
 import 'package:dartchess/dartchess.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:lichess_mobile/src/constants.dart';
-import 'package:lichess_mobile/src/model/analysis/analysis_controller.dart';
 import 'package:lichess_mobile/src/model/auth/auth_controller.dart';
 import 'package:lichess_mobile/src/model/common/chess.dart';
+import 'package:lichess_mobile/src/model/puzzle/puzzle.dart';
 import 'package:lichess_mobile/src/model/puzzle/puzzle_angle.dart';
 import 'package:lichess_mobile/src/model/puzzle/puzzle_controller.dart';
 import 'package:lichess_mobile/src/model/puzzle/puzzle_service.dart';
@@ -27,6 +27,7 @@ import 'package:lichess_mobile/src/view/analysis/analysis_screen.dart';
 import 'package:lichess_mobile/src/view/puzzle/puzzle_error_board_widget.dart';
 import 'package:lichess_mobile/src/view/puzzle/puzzle_feedback_widget.dart';
 import 'package:lichess_mobile/src/view/settings/toggle_sound_button.dart';
+import 'package:lichess_mobile/src/widgets/adaptive_action_sheet.dart';
 import 'package:lichess_mobile/src/widgets/board.dart';
 import 'package:lichess_mobile/src/widgets/bottom_bar.dart';
 import 'package:lichess_mobile/src/widgets/feedback.dart';
@@ -100,8 +101,22 @@ class _BodyState extends ConsumerState<_Body> {
   final _boardKey = GlobalKey(debugLabel: 'boardOnPuzzleStreakScreen');
   late final ChessboardController _controller;
 
+  /// The solved puzzle under review, or null when the live puzzle is displayed. It has its own
+  /// controller, so the live puzzle keeps its state.
+  ({int index, PuzzleContext context})? _review;
+
+  /// Bumped by every review navigation, so that a load overtaken by a later one is dropped.
+  int _reviewLoad = 0;
+
   /// Set once the solved live puzzle could not advance, until the next attempt.
   bool _advanceFailed = false;
+
+  PuzzleContext get _displayedContext => _review?.context ?? widget.initialPuzzleContext;
+
+  ({int index, int total})? get _streakReview {
+    final review = _review;
+    return review == null ? null : (index: review.index, total: widget.streak.score);
+  }
 
   @override
   void initState() {
@@ -112,9 +127,12 @@ class _BodyState extends ConsumerState<_Body> {
   @override
   void didUpdateWidget(_Body oldWidget) {
     super.didUpdateWidget(oldWidget);
-    // The streak feeds new puzzles by swapping the puzzle context (and thus the
-    // controller provider), so push the new puzzle onto the board.
-    if (oldWidget.initialPuzzleContext != widget.initialPuzzleContext) {
+    // A new run (they may share puzzles, never a start time) has no review to keep.
+    if (oldWidget.streak.timestamp != widget.streak.timestamp && _review != null) {
+      _leaveReview();
+    }
+    // A reviewer stays on their puzzle; returning to live picks up the new one.
+    if (oldWidget.initialPuzzleContext != widget.initialPuzzleContext && _review == null) {
       _applyBoardUpdate();
     }
   }
@@ -126,17 +144,18 @@ class _BodyState extends ConsumerState<_Body> {
   }
 
   PlayerSide _playerSide(PuzzleState state) {
-    return state.mode == PuzzleMode.load || state.currentPosition.isGameOver
-        ? PlayerSide.none
-        : state.mode == PuzzleMode.view
-        ? PlayerSide.both
-        : state.pov == Side.white
-        ? PlayerSide.white
-        : PlayerSide.black;
+    if (state.mode == PuzzleMode.load || state.currentPosition.isGameOver) {
+      return PlayerSide.none;
+    }
+    // In a replay the board locks while the opponent's reply is on its way.
+    if (state.mode == PuzzleMode.replay && state.currentPosition.turn != state.pov) {
+      return PlayerSide.none;
+    }
+    return state.pov == Side.white ? PlayerSide.white : PlayerSide.black;
   }
 
   GameData _buildGameData() {
-    final state = ref.read(puzzleControllerProvider(widget.initialPuzzleContext));
+    final state = ref.read(puzzleControllerProvider(_displayedContext));
     final boardPreferences = ref.read(boardPreferencesProvider);
     return buildGameData(
       fen: state.currentPosition.fen,
@@ -147,6 +166,56 @@ class _BodyState extends ConsumerState<_Body> {
       castlingMethod: boardPreferences.castlingMethod,
       boardHighlights: boardPreferences.boardHighlights,
     );
+  }
+
+  /// Pushes the latest puzzle position to the board controller without rebuilding it.
+  void _applyBoardUpdate() {
+    _controller.updatePosition(_buildGameData());
+  }
+
+  Future<void> _viewPuzzleAt(int index) async {
+    final load = ++_reviewLoad;
+    final Puzzle puzzle;
+    try {
+      final service = await ref.read(puzzleServiceProvider.future);
+      puzzle = await service.loadPuzzle(widget.streak.streak[index]);
+    } catch (_) {
+      if (mounted && load == _reviewLoad) {
+        showSnackBar(context, 'Could not load puzzle', type: SnackBarType.error);
+      }
+      return;
+    }
+    if (!mounted || load != _reviewLoad) return;
+    _controller.clearDrawnShapes();
+    setState(() {
+      _review = (
+        index: index,
+        context: PuzzleContext(
+          puzzle: puzzle,
+          angle: widget.initialPuzzleContext.angle,
+          // A user id would refresh the glicko through the batch endpoint on every load.
+          userId: null,
+          isPuzzleStreak: true,
+          isReview: true,
+        ),
+      );
+    });
+    _applyBoardUpdate();
+  }
+
+  /// Index in the run of the puzzle on the board.
+  int get _displayedIndex => _review?.index ?? widget.streak.index;
+
+  void _viewPreviousPuzzle() => _viewPuzzleAt(_displayedIndex - 1);
+
+  /// The puzzle after the reviewed one, the live puzzle being the last.
+  void _viewNextPuzzle() {
+    final index = _displayedIndex + 1;
+    if (index >= widget.streak.index) {
+      _returnToCurrentPuzzle();
+    } else {
+      _viewPuzzleAt(index);
+    }
   }
 
   /// Moves the streak on to the next puzzle, and tells the user when it cannot.
@@ -180,20 +249,28 @@ class _BodyState extends ConsumerState<_Body> {
     return _advanceFailed ? 'Could not load the next puzzle.' : null;
   }
 
-  /// Pushes the latest puzzle position to the board controller without rebuilding it.
-  void _applyBoardUpdate() {
-    _controller.updatePosition(_buildGameData());
+  void _leaveReview() {
+    _reviewLoad++;
+    _review = null;
+    _controller.clearDrawnShapes();
+  }
+
+  void _returnToCurrentPuzzle() {
+    setState(_leaveReview);
+    _applyBoardUpdate();
   }
 
   @override
   Widget build(BuildContext context) {
     final boardPreferences = ref.watch(boardPreferencesProvider);
-    final ctrlProvider = puzzleControllerProvider(widget.initialPuzzleContext);
+    // The live puzzle drives the streak; the displayed one, the board and the bottom bar.
+    final liveProvider = puzzleControllerProvider(widget.initialPuzzleContext);
+    final ctrlProvider = puzzleControllerProvider(_displayedContext);
     final puzzleState = ref.watch(ctrlProvider);
 
     // Set while the live puzzle is solved and its successor not there yet. Connectivity is only
     // watched then, so that it does not rebuild the screen during play.
-    final pendingAdvance = widget.streak.advancePending;
+    final pendingAdvance = _review == null && widget.streak.advancePending;
     final isOnline = !pendingAdvance || ref.watch(isDeviceOnlineProvider);
 
     // Shared by the portrait and landscape layouts.
@@ -201,11 +278,16 @@ class _BodyState extends ConsumerState<_Body> {
       puzzle: puzzleState.puzzle,
       state: puzzleState,
       onStreak: true,
+      streakReview: _streakReview,
       streakAdvanceNotice: pendingAdvance ? _advanceNotice(isOnline: isOnline) : null,
     );
     final bottomBar = _BottomBar(
-      initialPuzzleContext: widget.initialPuzzleContext,
+      puzzleContext: _displayedContext,
       streak: widget.streak,
+      isReviewing: _review != null,
+      onViewPrevious: _displayedIndex > 0 ? _viewPreviousPuzzle : null,
+      onViewNext: _review != null ? _viewNextPuzzle : null,
+      onJumpToLive: _returnToCurrentPuzzle,
       // Offline, the streak controller retries by itself on reconnect.
       onRetryAdvance: pendingAdvance && _advanceFailed && isOnline ? _advance : null,
     );
@@ -219,7 +301,7 @@ class _BodyState extends ConsumerState<_Body> {
           _controller.clearDrawnShapes();
           final authUser = ref.read(authControllerProvider);
           ref
-              .read(ctrlProvider.notifier)
+              .read(liveProvider.notifier)
               .onLoadPuzzle(
                 PuzzleContext(
                   puzzle: next.requireValue.puzzle,
@@ -231,7 +313,7 @@ class _BodyState extends ConsumerState<_Body> {
       }
     });
 
-    ref.listen(ctrlProvider, (previous, next) {
+    ref.listen(liveProvider, (previous, next) {
       if (previous?.result != PuzzleResult.lose && next.result == PuzzleResult.lose) {
         ref.read(puzzleStreakControllerProvider.notifier).gameOver();
       } else if (previous?.result != PuzzleResult.win && next.result == PuzzleResult.win) {
@@ -252,9 +334,14 @@ class _BodyState extends ConsumerState<_Body> {
     );
 
     final content = PopScope(
-      canPop: widget.streak.score == 0 || widget.streak.finished,
+      canPop: _review == null && (widget.streak.score == 0 || widget.streak.finished),
       onPopInvokedWithResult: (bool didPop, _) async {
         if (didPop) {
+          return;
+        }
+        // Back from a review returns to the live puzzle, not to the puzzle tab.
+        if (_review != null) {
+          _returnToCurrentPuzzle();
           return;
         }
         final NavigatorState navigator = Navigator.of(context);
@@ -506,7 +593,8 @@ class _BodyState extends ConsumerState<_Body> {
     return Theme.of(context).platform == TargetPlatform.android
         ? AndroidGesturesExclusionWidget(
             boardKey: _boardKey,
-            shouldExcludeGesturesOnFocusGained: puzzleState.mode != PuzzleMode.view,
+            // The board is played in every mode here, a done puzzle being replayed.
+            shouldExcludeGesturesOnFocusGained: true,
             shouldSetImmersiveMode: boardPreferences.immersiveModeWhilePlaying ?? false,
             child: content,
           )
@@ -516,33 +604,95 @@ class _BodyState extends ConsumerState<_Body> {
 
 class _BottomBar extends ConsumerWidget {
   const _BottomBar({
-    required this.initialPuzzleContext,
+    required this.puzzleContext,
     required this.streak,
+    required this.isReviewing,
+    required this.onViewPrevious,
+    required this.onViewNext,
+    required this.onJumpToLive,
     required this.onRetryAdvance,
   });
 
-  final PuzzleContext initialPuzzleContext;
+  final PuzzleContext puzzleContext;
   final PuzzleStreak streak;
+
+  /// Whether a solved puzzle is on the board rather than the live one.
+  final bool isReviewing;
+
+  /// Walk the run puzzle by puzzle; null at either end of it.
+  final VoidCallback? onViewPrevious;
+  final VoidCallback? onViewNext;
+  final VoidCallback onJumpToLive;
 
   /// Set while the solved live puzzle could not advance: tries again to load the next puzzle.
   final VoidCallback? onRetryAdvance;
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
-    final ctrlProvider = puzzleControllerProvider(initialPuzzleContext);
-    final puzzleState = ref.watch(ctrlProvider);
+    final ctrlProvider = puzzleControllerProvider(puzzleContext);
+    // Skipping is for the live puzzle in play; nothing else here depends on the puzzle.
+    final isReplaying = ref.watch(ctrlProvider.select((s) => s.mode == PuzzleMode.replay));
+
+    // The buttons that move through the run are labelled; menu and analysis stay icon-only, as
+    // on the puzzle screen.
+    final menuButton = BottomBarButton(
+      key: const ValueKey('menu'),
+      onTap: () => _showMenu(context, ref),
+      label: context.l10n.menu,
+      icon: Icons.menu,
+    );
+    final analysisButton = BottomBarButton(
+      key: const ValueKey('analysis'),
+      onTap: () => _openAnalysis(context, ref),
+      label: context.l10n.analysis,
+      icon: Icons.biotech,
+    );
+    // Greyed out on the first puzzle rather than removed, so that the bar keeps its shape.
+    final previousPuzzleButton = BottomBarButton(
+      key: const ValueKey('previous-puzzle'),
+      icon: CupertinoIcons.arrow_left,
+      label: 'Previous',
+      tooltip: 'Previous puzzle',
+      showLabel: true,
+      onTap: onViewPrevious,
+    );
 
     return BottomBar(
       children: [
-        if (!streak.finished)
+        menuButton,
+        // Off the live puzzle, the arrows walk the run; stepping through moves is for analysis.
+        if (isReviewing || streak.finished) ...[
+          analysisButton,
+          previousPuzzleButton,
           BottomBarButton(
-            icon: Icons.info_outline,
-            label: context.l10n.aboutX('Streak'),
+            key: const ValueKey('next-puzzle'),
+            icon: CupertinoIcons.arrow_right,
+            label: context.l10n.next,
+            tooltip: context.l10n.puzzleNextPuzzle,
             showLabel: true,
-            onTap: () => _streakInfoDialogBuilder(context),
+            onTap: onViewNext,
           ),
-        // A solved puzzle cannot be skipped, so a retry takes the button's place when needed.
-        if (!streak.finished)
+          if (streak.finished)
+            BottomBarButton(
+              key: const ValueKey('new-streak'),
+              // Stays tappable offline, so that it can say why a new streak needs the network.
+              onTap: ref.watch(puzzleStreakControllerProvider.select((s) => s.isLoading))
+                  ? null
+                  : () {
+                      if (!ref.read(isDeviceOnlineProvider)) {
+                        showSnackBar(context, "You're offline. Go online to start a new streak.");
+                        return;
+                      }
+                      ref.invalidate(puzzleStreakControllerProvider);
+                    },
+              highlighted: true,
+              label: context.l10n.puzzleNewStreak,
+              icon: Icons.skip_next,
+              showLabel: true,
+            ),
+        ] else ...[
+          previousPuzzleButton,
+          // A solved puzzle cannot be skipped, so a retry takes the button's place when needed.
           if (onRetryAdvance case final retry?)
             BottomBarButton(
               key: const ValueKey('retry-advance'),
@@ -557,76 +707,49 @@ class _BottomBar extends ConsumerWidget {
               icon: Icons.skip_next,
               label: context.l10n.skipThisMove,
               showLabel: true,
-              onTap: streak.hasSkipped || puzzleState.mode == PuzzleMode.view
+              onTap: streak.hasSkipped || isReplaying
                   ? null
                   : () {
                       ref.read(ctrlProvider.notifier).skipMove();
                       ref.read(puzzleStreakControllerProvider.notifier).skipMove();
                     },
             ),
-        if (streak.finished)
-          BottomBarButton(
-            onTap: () {
-              launchShareDialog(
-                context,
-                ShareParams(
-                  text: lichessUri('/training/${puzzleState.puzzle.puzzle.id}').toString(),
-                ),
-              );
-            },
-            label: 'Share this puzzle',
-            icon: Theme.of(context).platform == TargetPlatform.iOS ? Icons.ios_share : Icons.share,
+        ],
+      ],
+    );
+  }
+
+  void _openAnalysis(BuildContext context, WidgetRef ref) {
+    final ctrlProvider = puzzleControllerProvider(puzzleContext);
+    final puzzleState = ref.read(ctrlProvider);
+    Navigator.of(context, rootNavigator: true).push(
+      AnalysisScreen.buildRoute(
+        puzzleState.makeAnalysisOptions(ref.read(ctrlProvider.notifier).makePgn),
+      ),
+    );
+  }
+
+  Future<void> _showMenu(BuildContext context, WidgetRef ref) {
+    final ctrlProvider = puzzleControllerProvider(puzzleContext);
+    return showAdaptiveActionSheet(
+      context: context,
+      actions: [
+        if (isReviewing)
+          BottomSheetAction(
+            makeLabel: (context) => const Text('Back to current puzzle'),
+            onPressed: onJumpToLive,
           ),
-        if (streak.finished)
-          BottomBarButton(
-            onTap: () {
-              Navigator.of(context, rootNavigator: true).push(
-                AnalysisScreen.buildRoute(
-                  AnalysisOptions.pgn(
-                    id: puzzleState.puzzle.puzzle.id,
-                    orientation: puzzleState.pov,
-                    pgn: ref.read(ctrlProvider.notifier).makePgn(),
-                    isComputerAnalysisAllowed: true,
-                    variant: Variant.standard,
-                    initialMoveCursor: 0,
-                  ),
-                ),
-              );
-            },
-            label: context.l10n.analysis,
-            icon: Icons.biotech,
-          ),
-        if (streak.finished)
-          BottomBarButton(
-            onTap: puzzleState.canGoBack
-                ? () => ref.read(ctrlProvider.notifier).userPrevious()
-                : null,
-            label: 'Previous',
-            icon: CupertinoIcons.chevron_back,
-          ),
-        if (streak.finished)
-          BottomBarButton(
-            onTap: puzzleState.canGoNext ? () => ref.read(ctrlProvider.notifier).userNext() : null,
-            label: context.l10n.next,
-            icon: CupertinoIcons.chevron_forward,
-          ),
-        if (streak.finished)
-          BottomBarButton(
-            key: const ValueKey('new-streak'),
-            // Stays tappable offline, so that it can say why a new streak needs the network.
-            onTap: ref.watch(puzzleStreakControllerProvider.select((s) => s.isLoading))
-                ? null
-                : () {
-                    if (!ref.read(isDeviceOnlineProvider)) {
-                      showSnackBar(context, "You're offline. Go online to start a new streak.");
-                      return;
-                    }
-                    ref.invalidate(puzzleStreakControllerProvider);
-                  },
-            highlighted: true,
-            label: context.l10n.puzzleNewStreak,
-            icon: Icons.refresh,
-          ),
+        BottomSheetAction(
+          makeLabel: (context) => Text(context.l10n.mobileSharePuzzle),
+          onPressed: () {
+            final id = ref.read(ctrlProvider).puzzle.puzzle.id;
+            launchShareDialog(context, ShareParams(text: lichessUri('/training/$id').toString()));
+          },
+        ),
+        BottomSheetAction(
+          makeLabel: (context) => Text(context.l10n.aboutX('Streak')),
+          onPressed: () => _streakInfoDialogBuilder(context),
+        ),
       ],
     );
   }

--- a/test/model/puzzle/puzzle_controller_test.dart
+++ b/test/model/puzzle/puzzle_controller_test.dart
@@ -19,11 +19,15 @@ import 'package:lichess_mobile/src/network/http.dart';
 
 import '../../test_container.dart';
 import '../../test_helpers.dart';
+import '../../view/puzzle/example_data.dart';
 import '../auth/fake_auth_storage.dart';
 
 final _userId = fakeAuthUser.user.id;
 
 void main() {
+  // review moves reach the haptics platform channel
+  TestWidgetsFlutterBinding.ensureInitialized();
+
   group('PuzzleController.changeDifficulty', () {
     test('does not start the offline queue fill while resetBatch is in flight', () async {
       // Regression test: `resetBatch` saves a batch built from a snapshot taken
@@ -111,7 +115,70 @@ void main() {
       expect(container.read(puzzleQueueFillerProvider), isFalse);
     });
   });
+
+  group('PuzzleController in review', () {
+    test('opens the puzzle in replay mode and keeps it there past the first-move delay', () async {
+      final container = await makeContainer();
+      final provider = puzzleControllerProvider(_streakContext.copyWith(isReview: true));
+      final subscription = container.listen(provider, (_, _) {});
+      addTearDown(subscription.close);
+
+      expect(container.read(provider).mode, PuzzleMode.replay);
+      expect(container.read(provider).lastMove, isNotNull, reason: 'the setup move is highlighted');
+
+      // the first move timer must not flip the puzzle back into play mode
+      await Future<void>.delayed(const Duration(milliseconds: 1200));
+      expect(container.read(provider).mode, PuzzleMode.replay);
+    });
+
+    test('plays the opponent reply without waiting for the next-move button', () async {
+      final container = await makeContainer();
+      final provider = puzzleControllerProvider(_streakContext.copyWith(isReview: true));
+      final subscription = container.listen(provider, (_, _) {});
+      addTearDown(subscription.close);
+
+      final initialPath = container.read(provider).initialPath;
+
+      await container.read(provider.notifier).onUserMove(Move.parse('h4h2')!);
+
+      final state = container.read(provider);
+      expect(
+        state.currentPath.size - initialPath.size,
+        2,
+        reason: 'the solved move and the reply to it',
+      );
+      expect(state.node.sanMove.move.uci, 'h1h2', reason: 'the reply is the solution move');
+      expect(state.feedback, PuzzleFeedback.good);
+    });
+
+    test('takes back a wrong move', () async {
+      final container = await makeContainer();
+      final provider = puzzleControllerProvider(_streakContext.copyWith(isReview: true));
+      final subscription = container.listen(provider, (_, _) {});
+      addTearDown(subscription.close);
+
+      final initialPath = container.read(provider).initialPath;
+
+      await container.read(provider.notifier).onUserMove(Move.parse('b4b2')!);
+
+      final state = container.read(provider);
+      expect(state.currentPath, initialPath, reason: 'back to where the move was played from');
+      expect(state.feedback, PuzzleFeedback.bad);
+      expect(
+        state.node.children.map((c) => c.sanMove.move.uci),
+        isNot(contains('b4b2')),
+        reason: 'the variation is deleted, not merely stepped out of',
+      );
+    });
+  });
 }
+
+final _streakContext = PuzzleContext(
+  puzzle: puzzle,
+  angle: const PuzzleTheme(PuzzleThemeKey.mix),
+  userId: null,
+  isPuzzleStreak: true,
+);
 
 /// Waits for the fire-and-forget queue fill kicked off by the controller.
 Future<void> _waitForFill(ProviderContainer container) async {

--- a/test/model/puzzle/puzzle_storage_test.dart
+++ b/test/model/puzzle/puzzle_storage_test.dart
@@ -31,6 +31,39 @@ void main() {
       await storage.save(puzzle: puzzle);
       expect(storage.fetch(puzzleId: const PuzzleId('pId3')), completion(equals(puzzle)));
     });
+
+    test('saveAll stores every puzzle and cachedPuzzleIds reports them', () async {
+      final db = await openAppDatabase(dbFactory, inMemoryDatabasePath);
+
+      final container = await makeContainer(
+        overrides: {
+          databaseProvider: databaseProvider.overrideWith((ref) {
+            ref.onDispose(db.close);
+            return db;
+          }),
+        },
+      );
+
+      final storage = await container.read(puzzleStorageProvider.future);
+
+      final puzzles = IList([
+        for (final id in const ['pId1', 'pId2'])
+          puzzle.copyWith(puzzle: puzzle.puzzle.copyWith(id: PuzzleId(id))),
+      ]);
+      await storage.saveAll(puzzles: puzzles);
+
+      for (final saved in puzzles) {
+        expect(storage.fetch(puzzleId: saved.puzzle.id), completion(equals(saved)));
+      }
+
+      expect(
+        storage.cachedPuzzleIds(
+          ids: IList(const [PuzzleId('pId1'), PuzzleId('pId2'), PuzzleId('none1')]),
+        ),
+        completion(equals(ISet(const [PuzzleId('pId1'), PuzzleId('pId2')]))),
+      );
+      expect(storage.cachedPuzzleIds(ids: IList(const <PuzzleId>[])), completion(isEmpty));
+    });
   });
 }
 

--- a/test/model/puzzle/puzzle_streak_controller_test.dart
+++ b/test/model/puzzle/puzzle_streak_controller_test.dart
@@ -1,0 +1,1212 @@
+import 'dart:async';
+import 'dart:convert';
+
+import 'package:connectivity_plus/connectivity_plus.dart';
+import 'package:fast_immutable_collections/fast_immutable_collections.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:http/http.dart' as http;
+import 'package:http/testing.dart';
+import 'package:lichess_mobile/src/db/database.dart';
+import 'package:lichess_mobile/src/model/auth/auth_controller.dart';
+import 'package:lichess_mobile/src/model/common/id.dart';
+import 'package:lichess_mobile/src/model/puzzle/puzzle.dart';
+import 'package:lichess_mobile/src/model/puzzle/puzzle_storage.dart';
+import 'package:lichess_mobile/src/model/puzzle/puzzle_streak.dart';
+import 'package:lichess_mobile/src/model/puzzle/puzzle_streak_controller.dart';
+import 'package:lichess_mobile/src/model/puzzle/streak_storage.dart';
+import 'package:lichess_mobile/src/network/connectivity.dart';
+import 'package:lichess_mobile/src/network/http.dart';
+
+import '../../network/fake_http_client_factory.dart';
+import '../../test_container.dart';
+import '../../test_provider_scope.dart';
+import '../../utils/fake_connectivity.dart';
+import '../../view/puzzle/example_data.dart';
+import '../auth/fake_auth_storage.dart';
+import 'mock_server_responses.dart';
+
+String _puzzleJsonWithId(String id) {
+  final map = jsonDecode(mockDailyPuzzleResponse) as Map<String, dynamic>;
+  (map['puzzle'] as Map<String, dynamic>)['id'] = id;
+  return jsonEncode(map);
+}
+
+/// A `/api/streak` response for [ids], with [ids].first embedded.
+String _streakJson(List<String> ids) {
+  final map = jsonDecode(mockDailyPuzzleResponse) as Map<String, dynamic>;
+  (map['puzzle'] as Map<String, dynamic>)['id'] = ids.first;
+  map['streak'] = ids.join(' ');
+  return jsonEncode(map);
+}
+
+/// A `/api/puzzle/many` response with one puzzle per id.
+String _manyJson(Iterable<String> ids) {
+  return jsonEncode({'puzzles': ids.map((id) => jsonDecode(_puzzleJsonWithId(id))).toList()});
+}
+
+/// Puzzle ids requested via `/api/puzzle/many` (one entry per request) and `/api/puzzle/{id}`.
+class _RequestLog {
+  final manyIds = <List<String>>[];
+  final singleIds = <String>[];
+}
+
+/// Serves `/api/streak`, `/api/puzzle/many` and `/api/puzzle/{id}` for any id.
+MockClient _onlineClient(List<String> streakIds, {_RequestLog? log}) {
+  return MockClient((request) async {
+    final path = request.url.path;
+    if (path == '/api/streak') {
+      return http.Response(_streakJson(streakIds), 200);
+    }
+    if (path == '/api/puzzle/many') {
+      final requested = request.url.queryParameters['ids']!.split(',');
+      log?.manyIds.add(requested);
+      return http.Response(_manyJson(requested), 200);
+    }
+    if (path.startsWith('/api/puzzle/')) {
+      final id = path.split('/').last;
+      log?.singleIds.add(id);
+      return http.Response(_puzzleJsonWithId(id), 200);
+    }
+    return http.Response('', 404);
+  });
+}
+
+/// Throws while `isOnline()` is false, otherwise serves streaks, puzzles and streak-run posts
+/// (recorded into [postedRuns]).
+MockClient _reconnectingClient(
+  bool Function() isOnline, {
+  List<String>? streakIds,
+  List<int>? postedRuns,
+}) {
+  return MockClient((request) async {
+    if (!isOnline()) {
+      throw http.ClientException('offline');
+    }
+    final path = request.url.path;
+    if (request.method == 'POST' && path.startsWith('/api/streak/')) {
+      postedRuns?.add(int.parse(path.split('/').last));
+      return http.Response('', 200);
+    }
+    if (streakIds != null && path == '/api/streak') {
+      return http.Response(_streakJson(streakIds), 200);
+    }
+    if (path == '/api/puzzle/many') {
+      return http.Response(_manyJson(request.url.queryParameters['ids']!.split(',')), 200);
+    }
+    if (path.startsWith('/api/puzzle/')) {
+      return http.Response(_puzzleJsonWithId(path.split('/').last), 200);
+    }
+    return http.Response('', 200);
+  });
+}
+
+/// Keeps the autoDispose controller alive, as the streak screen does. Listening triggers `build()`,
+/// so call it after populating storage.
+ProviderSubscription<AsyncValue<StreakState>> _keepAlive(ProviderContainer container) {
+  return container.listen(puzzleStreakControllerProvider, (_, _) {}, onError: (_, _) {});
+}
+
+/// Polls until the controller carries an error. Its `.future` never completes on failure, since
+/// Riverpod auto-retries a failed provider.
+Future<Object?> _awaitBuildError(ProviderContainer container) async {
+  for (var i = 0; i < 200; i++) {
+    final value = container.read(puzzleStreakControllerProvider);
+    if (value.error != null) return value.error;
+    await Future<void>.delayed(const Duration(milliseconds: 10));
+  }
+  return null;
+}
+
+/// Polls until the controller carries a run, e.g. after a reconnect reloads a failed one.
+Future<StreakState?> _awaitStreak(ProviderContainer container) async {
+  for (var i = 0; i < 200; i++) {
+    final value = container.read(puzzleStreakControllerProvider);
+    if (value case AsyncData(:final value, isLoading: false)) return value;
+    await Future<void>.delayed(const Duration(milliseconds: 10));
+  }
+  return null;
+}
+
+/// Polls [storage] until [id] is present, since the prefetch is fire-and-forget.
+Future<Puzzle?> _waitForCached(PuzzleStorage storage, PuzzleId id) async {
+  for (var i = 0; i < 100; i++) {
+    final cached = await storage.fetch(puzzleId: id);
+    if (cached != null) return cached;
+    await Future<void>.delayed(const Duration(milliseconds: 10));
+  }
+  return null;
+}
+
+Future<void> _waitForConnectivity(ProviderContainer container, {required bool isOnline}) async {
+  for (var i = 0; i < 200; i++) {
+    if (container.read(connectivityChangesProvider).value?.isOnline == isOnline) return;
+    await Future<void>.delayed(const Duration(milliseconds: 10));
+  }
+  fail('connectivity did not report isOnline=$isOnline');
+}
+
+class _ClearThrowingStreakStorage extends StreakStorage {
+  const _ClearThrowingStreakStorage(super.ref, super.userId);
+
+  @override
+  Future<void> clearActiveStreak() => Future.error(Exception('simulated disk-write failure'));
+}
+
+class _SaveThrowingStorage extends PuzzleStorage {
+  _SaveThrowingStorage(super.db);
+
+  @override
+  Future<void> save({required Puzzle puzzle}) =>
+      Future.error(Exception('simulated disk-write failure'));
+}
+
+PuzzleStreak _activeStreak(List<String> ids, {int index = 0}) => PuzzleStreak(
+  streak: IList(ids.map((e) => PuzzleId(e))),
+  index: index,
+  hasSkipped: false,
+  finished: false,
+  timestamp: DateTime.now(),
+);
+
+Puzzle _puzzle(String id) => puzzle.copyWith(puzzle: puzzle.puzzle.copyWith(id: PuzzleId(id)));
+
+void main() {
+  // the connectivity provider registers an AppLifecycleListener
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  group('PuzzleStreakController local-first fetching', () {
+    test('a fresh streak caches its first puzzle, embedded in /api/streak', () async {
+      final ids = ['AAAAA', 'BBBBB', 'CCCCC'];
+      final container = await lichessClientContainer(_onlineClient(ids));
+
+      _keepAlive(container);
+      final state = await container.read(puzzleStreakControllerProvider.future);
+      expect(state.puzzle.puzzle.id, const PuzzleId('AAAAA'));
+
+      final puzzleStorage = await container.read(puzzleStorageProvider.future);
+      expect(
+        (await puzzleStorage.fetch(puzzleId: const PuzzleId('AAAAA')))?.puzzle.id,
+        const PuzzleId('AAAAA'),
+      );
+    });
+
+    test('a fresh streak can be resumed offline before the first solve', () async {
+      var online = true;
+      final container = await lichessClientContainer(
+        _reconnectingClient(() => online, streakIds: ['AAAAA', 'BBBBB', 'CCCCC']),
+      );
+
+      _keepAlive(container);
+      await container.read(puzzleStreakControllerProvider.future);
+
+      final saved = await container.read(streakStorageProvider(null)).loadActiveStreak();
+      expect(saved?.index, 0);
+
+      // going offline and reopening the screen resumes from the cache
+      online = false;
+      container.invalidate(puzzleStreakControllerProvider);
+      final resumed = await container.read(puzzleStreakControllerProvider.future);
+      expect(resumed.streak.index, 0);
+      expect(resumed.puzzle.puzzle.id, const PuzzleId('AAAAA'));
+    });
+
+    test('resumes an active streak offline when puzzles are cached', () async {
+      final container = await lichessClientContainer(offlineClient);
+
+      final puzzleStorage = await container.read(puzzleStorageProvider.future);
+      await puzzleStorage.save(puzzle: _puzzle('MptxK'));
+      await puzzleStorage.save(puzzle: _puzzle('4CZxz'));
+      await container
+          .read(streakStorageProvider(null))
+          .saveActiveStreak(_activeStreak(['MptxK', '4CZxz']));
+
+      _keepAlive(container);
+      final state = await container.read(puzzleStreakControllerProvider.future);
+
+      expect(state.streak.index, 0);
+      expect(state.puzzle.puzzle.id, const PuzzleId('MptxK'));
+    });
+
+    test('resuming an active streak offline with an empty cache surfaces an error', () async {
+      final container = await lichessClientContainer(offlineClient);
+
+      await container
+          .read(streakStorageProvider(null))
+          .saveActiveStreak(_activeStreak(['MptxK', '4CZxz']));
+
+      _keepAlive(container);
+      expect(await _awaitBuildError(container), isA<Exception>());
+    });
+
+    test('a corrupt cached current puzzle self-heals from the network', () async {
+      final ids = ['MptxK', '4CZxz'];
+      final container = await lichessClientContainer(_onlineClient(ids));
+
+      final db = await container.read(databaseProvider.future);
+      await db.insert('puzzle', {
+        'puzzleId': 'MptxK',
+        'lastModified': DateTime.now().toIso8601String(),
+        'data': 'not-json',
+      });
+      await container.read(streakStorageProvider(null)).saveActiveStreak(_activeStreak(ids));
+
+      _keepAlive(container);
+      final state = await container.read(puzzleStreakControllerProvider.future);
+      expect(state.puzzle.puzzle.id, const PuzzleId('MptxK'));
+
+      final puzzleStorage = await container.read(puzzleStorageProvider.future);
+      expect(
+        (await puzzleStorage.fetch(puzzleId: const PuzzleId('MptxK')))?.puzzle.id,
+        const PuzzleId('MptxK'),
+      );
+    });
+
+    test('starting a brand-new streak offline surfaces an error', () async {
+      final container = await lichessClientContainer(offlineClient);
+
+      _keepAlive(container);
+      expect(await _awaitBuildError(container), isNotNull);
+    });
+
+    test('prefetch warms the cache with a single /api/puzzle/many request', () async {
+      final ids = ['AAAAA', 'BBBBB', 'CCCCC', 'DDDDD', 'EEEEE'];
+      final requests = _RequestLog();
+      final container = await lichessClientContainer(
+        _onlineClient(ids, log: requests),
+        authUser: fakeAuthUser,
+      );
+
+      _keepAlive(container);
+      await container.read(puzzleStreakControllerProvider.future);
+
+      final puzzleStorage = await container.read(puzzleStorageProvider.future);
+      for (final id in ['BBBBB', 'CCCCC', 'DDDDD', 'EEEEE']) {
+        expect(
+          (await _waitForCached(puzzleStorage, PuzzleId(id)))?.puzzle.id,
+          PuzzleId(id),
+          reason: 'puzzle $id should have been prefetched',
+        );
+      }
+
+      // everything past the embedded first puzzle is warmed in one request
+      expect(requests.manyIds, [
+        ['BBBBB', 'CCCCC', 'DDDDD', 'EEEEE'],
+      ]);
+      expect(requests.singleIds, isEmpty);
+    });
+
+    test('the look-ahead buffer is replenished as the streak progresses', () async {
+      // the initial prefetch warms indexes 1-30, the second request the 30 after those
+      final ids = [for (var i = 0; i < 70; i++) 'PZ${i.toString().padLeft(3, '0')}'];
+      final requests = _RequestLog();
+      final container = await lichessClientContainer(
+        _onlineClient(ids, log: requests),
+        authUser: fakeAuthUser,
+      );
+
+      _keepAlive(container);
+      await container.read(puzzleStreakControllerProvider.future);
+
+      final puzzleStorage = await container.read(puzzleStorageProvider.future);
+      expect(await _waitForCached(puzzleStorage, PuzzleId(ids[30])), isNotNull);
+
+      final notifier = container.read(puzzleStreakControllerProvider.notifier);
+      for (var i = 0; i < 22; i++) {
+        expect(await notifier.next(), StreakAdvance.advanced);
+      }
+
+      for (var i = 0; i < 100 && requests.manyIds.length < 2; i++) {
+        await Future<void>.delayed(const Duration(milliseconds: 10));
+      }
+      expect(requests.manyIds, [
+        ids.sublist(1, 31),
+        ids.sublist(31, 61),
+      ], reason: 'a refill must start where the cached range ends, not overlap it');
+    });
+
+    /// Advances [n] times against a `/api/puzzle/many` that always answers [status], and returns
+    /// how many times it was called. Single puzzle fetches always succeed, as on lichess, where
+    /// `/api/puzzle/{id}` is not rate limited.
+    Future<int> countRefillsWhenManyFails(int status, {int advances = 10}) async {
+      final ids = [for (var i = 0; i < 40; i++) 'RZ${i.toString().padLeft(3, '0')}'];
+      var manyRequests = 0;
+      final client = MockClient((request) async {
+        final path = request.url.path;
+        if (path == '/api/streak') {
+          return http.Response(_streakJson(ids), 200);
+        }
+        if (path == '/api/puzzle/many') {
+          manyRequests++;
+          return http.Response('', status, request: request);
+        }
+        if (path.startsWith('/api/puzzle/')) {
+          return http.Response(_puzzleJsonWithId(path.split('/').last), 200);
+        }
+        return http.Response('', 404);
+      });
+
+      final container = await lichessClientContainer(client);
+      _keepAlive(container);
+      await container.read(puzzleStreakControllerProvider.future);
+
+      final notifier = container.read(puzzleStreakControllerProvider.notifier);
+      for (var i = 0; i < advances; i++) {
+        expect(await notifier.next(), StreakAdvance.advanced);
+      }
+      await Future<void>.delayed(const Duration(milliseconds: 50));
+      return manyRequests;
+    }
+
+    test('a look-ahead refill that fails transiently backs off, then retries', () async {
+      // 10 advances at a 5-advance back-off
+      final requests = await countRefillsWhenManyFails(503);
+      expect(
+        requests,
+        lessThanOrEqualTo(3),
+        reason: 'the failed refill must back off, not fire once per solved puzzle',
+      );
+      expect(
+        requests,
+        greaterThan(1),
+        reason: 'the back-off must expire on its own, without needing a reconnect',
+      );
+    });
+
+    test('a rate-limited look-ahead refill stands down for the rest of the run', () async {
+      // `/api/puzzle/many` shares a per-IP hourly budget with `/api/puzzle/batch/`, so a 429 will
+      // not clear within a run. Retrying only spends requests the rest of the app needs.
+      expect(await countRefillsWhenManyFails(429), 1);
+    });
+
+    test('a refused look-ahead refill is not retried on reconnect', () async {
+      var online = true;
+      var manyRequests = 0;
+      final ids = [for (var i = 0; i < 40; i++) 'RC${i.toString().padLeft(3, '0')}'];
+      final client = MockClient((request) async {
+        if (!online) throw http.ClientException('offline');
+        final path = request.url.path;
+        if (path == '/api/streak') {
+          return http.Response(_streakJson(ids), 200);
+        }
+        if (path == '/api/puzzle/many') {
+          manyRequests++;
+          return http.Response('', 429, request: request);
+        }
+        if (path.startsWith('/api/puzzle/')) {
+          return http.Response(_puzzleJsonWithId(path.split('/').last), 200);
+        }
+        return http.Response('', 404);
+      });
+
+      final container = await lichessClientContainer(client);
+      _keepAlive(container);
+      await container.read(puzzleStreakControllerProvider.future);
+      await _waitForConnectivity(container, isOnline: true);
+      await Future<void>.delayed(const Duration(milliseconds: 50));
+      expect(manyRequests, 1);
+
+      online = false;
+      FakeConnectivity.controller.add([ConnectivityResult.none]);
+      await _waitForConnectivity(container, isOnline: false);
+      online = true;
+      // connectivity changes are throttled
+      await Future<void>.delayed(kConnectivityThrottleDelay);
+      FakeConnectivity.controller.add([ConnectivityResult.wifi]);
+      await _waitForConnectivity(container, isOnline: true);
+      await Future<void>.delayed(const Duration(milliseconds: 50));
+
+      expect(manyRequests, 1, reason: 'the hourly budget does not clear on reconnect');
+    });
+
+    test('the run plays on normally once the look-ahead is rate limited', () async {
+      final ids = [for (var i = 0; i < 40; i++) 'RL${i.toString().padLeft(3, '0')}'];
+      final client = MockClient((request) async {
+        final path = request.url.path;
+        if (path == '/api/streak') {
+          return http.Response(_streakJson(ids), 200);
+        }
+        if (path == '/api/puzzle/many') {
+          return http.Response('', 429, request: request);
+        }
+        if (path.startsWith('/api/puzzle/')) {
+          return http.Response(_puzzleJsonWithId(path.split('/').last), 200);
+        }
+        return http.Response('', 404);
+      });
+
+      final container = await lichessClientContainer(client);
+      _keepAlive(container);
+      await container.read(puzzleStreakControllerProvider.future);
+
+      final notifier = container.read(puzzleStreakControllerProvider.notifier);
+      for (var i = 1; i < 10; i++) {
+        expect(await notifier.next(), StreakAdvance.advanced);
+        expect(
+          container.read(puzzleStreakControllerProvider).requireValue.puzzle.puzzle.id.value,
+          ids[i],
+        );
+      }
+    });
+
+    test('an id dropped from a /api/puzzle/many response is fetched on its own', () async {
+      final ids = [for (var i = 0; i < 45; i++) 'HZ${i.toString().padLeft(3, '0')}'];
+      final dropped = ids[10];
+      final requests = _RequestLog();
+      final client = MockClient((request) async {
+        final path = request.url.path;
+        if (path == '/api/streak') {
+          return http.Response(_streakJson(ids), 200);
+        }
+        if (path == '/api/puzzle/many') {
+          final requested = request.url.queryParameters['ids']!.split(',');
+          requests.manyIds.add(requested);
+          return http.Response(_manyJson(requested.where((id) => id != dropped)), 200);
+        }
+        if (path.startsWith('/api/puzzle/')) {
+          final id = path.split('/').last;
+          requests.singleIds.add(id);
+          return http.Response(_puzzleJsonWithId(id), 200);
+        }
+        return http.Response('', 404);
+      });
+
+      final container = await lichessClientContainer(client);
+      _keepAlive(container);
+      await container.read(puzzleStreakControllerProvider.future);
+
+      final puzzleStorage = await container.read(puzzleStorageProvider.future);
+      expect(await _waitForCached(puzzleStorage, PuzzleId(ids[30])), isNotNull);
+      expect(await puzzleStorage.fetch(puzzleId: PuzzleId(dropped)), isNull);
+
+      final notifier = container.read(puzzleStreakControllerProvider.notifier);
+
+      // the run reaches the dropped puzzle, which is fetched on its own
+      for (var i = 0; i < 10; i++) {
+        expect(await notifier.next(), StreakAdvance.advanced);
+      }
+      final state = container.read(puzzleStreakControllerProvider).requireValue;
+      expect(state.streak.index, 10);
+      expect(state.puzzle.puzzle.id, PuzzleId(dropped));
+      expect(requests.singleIds, contains(dropped));
+
+      // the hole does not cost a second look-ahead request: the window counts as warmed
+      await Future<void>.delayed(const Duration(milliseconds: 50));
+      expect(requests.manyIds, hasLength(1));
+    });
+
+    test('overlapping look-ahead refills issue a single /api/puzzle/many request', () async {
+      final ids = [for (var i = 0; i < 40; i++) 'QZ${i.toString().padLeft(3, '0')}'];
+      final requests = _RequestLog();
+      final gate = Completer<void>();
+      final client = MockClient((request) async {
+        final path = request.url.path;
+        if (path == '/api/streak') {
+          return http.Response(_streakJson(ids), 200);
+        }
+        if (path == '/api/puzzle/many') {
+          final requested = request.url.queryParameters['ids']!.split(',');
+          requests.manyIds.add(requested);
+          await gate.future;
+          return http.Response(_manyJson(requested), 200);
+        }
+        if (path.startsWith('/api/puzzle/')) {
+          final id = path.split('/').last;
+          requests.singleIds.add(id);
+          return http.Response(_puzzleJsonWithId(id), 200);
+        }
+        return http.Response('', 404);
+      });
+
+      final container = await lichessClientContainer(client);
+      _keepAlive(container);
+      await container.read(puzzleStreakControllerProvider.future);
+
+      for (var i = 0; i < 200 && requests.manyIds.isEmpty; i++) {
+        await Future<void>.delayed(const Duration(milliseconds: 10));
+      }
+      expect(requests.manyIds, hasLength(1));
+
+      // advancing while the first refill is still in flight
+      expect(
+        await container.read(puzzleStreakControllerProvider.notifier).next(),
+        StreakAdvance.advanced,
+      );
+      expect(requests.manyIds, hasLength(1));
+
+      gate.complete();
+      final puzzleStorage = await container.read(puzzleStorageProvider.future);
+      expect(await _waitForCached(puzzleStorage, PuzzleId(ids[5])), isNotNull);
+      expect(requests.manyIds, hasLength(1));
+    });
+
+    test(
+      'signing out mid-refill still warms the look-ahead of the streak that replaces it',
+      () async {
+        // signing out rebuilds the controller on the same notifier instance
+        final oldIds = [for (var i = 0; i < 40; i++) 'AA${i.toString().padLeft(3, '0')}'];
+        final newIds = [for (var i = 0; i < 40; i++) 'BB${i.toString().padLeft(3, '0')}'];
+        final requests = _RequestLog();
+        final gate = Completer<void>();
+        var streaksServed = 0;
+        final client = MockClient((request) async {
+          final path = request.url.path;
+          if (path == '/api/streak') {
+            return http.Response(_streakJson(streaksServed++ == 0 ? oldIds : newIds), 200);
+          }
+          if (path == '/api/puzzle/many') {
+            final requested = request.url.queryParameters['ids']!.split(',');
+            requests.manyIds.add(requested);
+            await gate.future;
+            return http.Response(_manyJson(requested), 200);
+          }
+          if (path.startsWith('/api/puzzle/')) {
+            final id = path.split('/').last;
+            requests.singleIds.add(id);
+            return http.Response(_puzzleJsonWithId(id), 200);
+          }
+          // token revocation on sign-out
+          return http.Response('', 200);
+        });
+
+        final container = await lichessClientContainer(client, authUser: fakeAuthUser);
+        _keepAlive(container);
+        await container.read(puzzleStreakControllerProvider.future);
+
+        for (var i = 0; i < 200 && requests.manyIds.isEmpty; i++) {
+          await Future<void>.delayed(const Duration(milliseconds: 10));
+        }
+        expect(requests.manyIds, hasLength(1));
+        expect(requests.manyIds.single.first, startsWith('AA'));
+
+        await container.read(authControllerProvider.notifier).signOut();
+        await container.read(puzzleStreakControllerProvider.future);
+
+        for (var i = 0; i < 200 && requests.manyIds.length < 2; i++) {
+          await Future<void>.delayed(const Duration(milliseconds: 10));
+        }
+        expect(
+          requests.manyIds,
+          hasLength(2),
+          reason: 'the anonymous streak should have asked for its own look-ahead window',
+        );
+        expect(requests.manyIds[1].first, startsWith('BB'));
+
+        gate.complete();
+        final puzzleStorage = await container.read(puzzleStorageProvider.future);
+        expect(await _waitForCached(puzzleStorage, PuzzleId(newIds[5])), isNotNull);
+      },
+    );
+
+    test('two concurrent advances move the streak only once', () async {
+      var online = false;
+      final client = MockClient((request) async {
+        if (!online) return http.Response('', 500);
+        final path = request.url.path;
+        if (path.startsWith('/api/puzzle/')) {
+          return http.Response(_puzzleJsonWithId(path.split('/').last), 200);
+        }
+        return http.Response('', 404);
+      });
+
+      final container = await lichessClientContainer(client);
+
+      final puzzleStorage = await container.read(puzzleStorageProvider.future);
+      await puzzleStorage.save(puzzle: _puzzle('MptxK'));
+      await container
+          .read(streakStorageProvider(null))
+          .saveActiveStreak(_activeStreak(['MptxK', '4CZxz', 'Bmn3z']));
+
+      _keepAlive(container);
+      // the next puzzle is not cached, so the advance has to await a fetch
+      await container.read(puzzleStreakControllerProvider.future);
+
+      online = true;
+      final notifier = container.read(puzzleStreakControllerProvider.notifier);
+      final results = await Future.wait([notifier.next(), notifier.next()]);
+
+      // whichever fetch lands first advances, the other stands down
+      expect(results, unorderedEquals([StreakAdvance.advanced, StreakAdvance.aborted]));
+
+      final state = container.read(puzzleStreakControllerProvider).requireValue;
+      expect(state.streak.index, 1);
+      expect(state.puzzle.puzzle.id, const PuzzleId('4CZxz'));
+    });
+
+    test('next() advances offline when the next puzzle is cached', () async {
+      final container = await lichessClientContainer(offlineClient);
+
+      final puzzleStorage = await container.read(puzzleStorageProvider.future);
+      await puzzleStorage.save(puzzle: _puzzle('MptxK'));
+      await puzzleStorage.save(puzzle: _puzzle('4CZxz'));
+      await container
+          .read(streakStorageProvider(null))
+          .saveActiveStreak(_activeStreak(['MptxK', '4CZxz']));
+
+      _keepAlive(container);
+      await container.read(puzzleStreakControllerProvider.future);
+      final result = await container.read(puzzleStreakControllerProvider.notifier).next();
+      expect(result, StreakAdvance.advanced);
+
+      final state = await container.read(puzzleStreakControllerProvider.future);
+      expect(state.streak.index, 1);
+      expect(state.puzzle.puzzle.id, const PuzzleId('4CZxz'));
+    });
+
+    test('a win that cannot advance offline stays on the solved puzzle', () async {
+      final container = await lichessClientContainer(offlineClient);
+
+      final puzzleStorage = await container.read(puzzleStorageProvider.future);
+      await puzzleStorage.save(puzzle: _puzzle('MptxK'));
+      await container
+          .read(streakStorageProvider(null))
+          .saveActiveStreak(_activeStreak(['MptxK', '4CZxz']));
+
+      _keepAlive(container);
+      await container.read(puzzleStreakControllerProvider.future);
+
+      final result = await container.read(puzzleStreakControllerProvider.notifier).next();
+      expect(result, StreakAdvance.unavailable);
+
+      final state = container.read(puzzleStreakControllerProvider).requireValue;
+      expect(state.streak.index, 0);
+      expect(state.puzzle.puzzle.id, const PuzzleId('MptxK'));
+    });
+
+    test('next() self-heals and resumes automatically once back online', () async {
+      var online = false;
+      final client = MockClient((request) async {
+        if (!online) return http.Response('', 500);
+        final path = request.url.path;
+        if (path.startsWith('/api/puzzle/')) {
+          return http.Response(_puzzleJsonWithId(path.split('/').last), 200);
+        }
+        return http.Response('', 404);
+      });
+
+      final container = await lichessClientContainer(client);
+
+      final puzzleStorage = await container.read(puzzleStorageProvider.future);
+      await puzzleStorage.save(puzzle: _puzzle('MptxK'));
+      await container
+          .read(streakStorageProvider(null))
+          .saveActiveStreak(_activeStreak(['MptxK', '4CZxz']));
+
+      _keepAlive(container);
+      await container.read(puzzleStreakControllerProvider.future);
+
+      online = true;
+      final result = await container.read(puzzleStreakControllerProvider.notifier).next();
+      expect(result, StreakAdvance.advanced);
+
+      final state = await container.read(puzzleStreakControllerProvider.future);
+      expect(state.streak.index, 1);
+      expect(state.puzzle.puzzle.id, const PuzzleId('4CZxz'));
+    });
+
+    test('a stuck advance resumes automatically on reconnect', () async {
+      var online = false;
+      final container = await lichessClientContainer(_reconnectingClient(() => online));
+
+      final puzzleStorage = await container.read(puzzleStorageProvider.future);
+      await puzzleStorage.save(puzzle: _puzzle('MptxK'));
+      await container
+          .read(streakStorageProvider(null))
+          .saveActiveStreak(_activeStreak(['MptxK', '4CZxz']));
+
+      _keepAlive(container);
+      await container.read(puzzleStreakControllerProvider.future);
+      await _waitForConnectivity(container, isOnline: false);
+
+      final result = await container.read(puzzleStreakControllerProvider.notifier).next();
+      expect(result, StreakAdvance.unavailable);
+
+      online = true;
+      FakeConnectivity.controller.add([ConnectivityResult.wifi]);
+      await _waitForConnectivity(container, isOnline: true);
+
+      for (var i = 0; i < 100; i++) {
+        if (container.read(puzzleStreakControllerProvider).value?.streak.index == 1) break;
+        await Future<void>.delayed(const Duration(milliseconds: 10));
+      }
+      final state = container.read(puzzleStreakControllerProvider).requireValue;
+      expect(state.streak.index, 1);
+      expect(state.puzzle.puzzle.id, const PuzzleId('4CZxz'));
+    });
+
+    test('a stuck advance that fails again on reconnect can be retried by hand', () async {
+      var online = false;
+      var failuresLeft = 0;
+      final container = await lichessClientContainer(
+        MockClient((request) async {
+          if (!online) throw http.ClientException('offline');
+          // the connectivity probe sends HEAD requests: only puzzle fetches fail
+          if (failuresLeft > 0 && request.url.path.startsWith('/api/puzzle/')) {
+            failuresLeft--;
+            return http.Response('', 500);
+          }
+          return http.Response(_puzzleJsonWithId(request.url.path.split('/').last), 200);
+        }),
+      );
+
+      final puzzleStorage = await container.read(puzzleStorageProvider.future);
+      await puzzleStorage.save(puzzle: _puzzle('MptxK'));
+      await container
+          .read(streakStorageProvider(null))
+          .saveActiveStreak(_activeStreak(['MptxK', '4CZxz']));
+
+      _keepAlive(container);
+      await container.read(puzzleStreakControllerProvider.future);
+      await _waitForConnectivity(container, isOnline: false);
+
+      final notifier = container.read(puzzleStreakControllerProvider.notifier);
+      expect(await notifier.next(), StreakAdvance.unavailable);
+
+      // the first request after the reconnect still fails
+      failuresLeft = 1;
+      online = true;
+      FakeConnectivity.controller.add([ConnectivityResult.wifi]);
+      await _waitForConnectivity(container, isOnline: true);
+      for (var i = 0; i < 20 && failuresLeft > 0; i++) {
+        await Future<void>.delayed(const Duration(milliseconds: 10));
+      }
+      expect(failuresLeft, 0, reason: 'the reconnect must try to advance');
+      final stuck = container.read(puzzleStreakControllerProvider).requireValue;
+      expect(stuck.streak.advancePending, isTrue, reason: 'the solve is still waiting');
+
+      expect(await notifier.next(), StreakAdvance.advanced);
+      final state = container.read(puzzleStreakControllerProvider).requireValue;
+      expect(state.streak.index, 1);
+      expect(state.puzzle.puzzle.id, const PuzzleId('4CZxz'));
+    });
+
+    test('a solve stranded offline is not replayed after leaving the screen', () async {
+      var online = false;
+      final container = await lichessClientContainer(_reconnectingClient(() => online));
+
+      final puzzleStorage = await container.read(puzzleStorageProvider.future);
+      await puzzleStorage.save(puzzle: _puzzle('MptxK'));
+      await container
+          .read(streakStorageProvider(null))
+          .saveActiveStreak(_activeStreak(['MptxK', '4CZxz']));
+
+      final open = _keepAlive(container);
+      await container.read(puzzleStreakControllerProvider.future);
+      await _waitForConnectivity(container, isOnline: false);
+
+      expect(
+        await container.read(puzzleStreakControllerProvider.notifier).next(),
+        StreakAdvance.unavailable,
+      );
+
+      final stranded = await container.read(streakStorageProvider(null)).loadActiveStreak();
+      expect(stranded?.index, 0);
+      expect(stranded?.advancePending, isTrue);
+      expect(stranded?.score, 1, reason: 'the stranded solve counts');
+      expect(
+        await container.read(savedStreakScoreProvider.future),
+        1,
+        reason: 'the puzzle tab badge shows the same score',
+      );
+
+      // leave the screen (autoDispose runs on a later tick)
+      open.close();
+      await Future<void>.delayed(const Duration(milliseconds: 10));
+      expect(container.exists(puzzleStreakControllerProvider), isFalse);
+
+      online = true;
+      FakeConnectivity.controller.add([ConnectivityResult.wifi]);
+
+      // reopening completes the pending advance
+      _keepAlive(container);
+      final resumed = await container.read(puzzleStreakControllerProvider.future);
+      expect(resumed.streak.index, 1, reason: 'the stranded solve must still count');
+      expect(resumed.puzzle.puzzle.id, const PuzzleId('4CZxz'));
+      expect(resumed.streak.advancePending, isFalse);
+
+      final saved = await container.read(streakStorageProvider(null)).loadActiveStreak();
+      expect(saved?.index, 1, reason: 'the completed advance must be persisted, not just shown');
+    });
+
+    test('a solve stranded offline is not replayed when resumed offline', () async {
+      var online = false;
+      final container = await lichessClientContainer(_reconnectingClient(() => online));
+
+      final puzzleStorage = await container.read(puzzleStorageProvider.future);
+      await puzzleStorage.save(puzzle: _puzzle('MptxK'));
+      await container
+          .read(streakStorageProvider(null))
+          .saveActiveStreak(_activeStreak(['MptxK', '4CZxz']).copyWith(advancePending: true));
+
+      _keepAlive(container);
+      expect(await _awaitBuildError(container), isA<Exception>());
+      await _waitForConnectivity(container, isOnline: false);
+
+      online = true;
+      FakeConnectivity.controller.add([ConnectivityResult.wifi]);
+
+      final resumed = await _awaitStreak(container);
+      expect(resumed?.streak.index, 1, reason: 'the stranded solve must still count');
+      expect(resumed?.puzzle.puzzle.id, const PuzzleId('4CZxz'));
+    });
+
+    test('gameOver() offline does not throw', () async {
+      final container = await lichessClientContainer(offlineClient);
+
+      final puzzleStorage = await container.read(puzzleStorageProvider.future);
+      await puzzleStorage.save(puzzle: _puzzle('MptxK'));
+      await puzzleStorage.save(puzzle: _puzzle('4CZxz'));
+      await container
+          .read(streakStorageProvider(null))
+          .saveActiveStreak(_activeStreak(['MptxK', '4CZxz']));
+
+      _keepAlive(container);
+      await container.read(puzzleStreakControllerProvider.future);
+      await container.read(puzzleStreakControllerProvider.notifier).gameOver();
+
+      final state = await container.read(puzzleStreakControllerProvider.future);
+      expect(state.streak.finished, isTrue);
+    });
+
+    test('savePendingScore keeps the best pending run', () async {
+      final container = await lichessClientContainer(offlineClient, authUser: fakeAuthUser);
+      final storage = container.read(streakStorageProvider(fakeAuthUser.user.id));
+
+      await storage.savePendingScore(3);
+      await storage.savePendingScore(8);
+      await storage.savePendingScore(5);
+      expect(await storage.loadPendingScore(), 8);
+
+      await storage.clearPendingScoreIfAtMost(5);
+      expect(await storage.loadPendingScore(), 8);
+
+      await storage.clearPendingScoreIfAtMost(8);
+      expect(await storage.loadPendingScore(), isNull);
+    });
+
+    test('gameOver() offline saves the streak score to post later', () async {
+      final container = await lichessClientContainer(offlineClient, authUser: fakeAuthUser);
+      final userId = fakeAuthUser.user.id;
+
+      final puzzleStorage = await container.read(puzzleStorageProvider.future);
+      await puzzleStorage.save(puzzle: _puzzle('MptxK'));
+      await puzzleStorage.save(puzzle: _puzzle('4CZxz'));
+      await container
+          .read(streakStorageProvider(userId))
+          .saveActiveStreak(_activeStreak(['MptxK', '4CZxz'], index: 1));
+
+      _keepAlive(container);
+      await container.read(puzzleStreakControllerProvider.future);
+      await container.read(puzzleStreakControllerProvider.notifier).gameOver();
+
+      expect(await container.read(streakStorageProvider(userId)).loadPendingScore(), 1);
+    });
+
+    test('gameOver() queues the score before clearing the run', () async {
+      final container = await makeContainer(
+        authUser: fakeAuthUser,
+        overrides: {
+          httpClientFactoryProvider: httpClientFactoryProvider.overrideWith(
+            (ref) => FakeHttpClientFactory(() => offlineClient),
+          ),
+          streakStorageProvider: streakStorageProvider.overrideWith(
+            (ref, userId) => _ClearThrowingStreakStorage(ref, userId),
+          ),
+        },
+      );
+      final userId = fakeAuthUser.user.id;
+
+      final puzzleStorage = await container.read(puzzleStorageProvider.future);
+      await puzzleStorage.save(puzzle: _puzzle('MptxK'));
+      await puzzleStorage.save(puzzle: _puzzle('4CZxz'));
+      await container
+          .read(streakStorageProvider(userId))
+          .saveActiveStreak(_activeStreak(['MptxK', '4CZxz'], index: 1));
+
+      _keepAlive(container);
+      await container.read(puzzleStreakControllerProvider.future);
+      await expectLater(
+        container.read(puzzleStreakControllerProvider.notifier).gameOver(),
+        throwsException,
+      );
+
+      expect(
+        await container.read(streakStorageProvider(userId)).loadPendingScore(),
+        1,
+        reason: 'a run must not be lost to whatever happens after it is queued',
+      );
+    });
+
+    test(
+      'a streak whose current puzzle the server refuses is ended and its score posted',
+      () async {
+        final postedRuns = <int>[];
+        final client = MockClient((request) async {
+          final path = request.url.path;
+          if (request.method == 'POST' && path.startsWith('/api/streak/')) {
+            postedRuns.add(int.parse(path.split('/').last));
+            return http.Response('', 200);
+          }
+          if (path == '/api/streak') {
+            return http.Response(_streakJson(['NEWa1', 'NEWb2']), 200);
+          }
+          if (path == '/api/puzzle/many') {
+            return http.Response(_manyJson(request.url.queryParameters['ids']!.split(',')), 200);
+          }
+          if (path == '/api/puzzle/GONE1') {
+            return http.Response('', 404);
+          }
+          if (path.startsWith('/api/puzzle/')) {
+            return http.Response(_puzzleJsonWithId(path.split('/').last), 200);
+          }
+          return http.Response('', 404);
+        });
+        final container = await lichessClientContainer(client, authUser: fakeAuthUser);
+        final userId = fakeAuthUser.user.id;
+        await container
+            .read(streakStorageProvider(userId))
+            .saveActiveStreak(_activeStreak(['MptxK', 'GONE1', '4CZxz'], index: 1));
+
+        _keepAlive(container);
+        final state = await container.read(puzzleStreakControllerProvider.future);
+
+        expect(state.puzzle.puzzle.id, const PuzzleId('NEWa1'), reason: 'a new run starts instead');
+        expect(state.streak.index, 0);
+        expect(postedRuns, [1], reason: 'the puzzles solved before the hole count');
+
+        final storage = container.read(streakStorageProvider(userId));
+        expect((await storage.loadActiveStreak())?.streak.first, const PuzzleId('NEWa1'));
+        expect(await storage.loadPendingScore(), isNull);
+      },
+    );
+
+    test('gameOver() does not queue a streak score the server rejects outright', () async {
+      final client = MockClient((request) async {
+        final path = request.url.path;
+        // lila answers BadRequest for a score it will never record, e.g. one out of range.
+        if (request.method == 'POST' && path.startsWith('/api/streak/')) {
+          return http.Response('', 400);
+        }
+        return http.Response('', 404);
+      });
+
+      final container = await lichessClientContainer(client, authUser: fakeAuthUser);
+      final userId = fakeAuthUser.user.id;
+
+      final puzzleStorage = await container.read(puzzleStorageProvider.future);
+      await puzzleStorage.save(puzzle: _puzzle('MptxK'));
+      await puzzleStorage.save(puzzle: _puzzle('4CZxz'));
+      await container
+          .read(streakStorageProvider(userId))
+          .saveActiveStreak(_activeStreak(['MptxK', '4CZxz'], index: 1));
+
+      _keepAlive(container);
+      await container.read(puzzleStreakControllerProvider.future);
+      await container.read(puzzleStreakControllerProvider.notifier).gameOver();
+
+      expect(
+        await container.read(streakStorageProvider(userId)).loadPendingScore(),
+        isNull,
+        reason: 'a rejected run must not be retried on every reconnect',
+      );
+    });
+
+    test('a next puzzle the server refuses ends the run with the solve counted', () async {
+      final postedRuns = <int>[];
+      final client = MockClient((request) async {
+        final path = request.url.path;
+        if (request.method == 'POST' && path.startsWith('/api/streak/')) {
+          postedRuns.add(int.parse(path.split('/').last));
+          return http.Response('', 200);
+        }
+        if (path == '/api/puzzle/GONE1') {
+          return http.Response('', 404);
+        }
+        if (path.startsWith('/api/puzzle/')) {
+          return http.Response(_puzzleJsonWithId(path.split('/').last), 200);
+        }
+        return http.Response('', 404);
+      });
+      final container = await lichessClientContainer(client, authUser: fakeAuthUser);
+      final userId = fakeAuthUser.user.id;
+      await container
+          .read(streakStorageProvider(userId))
+          .saveActiveStreak(_activeStreak(['MptxK', 'GONE1', '4CZxz']));
+
+      _keepAlive(container);
+      await container.read(puzzleStreakControllerProvider.future);
+
+      final result = await container.read(puzzleStreakControllerProvider.notifier).next();
+      expect(result, StreakAdvance.ended);
+
+      final state = container.read(puzzleStreakControllerProvider).requireValue;
+      expect(state.streak.finished, isTrue);
+      expect(state.streak.score, 1, reason: 'the solve counts');
+      expect(state.puzzle.puzzle.id, const PuzzleId('MptxK'), reason: 'the solved puzzle stays');
+      expect(postedRuns, [1]);
+
+      final storage = container.read(streakStorageProvider(userId));
+      expect(await storage.loadActiveStreak(), isNull);
+      expect(await storage.loadPendingScore(), isNull);
+    });
+
+    test('a pending streak score the server rejects outright is dropped', () async {
+      var posts = 0;
+      final client = MockClient((request) async {
+        final path = request.url.path;
+        if (request.method == 'POST' && path.startsWith('/api/streak/')) {
+          posts++;
+          return http.Response('', 400);
+        }
+        if (path == '/api/streak') {
+          return http.Response(_streakJson(['AAAAA', 'BBBBB', 'CCCCC']), 200);
+        }
+        if (path == '/api/puzzle/many') {
+          return http.Response(_manyJson(request.url.queryParameters['ids']!.split(',')), 200);
+        }
+        if (path.startsWith('/api/puzzle/')) {
+          return http.Response(_puzzleJsonWithId(path.split('/').last), 200);
+        }
+        return http.Response('', 404);
+      });
+
+      final container = await lichessClientContainer(client, authUser: fakeAuthUser);
+      final userId = fakeAuthUser.user.id;
+
+      await container.read(streakStorageProvider(userId)).savePendingScore(7);
+
+      _keepAlive(container);
+      await container.read(puzzleStreakControllerProvider.future);
+
+      for (var i = 0; i < 100 && posts == 0; i++) {
+        await Future<void>.delayed(const Duration(milliseconds: 10));
+      }
+      expect(posts, 1);
+      expect(await container.read(streakStorageProvider(userId)).loadPendingScore(), isNull);
+    });
+
+    test('a pending streak score survives a server error, to be posted later', () async {
+      var posts = 0;
+      final client = MockClient((request) async {
+        final path = request.url.path;
+        if (request.method == 'POST' && path.startsWith('/api/streak/')) {
+          posts++;
+          return http.Response('', 503);
+        }
+        if (path == '/api/streak') {
+          return http.Response(_streakJson(['AAAAA', 'BBBBB', 'CCCCC']), 200);
+        }
+        if (path == '/api/puzzle/many') {
+          return http.Response(_manyJson(request.url.queryParameters['ids']!.split(',')), 200);
+        }
+        if (path.startsWith('/api/puzzle/')) {
+          return http.Response(_puzzleJsonWithId(path.split('/').last), 200);
+        }
+        return http.Response('', 404);
+      });
+
+      final container = await lichessClientContainer(client, authUser: fakeAuthUser);
+      final userId = fakeAuthUser.user.id;
+
+      await container.read(streakStorageProvider(userId)).savePendingScore(7);
+
+      _keepAlive(container);
+      await container.read(puzzleStreakControllerProvider.future);
+
+      for (var i = 0; i < 100 && posts == 0; i++) {
+        await Future<void>.delayed(const Duration(milliseconds: 10));
+      }
+      expect(await container.read(streakStorageProvider(userId)).loadPendingScore(), 7);
+    });
+
+    test('a pending streak score is posted on the next build once back online', () async {
+      final postedRuns = <int>[];
+      final client = MockClient((request) async {
+        final path = request.url.path;
+        if (request.method == 'POST' && path.startsWith('/api/streak/')) {
+          postedRuns.add(int.parse(path.split('/').last));
+          return http.Response('', 200);
+        }
+        if (path == '/api/streak') {
+          return http.Response(_streakJson(['AAAAA', 'BBBBB', 'CCCCC']), 200);
+        }
+        if (path == '/api/puzzle/many') {
+          return http.Response(_manyJson(request.url.queryParameters['ids']!.split(',')), 200);
+        }
+        if (path.startsWith('/api/puzzle/')) {
+          return http.Response(_puzzleJsonWithId(path.split('/').last), 200);
+        }
+        return http.Response('', 404);
+      });
+
+      final container = await lichessClientContainer(client, authUser: fakeAuthUser);
+      final userId = fakeAuthUser.user.id;
+
+      await container.read(streakStorageProvider(userId)).savePendingScore(7);
+
+      _keepAlive(container);
+      await container.read(puzzleStreakControllerProvider.future);
+
+      for (var i = 0; i < 100 && postedRuns.isEmpty; i++) {
+        await Future<void>.delayed(const Duration(milliseconds: 10));
+      }
+      expect(postedRuns, [7]);
+      expect(await container.read(streakStorageProvider(userId)).loadPendingScore(), isNull);
+    });
+
+    test('gameOver() online clears a now-redundant lower pending score', () async {
+      final client = MockClient((request) async {
+        final path = request.url.path;
+        if (request.method == 'POST' && path == '/api/streak/2') {
+          return http.Response('', 200);
+        }
+        if (request.method == 'POST') {
+          return http.Response('', 500);
+        }
+        if (path.startsWith('/api/puzzle/')) {
+          return http.Response(_puzzleJsonWithId(path.split('/').last), 200);
+        }
+        return http.Response('', 404);
+      });
+
+      final container = await lichessClientContainer(client, authUser: fakeAuthUser);
+      final userId = fakeAuthUser.user.id;
+
+      await container.read(streakStorageProvider(userId)).savePendingScore(1);
+
+      final puzzleStorage = await container.read(puzzleStorageProvider.future);
+      await puzzleStorage.save(puzzle: _puzzle('kcN3a'));
+      await container
+          .read(streakStorageProvider(userId))
+          .saveActiveStreak(_activeStreak(['MptxK', '4CZxz', 'kcN3a'], index: 2));
+
+      _keepAlive(container);
+      await container.read(puzzleStreakControllerProvider.future);
+      await container.read(puzzleStreakControllerProvider.notifier).gameOver();
+
+      expect(await container.read(streakStorageProvider(userId)).loadPendingScore(), isNull);
+    });
+
+    test('a network-fetched puzzle is kept even when the cache write fails', () async {
+      final container = await makeContainer(
+        overrides: {
+          httpClientFactoryProvider: httpClientFactoryProvider.overrideWith(
+            (ref) => FakeHttpClientFactory(() => _onlineClient(['MptxK', '4CZxz'])),
+          ),
+          puzzleStorageProvider: puzzleStorageProvider.overrideWith((ref) async {
+            final db = await ref.watch(databaseProvider.future);
+            return _SaveThrowingStorage(db);
+          }),
+        },
+      );
+
+      await container
+          .read(streakStorageProvider(null))
+          .saveActiveStreak(_activeStreak(['MptxK', '4CZxz']));
+
+      _keepAlive(container);
+      final state = await container.read(puzzleStreakControllerProvider.future);
+      expect(state.puzzle.puzzle.id, const PuzzleId('MptxK'));
+    });
+  });
+}

--- a/test/model/puzzle/streak_lookahead_test.dart
+++ b/test/model/puzzle/streak_lookahead_test.dart
@@ -1,0 +1,105 @@
+import 'dart:convert';
+
+import 'package:fast_immutable_collections/fast_immutable_collections.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:http/http.dart' as http;
+import 'package:http/testing.dart';
+import 'package:lichess_mobile/src/model/common/id.dart';
+import 'package:lichess_mobile/src/model/puzzle/puzzle_repository.dart';
+import 'package:lichess_mobile/src/model/puzzle/puzzle_storage.dart';
+import 'package:lichess_mobile/src/model/puzzle/streak_lookahead.dart';
+
+import '../../test_container.dart';
+import '../../view/puzzle/example_data.dart';
+import 'mock_server_responses.dart';
+
+String _puzzleJsonWithId(String id) {
+  final map = jsonDecode(mockDailyPuzzleResponse) as Map<String, dynamic>;
+  (map['puzzle'] as Map<String, dynamic>)['id'] = id;
+  return jsonEncode(map);
+}
+
+/// A `/api/puzzle/many` response with one puzzle per id.
+String _manyJson(Iterable<String> ids) {
+  return jsonEncode({'puzzles': ids.map((id) => jsonDecode(_puzzleJsonWithId(id))).toList()});
+}
+
+void main() {
+  final run = IList([for (var i = 0; i < 70; i++) PuzzleId('LA${i.toString().padLeft(3, '0')}')]);
+
+  /// Serves `/api/puzzle/many` with [status], recording each request's ids into [requests].
+  MockClient manyClient(List<List<String>> requests, {int status = 200}) {
+    return MockClient((request) async {
+      if (request.url.path != '/api/puzzle/many') return http.Response('', 404);
+      final ids = request.url.queryParameters['ids']!.split(',');
+      requests.add(ids);
+      return http.Response(status == 200 ? _manyJson(ids) : '', status, request: request);
+    });
+  }
+
+  Future<StreakLookahead> makeLookahead(MockClient client) async {
+    final container = await lichessClientContainer(client);
+    return StreakLookahead(
+      run,
+      storage: await container.read(puzzleStorageProvider.future),
+      repository: container.read(puzzleRepositoryProvider),
+    );
+  }
+
+  group('StreakLookahead', () {
+    test('caches a window past the current puzzle, then the next one once it runs low', () async {
+      final requests = <List<String>>[];
+      final lookahead = await makeLookahead(manyClient(requests));
+
+      await lookahead.refill(0);
+      expect(requests, [run.sublist(1, 31).map((id) => id.value)]);
+
+      // still enough cached ahead
+      await lookahead.refill(20);
+      expect(requests, hasLength(1));
+
+      await lookahead.refill(21);
+      expect(requests, hasLength(2), reason: 'fewer than the margin cached past index 21');
+      expect(requests[1], run.sublist(31, 61).map((id) => id.value));
+      expect(await lookahead.storage.fetch(puzzleId: run[60]), isNotNull);
+    });
+
+    test('skips the puzzles already stored, and stops at the end of the run', () async {
+      final requests = <List<String>>[];
+      final lookahead = await makeLookahead(manyClient(requests));
+      await lookahead.storage.save(
+        puzzle: puzzle.copyWith(puzzle: puzzle.puzzle.copyWith(id: run[62])),
+      );
+
+      await lookahead.refill(60);
+      expect(requests, [
+        [run[61].value, ...run.sublist(63).map((id) => id.value)],
+      ]);
+
+      await lookahead.refill(69);
+      expect(requests, hasLength(1));
+    });
+
+    test('a failed refill backs off for a few advances, then retries', () async {
+      final requests = <List<String>>[];
+      final lookahead = await makeLookahead(manyClient(requests, status: 503));
+
+      for (var i = 0; i < 5; i++) {
+        await lookahead.refill(i);
+      }
+      expect(requests, hasLength(1), reason: 'not once per solved puzzle');
+      await lookahead.refill(5);
+      expect(requests, hasLength(2));
+    });
+
+    test('a refused refill stands down for the rest of the run', () async {
+      final requests = <List<String>>[];
+      final lookahead = await makeLookahead(manyClient(requests, status: 429));
+
+      for (var i = 0; i < 69; i++) {
+        await lookahead.refill(i);
+      }
+      expect(requests, hasLength(1));
+    });
+  });
+}

--- a/test/network/http_test.dart
+++ b/test/network/http_test.dart
@@ -20,6 +20,26 @@ void main() {
     FakeClient.reset();
   });
 
+  group('isPermanentFailure', () {
+    ServerException serverException(int status) =>
+        ServerException(status, 'error', Uri.parse('https://lichess.org/api/test'), null);
+
+    test('a 4xx is final', () {
+      expect(isPermanentFailure(serverException(400)), isTrue);
+      expect(isPermanentFailure(serverException(404)), isTrue);
+    });
+
+    test('a 401, a 429 and a 5xx may pass later', () {
+      expect(isPermanentFailure(serverException(401)), isFalse);
+      expect(isPermanentFailure(serverException(429)), isFalse);
+      expect(isPermanentFailure(serverException(503)), isFalse);
+    });
+
+    test('a network error may pass later', () {
+      expect(isPermanentFailure(http.ClientException('offline')), isFalse);
+    });
+  });
+
   group('shouldRetryOn429', () {
     http.Response response(int status, {String method = 'GET', String path = '/api/test'}) {
       return http.Response(
@@ -58,6 +78,15 @@ void main() {
         shouldRetryOn429(response(429, method: 'GET', path: '/api/puzzle/batch/advancedPawn')),
         isFalse,
       );
+    });
+
+    test('does not retry a streak look-ahead refill (GET /api/puzzle/many)', () {
+      expect(shouldRetryOn429(response(429, path: '/api/puzzle/many')), isFalse);
+    });
+
+    test('retries other puzzle endpoints', () {
+      expect(shouldRetryOn429(response(429, path: '/api/puzzle/abcde')), isTrue);
+      expect(shouldRetryOn429(response(429, path: '/api/puzzle/manyfold')), isTrue);
     });
   });
 

--- a/test/test_container.dart
+++ b/test/test_container.dart
@@ -40,8 +40,9 @@ final testContainerMockClient = MockClient((request) async {
 
 /// Returns a [ProviderContainer] with the [httpClientFactoryProvider] configured
 /// with the given [mockClient].
-Future<ProviderContainer> lichessClientContainer(MockClient mockClient) {
+Future<ProviderContainer> lichessClientContainer(MockClient mockClient, {AuthUser? authUser}) {
   return makeContainer(
+    authUser: authUser,
     overrides: {
       httpClientFactoryProvider: httpClientFactoryProvider.overrideWith((ref) {
         return FakeHttpClientFactory(() => mockClient);

--- a/test/view/puzzle/streak_screen_test.dart
+++ b/test/view/puzzle/streak_screen_test.dart
@@ -1,6 +1,8 @@
 import 'package:dartchess/dartchess.dart';
 import 'package:flutter_test/flutter_test.dart';
+import 'package:http/http.dart' as http;
 import 'package:http/testing.dart';
+import 'package:lichess_mobile/src/network/connectivity.dart';
 import 'package:lichess_mobile/src/network/http.dart';
 import 'package:lichess_mobile/src/utils/navigation.dart';
 import 'package:lichess_mobile/src/view/puzzle/streak_screen.dart';
@@ -216,8 +218,129 @@ void main() {
       //now, the text should say 'Your turn'.
       expect(find.text('Your turn'), findsOneWidget);
     });
+
+    testWidgets('a new streak cannot start offline, and the button says so', (tester) async {
+      final app = await makeTestProviderScopeApp(
+        tester,
+        home: const StreakScreen(),
+        overrides: {
+          lichessClientProvider: lichessClientProvider.overrideWith(
+            (ref) => LichessClient(client, ref),
+          ),
+          isDeviceOnlineProvider: isDeviceOnlineProvider.overrideWithValue(false),
+        },
+      );
+      await tester.pumpWidget(app);
+      await tester.pumpAndSettle(const Duration(seconds: 2));
+
+      // lose the run on the first move
+      await playMove(tester, 'f6', 'f7', orientation: Side.black);
+      await tester.pumpAndSettle(const Duration(milliseconds: 500));
+      expect(find.text('GAME OVER'), findsOneWidget);
+
+      final newStreakButton = find.byKey(const ValueKey('new-streak'));
+      expect(tester.widget<BottomBarButton>(newStreakButton).onTap, isNotNull);
+      await tester.tap(newStreakButton);
+      await tester.pumpAndSettle(const Duration(milliseconds: 500));
+
+      // the game over board stays, with an explanation
+      expect(find.text("You're offline. Go online to start a new streak."), findsOneWidget);
+      expect(find.text('GAME OVER'), findsOneWidget);
+    });
+
+    testWidgets('a solve stranded offline says it is waiting for a connection', (tester) async {
+      final app = await makeTestProviderScopeApp(
+        tester,
+        home: const StreakScreen(),
+        overrides: {
+          lichessClientProvider: lichessClientProvider.overrideWith(
+            (ref) => LichessClient(streakOnlyClient, ref),
+          ),
+          isDeviceOnlineProvider: isDeviceOnlineProvider.overrideWithValue(false),
+        },
+      );
+      await tester.pumpWidget(app);
+      await tester.pumpAndSettle(const Duration(seconds: 2));
+
+      // solve the first puzzle: the next one is neither cached nor reachable
+      await playMove(tester, 'e5', 'e1', orientation: Side.black);
+      await tester.pumpAndSettle(const Duration(milliseconds: 500));
+      await playMove(tester, 'f6', 'f4', orientation: Side.black);
+      await tester.pumpAndSettle(const Duration(milliseconds: 500));
+      await playMove(tester, 'f4', 'f2', orientation: Side.black);
+      await tester.pumpAndSettle(const Duration(seconds: 1));
+
+      // the solve counts, and the screen says what it is waiting for
+      expect(find.textContaining(RegExp('1\$')), findsOneWidget);
+      expect(find.text('Success!'), findsOneWidget);
+      expect(find.text('Waiting for connection to load the next puzzle.'), findsOneWidget);
+      expect(
+        find.text("You're offline. Your streak will continue when you reconnect."),
+        findsOneWidget,
+      );
+      // the reconnect is retried by the controller, so there is nothing to tap
+      expect(find.byKey(const ValueKey('retry-advance')), findsNothing);
+    });
+
+    testWidgets('a solve that cannot advance online offers a retry', (tester) async {
+      // the next puzzle fails to load once, when the advance fetches it
+      var failuresLeft = 1;
+      final flakyClient = MockClient((request) async {
+        if (request.url.path == '/api/puzzle/4CZxz' && failuresLeft > 0) {
+          failuresLeft--;
+          return http.Response('', 500);
+        }
+        return http.Response.fromStream(
+          await client.send(http.Request(request.method, request.url)),
+        );
+      });
+      final app = await makeTestProviderScopeApp(
+        tester,
+        home: const StreakScreen(),
+        overrides: {
+          lichessClientProvider: lichessClientProvider.overrideWith(
+            (ref) => LichessClient(flakyClient, ref),
+          ),
+        },
+      );
+      await tester.pumpWidget(app);
+      await tester.pumpAndSettle(const Duration(seconds: 2));
+
+      final retryFinder = find.byKey(const ValueKey('retry-advance'));
+      expect(retryFinder, findsNothing);
+
+      await playMove(tester, 'e5', 'e1', orientation: Side.black);
+      await tester.pumpAndSettle(const Duration(milliseconds: 500));
+      await playMove(tester, 'f6', 'f4', orientation: Side.black);
+      await tester.pumpAndSettle(const Duration(milliseconds: 500));
+      await playMove(tester, 'f4', 'f2', orientation: Side.black);
+      await tester.pumpAndSettle(const Duration(seconds: 1));
+
+      // the solve counts, the screen says what went wrong and the skip button became a retry
+      expect(find.textContaining(RegExp('1\$')), findsOneWidget);
+      expect(find.text('Could not load the next puzzle.'), findsOneWidget);
+      expect(find.byKey(const ValueKey('skip')), findsNothing);
+      expect(retryFinder, findsOneWidget);
+
+      await tester.tap(retryFinder);
+      await tester.pumpAndSettle(const Duration(seconds: 2));
+
+      // on the second puzzle (rating 1058), with the bar back to normal
+      expect(find.textContaining('1058'), findsOneWidget);
+      expect(find.text('Could not load the next puzzle.'), findsNothing);
+      expect(retryFinder, findsNothing);
+      expect(find.byKey(const ValueKey('skip')), findsOneWidget);
+    });
   });
 }
+
+/// Serves the streak, then goes offline: nothing is cached ahead of the first puzzle.
+final streakOnlyClient = MockClient((request) async {
+  if (request.url.path == '/api/streak') {
+    return http.Response.fromStream(await client.send(http.Request(request.method, request.url)));
+  }
+  throw http.ClientException('offline');
+});
 
 final client = MockClient((request) {
   if (request.url.path == '/api/streak') {

--- a/test/view/puzzle/streak_screen_test.dart
+++ b/test/view/puzzle/streak_screen_test.dart
@@ -219,6 +219,195 @@ void main() {
       expect(find.text('Your turn'), findsOneWidget);
     });
 
+    testWidgets('reviewing the failed puzzle replays it', (tester) async {
+      final app = await makeTestProviderScopeApp(
+        tester,
+        home: const StreakScreen(),
+        overrides: {
+          lichessClientProvider: lichessClientProvider.overrideWith(
+            (ref) => LichessClient(client, ref),
+          ),
+        },
+      );
+      await tester.pumpWidget(app);
+      await tester.pumpAndSettle(const Duration(seconds: 2));
+
+      // solution is e5e1 g1h2 f6f4 g2g3 f4f2: play the first move, then lose the run on f6f7
+      await playMove(tester, 'e5', 'e1', orientation: Side.black);
+      await tester.pumpAndSettle(const Duration(milliseconds: 500));
+      await playMove(tester, 'f6', 'f7', orientation: Side.black);
+      await tester.pumpAndSettle(const Duration(milliseconds: 500));
+      expect(find.text('GAME OVER'), findsOneWidget);
+
+      // in review, the same wrong move is taken back
+      await playMove(tester, 'f6', 'f7', orientation: Side.black);
+      await tester.pumpAndSettle(const Duration(milliseconds: 600));
+      expect(find.text('Try something else.'), findsOneWidget);
+
+      // and the opponent answers the right move without the next-move button
+      await playMove(tester, 'f6', 'f4', orientation: Side.black);
+      await tester.pumpAndSettle(const Duration(milliseconds: 600));
+      expect(find.text('Best move!'), findsOneWidget);
+    });
+
+    testWidgets('can review a previous puzzle and return to the live one', (tester) async {
+      final app = await makeTestProviderScopeApp(
+        tester,
+        home: const StreakScreen(),
+        overrides: {
+          lichessClientProvider: lichessClientProvider.overrideWith(
+            (ref) => LichessClient(client, ref),
+          ),
+        },
+      );
+      await tester.pumpWidget(app);
+      await tester.pumpAndSettle(const Duration(seconds: 2));
+
+      final previousPuzzleFinder = find.byKey(const ValueKey('previous-puzzle'));
+      final nextPuzzleFinder = find.byKey(const ValueKey('next-puzzle'));
+      final skipFinder = find.byWidgetPredicate(
+        (widget) => widget is BottomBarButton && widget.label == 'Skip this move',
+      );
+      final menuFinder = find.byWidgetPredicate(
+        (widget) => widget is BottomBarButton && widget.label == 'Menu',
+      );
+
+      // first puzzle: [Menu] [Previous] [Skip], with previous greyed out
+      expect(tester.widget<BottomBarButton>(previousPuzzleFinder).enabled, isFalse);
+      expect(menuFinder, findsOneWidget);
+
+      // live menu: Share + About only
+      await tester.tap(menuFinder);
+      await tester.pumpAndSettle();
+      expect(find.text('Share this puzzle'), findsOneWidget);
+      expect(find.text('About Streak'), findsOneWidget);
+      expect(find.text('Analysis board'), findsNothing);
+      expect(find.text('Previous puzzle'), findsNothing);
+      expect(find.text('Back to current puzzle'), findsNothing);
+      await tester.tapAt(const Offset(20, 20));
+      await tester.pumpAndSettle();
+
+      // solve the first puzzle to advance to the second
+      await playMove(tester, 'e5', 'e1', orientation: Side.black);
+      await tester.pumpAndSettle(const Duration(milliseconds: 500));
+      await playMove(tester, 'f6', 'f4', orientation: Side.black);
+      await tester.pumpAndSettle(const Duration(milliseconds: 500));
+      await playMove(tester, 'f4', 'f2', orientation: Side.black);
+      await tester.pumpAndSettle(const Duration(seconds: 1));
+
+      // second puzzle: [Menu] [Previous] [Skip], with previous now live
+      expect(find.textContaining(RegExp('1\$')), findsOneWidget);
+      expect(menuFinder, findsOneWidget);
+      expect(tester.widget<BottomBarButton>(previousPuzzleFinder).onTap, isNotNull);
+      expect(skipFinder, findsOneWidget);
+
+      // the board shows the live (second) puzzle, rating 1058
+      expect(find.textContaining('1058'), findsOneWidget);
+      expect(find.textContaining('1012'), findsNothing);
+
+      // review the first (solved) puzzle
+      await tester.tap(previousPuzzleFinder);
+      await tester.pumpAndSettle(const Duration(seconds: 1));
+
+      // review: [Menu] [Analysis] [Previous] [Next], previous disabled on the first puzzle
+      expect(menuFinder, findsOneWidget);
+      expect(find.byKey(const ValueKey('analysis')), findsOneWidget);
+      expect(tester.widget<BottomBarButton>(previousPuzzleFinder).onTap, isNull);
+      expect(nextPuzzleFinder, findsOneWidget);
+      expect(skipFinder, findsNothing);
+      expect(find.byKey(const ValueKey('next-move')), findsNothing);
+
+      // the board shows the reviewed (first) puzzle, rating 1012
+      expect(find.textContaining('1012'), findsWidgets);
+      expect(find.textContaining('1058'), findsNothing);
+
+      // in review, not reloaded into play
+      expect(find.text('Solved puzzle 1 of 1'), findsOneWidget);
+      expect(find.text('Success!'), findsNothing);
+      expect(find.textContaining('Your turn'), findsNothing);
+
+      // review menu: Share + Back to current + About
+      await tester.tap(menuFinder);
+      await tester.pumpAndSettle();
+      expect(find.text('Analysis board'), findsNothing);
+      expect(find.text('Share this puzzle'), findsOneWidget);
+      expect(find.text('Back to current puzzle'), findsOneWidget);
+      expect(find.text('About Streak'), findsOneWidget);
+
+      await tester.tapAt(const Offset(20, 20));
+      await tester.pumpAndSettle();
+
+      // the back gesture leaves the review, not the streak
+      await tester.state<NavigatorState>(find.byType(Navigator).first).maybePop();
+      await tester.pumpAndSettle(const Duration(seconds: 2));
+      expect(find.text('No worries, your score will be saved locally.'), findsNothing);
+      expect(nextPuzzleFinder, findsNothing);
+      expect(skipFinder, findsOneWidget);
+      expect(find.textContaining('1058'), findsOneWidget);
+
+      // review again, and return to the live puzzle through the bottom bar this time
+      await tester.tap(previousPuzzleFinder);
+      await tester.pumpAndSettle(const Duration(seconds: 1));
+      expect(find.text('Solved puzzle 1 of 1'), findsOneWidget);
+      await tester.tap(nextPuzzleFinder);
+      await tester.pumpAndSettle(const Duration(seconds: 2));
+
+      expect(nextPuzzleFinder, findsNothing);
+      expect(skipFinder, findsOneWidget);
+
+      // back on the live puzzle (rating 1058), still mid-play
+      expect(find.textContaining('1058'), findsOneWidget);
+      expect(find.textContaining('1012'), findsNothing);
+      expect(find.text('Solved puzzle 1 of 1'), findsNothing);
+    });
+
+    testWidgets('a solved puzzle is still reachable once the run is over', (tester) async {
+      final app = await makeTestProviderScopeApp(
+        tester,
+        home: const StreakScreen(),
+        overrides: {
+          lichessClientProvider: lichessClientProvider.overrideWith(
+            (ref) => LichessClient(client, ref),
+          ),
+        },
+      );
+      await tester.pumpWidget(app);
+      await tester.pumpAndSettle(const Duration(seconds: 2));
+
+      // solve the first puzzle
+      await playMove(tester, 'e5', 'e1', orientation: Side.black);
+      await tester.pumpAndSettle(const Duration(milliseconds: 500));
+      await playMove(tester, 'f6', 'f4', orientation: Side.black);
+      await tester.pumpAndSettle(const Duration(milliseconds: 500));
+      await playMove(tester, 'f4', 'f2', orientation: Side.black);
+      await tester.pumpAndSettle(const Duration(seconds: 1));
+
+      // fail the second one (the solution is Qc8)
+      await playMove(tester, 'e6', 'f7', orientation: Side.white);
+      await tester.pumpAndSettle(const Duration(seconds: 1));
+      expect(find.text('GAME OVER'), findsOneWidget);
+
+      // once the run is over: [Menu] [Analysis] [Previous] [Next] [New streak]. The arrows walk
+      // the run, and next is spent because the failed puzzle is the last one.
+      expect(find.byKey(const ValueKey('analysis')), findsOneWidget);
+      expect(find.byKey(const ValueKey('previous-move')), findsNothing);
+      expect(find.byKey(const ValueKey('next-move')), findsNothing);
+      expect(findByTooltip('New streak'), findsOneWidget);
+      expect(
+        tester.widget<BottomBarButton>(find.byKey(const ValueKey('next-puzzle'))).enabled,
+        isFalse,
+      );
+
+      await tester.tap(find.byKey(const ValueKey('previous-puzzle')));
+      await tester.pumpAndSettle(const Duration(seconds: 1));
+
+      // reviewing the solved first puzzle (1012), not the failed one (1058)
+      expect(find.textContaining('1012'), findsWidgets);
+      expect(find.textContaining('1058'), findsNothing);
+      expect(find.text('Solved puzzle 1 of 1'), findsOneWidget);
+      expect(find.text('GAME OVER'), findsNothing);
+    });
+
     testWidgets('a new streak cannot start offline, and the button says so', (tester) async {
       final app = await makeTestProviderScopeApp(
         tester,
@@ -330,6 +519,43 @@ void main() {
       expect(find.text('Could not load the next puzzle.'), findsNothing);
       expect(retryFinder, findsNothing);
       expect(find.byKey(const ValueKey('skip')), findsOneWidget);
+    });
+
+    testWidgets('a new streak started from a review shows its live puzzle', (tester) async {
+      final app = await makeTestProviderScopeApp(
+        tester,
+        home: const StreakScreen(),
+        overrides: {
+          lichessClientProvider: lichessClientProvider.overrideWith(
+            (ref) => LichessClient(client, ref),
+          ),
+        },
+      );
+      await tester.pumpWidget(app);
+      await tester.pumpAndSettle(const Duration(seconds: 2));
+
+      // solve the first puzzle, fail the second, review the first
+      await playMove(tester, 'e5', 'e1', orientation: Side.black);
+      await tester.pumpAndSettle(const Duration(milliseconds: 500));
+      await playMove(tester, 'f6', 'f4', orientation: Side.black);
+      await tester.pumpAndSettle(const Duration(milliseconds: 500));
+      await playMove(tester, 'f4', 'f2', orientation: Side.black);
+      await tester.pumpAndSettle(const Duration(seconds: 1));
+      await playMove(tester, 'e6', 'f7', orientation: Side.white);
+      await tester.pumpAndSettle(const Duration(seconds: 1));
+      await tester.tap(find.byKey(const ValueKey('previous-puzzle')));
+      await tester.pumpAndSettle(const Duration(seconds: 1));
+      expect(find.text('Solved puzzle 1 of 1'), findsOneWidget);
+
+      await tester.tap(find.byKey(const ValueKey('new-streak')));
+      await tester.pumpAndSettle(const Duration(seconds: 2));
+
+      // the review is over: the new run's first puzzle is on the board, in play
+      expect(find.text('Solved puzzle 1 of 1'), findsNothing);
+      expect(find.byKey(const ValueKey('next-puzzle')), findsNothing);
+      expect(find.byKey(const ValueKey('skip')), findsOneWidget);
+      expect(find.text('Your turn'), findsOneWidget);
+      expect(find.textContaining(RegExp('0\$')), findsOneWidget);
     });
   });
 }


### PR DESCRIPTION
I was trying to do puzzle streak on the train, and I realized it didn't have an offline option. I also kept wanting to view puzzles I got correct, but wasn't 100% sure of the solution.

Architectural:
1. Fetch 30 puzzles at a time with the new "apiMany"
2. Save them for offline use

Live puzzle:
1. Add previous button
2. Once we've failed the streak, change the weird refresh icon to be a "skip" icon, and label it "New Streak" to eliminate user confusion.

On past puzzles:
1. Remove unlabelled "<" ">" arrows. If the user wants to analyze, they can go to analysis.
2. Replace "<" ">" buttons with "previous" / "next" buttons

[Screen_recording_20260902_160358_gh.webm](https://github.com/user-attachments/assets/cc8375fb-7796-4bef-9385-b3ac71bc6cda)

---
AI Generated description:
## The commits

Five commits, best read in order.

**puzzle: fetch several puzzles by id in one request**

`PuzzleRepository.fetchMany` on top of `/api/puzzle/many`, plus `PuzzleStorage.cachedPuzzleIds` and `saveAll` so a caller can ask only for what isn't on disk and write the answer in one transaction. The endpoint drops ids it can't serve, so the response can be shorter than the request. Nothing calls it yet at this point in the series.

**puzzle: load a puzzle from the cache or the server in one place**

`PuzzleService.loadPuzzle` reads a puzzle from SQLite and falls back to the server on a miss; `cachePuzzle` writes one and logs a failed write instead of throwing, because the cache is an optimisation, not the source of truth. `puzzleProvider` and `solve()` go through these instead of open-coding the same thing.

**network: keep puzzle fetches out of the retry, and name the failures worth retrying**

`/api/puzzle/many` joins the batch endpoints in the "don't retry a 429" list: a prefetch that just got rate limited should stop, not double the burst. `isPermanentFailure` says whether a request is worth trying again later. A 4xx will fail the same way next time, except 429 and 401, which pass once the limit resets or the session is renewed. The streak uses it to decide what to drop and what to leave queued.

**streak: play offline from a local look-ahead buffer**

The controller reads puzzles from the cache first, and keeps 30 puzzles cached ahead of the current one with a single `/api/puzzle/many` request, refilling once fewer than 10 remain. Each refill starts where the cached range ends so the windows don't overlap. Refills are best-effort: a failed one backs off for a few advances, a 4xx stands the refill down for the rest of the run, and play continues one puzzle at a time from `/api/puzzle/{id}`, which isn't rate limited.

A solve whose next puzzle isn't available yet is saved as `advancePending` and counts towards the score from that moment, so cutting the run short or failing later doesn't replay a puzzle you already solved. `PuzzleStreak.score` is the one place that answers "how long is this run", for the tab badge, the counter on screen and the posted run. On reconnect the controller tries the advance once more; if that fails too, the bar offers a retry. Connectivity only reports online once lichess itself answers, so there's no captive portal to retry through. If the server refuses the next puzzle outright, the run ends with the solve counted and the score posted, the same way a saved run in that state is ended on the next visit.

A run that ends offline queues its score in the preferences. `StreakScoreSync` posts it on reconnect or on a cold start that is already online, so it doesn't sit there until the streak screen is opened again. Only the best pending run is kept (the server keeps the best score anyway), and a score the server rejects for good is dropped rather than re-posted forever.

The puzzle tab lets you open a saved streak offline, and the new streak button stays tappable offline so it can say why nothing happens instead of being greyed out.

**streak: review the solved puzzles of the run**

Previous/Next in the bottom bar walk the run puzzle by puzzle, and the feedback tile says which one is on the board ("Solved puzzle 2 of 4"). A reviewed puzzle gets its own `puzzleControllerProvider` key, so the live puzzle keeps its state and stays the only thing driving the streak. It carries no user id, otherwise each load would refresh the glicko through the batch endpoint.

Reviewing replays the puzzle: a right move is answered, a wrong one taken back. That needed a distinct `PuzzleMode.replay`. On the streak screen a puzzle that's over (won, lost or reviewed) keeps checking moves against the solution, whereas on the puzzle screen view mode is a free analysis board. Everything that used to care about "view mode, but on a streak" now just switches on the mode. The replay goes through the existing play branch of `onUserMove` rather than a second copy of the solution checking; only the error sound and the take-back differ.

Back from a review returns to the live puzzle, not to the puzzle tab. Starting a new streak from a review drops the review. The bar keeps one previous/next pair in every state, greyed out at the ends, so it doesn't change shape.

## Things worth knowing

- The run is saved to disk as soon as it starts, since it has to be there to resume offline. That means backing out of the first puzzle without playing it brings the same puzzle back next time.
- The controller tests poll with short real delays instead of `FakeAsync`, because they go through a real sqflite database.
- The old move-by-move Previous/Next after a loss is gone; the arrows now walk the run. The solution is still in the move list and on the analysis board.

## Tests

Widget tests on the streak screen for review, new streak from a review, a solve stranded offline, and a retry after a failed load while online. Controller tests for the cache-first loading, prefetch and refill windows, back-off and rate limiting, reconnect, the pending score queue, and a run whose puzzle the server refuses.

AI tools used: Claude Opus 5, Fable 5 and Fable 5.1.
