### PR TITLE
Save clock tool's last used time preference

### DIFF
--- a/lib/src/model/clock/clock_tool_controller.dart
+++ b/lib/src/model/clock/clock_tool_controller.dart
@@ -33,7 +33,10 @@ class ClockToolController extends Notifier<ClockState> {
     ClockSide.top: false,
     ClockSide.bottom: false,
   };
-  late Duration _emergencyThreshold;
+  final Map<ClockSide, Duration> _emergencyThresholds = {
+    ClockSide.top: Duration.zero,
+    ClockSide.bottom: Duration.zero,
+  };
   DateTime? _delayStartedAt;
   Duration? _delayDuration;
   Duration? _pausedDelayRemaining;
@@ -43,19 +46,23 @@ class ClockToolController extends Notifier<ClockState> {
   ClockState build() {
     // using read is good enough as config change updates in-memory state which re-renders the ui
     // and prefs are also saved
-    final timeIncrement = ref.read(clockToolPreferencesProvider).timeIncrement;
-    final time = Duration(seconds: timeIncrement.time);
-    final increment = Duration(seconds: timeIncrement.increment);
-    _emergencyThreshold = _calculateEmergencyThreshold(time);
+    final topTimeIncrement = ref.read(clockToolPreferencesProvider).topTimeIncrement;
+    final topTime = Duration(seconds: topTimeIncrement.time);
+    final topIncrement = Duration(seconds: topTimeIncrement.increment);
+    final bottomTimeIncrement = ref.read(clockToolPreferencesProvider).bottomTimeIncrement;
+    final bottomTime = Duration(seconds: bottomTimeIncrement.time);
+    final bottomIncrement = Duration(seconds: bottomTimeIncrement.increment);
+    _emergencyThresholds[ClockSide.top] = _calculateEmergencyThreshold(topTime);
+    _emergencyThresholds[ClockSide.bottom] = _calculateEmergencyThreshold(bottomTime);
     final options = ClockOptions(
       type: ClockTimeControlType.increment,
-      topTime: time,
-      bottomTime: time,
-      topIncrement: increment,
-      bottomIncrement: increment,
+      topTime: topTime,
+      bottomTime: bottomTime,
+      topIncrement: topIncrement,
+      bottomIncrement: bottomIncrement,
     );
 
-    _clock = ChessClock(blackTime: time, whiteTime: time, onFlag: _onFlagged);
+    _clock = ChessClock(blackTime: topTime, whiteTime: bottomTime, onFlag: _onFlagged);
 
     // Add listeners for both clocks
     _clock.whiteTime.addListener(onClockEmergency);
@@ -88,7 +95,7 @@ class ClockToolController extends Notifier<ClockState> {
     final activeSideTime = activeSide == ClockSide.top
         ? _clock.blackTime.value
         : _clock.whiteTime.value;
-    if (activeSideTime <= _emergencyThreshold) {
+    if (activeSideTime <= _emergencyThresholds[activeSide]!) {
       ref.read(soundServiceProvider).play(Sound.lowTime);
       _hasPlayedLowTimeSound[activeSide] = true;
     }
@@ -117,20 +124,11 @@ class ClockToolController extends Notifier<ClockState> {
     _startActiveSide(playerType.opposite);
   }
 
-  void updateDuration(ClockSide playerType, Duration duration) {
-    if (state.flagged != null || state.paused) {
-      return;
-    }
-
-    _clock.setTimes(
-      whiteTime: playerType == ClockSide.bottom ? duration + state.options.topIncrement : null,
-      blackTime: playerType == ClockSide.top ? duration + state.options.bottomIncrement : null,
-    );
-  }
-
   void updateOptions(TimeIncrement timeIncrement) {
     final options = ClockOptions.fromTimeIncrement(timeIncrement, type: state.options.type);
-    _emergencyThreshold = _calculateEmergencyThreshold(Duration(seconds: timeIncrement.time));
+    final threshold = _calculateEmergencyThreshold(Duration(seconds: timeIncrement.time));
+    _emergencyThresholds[ClockSide.top] = threshold;
+    _emergencyThresholds[ClockSide.bottom] = threshold;
     _hasPlayedLowTimeSound[ClockSide.top] = false;
     _hasPlayedLowTimeSound[ClockSide.bottom] = false;
     _clock.setTimes(blackTime: options.topTime, whiteTime: options.bottomTime);
@@ -156,6 +154,8 @@ class ClockToolController extends Notifier<ClockState> {
           ? Duration(seconds: clock.increment)
           : state.options.bottomIncrement,
     );
+    _emergencyThresholds[player] = _calculateEmergencyThreshold(Duration(seconds: clock.time));
+    _hasPlayedLowTimeSound[player] = false;
     _clock.setTimes(blackTime: options.topTime, whiteTime: options.bottomTime);
     state = ClockState(
       options: options,
@@ -164,7 +164,12 @@ class ClockToolController extends Notifier<ClockState> {
       activeSide: state.activeSide,
       clockOrientation: state.clockOrientation,
     );
-    ref.read(clockToolPreferencesProvider.notifier).setTimeIncrement(clock);
+
+    if (player == ClockSide.top) {
+      ref.read(clockToolPreferencesProvider.notifier).setTopTimeIncrement(clock);
+    } else {
+      ref.read(clockToolPreferencesProvider.notifier).setBottomTimeIncrement(clock);
+    }
   }
 
   void updateClockType(ClockTimeControlType type) {
@@ -205,14 +210,9 @@ class ClockToolController extends Notifier<ClockState> {
     final active = state.activeSide;
     // If the active side started at zero, only resume ticking after that side
     // has completed at least one move; otherwise behave normally.
-    final Duration initialOfActive = active == ClockSide.top
-        ? state.options.topTime
-        : state.options.bottomTime;
-    final bool hasActiveMoved = active == ClockSide.top
-        ? state.topMoves > 0
-        : state.bottomMoves > 0;
+    final bool hasActiveMoved = active != null && state.getMovesCount(active) > 0;
 
-    if (active != null && (initialOfActive.inMilliseconds != 0 || hasActiveMoved)) {
+    if (active != null && (state.options.getStartTime(active).inMilliseconds != 0 || hasActiveMoved)) {
       final delay = _pausedDelayRemaining;
       _markDelay(delay);
       _clock.start(delay: delay);
@@ -229,13 +229,8 @@ class ClockToolController extends Notifier<ClockState> {
     // Start the countdown only if either this is not a zero-start clock
     // or the active side has already made at least one move.
     // This makes 0+increment modes usable.
-    final Duration initialOfActive = activeSide == ClockSide.top
-        ? state.options.topTime
-        : state.options.bottomTime;
-    final bool hasActiveMoved = activeSide == ClockSide.top
-        ? state.topMoves > 0
-        : state.bottomMoves > 0;
-    if (initialOfActive.inMilliseconds != 0 || hasActiveMoved) {
+    final bool hasActiveMoved = state.getMovesCount(activeSide) > 0;
+    if (state.options.getStartTime(activeSide).inMilliseconds != 0 || hasActiveMoved) {
       final delay = _delayFor(activeSide);
       _markDelay(delay);
       _activeTurnStartedWithTime = state.getDuration(activeSide).value;
@@ -339,6 +334,10 @@ sealed class ClockOptions with _$ClockOptions {
 
   bool hasIncrement(ClockSide playerType) {
     return getIncrement(playerType) > 0;
+  }
+
+  Duration getStartTime(ClockSide playerType) {
+    return playerType == ClockSide.top ? topTime : bottomTime;
   }
 }
 

--- a/lib/src/model/clock/clock_tool_controller.dart
+++ b/lib/src/model/clock/clock_tool_controller.dart
@@ -212,7 +212,8 @@ class ClockToolController extends Notifier<ClockState> {
     // has completed at least one move; otherwise behave normally.
     final bool hasActiveMoved = active != null && state.getMovesCount(active) > 0;
 
-    if (active != null && (state.options.getStartTime(active).inMilliseconds != 0 || hasActiveMoved)) {
+    if (active != null &&
+        (state.options.getStartTime(active).inMilliseconds != 0 || hasActiveMoved)) {
       final delay = _pausedDelayRemaining;
       _markDelay(delay);
       _clock.start(delay: delay);

--- a/lib/src/model/clock/clock_tool_controller.dart
+++ b/lib/src/model/clock/clock_tool_controller.dart
@@ -4,6 +4,7 @@ import 'package:flutter/foundation.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:freezed_annotation/freezed_annotation.dart';
 import 'package:lichess_mobile/src/model/clock/chess_clock.dart';
+import 'package:lichess_mobile/src/model/clock/clock_tool_preferences.dart';
 import 'package:lichess_mobile/src/model/common/service/sound_service.dart';
 import 'package:lichess_mobile/src/model/common/time_increment.dart';
 
@@ -40,10 +41,11 @@ class ClockToolController extends Notifier<ClockState> {
 
   @override
   ClockState build() {
-    const time = Duration(minutes: 10);
-    const increment = Duration.zero;
+    final timeIncrement = ref.watch(clockToolPreferencesProvider).timeIncrement;
+    final time = Duration(seconds: timeIncrement.time);
+    final increment = Duration(seconds: timeIncrement.increment);
     _emergencyThreshold = _calculateEmergencyThreshold(time);
-    const options = ClockOptions(
+    final options = ClockOptions(
       type: ClockTimeControlType.increment,
       topTime: time,
       bottomTime: time,
@@ -135,6 +137,7 @@ class ClockToolController extends Notifier<ClockState> {
       topTime: _clock.blackTime,
       bottomTime: _clock.whiteTime,
     );
+    ref.read(clockToolPreferencesProvider.notifier).setTimeIncrement(timeIncrement);
   }
 
   void updateOptionsCustom(TimeIncrement clock, ClockSide player) {
@@ -159,6 +162,7 @@ class ClockToolController extends Notifier<ClockState> {
       activeSide: state.activeSide,
       clockOrientation: state.clockOrientation,
     );
+    ref.read(clockToolPreferencesProvider.notifier).setTimeIncrement(clock);
   }
 
   void updateClockType(ClockTimeControlType type) {

--- a/lib/src/model/clock/clock_tool_controller.dart
+++ b/lib/src/model/clock/clock_tool_controller.dart
@@ -41,7 +41,9 @@ class ClockToolController extends Notifier<ClockState> {
 
   @override
   ClockState build() {
-    final timeIncrement = ref.watch(clockToolPreferencesProvider).timeIncrement;
+    // using read is good enough as config change updates in-memory state which re-renders the ui
+    // and prefs are also saved
+    final timeIncrement = ref.read(clockToolPreferencesProvider).timeIncrement;
     final time = Duration(seconds: timeIncrement.time);
     final increment = Duration(seconds: timeIncrement.increment);
     _emergencyThreshold = _calculateEmergencyThreshold(time);

--- a/lib/src/model/clock/clock_tool_preferences.dart
+++ b/lib/src/model/clock/clock_tool_preferences.dart
@@ -29,7 +29,7 @@ class ClockToolPreferences extends Notifier<ClockToolPrefs>
     return fetch();
   }
 
-  Future<void> setTimeIncrement(TimeIncrement timeIncrement) async {
+  Future<void> setTimeIncrement(TimeIncrement timeIncrement) {
     return save(state.copyWith(timeIncrement: timeIncrement));
   }
 }

--- a/lib/src/model/clock/clock_tool_preferences.dart
+++ b/lib/src/model/clock/clock_tool_preferences.dart
@@ -1,0 +1,52 @@
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:freezed_annotation/freezed_annotation.dart';
+import 'package:lichess_mobile/src/model/common/time_increment.dart';
+import 'package:lichess_mobile/src/model/settings/preferences_storage.dart';
+import 'package:lichess_mobile/src/model/user/user.dart';
+
+part 'clock_tool_preferences.freezed.dart';
+part 'clock_tool_preferences.g.dart';
+
+final clockToolPreferencesProvider = NotifierProvider<ClockToolPreferences, ClockToolPrefs>(
+  ClockToolPreferences.new,
+  name: 'ClockToolPreferencesProvider',
+);
+
+class ClockToolPreferences extends Notifier<ClockToolPrefs>
+    with SessionPreferencesStorage<ClockToolPrefs> {
+  @override
+  @protected
+  final prefCategory = PrefCategory.clockTool;
+
+  @override
+  ClockToolPrefs defaults({LightUser? user}) => ClockToolPrefs.defaults;
+
+  @override
+  ClockToolPrefs fromJson(Map<String, dynamic> json) => ClockToolPrefs.fromJson(json);
+
+  @override
+  ClockToolPrefs build() {
+    return fetch();
+  }
+
+  Future<void> setTimeIncrement(TimeIncrement timeIncrement) async {
+    return save(state.copyWith(timeIncrement: timeIncrement));
+  }
+}
+
+@Freezed(fromJson: true, toJson: true)
+sealed class ClockToolPrefs with _$ClockToolPrefs implements Serializable {
+  const ClockToolPrefs._();
+
+  const factory ClockToolPrefs({required TimeIncrement timeIncrement}) = _ClockToolPrefs;
+
+  static const defaults = ClockToolPrefs(timeIncrement: TimeIncrement(600, 0));
+
+  factory ClockToolPrefs.fromJson(Map<String, dynamic> json) {
+    try {
+      return _$ClockToolPrefsFromJson(json);
+    } catch (_) {
+      return defaults;
+    }
+  }
+}

--- a/lib/src/model/clock/clock_tool_preferences.dart
+++ b/lib/src/model/clock/clock_tool_preferences.dart
@@ -30,7 +30,9 @@ class ClockToolPreferences extends Notifier<ClockToolPrefs>
   }
 
   Future<void> setTimeIncrement(TimeIncrement timeIncrement) {
-    return save(state.copyWith(topTimeIncrement: timeIncrement, bottomTimeIncrement: timeIncrement));
+    return save(
+      state.copyWith(topTimeIncrement: timeIncrement, bottomTimeIncrement: timeIncrement),
+    );
   }
 
   Future<void> setTopTimeIncrement(TimeIncrement timeIncrement) {

--- a/lib/src/model/clock/clock_tool_preferences.dart
+++ b/lib/src/model/clock/clock_tool_preferences.dart
@@ -30,7 +30,15 @@ class ClockToolPreferences extends Notifier<ClockToolPrefs>
   }
 
   Future<void> setTimeIncrement(TimeIncrement timeIncrement) {
-    return save(state.copyWith(timeIncrement: timeIncrement));
+    return save(state.copyWith(topTimeIncrement: timeIncrement, bottomTimeIncrement: timeIncrement));
+  }
+
+  Future<void> setTopTimeIncrement(TimeIncrement timeIncrement) {
+    return save(state.copyWith(topTimeIncrement: timeIncrement));
+  }
+
+  Future<void> setBottomTimeIncrement(TimeIncrement timeIncrement) {
+    return save(state.copyWith(bottomTimeIncrement: timeIncrement));
   }
 }
 
@@ -38,9 +46,15 @@ class ClockToolPreferences extends Notifier<ClockToolPrefs>
 sealed class ClockToolPrefs with _$ClockToolPrefs implements Serializable {
   const ClockToolPrefs._();
 
-  const factory ClockToolPrefs({required TimeIncrement timeIncrement}) = _ClockToolPrefs;
+  const factory ClockToolPrefs({
+    required TimeIncrement topTimeIncrement,
+    required TimeIncrement bottomTimeIncrement,
+  }) = _ClockToolPrefs;
 
-  static const defaults = ClockToolPrefs(timeIncrement: TimeIncrement(600, 0));
+  static const defaults = ClockToolPrefs(
+    topTimeIncrement: TimeIncrement(600, 0),
+    bottomTimeIncrement: TimeIncrement(600, 0),
+  );
 
   factory ClockToolPrefs.fromJson(Map<String, dynamic> json) {
     try {

--- a/lib/src/model/settings/preferences_storage.dart
+++ b/lib/src/model/settings/preferences_storage.dart
@@ -31,7 +31,8 @@ enum PrefCategory {
   broadcast('preferences.broadcast'),
   engineEvaluation('preferences.engineEvaluation'),
   offlineComputerGame('preferences.offlineComputerGame'),
-  log('preferences.log');
+  log('preferences.log'),
+  clockTool('preferences.clockTool');
 
   const PrefCategory(this.storageKey);
 

--- a/test/model/clock/clock_tool_controller_test.dart
+++ b/test/model/clock/clock_tool_controller_test.dart
@@ -2,15 +2,30 @@ import 'package:fake_async/fake_async.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:lichess_mobile/src/model/clock/clock_tool_controller.dart';
+import 'package:lichess_mobile/src/model/clock/clock_tool_preferences.dart';
 import 'package:lichess_mobile/src/model/common/service/sound_service.dart';
 import 'package:lichess_mobile/src/model/common/time_increment.dart';
 
 import '../common/service/fake_sound_service.dart';
 
+class FakeClockToolPreferences extends ClockToolPreferences {
+  @override
+  ClockToolPrefs build() => ClockToolPrefs.defaults;
+
+  @override
+  Future<void> setTimeIncrement(TimeIncrement timeIncrement) async {
+    await Future.delayed(Duration.zero);
+    state = state.copyWith(timeIncrement: timeIncrement);
+  }
+}
+
 void main() {
   ProviderContainer makeClockContainer() {
     final container = ProviderContainer(
-      overrides: [soundServiceProvider.overrideWithValue(FakeSoundService())],
+      overrides: [
+        soundServiceProvider.overrideWithValue(FakeSoundService()),
+        clockToolPreferencesProvider.overrideWith(FakeClockToolPreferences.new),
+      ],
     );
     final subscription = container.listen(clockToolControllerProvider, (_, _) {});
     addTearDown(subscription.close);

--- a/test/model/clock/clock_tool_controller_test.dart
+++ b/test/model/clock/clock_tool_controller_test.dart
@@ -15,7 +15,7 @@ class FakeClockToolPreferences extends ClockToolPreferences {
   @override
   Future<void> setTimeIncrement(TimeIncrement timeIncrement) async {
     await Future<void>.delayed(Duration.zero);
-    state = state.copyWith(timeIncrement: timeIncrement);
+    state = state.copyWith(topTimeIncrement: timeIncrement, bottomTimeIncrement: timeIncrement);
   }
 }
 

--- a/test/model/clock/clock_tool_controller_test.dart
+++ b/test/model/clock/clock_tool_controller_test.dart
@@ -14,7 +14,7 @@ class FakeClockToolPreferences extends ClockToolPreferences {
 
   @override
   Future<void> setTimeIncrement(TimeIncrement timeIncrement) async {
-    await Future.delayed(Duration.zero);
+    await Future<void>.delayed(Duration.zero);
     state = state.copyWith(timeIncrement: timeIncrement);
   }
 }


### PR DESCRIPTION
Closes #3394 

1. Created a new clock tool preferences file as there wasn't already.
2. Earlier 10sec was the fixed value used so kept same as the default config value.
3.  The UI is rendered by the state driven by ClockToolController. hence let it read the default value from preferences in build().
4. updateOptions and updateOptionsCustom of ClockToolController are the only two methods that update the clock tool state, so updated them to write to the prefs as well.

### Update (12 July): Based on testing/feedback, new changes :

### Clock Preferences:

* Asymmetrical Tracking: Refactored ClockToolPrefs to store topTimeIncrement and bottomTimeIncrement separately. The tool now remembers separate settings for each clock across app sessions. 
* Helper Method: Added getStartTime(ClockSide) to ClockOptions to simplify and avoid repetitive logic within the controller.

### Emergency Threshold Bug Fix:

* Problem: Previously, a single shared _emergencyThreshold was used for both clocks. In games with different starting times, the low-time sound would trigger at incorrect intervals.

* Fix: Implemented a map-based _emergencyThresholds to track threshold separately for the two clocks. onClockEmergency now correctly references the active player's specific threshold.

### Clean-up & Dead Code Removal:

* updateDuration Removal: Identified and removed the updateDuration method. The function was unused in the codebase and contained a logical error where side increments were swapped. ClockSide bottom using topIncrement and ClockSide top using bottomIncrement which is wrong.

### Impact:

* Users can now play handicap games with remembered settings for both sides.
* Low-time warnings are now accurate for both players in asymmetrical games.

### Tested

Clocks separate default time tracking:
* Used central settings button to change both clocks time. The default time persists for both.
* Used top or bottom aligned settings button to change individual clocks time. The default time persists.
https://github.com/user-attachments/assets/35428792-f86b-4247-85f5-a33b188b2438

Emergency threshold bug (No Sound at Emergency threshold (10% of the total time)) :
https://github.com/user-attachments/assets/7120efc9-3bab-4a0c-a925-eac386693ed6

Emergency threshold bug fixed:
https://github.com/user-attachments/assets/3d8dbad4-f2f1-423e-a131-b8cecf502dc7




