### PR TITLE
chore(logging): pass exceptions as args to Logger

### DIFF
--- a/lib/src/app_links_service.dart
+++ b/lib/src/app_links_service.dart
@@ -85,7 +85,7 @@ class AppLinksService {
     try {
       await _handleUri(uri, animated: animated);
     } catch (e, st) {
-      _logger.severe('Error handling app link: $e\n$st');
+      _logger.severe('Error handling app link:', e, st);
     }
   }
 
@@ -282,7 +282,7 @@ class AppLinksService {
         } catch (e, st) {
           // Fall back to the current daily puzzle rather than leaving the tap
           // as a no-op when the widget's cached id is stale or unreachable.
-          _logger.info('Failed to load widget puzzle id $puzzleId, falling back: $e', e, st);
+          _logger.info('Failed to load widget puzzle id $puzzleId, falling back:', e, st);
           puzzle = dailyPuzzle;
         }
       }
@@ -297,7 +297,7 @@ class AppLinksService {
         animated: animated,
       );
     } catch (e, st) {
-      _logger.severe('Failed to open daily puzzle from widget: $e\n$st');
+      _logger.severe('Failed to open daily puzzle from widget:', e, st);
     }
   }
 
@@ -312,7 +312,7 @@ class AppLinksService {
 
       return true;
     } catch (e, st) {
-      _logger.info('Not a challenge link: $e', e, st);
+      _logger.info('Not a challenge link:', e, st);
     }
     return false;
   }
@@ -345,7 +345,7 @@ class AppLinksService {
         return [TvScreen.buildRoute(gameId: gameId, user: user, orientation: orientation)];
       }
     } catch (e, st) {
-      _logger.info('Not a game link: $e', e, st);
+      _logger.info('Not a game link:', e, st);
     }
 
     return null;

--- a/lib/src/db/database.dart
+++ b/lib/src/db/database.dart
@@ -44,8 +44,8 @@ Future<int?> _getDatabaseVersion(Database db) async {
     final versionStr = (await db.rawQuery('SELECT sqlite_version()')).first.values.first.toString();
     final versionCells = versionStr.split('.').map((i) => int.parse(i)).toList();
     return versionCells[0] * 100000 + versionCells[1] * 1000 + versionCells[2];
-  } catch (e) {
-    _logger.warning('Error occurred while fetching SQLite version:', e);
+  } catch (e, st) {
+    _logger.warning('Error occurred while fetching SQLite version:', e, st);
     return null;
   }
 }

--- a/lib/src/db/database.dart
+++ b/lib/src/db/database.dart
@@ -45,7 +45,7 @@ Future<int?> _getDatabaseVersion(Database db) async {
     final versionCells = versionStr.split('.').map((i) => int.parse(i)).toList();
     return versionCells[0] * 100000 + versionCells[1] * 1000 + versionCells[2];
   } catch (e) {
-    _logger.warning('Error occurred while fetching SQLite version: $e');
+    _logger.warning('Error occurred while fetching SQLite version:', e);
     return null;
   }
 }

--- a/lib/src/init.dart
+++ b/lib/src/init.dart
@@ -55,7 +55,7 @@ Future<void> initializeApp() async {
       prefs.setString('installed_version', appVersion.canonicalizedVersion);
     }
   } catch (e, st) {
-    _logger.severe('Error during app initialization: $e');
+    _logger.severe('Error during app initialization:', e, st);
     LichessBinding.instance.firebaseCrashlytics.recordError(
       e,
       st,
@@ -94,7 +94,7 @@ Future<void> preloadPieceImages() async {
     try {
       boardPrefs = BoardPrefs.fromJson(jsonDecode(storedPrefs) as Map<String, dynamic>);
     } catch (e) {
-      _logger.warning('Failed to decode board preferences: $e');
+      _logger.warning('Failed to decode board preferences:', e);
     }
   }
 
@@ -122,7 +122,7 @@ Future<void> androidDisplayInitialization(WidgetsBinding widgetsBinding) async {
       setSystemColors(palette, colorSchemes);
     });
   } catch (e) {
-    _logger.fine('Device does not support core palette: $e');
+    _logger.fine('Device does not support core palette:', e);
   }
 
   // lock orientation to portrait on android phones

--- a/lib/src/init.dart
+++ b/lib/src/init.dart
@@ -93,8 +93,8 @@ Future<void> preloadPieceImages() async {
   if (storedPrefs != null) {
     try {
       boardPrefs = BoardPrefs.fromJson(jsonDecode(storedPrefs) as Map<String, dynamic>);
-    } catch (e) {
-      _logger.warning('Failed to decode board preferences:', e);
+    } catch (e, st) {
+      _logger.warning('Failed to decode board preferences:', e, st);
     }
   }
 
@@ -121,8 +121,8 @@ Future<void> androidDisplayInitialization(WidgetsBinding widgetsBinding) async {
 
       setSystemColors(palette, colorSchemes);
     });
-  } catch (e) {
-    _logger.fine('Device does not support core palette:', e);
+  } catch (e, st) {
+    _logger.fine('Device does not support core palette:', e, st);
   }
 
   // lock orientation to portrait on android phones

--- a/lib/src/model/analysis/retro_controller.dart
+++ b/lib/src/model/analysis/retro_controller.dart
@@ -141,9 +141,9 @@ class RetroController extends AsyncNotifier<RetroState>
       state = AsyncValue.data(retroState);
 
       if (currentServerAnalysis.value != ServerAnalysisSource.game(gameId: options.id)) {
-        requestServerAnalysis().catchError((Object e, StackTrace s) {
-          _logger.warning('Failed to request server analysis', e, s);
-          state = AsyncError(e, s);
+        requestServerAnalysis().catchError((Object e, StackTrace st) {
+          _logger.warning('Failed to request server analysis', e, st);
+          state = AsyncError(e, st);
         });
       }
 

--- a/lib/src/model/analysis/server_analysis_service.dart
+++ b/lib/src/model/analysis/server_analysis_service.dart
@@ -143,8 +143,8 @@ class ServerAnalysisService {
         _currentAnalysis.value = source;
         _socketClient!.firstConnection
             .timeout(const Duration(seconds: 3))
-            .onError((err, st) {
-              _logger.severe('Error connecting to analysis socket', err, st);
+            .onError((e, st) {
+              _logger.severe('Error connecting to analysis socket', e, st);
               _cancelAnalysis();
             })
             .whenComplete(() {

--- a/lib/src/model/broadcast/broadcast_analysis_controller.dart
+++ b/lib/src/model/broadcast/broadcast_analysis_controller.dart
@@ -258,7 +258,7 @@ class BroadcastAnalysisController extends AsyncNotifier<BroadcastAnalysisState>
     try {
       result = _root.addMoveAt(path, uciMove, clock: clock);
     } on PlayException catch (e) {
-      _logger.warning('Could not add broadcast move $uciMove at $path: $e');
+      _logger.warning('Could not add broadcast move $uciMove at $path:', e);
       _reloadPgn();
       return;
     }

--- a/lib/src/model/broadcast/broadcast_analysis_controller.dart
+++ b/lib/src/model/broadcast/broadcast_analysis_controller.dart
@@ -257,8 +257,8 @@ class BroadcastAnalysisController extends AsyncNotifier<BroadcastAnalysisState>
     final (UciPath? newPath, bool isNewNode) result;
     try {
       result = _root.addMoveAt(path, uciMove, clock: clock);
-    } on PlayException catch (e) {
-      _logger.warning('Could not add broadcast move $uciMove at $path:', e);
+    } on PlayException catch (e, st) {
+      _logger.warning('Could not add broadcast move $uciMove at $path:', e, st);
       _reloadPgn();
       return;
     }

--- a/lib/src/model/common/service/sound_service.dart
+++ b/lib/src/model/common/service/sound_service.dart
@@ -88,7 +88,7 @@ class SoundService {
       await _soundEffectPlugin.initialize(maxStreams: _kMaxConcurrentStreams);
       await _loadAllSounds(theme);
     } catch (e) {
-      _logger.warning('Failed to initialize sound service: $e');
+      _logger.warning('Failed to initialize sound service:', e);
     }
   }
 

--- a/lib/src/model/common/service/sound_service.dart
+++ b/lib/src/model/common/service/sound_service.dart
@@ -87,8 +87,8 @@ class SoundService {
               .soundTheme;
       await _soundEffectPlugin.initialize(maxStreams: _kMaxConcurrentStreams);
       await _loadAllSounds(theme);
-    } catch (e) {
-      _logger.warning('Failed to initialize sound service:', e);
+    } catch (e, st) {
+      _logger.warning('Failed to initialize sound service:', e, st);
     }
   }
 

--- a/lib/src/model/correspondence/correspondence_service.dart
+++ b/lib/src/model/correspondence/correspondence_service.dart
@@ -124,8 +124,8 @@ class CorrespondenceService {
             playableGame,
           ),
       ]);
-    } catch (e, s) {
-      _log.warning('Failed to sync correspondence games', e, s);
+    } catch (e, st) {
+      _log.warning('Failed to sync correspondence games', e, st);
     }
   }
 
@@ -204,8 +204,8 @@ class CorrespondenceService {
           _log.info('Cannot play game ${gameToSync.id} move because its state has changed');
           updateStoredGame(gameToSync.fullId, playableGame);
         }
-      } catch (e, s) {
-        _log.severe('Failed to sync correspondence game ${gameToSync.id}', e, s);
+      } catch (e, st) {
+        _log.severe('Failed to sync correspondence game ${gameToSync.id}', e, st);
       } finally {
         streamSubscription?.cancel();
         socket?.close();

--- a/lib/src/model/engine/evaluation_service.dart
+++ b/lib/src/model/engine/evaluation_service.dart
@@ -408,8 +408,8 @@ class EvaluationService {
       _currentVariant = variant;
 
       _protocol.connected((cmd) => _stockfish.stdin = cmd);
-    } catch (e, s) {
-      _logger.severe('Error initializing engine', e, s);
+    } catch (e, st) {
+      _logger.severe('Error initializing engine', e, st);
       _setEngineState(EngineState.error);
     } finally {
       _initInProgress = false;

--- a/lib/src/model/engine/nnue_service.dart
+++ b/lib/src/model/engine/nnue_service.dart
@@ -89,7 +89,7 @@ class NnueService {
     try {
       files = nnueFiles;
     } catch (e) {
-      _logger.warning('Error getting NNUE files: $e');
+      _logger.warning('Error getting NNUE files:', e);
       return false;
     }
 
@@ -112,7 +112,7 @@ class NnueService {
 
       return false;
     } catch (e) {
-      _logger.warning('Error checking NNUE files: $e');
+      _logger.warning('Error checking NNUE files:', e);
       return false;
     }
   }
@@ -130,7 +130,7 @@ class NnueService {
       try {
         files = nnueFiles;
       } catch (e) {
-        _logger.warning('Error getting NNUE files: $e');
+        _logger.warning('Error getting NNUE files:', e);
         return false;
       }
 

--- a/lib/src/model/engine/nnue_service.dart
+++ b/lib/src/model/engine/nnue_service.dart
@@ -88,8 +88,8 @@ class NnueService {
     final NNUEFiles files;
     try {
       files = nnueFiles;
-    } catch (e) {
-      _logger.warning('Error getting NNUE files:', e);
+    } catch (e, st) {
+      _logger.warning('Error getting NNUE files:', e, st);
       return false;
     }
 
@@ -111,8 +111,8 @@ class NnueService {
       }
 
       return false;
-    } catch (e) {
-      _logger.warning('Error checking NNUE files:', e);
+    } catch (e, st) {
+      _logger.warning('Error checking NNUE files:', e, st);
       return false;
     }
   }
@@ -129,8 +129,8 @@ class NnueService {
       final NNUEFiles files;
       try {
         files = nnueFiles;
-      } catch (e) {
-        _logger.warning('Error getting NNUE files:', e);
+      } catch (e, st) {
+        _logger.warning('Error getting NNUE files:', e, st);
         return false;
       }
 

--- a/lib/src/model/game/game_controller.dart
+++ b/lib/src/model/game/game_controller.dart
@@ -220,7 +220,7 @@ class GameController extends AsyncNotifier<GameState> with ChatMixin<GameState> 
         reason: 'PlayException thrown when making SAN of user move',
         information: ['move: $move', 'position: ${curState.game.lastPosition}'],
       );
-      _logger.warning('Invalid user move: $e');
+      _logger.warning('Invalid user move:', e);
       return;
     }
     final (newPos, newSan) = sanResult;
@@ -286,7 +286,7 @@ class GameController extends AsyncNotifier<GameState> with ChatMixin<GameState> 
         reason: 'PlayException thrown when making SAN of confirm move',
         information: ['move: $moveToConfirm', 'position: ${curState.game.lastPosition}'],
       );
-      _logger.warning('Invalid confirm move: $e');
+      _logger.warning('Invalid confirm move:', e);
       state = AsyncValue.data(curState.copyWith(moveToConfirm: null));
       return;
     }

--- a/lib/src/model/game/game_controller.dart
+++ b/lib/src/model/game/game_controller.dart
@@ -213,14 +213,14 @@ class GameController extends AsyncNotifier<GameState> with ChatMixin<GameState> 
     final (Position, String) sanResult;
     try {
       sanResult = curState.game.lastPosition.makeSan(move);
-    } on PlayException catch (e) {
+    } on PlayException catch (e, st) {
       LichessBinding.instance.firebaseCrashlytics.recordError(
         'Invalid user move: $e',
-        null,
+        st,
         reason: 'PlayException thrown when making SAN of user move',
         information: ['move: $move', 'position: ${curState.game.lastPosition}'],
       );
-      _logger.warning('Invalid user move:', e);
+      _logger.warning('Invalid user move:', e, st);
       return;
     }
     final (newPos, newSan) = sanResult;
@@ -279,14 +279,14 @@ class GameController extends AsyncNotifier<GameState> with ChatMixin<GameState> 
     final (Position, String) sanResult;
     try {
       sanResult = curState.game.lastPosition.makeSan(moveToConfirm);
-    } on PlayException catch (e) {
+    } on PlayException catch (e, st) {
       LichessBinding.instance.firebaseCrashlytics.recordError(
         'Invalid confirm move: $e',
-        null,
+        st,
         reason: 'PlayException thrown when making SAN of confirm move',
         information: ['move: $moveToConfirm', 'position: ${curState.game.lastPosition}'],
       );
-      _logger.warning('Invalid confirm move:', e);
+      _logger.warning('Invalid confirm move:', e, st);
       state = AsyncValue.data(curState.copyWith(moveToConfirm: null));
       return;
     }
@@ -1050,8 +1050,8 @@ class GameController extends AsyncNotifier<GameState> with ChatMixin<GameState> 
     try {
       final result = await _getPostGameData();
       gameWithPostData = _mergePostGameData(game, result, rewriteSteps: true);
-    } catch (e, s) {
-      _logger.warning('Could not get post game data', e, s);
+    } catch (e, st) {
+      _logger.warning('Could not get post game data', e, st);
     }
 
     await _storeGame(gameWithPostData);

--- a/lib/src/model/lobby/create_game_service.dart
+++ b/lib/src/model/lobby/create_game_service.dart
@@ -101,10 +101,10 @@ class CreateGameService {
 
     try {
       await LobbyRepository(lichessClient).createSeek(actualSeek, sri: sri);
-    } catch (e) {
-      _log.warning('Failed to create seek', e);
+    } catch (e, st) {
+      _log.warning('Failed to create seek', e, st);
       if (!completer.isCompleted) {
-        completer.completeError(e);
+        completer.completeError(e, st);
       }
     }
 
@@ -182,15 +182,15 @@ class CreateGameService {
                   ),
                 );
               }
-            } catch (e) {
-              _log.warning('Failed to reload challenge', e);
+            } catch (e, st) {
+              _log.warning('Failed to reload challenge', e, st);
             }
           }
         }),
         completer,
       );
-    } catch (e) {
-      _log.warning('Failed to create challenge socket, completing with error', e);
+    } catch (e, st) {
+      _log.warning('Failed to create challenge socket, completing with error', e, st);
       // if the completer is not yet completed, complete it with an error
       if (!completer.isCompleted) {
         completer.completeError(e);
@@ -250,8 +250,8 @@ class CreateGameService {
                   updatedChallenge.declineReason ?? ChallengeDeclineReason.generic,
                 );
               }
-            } catch (e) {
-              _log.warning('Failed to reload challenge', e);
+            } catch (e, st) {
+              _log.warning('Failed to reload challenge', e, st);
             }
           }
         }),
@@ -263,8 +263,8 @@ class CreateGameService {
       if (!completer.isCompleted) {
         completer.complete(null);
       }
-    } catch (e) {
-      _log.warning('Failed to create challenge', e);
+    } catch (e, st) {
+      _log.warning('Failed to create challenge', e, st);
       // if the completer is not yet completed, complete it with an error
       if (!completer.isCompleted) {
         completer.completeError(e);
@@ -283,8 +283,8 @@ class CreateGameService {
       if (_lobbyConnection != null && _lobbyConnection!.$2.isCompleted == false) {
         _lobbyConnection!.$2.complete(const GameSeekCancelled());
       }
-    } catch (e) {
-      _log.warning('Failed to cancel seek: $e', e);
+    } catch (e, st) {
+      _log.warning('Failed to cancel seek: $e', e, st);
       rethrow;
     }
   }
@@ -299,8 +299,8 @@ class CreateGameService {
         if (_challengeConnection != null && _challengeConnection!.$4.isCompleted == false) {
           _challengeConnection!.$4.complete(const ChallengeResponseCancelled());
         }
-      } catch (e) {
-        _log.warning('Failed to cancel challenge: $e', e);
+      } catch (e, st) {
+        _log.warning('Failed to cancel challenge: $e', e, st);
         rethrow;
       }
     }

--- a/lib/src/model/log/app_log_service.dart
+++ b/lib/src/model/log/app_log_service.dart
@@ -56,7 +56,7 @@ class AppLogService {
         if (_loggersToShowInTerminal.contains(record.loggerName) &&
             record.level >= Level.FINE &&
             !Platform.environment.containsKey('FLUTTER_TEST')) {
-          debugPrint('[${record.loggerName}] ${record.message}');
+          debugPrint('[${record.loggerName}] ${record.message} ${record.error}');
         }
       } else {
         if (record.loggerName == 'Stockfish' && record.level >= Level.SEVERE) {

--- a/lib/src/model/notifications/notification_service.dart
+++ b/lib/src/model/notifications/notification_service.dart
@@ -318,8 +318,8 @@ class NotificationService {
     if (badge != null) {
       try {
         await BadgeService.instance.setBadge(int.parse(badge));
-      } catch (e) {
-        _logger.severe('Could not parse badge: $badge', e);
+      } catch (e, st) {
+        _logger.severe('Could not parse badge: $badge', e, st);
       }
     }
   }
@@ -390,8 +390,8 @@ class NotificationService {
       await ref.read(notificationServiceProvider)._processFcmMessage(message, fromBackground: true);
 
       ref.dispose();
-    } catch (e) {
-      _logger.severe('Error when processing an FCM background message:', e);
+    } catch (e, st) {
+      _logger.severe('Error when processing an FCM background message:', e, st);
       ref.dispose();
     }
   }

--- a/lib/src/model/notifications/notification_service.dart
+++ b/lib/src/model/notifications/notification_service.dart
@@ -133,7 +133,7 @@ class NotificationService {
           final success = await registerDevice();
           if (success) _registeredDevice = true;
         } catch (e, st) {
-          _logger.severe('Could not setup push notifications; $e\n$st');
+          _logger.severe('Could not setup push notifications:', e, st);
         }
       }
     });
@@ -319,7 +319,7 @@ class NotificationService {
       try {
         await BadgeService.instance.setBadge(int.parse(badge));
       } catch (e) {
-        _logger.severe('Could not parse badge: $badge');
+        _logger.severe('Could not parse badge: $badge', e);
       }
     }
   }
@@ -354,7 +354,7 @@ class NotificationService {
     try {
       await _ref.withClient((client) => client.post(Uri(path: '/mobile/unregister')));
     } catch (e, st) {
-      _logger.severe('could not unregister device; $e', e, st);
+      _logger.severe('could not unregister device:', e, st);
     }
   }
 
@@ -372,7 +372,7 @@ class NotificationService {
       await _ref.withClient((client) => client.post(Uri(path: '/mobile/register/firebase/$token')));
       return true;
     } catch (e, st) {
-      _logger.severe('could not register device; $e', e, st);
+      _logger.severe('could not register device:', e, st);
       return false;
     }
   }
@@ -391,7 +391,7 @@ class NotificationService {
 
       ref.dispose();
     } catch (e) {
-      _logger.severe('Error when processing an FCM background message: $e');
+      _logger.severe('Error when processing an FCM background message:', e);
       ref.dispose();
     }
   }

--- a/lib/src/model/offline_computer/offline_computer_game_controller.dart
+++ b/lib/src/model/offline_computer/offline_computer_game_controller.dart
@@ -361,7 +361,7 @@ class OfflineComputerGameController extends Notifier<OfflineComputerGameState> {
         _playEngineMoveAfterPlayerAnimation();
       }
     } catch (e) {
-      _logger.warning('Error evaluating move: $e');
+      _logger.warning('Error evaluating move:', e);
       if (ref.mounted) {
         state = state.copyWith(isEvaluatingMove: false);
         if (state.game.playable && state.turn != state.game.playerSide) {
@@ -490,7 +490,7 @@ class OfflineComputerGameController extends Notifier<OfflineComputerGameState> {
         break;
       }
     } catch (e) {
-      _logger.fine('Could not get cloud eval: $e');
+      _logger.fine('Could not get cloud eval:', e);
     }
 
     return eval;
@@ -614,7 +614,7 @@ class OfflineComputerGameController extends Notifier<OfflineComputerGameState> {
           .getTablebaseEntry(position.fen, Variant.fromRule(position.rule));
       return tablebaseEntryToCloudEval(entry, position);
     } catch (e) {
-      _logger.fine('Could not get tablebase eval: $e');
+      _logger.fine('Could not get tablebase eval:', e);
       return null;
     }
   }

--- a/lib/src/model/offline_computer/offline_computer_game_controller.dart
+++ b/lib/src/model/offline_computer/offline_computer_game_controller.dart
@@ -360,8 +360,8 @@ class OfflineComputerGameController extends Notifier<OfflineComputerGameState> {
       if (state.game.playable && state.turn != state.game.playerSide) {
         _playEngineMoveAfterPlayerAnimation();
       }
-    } catch (e) {
-      _logger.warning('Error evaluating move:', e);
+    } catch (e, st) {
+      _logger.warning('Error evaluating move:', e, st);
       if (ref.mounted) {
         state = state.copyWith(isEvaluatingMove: false);
         if (state.game.playable && state.turn != state.game.playerSide) {
@@ -489,8 +489,8 @@ class OfflineComputerGameController extends Notifier<OfflineComputerGameState> {
         eval = CloudEval(depth: depth, nodes: nodes, pvs: pvs, position: work.position);
         break;
       }
-    } catch (e) {
-      _logger.fine('Could not get cloud eval:', e);
+    } catch (e, st) {
+      _logger.fine('Could not get cloud eval:', e, st);
     }
 
     return eval;
@@ -598,8 +598,8 @@ class OfflineComputerGameController extends Notifier<OfflineComputerGameState> {
       return await repository
           .getMasterDatabase(fen, since: MasterDb.kEarliestYear)
           .timeout(const Duration(seconds: 2));
-    } catch (e) {
-      _logger.fine('Failed to fetch master database: $e');
+    } catch (e, st) {
+      _logger.fine('Failed to fetch master database:', e, st);
       return null;
     }
   }
@@ -613,8 +613,8 @@ class OfflineComputerGameController extends Notifier<OfflineComputerGameState> {
           .read(tablebaseRepositoryProvider)
           .getTablebaseEntry(position.fen, Variant.fromRule(position.rule));
       return tablebaseEntryToCloudEval(entry, position);
-    } catch (e) {
-      _logger.fine('Could not get tablebase eval:', e);
+    } catch (e, st) {
+      _logger.fine('Could not get tablebase eval:', e, st);
       return null;
     }
   }
@@ -656,9 +656,9 @@ class OfflineComputerGameController extends Notifier<OfflineComputerGameState> {
     } on MoveRequestCancelledException {
       // Expected cancellation when evaluationService.stop() is called; ignore.
       return;
-    } catch (e, s) {
+    } catch (e, st) {
       // Unexpected engine error occurred.
-      _logger.warning('Failed to play engine move!', e, s);
+      _logger.warning('Failed to play engine move!', e, st);
     } finally {
       if (state.game.playable || state.game.finished) {
         state = state.copyWith(isEngineThinking: false);

--- a/lib/src/model/offline_computer/offline_computer_game_storage.dart
+++ b/lib/src/model/offline_computer/offline_computer_game_storage.dart
@@ -55,8 +55,8 @@ class OfflineComputerGameStorage {
       }
 
       return SavedOfflineComputerGame.fromJson(json);
-    } catch (e) {
-      _logger.warning('Failed to fetch game:', e);
+    } catch (e, st) {
+      _logger.warning('Failed to fetch game:', e, st);
       return null;
     }
   }
@@ -67,8 +67,8 @@ class OfflineComputerGameStorage {
       final file = await _getFile();
       _logger.info('Saving game to ${file.path}');
       await file.writeAsString(jsonEncode(savedGame.toJson()));
-    } catch (e) {
-      _logger.warning('Failed to save game:', e);
+    } catch (e, st) {
+      _logger.warning('Failed to save game:', e, st);
     }
   }
 }

--- a/lib/src/model/offline_computer/offline_computer_game_storage.dart
+++ b/lib/src/model/offline_computer/offline_computer_game_storage.dart
@@ -56,7 +56,7 @@ class OfflineComputerGameStorage {
 
       return SavedOfflineComputerGame.fromJson(json);
     } catch (e) {
-      _logger.warning('Failed to fetch game: $e');
+      _logger.warning('Failed to fetch game:', e);
       return null;
     }
   }
@@ -68,7 +68,7 @@ class OfflineComputerGameStorage {
       _logger.info('Saving game to ${file.path}');
       await file.writeAsString(jsonEncode(savedGame.toJson()));
     } catch (e) {
-      _logger.warning('Failed to save game: $e');
+      _logger.warning('Failed to save game:', e);
     }
   }
 }

--- a/lib/src/model/over_the_board/over_the_board_game_storage.dart
+++ b/lib/src/model/over_the_board/over_the_board_game_storage.dart
@@ -61,7 +61,7 @@ class OverTheBoardGameStorage {
 
       return SavedOtbGame.fromJson(json);
     } catch (e) {
-      _logger.warning('[OtbGameStorage] failed to fetch game: $e');
+      _logger.warning('[OtbGameStorage] failed to fetch game:', e);
       return null;
     }
   }
@@ -86,7 +86,7 @@ class OverTheBoardGameStorage {
         ),
       );
     } catch (e) {
-      _logger.warning('[OtbGameStorage] failed to save game: $e');
+      _logger.warning('[OtbGameStorage] failed to save game:', e);
     }
   }
 }

--- a/lib/src/model/over_the_board/over_the_board_game_storage.dart
+++ b/lib/src/model/over_the_board/over_the_board_game_storage.dart
@@ -60,8 +60,8 @@ class OverTheBoardGameStorage {
       }
 
       return SavedOtbGame.fromJson(json);
-    } catch (e) {
-      _logger.warning('[OtbGameStorage] failed to fetch game:', e);
+    } catch (e, st) {
+      _logger.warning('[OtbGameStorage] failed to fetch game:', e, st);
       return null;
     }
   }
@@ -85,8 +85,8 @@ class OverTheBoardGameStorage {
           ).toJson(),
         ),
       );
-    } catch (e) {
-      _logger.warning('[OtbGameStorage] failed to save game:', e);
+    } catch (e, st) {
+      _logger.warning('[OtbGameStorage] failed to save game:', e, st);
     }
   }
 }

--- a/lib/src/model/settings/preferences_storage.dart
+++ b/lib/src/model/settings/preferences_storage.dart
@@ -63,8 +63,8 @@ mixin PreferencesStorage<T extends Serializable> on Notifier<T> {
     }
     try {
       return fromJson(jsonDecode(stored) as Map<String, dynamic>);
-    } catch (e) {
-      _logger.warning('Failed to decode $prefCategory preferences:', e);
+    } catch (e, st) {
+      _logger.warning('Failed to decode $prefCategory preferences:', e, st);
       return defaults;
     }
   }
@@ -99,8 +99,8 @@ mixin SessionPreferencesStorage<T extends Serializable> on Notifier<T> {
     }
     try {
       return fromJson(jsonDecode(stored) as Map<String, dynamic>);
-    } catch (e) {
-      _logger.warning('Failed to decode $prefCategory preferences:', e);
+    } catch (e, st) {
+      _logger.warning('Failed to decode $prefCategory preferences:', e, st);
       return defaults(user: authUser?.user);
     }
   }

--- a/lib/src/model/settings/preferences_storage.dart
+++ b/lib/src/model/settings/preferences_storage.dart
@@ -64,7 +64,7 @@ mixin PreferencesStorage<T extends Serializable> on Notifier<T> {
     try {
       return fromJson(jsonDecode(stored) as Map<String, dynamic>);
     } catch (e) {
-      _logger.warning('Failed to decode $prefCategory preferences: $e');
+      _logger.warning('Failed to decode $prefCategory preferences:', e);
       return defaults;
     }
   }
@@ -100,7 +100,7 @@ mixin SessionPreferencesStorage<T extends Serializable> on Notifier<T> {
     try {
       return fromJson(jsonDecode(stored) as Map<String, dynamic>);
     } catch (e) {
-      _logger.warning('Failed to decode $prefCategory preferences: $e');
+      _logger.warning('Failed to decode $prefCategory preferences:', e);
       return defaults(user: authUser?.user);
     }
   }

--- a/lib/src/network/http.dart
+++ b/lib/src/network/http.dart
@@ -218,13 +218,13 @@ Future<bool> downloadFile(
         })
         .pipe(sink);
   } catch (e) {
-    _logger.warning('Failed to download file: $e');
+    _logger.warning('Failed to download file:', e);
   } finally {
     try {
       await sink.flush();
       await sink.close();
     } on FileSystemException catch (e) {
-      _logger.warning('Failed to save file: $e');
+      _logger.warning('Failed to save file:', e);
     }
   }
 
@@ -365,7 +365,7 @@ class LichessClient implements Client {
 
       return response;
     } catch (e, st) {
-      _logger.warning('Request to ${request.url} failed: $e', e, st);
+      _logger.warning('Request to ${request.url} failed:', e, st);
       rethrow;
     }
   }
@@ -490,7 +490,7 @@ class DefaultClient implements Client {
 
       return response;
     } catch (e, st) {
-      _logger.warning('Request to ${request.url} failed: $e', e, st);
+      _logger.warning('Request to ${request.url} failed:', e, st);
       rethrow;
     }
   }
@@ -685,7 +685,7 @@ extension ClientExtension on Client {
     try {
       return mapper(json);
     } catch (e, st) {
-      _logger.severe('Could not read JSON object as $T: $e', e, st);
+      _logger.severe('Could not read JSON object as $T:', e, st);
       throw ClientException('Could not read JSON object as $T: $e\n$st', url);
     }
   }
@@ -721,7 +721,7 @@ extension ClientExtension on Client {
           list.add(mapped);
         }
       } catch (e, st) {
-        _logger.severe('Could not read JSON object as $T: $e', e, st);
+        _logger.severe('Could not read JSON object as $T:', e, st);
         throw ClientException('Could not read JSON object as $T: $e', url);
       }
     }
@@ -799,7 +799,7 @@ extension ClientExtension on Client {
     try {
       return mapper(json);
     } catch (e, st) {
-      _logger.severe('Could not read json as $T: $e', e, st);
+      _logger.severe('Could not read json as $T:', e, st);
       throw ClientException('Could not read json as $T: $e', url);
     }
   }

--- a/lib/src/network/http.dart
+++ b/lib/src/network/http.dart
@@ -217,14 +217,14 @@ Future<bool> downloadFile(
           return s;
         })
         .pipe(sink);
-  } catch (e) {
-    _logger.warning('Failed to download file:', e);
+  } catch (e, st) {
+    _logger.warning('Failed to download file:', e, st);
   } finally {
     try {
       await sink.flush();
       await sink.close();
-    } on FileSystemException catch (e) {
-      _logger.warning('Failed to save file:', e);
+    } on FileSystemException catch (e, st) {
+      _logger.warning('Failed to save file:', e, st);
     }
   }
 
@@ -770,8 +770,8 @@ extension ClientExtension on Client {
         final json = jsonDecode(e) as Map<String, dynamic>;
         return mapper(json);
       });
-    } catch (e) {
-      _logger.severe('Could not read nd-json object as $T.');
+    } catch (e, st) {
+      _logger.severe('Could not read nd-json object as $T.', e, st);
       throw ClientException('Could not read nd-json object as $T: $e', url);
     }
   }
@@ -832,8 +832,8 @@ extension ClientExtension on Client {
           return mapper(json);
         }),
       );
-    } catch (e) {
-      _logger.severe('Could not read nd-json objects as List<$T>.');
+    } catch (e, st) {
+      _logger.severe('Could not read nd-json objects as List<$T>.', e, st);
       throw ClientException(
         'Could not read nd-json objects as List<$T>: $e',
         response.request?.url,

--- a/lib/src/network/socket.dart
+++ b/lib/src/network/socket.dart
@@ -298,8 +298,8 @@ class SocketClient {
       }
 
       _resendAcks();
-    } catch (error) {
-      _logger.severe('WebSocket connection failed:', error);
+    } catch (e, st) {
+      _logger.severe('WebSocket connection failed:', e, st);
       _averageLag.value = Duration.zero;
       _scheduleReconnect(autoReconnectDelay);
     }

--- a/lib/src/network/socket.dart
+++ b/lib/src/network/socket.dart
@@ -299,7 +299,7 @@ class SocketClient {
 
       _resendAcks();
     } catch (error) {
-      _logger.severe('WebSocket connection failed: $error', error);
+      _logger.severe('WebSocket connection failed:', error);
       _averageLag.value = Duration.zero;
       _scheduleReconnect(autoReconnectDelay);
     }
@@ -392,7 +392,7 @@ class SocketClient {
               _averageLag.value = Duration.zero;
             })
             .catchError((Object? error) {
-              _logger.warning('WebSocket connection to $route could not be closed: $error', error);
+              _logger.warning('WebSocket connection to $route could not be closed:', error);
               if (isDisposed) {
                 return;
               }

--- a/lib/src/shared_pgn_service.dart
+++ b/lib/src/shared_pgn_service.dart
@@ -40,14 +40,14 @@ class SharedPgnService {
         final pgn = await _methods.invokeMethod<String>('getInitialPgn');
         if (pgn != null) _handlePgn(pgn);
       } catch (e, st) {
-        _logger.severe('Error handling initial shared PGN: $e\n$st');
+        _logger.severe('Error handling initial shared PGN:', e, st);
       }
     });
 
     // PGN shared while the app is already running.
     _subscription = _events.receiveBroadcastStream().listen((event) {
       if (event is String) _handlePgn(event);
-    }, onError: (Object e, StackTrace st) => _logger.severe('Error in shared PGN stream: $e\n$st'));
+    }, onError: (Object e, StackTrace st) => _logger.severe('Error in shared PGN stream:', e, st));
   }
 
   void _handlePgn(String pgnText) {

--- a/lib/src/utils/badge_service.dart
+++ b/lib/src/utils/badge_service.dart
@@ -20,8 +20,8 @@ class BadgeService {
 
     try {
       await _channel.invokeMethod<int>('setBadge', <String, dynamic>{'badge': value});
-    } on PlatformException catch (e) {
-      _log.severe(e);
+    } on PlatformException catch (e, st) {
+      _log.severe(e, st);
     }
   }
 }

--- a/lib/src/utils/json.dart
+++ b/lib/src/utils/json.dart
@@ -27,7 +27,7 @@ IList<T> decodeObjectList<T>(Object? json, {required T? Function(Map<String, dyn
         list.add(mapped);
       }
     } catch (e, st) {
-      _logger.severe('Could not read JSON object as $T: $e', e, st);
+      _logger.severe('Could not read JSON object as $T:', e, st);
       throw Exception('Could not read JSON object as $T: $e');
     }
   }

--- a/lib/src/view/analysis/analysis_screen.dart
+++ b/lib/src/view/analysis/analysis_screen.dart
@@ -151,7 +151,7 @@ class _AnalysisScreenState extends ConsumerState<_AnalysisScreen>
           ),
         );
       case AsyncError(:final error, :final stackTrace):
-        _logger.severe('Cannot load analysis: $error', stackTrace);
+        _logger.severe('Cannot load analysis:', error, stackTrace);
         return FullScreenRetryRequest(onRetry: () => ref.invalidate(ctrlProvider));
       case _:
         return Scaffold(

--- a/lib/src/view/settings/app_log_settings_screen.dart
+++ b/lib/src/view/settings/app_log_settings_screen.dart
@@ -183,20 +183,34 @@ class _LogTile extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    return ListTile(
+    const titleStyle = TextStyle(fontSize: 14, letterSpacing: -0.15);
+    final subtitleStyle = TextStyle(color: textShade(context, 0.7), fontSize: 12);
+
+    final leading = SizedBox(
+      width: 30,
+      child: Text(entry.levelName, style: const TextStyle(fontSize: 12)),
+    );
+    final title = Text('[${entry.loggerName}] ${entry.message}', style: titleStyle);
+    final subtitle = Text(_logDateFormatter.format(entry.logTime), style: subtitleStyle);
+
+    if (entry.error == null && entry.stackTrace == null) {
+      return ListTile(dense: true, leading: leading, title: title, subtitle: subtitle);
+    }
+
+    final error = entry.error;
+    final stackTrace = entry.stackTrace;
+    return ExpansionTile(
       dense: true,
-      leading: SizedBox(
-        width: 30,
-        child: Text(entry.levelName, style: const TextStyle(fontSize: 12)),
-      ),
-      title: Text(
-        '[${entry.loggerName}] ${entry.message}',
-        style: const TextStyle(fontSize: 14, letterSpacing: -0.15),
-      ),
-      subtitle: Text(
-        _logDateFormatter.format(entry.logTime),
-        style: TextStyle(color: textShade(context, 0.7), fontSize: 12),
-      ),
+      leading: leading,
+      title: title,
+      subtitle: subtitle,
+      children: [
+        ListTile(
+          dense: true,
+          title: error != null ? Text(error, style: titleStyle) : null,
+          subtitle: stackTrace != null ? Text(stackTrace, style: subtitleStyle) : null,
+        ),
+      ],
     );
   }
 }

--- a/lib/src/view/study/study_screen.dart
+++ b/lib/src/view/study/study_screen.dart
@@ -74,7 +74,7 @@ class _StudyScreenLoader extends ConsumerWidget {
       case AsyncData(:final value):
         return _StudyScreen(options: options, studyState: value);
       case AsyncError(:final error, :final stackTrace):
-        _logger.severe('Cannot load study: $error', stackTrace);
+        _logger.severe('Cannot load study:', error, stackTrace);
         return Scaffold(
           appBar: AppBar(title: const Text('')),
           body: DefaultTabController(


### PR DESCRIPTION
- I passed the error and the stack trace as arguments to comply with the `logging` contract. (`(Object? message, [Object? error, StackTrace? stackTrace])`).
- I replaced the `;` with `:` in the log messages.

I think there might be a regression.
On the App Logs page, the logs that displayed the error and/or stack trace will no longer be visible on that page.
Perhaps add a pop-up with the log details when clicked.