### PR TITLE
refactor(chat): remove inputText in ChatState for reduce rebuild

### DIFF
--- a/lib/src/model/chat/chat_mixin.dart
+++ b/lib/src/model/chat/chat_mixin.dart
@@ -29,11 +29,8 @@ String _storeKey(StringId id) => 'chat.$id';
 sealed class ChatState with _$ChatState {
   const ChatState._();
 
-  const factory ChatState({
-    required IList<ChatMessage> messages,
-    required int unreadMessages,
-    @Default('') String inputText,
-  }) = _ChatState;
+  const factory ChatState({required IList<ChatMessage> messages, required int unreadMessages}) =
+      _ChatState;
 }
 
 /// Interface for a Notifier's State that uses [ChatMixin].
@@ -228,12 +225,5 @@ mixin ChatMixin<T extends ChatMixinState> on AnyNotifier<AsyncValue<T>, T> {
         ),
       );
     }
-  }
-
-  /// Updates the text of the chat input field.
-  void setInputText(String text) {
-    final chatState = state.value?.chatState;
-    if (chatState == null) return;
-    updateChatState(chatState.copyWith(inputText: text));
   }
 }

--- a/lib/src/view/chat/chat_screen.dart
+++ b/lib/src/view/chat/chat_screen.dart
@@ -287,16 +287,6 @@ class _ChatBottomBarState extends ConsumerState<_ChatBottomBar> {
   final _textController = TextEditingController();
 
   @override
-  void initState() {
-    super.initState();
-    final draft = ref.read(chatProvider(widget.options)).asData?.value?.inputText ?? '';
-    _textController.text = draft;
-    _textController.addListener(() {
-      ref.read(chatNotifierProvider(widget.options)).setInputText(_textController.text);
-    });
-  }
-
-  @override
   void dispose() {
     _textController.dispose();
     super.dispose();
@@ -304,15 +294,14 @@ class _ChatBottomBarState extends ConsumerState<_ChatBottomBar> {
 
   @override
   Widget build(BuildContext context) {
-    final authUser = ref.watch(authControllerProvider);
+    final isLoggedIn = ref.watch(isLoggedInProvider);
     final sendButton = ValueListenableBuilder<TextEditingValue>(
       valueListenable: _textController,
       builder: (context, value, child) => SemanticIconButton(
-        onPressed: authUser != null && value.text.isNotEmpty
+        onPressed: isLoggedIn && value.text.isNotEmpty
             ? () {
                 ref.read(chatNotifierProvider(widget.options)).postMessage(_textController.text);
                 _textController.clear();
-                ref.read(chatNotifierProvider(widget.options)).setInputText('');
               }
             : null,
         icon: const Icon(Icons.send),
@@ -320,7 +309,7 @@ class _ChatBottomBarState extends ConsumerState<_ChatBottomBar> {
         semanticsLabel: context.l10n.send,
       ),
     );
-    final placeholder = authUser != null ? context.l10n.talkInChat : context.l10n.loginToChat;
+    final placeholder = isLoggedIn ? context.l10n.talkInChat : context.l10n.loginToChat;
     return SafeArea(
       top: false,
       child: Padding(
@@ -337,7 +326,7 @@ class _ChatBottomBarState extends ConsumerState<_ChatBottomBar> {
           minLines: 1,
           maxLines: 4,
           enableSuggestions: true,
-          readOnly: authUser == null,
+          readOnly: !isLoggedIn,
         ),
       ),
     );

--- a/test/model/chat/chat_mixin_test.dart
+++ b/test/model/chat/chat_mixin_test.dart
@@ -357,30 +357,6 @@ void main() {
     });
   });
 
-  group('ChatMixin.setInputText', () {
-    test('updates the input text', () async {
-      final container = await makeContainer();
-      final provider = _makeProvider(initialData: _chatData([]));
-      final notifier = container.read(provider.notifier);
-      await container.read(provider.future);
-
-      notifier.setInputText('draw?');
-
-      expect(container.read(provider).requireValue.chatState!.inputText, 'draw?');
-    });
-
-    test('is a no-op when chat is not initialized', () async {
-      final container = await makeContainer();
-      final provider = _makeProvider();
-      final notifier = container.read(provider.notifier);
-      await container.read(provider.future);
-
-      notifier.setInputText('draw?');
-
-      expect(container.read(provider).requireValue.chatState, isNull);
-    });
-  });
-
   group('ChatMixin.postMessage', () {
     test('sends a talk message over the current socket', () async {
       final fakeChannel = FakeWebSocketChannel(Uri(path: kDefaultSocketRoute));

--- a/test/view/chat/chat_screen_test.dart
+++ b/test/view/chat/chat_screen_test.dart
@@ -51,9 +51,6 @@ class _FakeChatNotifier extends AsyncNotifier<_FakeChatState> with ChatMixin<_Fa
 
   @override
   void onForegroundLost() {}
-
-  @override
-  void setInputText(String text) {}
 }
 
 class HangNotifier extends Notifier<bool> {


### PR DESCRIPTION
On v0.25.3, every time I type a letter, the keyboard disappears.
This prevents the watch from being triggered in the parent.
There is no processing of `inputText` in the provider.
We can remove it to avoid duplicating the truth between the TextController and the Provider.

I also replace `authUser == null` by `isLoggedIn` from `isLoggedInProvider`