### PR TITLE
fix: improve accessibility semantics in CreateGameWidget

### DIFF
--- a/lib/src/view/play/create_game_widget.dart
+++ b/lib/src/view/play/create_game_widget.dart
@@ -40,73 +40,89 @@ class CreateGameWidget extends ConsumerWidget {
           mainAxisAlignment: MainAxisAlignment.spaceBetween,
           children: [
             Expanded(
-              child: Column(
-                crossAxisAlignment: CrossAxisAlignment.stretch,
-                mainAxisSize: MainAxisSize.min,
-                children: [
-                  Text(context.l10n.timeControl, style: labelStyle),
-                  OutlinedButton.icon(
-                    style: OutlinedButton.styleFrom(
-                      side: BorderSide(color: Theme.of(context).dividerColor),
+              child: Semantics(
+                container: true,
+                button: true,
+                label: '${context.l10n.timeControl}: ${playPrefs.timeIncrement.display}',
+                excludeSemantics: true,
+                child: Column(
+                  crossAxisAlignment: CrossAxisAlignment.stretch,
+                  mainAxisSize: MainAxisSize.min,
+                  children: [
+                    Text(context.l10n.timeControl, style: labelStyle),
+                    OutlinedButton.icon(
+                      style: OutlinedButton.styleFrom(
+                        side: BorderSide(color: Theme.of(context).dividerColor),
+                      ),
+                      icon: Icon(playPrefs.timeIncrement.speed.icon),
+                      label: Text(
+                        playPrefs.timeIncrement.display,
+                        style: const TextStyle(letterSpacing: 2.0),
+                      ),
+                      onPressed: () {
+                        final double screenHeight = MediaQuery.sizeOf(context).height;
+                        showModalBottomSheet<void>(
+                          context: context,
+                          isScrollControlled: true,
+                          constraints: BoxConstraints(
+                            maxHeight: screenHeight - (screenHeight / 10),
+                          ),
+                          builder: (BuildContext context) {
+                            return TimeControlModal(
+                              timeIncrement: playPrefs.timeIncrement,
+                              onSelected: (choice) {
+                                ref
+                                    .read(gameSetupPreferencesProvider.notifier)
+                                    .setTimeIncrement(choice);
+                              },
+                            );
+                          },
+                        );
+                      },
                     ),
-                    icon: Icon(playPrefs.timeIncrement.speed.icon),
-                    label: Text(
-                      playPrefs.timeIncrement.display,
-                      style: const TextStyle(letterSpacing: 2.0),
-                    ),
-                    onPressed: () {
-                      final double screenHeight = MediaQuery.sizeOf(context).height;
-                      showModalBottomSheet<void>(
-                        context: context,
-                        isScrollControlled: true,
-                        constraints: BoxConstraints(maxHeight: screenHeight - (screenHeight / 10)),
-                        builder: (BuildContext context) {
-                          return TimeControlModal(
-                            timeIncrement: playPrefs.timeIncrement,
-                            onSelected: (choice) {
-                              ref
-                                  .read(gameSetupPreferencesProvider.notifier)
-                                  .setTimeIncrement(choice);
-                            },
-                          );
-                        },
-                      );
-                    },
-                  ),
-                ],
+                  ],
+                ),
               ),
             ),
             const SizedBox(width: 8.0),
             Expanded(
-              child: Column(
-                crossAxisAlignment: CrossAxisAlignment.stretch,
-                mainAxisSize: MainAxisSize.min,
-                children: [
-                  Text(context.l10n.variant, style: labelStyle),
-                  OutlinedButton.icon(
-                    style: OutlinedButton.styleFrom(
-                      side: BorderSide(color: Theme.of(context).dividerColor),
+              child: Semantics(
+                container: true,
+                button: true,
+                label: '${context.l10n.variant}: ${playPrefs.customVariant.label(context.l10n)}',
+                excludeSemantics: true,
+                child: Column(
+                  crossAxisAlignment: CrossAxisAlignment.stretch,
+                  mainAxisSize: MainAxisSize.min,
+                  children: [
+                    Text(context.l10n.variant, style: labelStyle),
+                    OutlinedButton.icon(
+                      style: OutlinedButton.styleFrom(
+                        side: BorderSide(color: Theme.of(context).dividerColor),
+                      ),
+                      icon: playPrefs.customVariant != Variant.standard
+                          ? Icon(playPrefs.customVariant.icon)
+                          : null,
+                      label: Text(playPrefs.customVariant.label(context.l10n)),
+                      onPressed: () {
+                        showChoicePicker(
+                          context,
+                          title: Text(context.l10n.variant),
+                          choices: playSupportedVariants
+                              .where((v) => v != Variant.fromPosition)
+                              .toList(),
+                          selectedItem: playPrefs.customVariant,
+                          labelBuilder: (variant) => VariantLabel(variant),
+                          onSelectedItemChanged: (Variant variant) {
+                            ref
+                                .read(gameSetupPreferencesProvider.notifier)
+                                .setCustomVariant(variant);
+                          },
+                        );
+                      },
                     ),
-                    icon: playPrefs.customVariant != Variant.standard
-                        ? Icon(playPrefs.customVariant.icon)
-                        : null,
-                    label: Text(playPrefs.customVariant.label(context.l10n)),
-                    onPressed: () {
-                      showChoicePicker(
-                        context,
-                        title: Text(context.l10n.variant),
-                        choices: playSupportedVariants
-                            .where((v) => v != Variant.fromPosition)
-                            .toList(),
-                        selectedItem: playPrefs.customVariant,
-                        labelBuilder: (variant) => VariantLabel(variant),
-                        onSelectedItemChanged: (Variant variant) {
-                          ref.read(gameSetupPreferencesProvider.notifier).setCustomVariant(variant);
-                        },
-                      );
-                    },
-                  ),
-                ],
+                  ],
+                ),
               ),
             ),
           ],
@@ -116,100 +132,118 @@ class CreateGameWidget extends ConsumerWidget {
           Row(
             children: [
               Expanded(
-                child: Column(
-                  crossAxisAlignment: CrossAxisAlignment.stretch,
-                  mainAxisSize: MainAxisSize.min,
-                  children: [
-                    Text(context.l10n.gameMode, style: labelStyle),
-                    OutlinedButton(
-                      style: OutlinedButton.styleFrom(
-                        side: BorderSide(color: Theme.of(context).dividerColor),
+                child: Semantics(
+                  container: true,
+                  button: true,
+                  label:
+                      '${context.l10n.gameMode}: ${playPrefs.customRated ? context.l10n.rated : context.l10n.casual}',
+                  excludeSemantics: true,
+                  child: Column(
+                    crossAxisAlignment: CrossAxisAlignment.stretch,
+                    mainAxisSize: MainAxisSize.min,
+                    children: [
+                      Text(context.l10n.gameMode, style: labelStyle),
+                      OutlinedButton(
+                        style: OutlinedButton.styleFrom(
+                          side: BorderSide(color: Theme.of(context).dividerColor),
+                        ),
+                        onPressed: () {
+                          showChoicePicker(
+                            context,
+                            title: Text(context.l10n.gameMode),
+                            choices: [context.l10n.casual, context.l10n.rated],
+                            selectedItem: playPrefs.customRated
+                                ? context.l10n.rated
+                                : context.l10n.casual,
+                            labelBuilder: (String label) => Text(label),
+                            onSelectedItemChanged: (String label) {
+                              ref
+                                  .read(gameSetupPreferencesProvider.notifier)
+                                  .setCustomRated(label == context.l10n.rated);
+                            },
+                          );
+                        },
+                        child: Text(
+                          playPrefs.customRated ? context.l10n.rated : context.l10n.casual,
+                        ),
                       ),
-                      onPressed: () {
-                        showChoicePicker(
-                          context,
-                          title: Text(context.l10n.gameMode),
-                          choices: [context.l10n.casual, context.l10n.rated],
-                          selectedItem: playPrefs.customRated
-                              ? context.l10n.rated
-                              : context.l10n.casual,
-                          labelBuilder: (String label) => Text(label),
-                          onSelectedItemChanged: (String label) {
-                            ref
-                                .read(gameSetupPreferencesProvider.notifier)
-                                .setCustomRated(label == context.l10n.rated);
-                          },
-                        );
-                      },
-                      child: Text(playPrefs.customRated ? context.l10n.rated : context.l10n.casual),
-                    ),
-                  ],
+                    ],
+                  ),
                 ),
               ),
               const SizedBox(width: 8.0),
               Expanded(
-                child: Column(
-                  crossAxisAlignment: CrossAxisAlignment.stretch,
-                  mainAxisSize: MainAxisSize.min,
-                  children: [
-                    GestureDetector(
-                      onTap: canUseRatingRange
-                          ? null
-                          : () => _showDisabledRatingRangeExplanation(context),
-                      child: Row(
-                        mainAxisSize: .min,
-                        children: [
-                          Text(context.l10n.ratingFilter, style: labelStyle),
-                          if (!canUseRatingRange)
-                            Padding(
-                              padding: const EdgeInsets.only(left: 4.0),
-                              child: Icon(
-                                Icons.info_outline,
-                                size: 16.0,
-                                color: Theme.of(context).disabledColor,
-                              ),
-                            ),
-                        ],
-                      ),
-                    ),
-                    OutlinedButton(
-                      style: OutlinedButton.styleFrom(
-                        side: BorderSide(color: Theme.of(context).dividerColor),
-                        foregroundColor: canUseRatingRange ? null : Theme.of(context).disabledColor,
-                      ),
-                      onPressed: canUseRatingRange
-                          ? () {
-                              showModalBottomSheet<void>(
-                                context: context,
-                                constraints: BoxConstraints(
-                                  minHeight: MediaQuery.sizeOf(context).height * 0.4,
+                child: Semantics(
+                  container: true,
+                  button: true,
+                  label:
+                      '${context.l10n.ratingFilter}: ${canUseRatingRange ? '${playPrefs.customRatingDelta.$1 == 0 ? '-' : ''}${playPrefs.customRatingDelta.$1} / +${playPrefs.customRatingDelta.$2}' : '-500 / +500'}',
+                  excludeSemantics: true,
+                  child: Column(
+                    crossAxisAlignment: CrossAxisAlignment.stretch,
+                    mainAxisSize: MainAxisSize.min,
+                    children: [
+                      GestureDetector(
+                        onTap: canUseRatingRange
+                            ? null
+                            : () => _showDisabledRatingRangeExplanation(context),
+                        child: Row(
+                          mainAxisSize: .min,
+                          children: [
+                            Text(context.l10n.ratingFilter, style: labelStyle),
+                            if (!canUseRatingRange)
+                              Padding(
+                                padding: const EdgeInsets.only(left: 4.0),
+                                child: Icon(
+                                  Icons.info_outline,
+                                  size: 16.0,
+                                  color: Theme.of(context).disabledColor,
                                 ),
-                                isScrollControlled: true,
-                                builder: (BuildContext context) {
-                                  return BottomSheetScrollableContainer(
-                                    children: [
-                                      PlayRatingRange(
-                                        perf: userPerf,
-                                        ratingDelta: playPrefs.customRatingDelta,
-                                        onRatingDeltaChange: (int subtract, int add) {
-                                          ref
-                                              .read(gameSetupPreferencesProvider.notifier)
-                                              .setCustomRatingRange(subtract, add);
-                                        },
-                                      ),
-                                    ],
-                                  );
-                                },
-                              );
-                            }
-                          : () => _showDisabledRatingRangeExplanation(context),
-                      child: canUseRatingRange
-                          ? Text(
-                              '${playPrefs.customRatingDelta.$1 == 0 ? '-' : ''}${playPrefs.customRatingDelta.$1} / +${playPrefs.customRatingDelta.$2}',
-                            )
-                          : const Text('-500 / +500'),
-                    ),
-                  ],
+                              ),
+                          ],
+                        ),
+                      ),
+                      OutlinedButton(
+                        style: OutlinedButton.styleFrom(
+                          side: BorderSide(color: Theme.of(context).dividerColor),
+                          foregroundColor: canUseRatingRange
+                              ? null
+                              : Theme.of(context).disabledColor,
+                        ),
+                        onPressed: canUseRatingRange
+                            ? () {
+                                showModalBottomSheet<void>(
+                                  context: context,
+                                  constraints: BoxConstraints(
+                                    minHeight: MediaQuery.sizeOf(context).height * 0.4,
+                                  ),
+                                  isScrollControlled: true,
+                                  builder: (BuildContext context) {
+                                    return BottomSheetScrollableContainer(
+                                      children: [
+                                        PlayRatingRange(
+                                          perf: userPerf,
+                                          ratingDelta: playPrefs.customRatingDelta,
+                                          onRatingDeltaChange: (int subtract, int add) {
+                                            ref
+                                                .read(gameSetupPreferencesProvider.notifier)
+                                                .setCustomRatingRange(subtract, add);
+                                          },
+                                        ),
+                                      ],
+                                    );
+                                  },
+                                );
+                              }
+                            : () => _showDisabledRatingRangeExplanation(context),
+                        child: canUseRatingRange
+                            ? Text(
+                                '${playPrefs.customRatingDelta.$1 == 0 ? '-' : ''}${playPrefs.customRatingDelta.$1} / +${playPrefs.customRatingDelta.$2}',
+                              )
+                            : const Text('-500 / +500'),
+                      ),
+                    ],
+                  ),
                 ),
               ),
             ],


### PR DESCRIPTION
Problem
With VoiceOver enabled, the create game panel announces labels and values separately due to geometric traversal order:

❌ "Time Control" → "Variant" → "10+0" → "Standard"

Each label is completely separated from its corresponding input, which is confusing for blind users.
Solution
Wrapped each label+button pair in a Semantics widget so VoiceOver and TalkBack announce each field as a single grouped element with its current value:

✅ "Time control: 10+0" → "Variant: Standard" → "Game mode: Casual" → "Rating filter: -500 / +500"

This follows the existing pattern already established in SettingsListTile (lib/src/widgets/settings.dart:36).
Fixes #3328