### PR TITLE
fix UserTV advancing to next game

### DIFF
--- a/lib/src/model/tv/tv_controller.dart
+++ b/lib/src/model/tv/tv_controller.dart
@@ -46,9 +46,11 @@ class TvController extends AsyncNotifier<TvGameControllerParams> {
     state = AsyncValue.data((gameId: game.$1, orientation: game.$2, source: params));
   }
 
-  /// Re-resolves the current game (the channel may have switched while the app
-  /// was in the background).
-  Future<void> onFocusRegained() async {
+  /// Looks up which game should be watched now and switches to it.
+  ///
+  /// For channel TV this re-fetches the channel's featured game; for user TV it
+  /// fetches the user's current game from the API.
+  Future<void> resolveCurrentGame() async {
     state = AsyncValue.data(await _resolveGame(null));
   }
 

--- a/lib/src/model/tv/tv_game_controller.dart
+++ b/lib/src/model/tv/tv_game_controller.dart
@@ -180,18 +180,30 @@ class TvGameController extends AsyncNotifier<TvGameState> with ChatMixin<TvGameS
     state = AsyncValue.data(state.requireValue.copyWith(chatState: newState));
   }
 
+  Future<void> _onResyncOrRematchTaken() async {
+    if (!ref.mounted) return;
+    if (params.source.userId != null) {
+      await ref.read(tvControllerProvider(params.source).notifier).resolveCurrentGame();
+    } else {
+      _onReload?.call();
+    }
+  }
+
   @protected
   @override
   void handleSocketEvent(SocketEvent event) {
     super.handleSocketEvent(event);
+
+    if (event.topic == 'resync' || event.topic == 'rematchTaken') {
+      unawaited(_onResyncOrRematchTaken());
+      return;
+    }
 
     if (!state.hasValue) {
       return;
     }
 
     switch (event.topic) {
-      case 'resync':
-        _onReload?.call();
       case 'reload':
         if (event.data is Map<String, dynamic>) {
           final data = event.data as Map<String, dynamic>;
@@ -214,8 +226,6 @@ class TvGameController extends AsyncNotifier<TvGameState> with ChatMixin<TvGameS
               const IList.empty();
           state = AsyncData(state.requireValue.copyWith(nbWatchers: nb, watcherNames: users));
         }
-      case 'rematchTaken':
-        _onReload?.call();
       case 'move' || 'drop':
         final curState = state.requireValue;
         final data = MoveEvent.fromJson(event.data as Map<String, dynamic>);

--- a/lib/src/network/socket.dart
+++ b/lib/src/network/socket.dart
@@ -221,7 +221,13 @@ class SocketClient {
     _ackResendTimer = Timer.periodic(resendAckDelay, (_) => _resendAcks());
 
     final authUser = getSession();
-    final uri = lichessWSUri(route.path, version != null ? {'v': version.toString()} : null);
+
+    final queryParameters = Map<String, String>.from(route.queryParameters);
+    if (version != null) {
+      queryParameters['v'] = version.toString();
+    }
+    final uri = lichessWSUri(route.path, queryParameters.isNotEmpty ? queryParameters : null);
+
     final Map<String, String> headers = authUser != null
         ? {'Authorization': 'Bearer ${signBearerToken(authUser.token)}'}
         : {};

--- a/lib/src/view/watch/tv_screen.dart
+++ b/lib/src/view/watch/tv_screen.dart
@@ -73,7 +73,7 @@ class _TvScreenState extends ConsumerState<TvScreen> {
 
     return FocusDetector(
       onFocusRegained: () {
-        ref.read(_tvCtrl.notifier).onFocusRegained();
+        ref.read(_tvCtrl.notifier).resolveCurrentGame();
         if (gameParams != null) {
           ref.read(tvGameControllerProvider(gameParams).notifier).onFocusRegained();
         }

--- a/test/network/fake_websocket_channel.dart
+++ b/test/network/fake_websocket_channel.dart
@@ -73,7 +73,7 @@ class FakeWebSocketChannelFactory implements WebSocketChannelFactory {
     Map<String, dynamic>? headers,
     Duration timeout = const Duration(seconds: 1),
   }) {
-    return Future.value(createFunction(Uri(path: Uri.parse(url).path)));
+    return Future.value(createFunction(Uri.parse(url)));
   }
 }
 
@@ -109,10 +109,11 @@ typedef FakeSocketServerHandlers =
 /// verify that the client sends the expected messages.
 class FakeWebSocketChannel implements WebSocketChannel {
   FakeWebSocketChannel(
-    this.route, {
+    Uri socketRoute, {
     this.connectionLag = kFakeWebSocketConnectionLag,
     this.serverHandlers = const {},
-  }) : assert(route.path.isNotEmpty, 'Route path must not be empty'),
+  }) : route = Uri(path: socketRoute.path),
+       assert(socketRoute.path.isNotEmpty, 'Route path must not be empty'),
        assert(connectionLag > Duration.zero, 'Connection lag must be greater than 0') {
     _sink = _FakeWebSocketSink(this, serverHandlers);
   }

--- a/test/view/watch/tv_screen_test.dart
+++ b/test/view/watch/tv_screen_test.dart
@@ -2,11 +2,18 @@ import 'package:chessground/chessground.dart';
 import 'package:dartchess/dartchess.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
+import 'package:http/testing.dart';
 import 'package:lichess_mobile/src/model/common/id.dart';
+import 'package:lichess_mobile/src/model/game/exported_game.dart';
 import 'package:lichess_mobile/src/model/tv/tv_channel.dart';
+import 'package:lichess_mobile/src/model/user/user.dart';
+import 'package:lichess_mobile/src/network/http.dart';
+import 'package:lichess_mobile/src/network/socket.dart';
 import 'package:lichess_mobile/src/view/watch/tv_screen.dart';
 
+import '../../example_data.dart';
 import '../../model/game/game_socket_example_data.dart';
+import '../../network/fake_http_client_factory.dart';
 import '../../network/fake_websocket_channel.dart';
 import '../../test_helpers.dart';
 import '../../test_provider_scope.dart';
@@ -16,12 +23,29 @@ void main() {
   // The TV controller opens this socket route for the initial game.
   final tvSocketUri = Uri(path: '/watch/$gameId/white/v6');
 
-  Future<void> loadGame(WidgetTester tester, {String pgn = ''}) async {
+  Uri watchSocketUri(GameId id, Side orientation) =>
+      Uri(path: '/watch/${id.value}/${orientation.name}/v6');
+
+  Future<void> loadGame(
+    WidgetTester tester, {
+    String pgn = '',
+    Uri? socketUri,
+    GameId? gameId,
+    ExportedGame? game,
+    String whiteUserName = 'Peter',
+    String blackUserName = 'Steven',
+  }) async {
+    final uri = socketUri ?? tvSocketUri;
+    final id = gameId ?? game?.id ?? const GameId('qVChCOTc');
     await tester.pump(kFakeWebSocketConnectionLag);
-    sendServerSocketMessages(tvSocketUri, [
-      makeFullEvent(gameId, pgn, whiteUserName: 'Peter', blackUserName: 'Steven'),
+    sendServerSocketMessages(uri, [
+      makeFullEvent(
+        id,
+        pgn,
+        whiteUserName: game?.white.user?.name ?? whiteUserName,
+        blackUserName: game?.black.user?.name ?? blackUserName,
+      ),
     ]);
-    // wait for socket message handling
     await tester.pump();
   }
 
@@ -94,5 +118,65 @@ void main() {
       expect(getBoardPieces(tester).containsKey(Square.e4), isFalse);
       expect(tester.widget<Chessboard>(find.byType(Chessboard)).interactive, isFalse);
     });
+
+    testWidgets('user TV advances when the watched player starts a new game', (tester) async {
+      final user = LightUser(id: UserId.fromUserName('nfchess13'), name: 'NFChess13');
+      final games = generateExportedGames(count: 2, username: 'nfchess13');
+      Uri? userTvWatch;
+
+      await tester.pumpWidget(
+        await makeTestProviderScopeApp(
+          tester,
+          home: TvScreen(user: user, initialGame: (games[0].id, Side.white)),
+          overrides: {
+            httpClientFactoryProvider: httpClientFactoryProvider.overrideWith(
+              (_) => FakeHttpClientFactory(
+                () => MockClient(
+                  (r) => r.url.path == '/api/user/nfchess13/current-game'
+                      ? mockResponse(_currentGameJson(games[1]), 200)
+                      : mockResponse('', 404),
+                ),
+              ),
+            ),
+            webSocketChannelFactoryProvider: webSocketChannelFactoryProvider.overrideWith(
+              (_) => FakeWebSocketChannelFactory((uri) {
+                if (uri.queryParameters.containsKey('userTv')) {
+                  userTvWatch = Uri(path: uri.path);
+                }
+                return createDefaultFakeWebSocketChannel(uri);
+              }),
+            ),
+          },
+        ),
+      );
+      // load first game, opponent is called "Black"
+      await loadGame(tester, socketUri: watchSocketUri(games[0].id, Side.white), game: games[0]);
+      expect(find.text('Black'), findsOneWidget);
+      expect(
+        userTvWatch,
+        isNotNull,
+        reason: 'The user TV socket should have been opened when loading the first game.',
+      );
+      // server sends a resync event, which should trigger a request to the current-game endpoint and load the new game
+      sendServerSocketMessages(userTvWatch!, ['{"t": "resync"}']);
+      await tester.pump();
+      await tester.pump(kFakeWebSocketConnectionLag);
+      await loadGame(
+        tester,
+        socketUri: watchSocketUri(games[1].id, games[1].youAre!),
+        game: games[1],
+      );
+      // new game is loaded and opponent is called "White"
+      expect(find.text('Black'), findsNothing);
+      expect(find.text('White'), findsOneWidget);
+    });
   });
+}
+
+String _currentGameJson(ExportedGame game) {
+  final white = game.white.user!;
+  final black = game.black.user!;
+  return '''
+{"id":"${game.id.value}","rated":true,"source":"lobby","variant":"standard","speed":"blitz","perf":"blitz","createdAt":0,"lastMoveAt":0,"status":"started","players":{"white":{"user":{"name":"${white.name}","id":"${white.id}"},"rating":1500},"black":{"user":{"name":"${black.name}","id":"${black.id}"},"rating":1500}},"moves":"","clock":{"initial":120,"increment":3,"totalTime":160},"lastFen":"rnbqkbnr/pppppppp/8/8/8/8/PPPPPPPP/RNBQKBNR w KQkq - 0 1"}
+''';
 }


### PR DESCRIPTION
UserTV was not auto connecting to the next game automatically. There were two problems:
- The Queryparameter usertv? was not sent to the server, so the server did not know that it should send a `resync` event, when the user starts a new game.
- `resync/rematchTaken` reconnected to the same game instead of fetching the new game

Added a test that fails without both fixes.

Video: 

[Screencast_20260626_101113.webm](https://github.com/user-attachments/assets/54c6560f-0451-4bb6-8a6c-bf196ec89f52)
