### PR TITLE
Make offline puzzle count configurable

### DIFF
--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -38,6 +38,7 @@
   "mobileNotFollowingAnyUser": "You are not following any users.",
   "mobileOkButton": "OK",
   "mobileOverTheBoard": "Over the board",
+  "mobileNbOfflinePuzzles": "Offline puzzles",
   "mobilePlayersMatchingSearchTerm": "Players with \"{param}\"",
   "@mobilePlayersMatchingSearchTerm": {
     "placeholders": {

--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -32,13 +32,13 @@
   "mobileHomeTab": "Home",
   "mobileLiveStreamers": "Live streamers",
   "mobileMustBeLoggedIn": "You must be logged in to view this page.",
+  "mobileNbOfflinePuzzles": "Offline puzzles",
   "mobileNewGame": "New game",
   "mobileNoSearchResults": "No results",
   "mobileNotAllFeaturesAreAvailable": "Please note that not all features from the old app or the website are currently available, but we are adding features all the time.",
   "mobileNotFollowingAnyUser": "You are not following any users.",
   "mobileOkButton": "OK",
   "mobileOverTheBoard": "Over the board",
-  "mobileNbOfflinePuzzles": "Offline puzzles",
   "mobilePlayersMatchingSearchTerm": "Players with \"{param}\"",
   "@mobilePlayersMatchingSearchTerm": {
     "placeholders": {

--- a/lib/l10n/l10n.dart
+++ b/lib/l10n/l10n.dart
@@ -346,6 +346,12 @@ abstract class AppLocalizations {
   /// **'Over the board'**
   String get mobileOverTheBoard;
 
+  /// No description provided for @mobileNbOfflinePuzzles.
+  ///
+  /// In en, this message translates to:
+  /// **'Offline puzzles'**
+  String get mobileNbOfflinePuzzles;
+
   /// No description provided for @mobilePlayersMatchingSearchTerm.
   ///
   /// In en, this message translates to:

--- a/lib/l10n/l10n.dart
+++ b/lib/l10n/l10n.dart
@@ -310,6 +310,12 @@ abstract class AppLocalizations {
   /// **'You must be logged in to view this page.'**
   String get mobileMustBeLoggedIn;
 
+  /// No description provided for @mobileNbOfflinePuzzles.
+  ///
+  /// In en, this message translates to:
+  /// **'Offline puzzles'**
+  String get mobileNbOfflinePuzzles;
+
   /// No description provided for @mobileNewGame.
   ///
   /// In en, this message translates to:
@@ -345,12 +351,6 @@ abstract class AppLocalizations {
   /// In en, this message translates to:
   /// **'Over the board'**
   String get mobileOverTheBoard;
-
-  /// No description provided for @mobileNbOfflinePuzzles.
-  ///
-  /// In en, this message translates to:
-  /// **'Offline puzzles'**
-  String get mobileNbOfflinePuzzles;
 
   /// No description provided for @mobilePlayersMatchingSearchTerm.
   ///

--- a/lib/l10n/l10n_af.dart
+++ b/lib/l10n/l10n_af.dart
@@ -88,6 +88,9 @@ class AppLocalizationsAf extends AppLocalizations {
   String get mobileOverTheBoard => 'Oor die bord';
 
   @override
+  String get mobileNbOfflinePuzzles => 'Offline puzzles';
+
+  @override
   String mobilePlayersMatchingSearchTerm(String param) {
     return 'Spelers met \"$param\"';
   }

--- a/lib/l10n/l10n_af.dart
+++ b/lib/l10n/l10n_af.dart
@@ -70,6 +70,9 @@ class AppLocalizationsAf extends AppLocalizations {
   String get mobileMustBeLoggedIn => 'Jy moet ingeteken wees om hierdie bladsy te kan sien.';
 
   @override
+  String get mobileNbOfflinePuzzles => 'Offline puzzles';
+
+  @override
   String get mobileNewGame => 'New game';
 
   @override
@@ -86,9 +89,6 @@ class AppLocalizationsAf extends AppLocalizations {
 
   @override
   String get mobileOverTheBoard => 'Oor die bord';
-
-  @override
-  String get mobileNbOfflinePuzzles => 'Offline puzzles';
 
   @override
   String mobilePlayersMatchingSearchTerm(String param) {

--- a/lib/l10n/l10n_ar.dart
+++ b/lib/l10n/l10n_ar.dart
@@ -88,6 +88,9 @@ class AppLocalizationsAr extends AppLocalizations {
   String get mobileOverTheBoard => 'على الرقعة';
 
   @override
+  String get mobileNbOfflinePuzzles => 'Offline puzzles';
+
+  @override
   String mobilePlayersMatchingSearchTerm(String param) {
     return 'لاعبين مع';
   }

--- a/lib/l10n/l10n_ar.dart
+++ b/lib/l10n/l10n_ar.dart
@@ -70,6 +70,9 @@ class AppLocalizationsAr extends AppLocalizations {
   String get mobileMustBeLoggedIn => 'لعرض هذه الصفحة، قم بتسجيل الدخول.';
 
   @override
+  String get mobileNbOfflinePuzzles => 'Offline puzzles';
+
+  @override
   String get mobileNewGame => 'مباراة جديدة';
 
   @override
@@ -86,9 +89,6 @@ class AppLocalizationsAr extends AppLocalizations {
 
   @override
   String get mobileOverTheBoard => 'على الرقعة';
-
-  @override
-  String get mobileNbOfflinePuzzles => 'Offline puzzles';
 
   @override
   String mobilePlayersMatchingSearchTerm(String param) {

--- a/lib/l10n/l10n_az.dart
+++ b/lib/l10n/l10n_az.dart
@@ -88,6 +88,9 @@ class AppLocalizationsAz extends AppLocalizations {
   String get mobileOverTheBoard => 'Taxta üzərində';
 
   @override
+  String get mobileNbOfflinePuzzles => 'Offline puzzles';
+
+  @override
   String mobilePlayersMatchingSearchTerm(String param) {
     return '\"$param\" ilə oyunçular';
   }

--- a/lib/l10n/l10n_az.dart
+++ b/lib/l10n/l10n_az.dart
@@ -70,6 +70,9 @@ class AppLocalizationsAz extends AppLocalizations {
   String get mobileMustBeLoggedIn => 'Bu səhifəni görmək üçün daxil olmalısınız.';
 
   @override
+  String get mobileNbOfflinePuzzles => 'Offline puzzles';
+
+  @override
   String get mobileNewGame => 'New game';
 
   @override
@@ -86,9 +89,6 @@ class AppLocalizationsAz extends AppLocalizations {
 
   @override
   String get mobileOverTheBoard => 'Taxta üzərində';
-
-  @override
-  String get mobileNbOfflinePuzzles => 'Offline puzzles';
 
   @override
   String mobilePlayersMatchingSearchTerm(String param) {

--- a/lib/l10n/l10n_be.dart
+++ b/lib/l10n/l10n_be.dart
@@ -88,6 +88,9 @@ class AppLocalizationsBe extends AppLocalizations {
   String get mobileOverTheBoard => 'За дошкай';
 
   @override
+  String get mobileNbOfflinePuzzles => 'Offline puzzles';
+
+  @override
   String mobilePlayersMatchingSearchTerm(String param) {
     return 'Гульцы з «$param»';
   }

--- a/lib/l10n/l10n_be.dart
+++ b/lib/l10n/l10n_be.dart
@@ -70,6 +70,9 @@ class AppLocalizationsBe extends AppLocalizations {
   String get mobileMustBeLoggedIn => 'Вам патрэбна ўвайсці ў уліковы запіс каб паглядзець гэтую старонку.';
 
   @override
+  String get mobileNbOfflinePuzzles => 'Offline puzzles';
+
+  @override
   String get mobileNewGame => 'Новая гульня';
 
   @override
@@ -86,9 +89,6 @@ class AppLocalizationsBe extends AppLocalizations {
 
   @override
   String get mobileOverTheBoard => 'За дошкай';
-
-  @override
-  String get mobileNbOfflinePuzzles => 'Offline puzzles';
 
   @override
   String mobilePlayersMatchingSearchTerm(String param) {

--- a/lib/l10n/l10n_bg.dart
+++ b/lib/l10n/l10n_bg.dart
@@ -88,6 +88,9 @@ class AppLocalizationsBg extends AppLocalizations {
   String get mobileOverTheBoard => 'Двама над дъската';
 
   @override
+  String get mobileNbOfflinePuzzles => 'Offline puzzles';
+
+  @override
   String mobilePlayersMatchingSearchTerm(String param) {
     return 'Играчи с „$param“ в името';
   }

--- a/lib/l10n/l10n_bg.dart
+++ b/lib/l10n/l10n_bg.dart
@@ -70,6 +70,9 @@ class AppLocalizationsBg extends AppLocalizations {
   String get mobileMustBeLoggedIn => 'Влезте в профила си, за да видите страницата.';
 
   @override
+  String get mobileNbOfflinePuzzles => 'Offline puzzles';
+
+  @override
   String get mobileNewGame => 'Нова партия';
 
   @override
@@ -86,9 +89,6 @@ class AppLocalizationsBg extends AppLocalizations {
 
   @override
   String get mobileOverTheBoard => 'Двама над дъската';
-
-  @override
-  String get mobileNbOfflinePuzzles => 'Offline puzzles';
 
   @override
   String mobilePlayersMatchingSearchTerm(String param) {

--- a/lib/l10n/l10n_bn.dart
+++ b/lib/l10n/l10n_bn.dart
@@ -88,6 +88,9 @@ class AppLocalizationsBn extends AppLocalizations {
   String get mobileOverTheBoard => 'একই বোর্ড/ডিভাইসে';
 
   @override
+  String get mobileNbOfflinePuzzles => 'Offline puzzles';
+
+  @override
   String mobilePlayersMatchingSearchTerm(String param) {
     return 'যে খেলোয়াড়-দের নামে \"$param\" আছে।';
   }

--- a/lib/l10n/l10n_bn.dart
+++ b/lib/l10n/l10n_bn.dart
@@ -70,6 +70,9 @@ class AppLocalizationsBn extends AppLocalizations {
   String get mobileMustBeLoggedIn => 'এই পাতাটি দেখতে লগইন করুন।';
 
   @override
+  String get mobileNbOfflinePuzzles => 'Offline puzzles';
+
+  @override
   String get mobileNewGame => 'New game';
 
   @override
@@ -86,9 +89,6 @@ class AppLocalizationsBn extends AppLocalizations {
 
   @override
   String get mobileOverTheBoard => 'একই বোর্ড/ডিভাইসে';
-
-  @override
-  String get mobileNbOfflinePuzzles => 'Offline puzzles';
 
   @override
   String mobilePlayersMatchingSearchTerm(String param) {

--- a/lib/l10n/l10n_bs.dart
+++ b/lib/l10n/l10n_bs.dart
@@ -88,6 +88,9 @@ class AppLocalizationsBs extends AppLocalizations {
   String get mobileOverTheBoard => 'Preko ploče';
 
   @override
+  String get mobileNbOfflinePuzzles => 'Offline puzzles';
+
+  @override
   String mobilePlayersMatchingSearchTerm(String param) {
     return 'Igrači sa \"$param\"';
   }

--- a/lib/l10n/l10n_bs.dart
+++ b/lib/l10n/l10n_bs.dart
@@ -70,6 +70,9 @@ class AppLocalizationsBs extends AppLocalizations {
   String get mobileMustBeLoggedIn => 'Morate biti prijavljeni da biste vidjeli ovu stranicu.';
 
   @override
+  String get mobileNbOfflinePuzzles => 'Offline puzzles';
+
+  @override
   String get mobileNewGame => 'New game';
 
   @override
@@ -86,9 +89,6 @@ class AppLocalizationsBs extends AppLocalizations {
 
   @override
   String get mobileOverTheBoard => 'Preko ploče';
-
-  @override
-  String get mobileNbOfflinePuzzles => 'Offline puzzles';
 
   @override
   String mobilePlayersMatchingSearchTerm(String param) {

--- a/lib/l10n/l10n_ca.dart
+++ b/lib/l10n/l10n_ca.dart
@@ -88,6 +88,9 @@ class AppLocalizationsCa extends AppLocalizations {
   String get mobileOverTheBoard => 'Juga sobre el tauler';
 
   @override
+  String get mobileNbOfflinePuzzles => 'Offline puzzles';
+
+  @override
   String mobilePlayersMatchingSearchTerm(String param) {
     return 'Jugadors amb \"$param\"';
   }

--- a/lib/l10n/l10n_ca.dart
+++ b/lib/l10n/l10n_ca.dart
@@ -70,6 +70,9 @@ class AppLocalizationsCa extends AppLocalizations {
   String get mobileMustBeLoggedIn => 'Has d\'estar connectat per veure aquesta pàgina.';
 
   @override
+  String get mobileNbOfflinePuzzles => 'Offline puzzles';
+
+  @override
   String get mobileNewGame => 'Nova partida';
 
   @override
@@ -86,9 +89,6 @@ class AppLocalizationsCa extends AppLocalizations {
 
   @override
   String get mobileOverTheBoard => 'Juga sobre el tauler';
-
-  @override
-  String get mobileNbOfflinePuzzles => 'Offline puzzles';
 
   @override
   String mobilePlayersMatchingSearchTerm(String param) {

--- a/lib/l10n/l10n_cs.dart
+++ b/lib/l10n/l10n_cs.dart
@@ -88,6 +88,9 @@ class AppLocalizationsCs extends AppLocalizations {
   String get mobileOverTheBoard => 'Jako na šachovnici';
 
   @override
+  String get mobileNbOfflinePuzzles => 'Offline puzzles';
+
+  @override
   String mobilePlayersMatchingSearchTerm(String param) {
     return 'Hráči s „$param“';
   }

--- a/lib/l10n/l10n_cs.dart
+++ b/lib/l10n/l10n_cs.dart
@@ -70,6 +70,9 @@ class AppLocalizationsCs extends AppLocalizations {
   String get mobileMustBeLoggedIn => 'Pro zobrazení této stránky musíte být přihlášeni.';
 
   @override
+  String get mobileNbOfflinePuzzles => 'Offline puzzles';
+
+  @override
   String get mobileNewGame => 'Nová hra';
 
   @override
@@ -86,9 +89,6 @@ class AppLocalizationsCs extends AppLocalizations {
 
   @override
   String get mobileOverTheBoard => 'Jako na šachovnici';
-
-  @override
-  String get mobileNbOfflinePuzzles => 'Offline puzzles';
 
   @override
   String mobilePlayersMatchingSearchTerm(String param) {

--- a/lib/l10n/l10n_da.dart
+++ b/lib/l10n/l10n_da.dart
@@ -88,6 +88,9 @@ class AppLocalizationsDa extends AppLocalizations {
   String get mobileOverTheBoard => 'Spil offline, brug som bræt';
 
   @override
+  String get mobileNbOfflinePuzzles => 'Offline puzzles';
+
+  @override
   String mobilePlayersMatchingSearchTerm(String param) {
     return 'Spillere med \"$param\"';
   }

--- a/lib/l10n/l10n_da.dart
+++ b/lib/l10n/l10n_da.dart
@@ -70,6 +70,9 @@ class AppLocalizationsDa extends AppLocalizations {
   String get mobileMustBeLoggedIn => 'Du skal være logget ind for at se denne side.';
 
   @override
+  String get mobileNbOfflinePuzzles => 'Offline puzzles';
+
+  @override
   String get mobileNewGame => 'Nyt parti';
 
   @override
@@ -86,9 +89,6 @@ class AppLocalizationsDa extends AppLocalizations {
 
   @override
   String get mobileOverTheBoard => 'Spil offline, brug som bræt';
-
-  @override
-  String get mobileNbOfflinePuzzles => 'Offline puzzles';
 
   @override
   String mobilePlayersMatchingSearchTerm(String param) {

--- a/lib/l10n/l10n_de.dart
+++ b/lib/l10n/l10n_de.dart
@@ -88,6 +88,9 @@ class AppLocalizationsDe extends AppLocalizations {
   String get mobileOverTheBoard => 'Spiele offline gegen Mensch';
 
   @override
+  String get mobileNbOfflinePuzzles => 'Offline puzzles';
+
+  @override
   String mobilePlayersMatchingSearchTerm(String param) {
     return 'Spieler mit \"$param\"';
   }

--- a/lib/l10n/l10n_de.dart
+++ b/lib/l10n/l10n_de.dart
@@ -70,6 +70,9 @@ class AppLocalizationsDe extends AppLocalizations {
   String get mobileMustBeLoggedIn => 'Du musst eingeloggt sein, um diese Seite anzuzeigen.';
 
   @override
+  String get mobileNbOfflinePuzzles => 'Offline puzzles';
+
+  @override
   String get mobileNewGame => 'Neue Partie';
 
   @override
@@ -86,9 +89,6 @@ class AppLocalizationsDe extends AppLocalizations {
 
   @override
   String get mobileOverTheBoard => 'Spiele offline gegen Mensch';
-
-  @override
-  String get mobileNbOfflinePuzzles => 'Offline puzzles';
 
   @override
   String mobilePlayersMatchingSearchTerm(String param) {

--- a/lib/l10n/l10n_el.dart
+++ b/lib/l10n/l10n_el.dart
@@ -88,6 +88,9 @@ class AppLocalizationsEl extends AppLocalizations {
   String get mobileOverTheBoard => 'Παρτίδα χωρίς σύνδεση';
 
   @override
+  String get mobileNbOfflinePuzzles => 'Offline puzzles';
+
+  @override
   String mobilePlayersMatchingSearchTerm(String param) {
     return 'Παίκτες με \"$param\"';
   }

--- a/lib/l10n/l10n_el.dart
+++ b/lib/l10n/l10n_el.dart
@@ -70,6 +70,9 @@ class AppLocalizationsEl extends AppLocalizations {
   String get mobileMustBeLoggedIn => 'Πρέπει να συνδεθείτε για να δείτε αυτή τη σελίδα.';
 
   @override
+  String get mobileNbOfflinePuzzles => 'Offline puzzles';
+
+  @override
   String get mobileNewGame => 'Νέα παρτίδα';
 
   @override
@@ -86,9 +89,6 @@ class AppLocalizationsEl extends AppLocalizations {
 
   @override
   String get mobileOverTheBoard => 'Παρτίδα χωρίς σύνδεση';
-
-  @override
-  String get mobileNbOfflinePuzzles => 'Offline puzzles';
 
   @override
   String mobilePlayersMatchingSearchTerm(String param) {

--- a/lib/l10n/l10n_en.dart
+++ b/lib/l10n/l10n_en.dart
@@ -88,6 +88,9 @@ class AppLocalizationsEn extends AppLocalizations {
   String get mobileOverTheBoard => 'Over the board';
 
   @override
+  String get mobileNbOfflinePuzzles => 'Offline puzzles';
+
+  @override
   String mobilePlayersMatchingSearchTerm(String param) {
     return 'Players with \"$param\"';
   }

--- a/lib/l10n/l10n_en.dart
+++ b/lib/l10n/l10n_en.dart
@@ -70,6 +70,9 @@ class AppLocalizationsEn extends AppLocalizations {
   String get mobileMustBeLoggedIn => 'You must be logged in to view this page.';
 
   @override
+  String get mobileNbOfflinePuzzles => 'Offline puzzles';
+
+  @override
   String get mobileNewGame => 'New game';
 
   @override
@@ -86,9 +89,6 @@ class AppLocalizationsEn extends AppLocalizations {
 
   @override
   String get mobileOverTheBoard => 'Over the board';
-
-  @override
-  String get mobileNbOfflinePuzzles => 'Offline puzzles';
 
   @override
   String mobilePlayersMatchingSearchTerm(String param) {

--- a/lib/l10n/l10n_eo.dart
+++ b/lib/l10n/l10n_eo.dart
@@ -88,6 +88,9 @@ class AppLocalizationsEo extends AppLocalizations {
   String get mobileOverTheBoard => 'Ludi fizike kun aliulo';
 
   @override
+  String get mobileNbOfflinePuzzles => 'Offline puzzles';
+
+  @override
   String mobilePlayersMatchingSearchTerm(String param) {
     return 'Ludantanto kun \"$param\"';
   }

--- a/lib/l10n/l10n_eo.dart
+++ b/lib/l10n/l10n_eo.dart
@@ -70,6 +70,9 @@ class AppLocalizationsEo extends AppLocalizations {
   String get mobileMustBeLoggedIn => 'Vi devas esti ensalutata por spekti ĉi tiun paĝon.';
 
   @override
+  String get mobileNbOfflinePuzzles => 'Offline puzzles';
+
+  @override
   String get mobileNewGame => 'Nova ludo';
 
   @override
@@ -86,9 +89,6 @@ class AppLocalizationsEo extends AppLocalizations {
 
   @override
   String get mobileOverTheBoard => 'Ludi fizike kun aliulo';
-
-  @override
-  String get mobileNbOfflinePuzzles => 'Offline puzzles';
 
   @override
   String mobilePlayersMatchingSearchTerm(String param) {

--- a/lib/l10n/l10n_es.dart
+++ b/lib/l10n/l10n_es.dart
@@ -88,6 +88,9 @@ class AppLocalizationsEs extends AppLocalizations {
   String get mobileOverTheBoard => 'Jugar sin conexión';
 
   @override
+  String get mobileNbOfflinePuzzles => 'Offline puzzles';
+
+  @override
   String mobilePlayersMatchingSearchTerm(String param) {
     return 'Jugadores con \"$param\"';
   }

--- a/lib/l10n/l10n_es.dart
+++ b/lib/l10n/l10n_es.dart
@@ -70,6 +70,9 @@ class AppLocalizationsEs extends AppLocalizations {
   String get mobileMustBeLoggedIn => 'Debes iniciar sesión para ver esta página.';
 
   @override
+  String get mobileNbOfflinePuzzles => 'Offline puzzles';
+
+  @override
   String get mobileNewGame => 'Nueva Partida';
 
   @override
@@ -86,9 +89,6 @@ class AppLocalizationsEs extends AppLocalizations {
 
   @override
   String get mobileOverTheBoard => 'Jugar sin conexión';
-
-  @override
-  String get mobileNbOfflinePuzzles => 'Offline puzzles';
 
   @override
   String mobilePlayersMatchingSearchTerm(String param) {

--- a/lib/l10n/l10n_et.dart
+++ b/lib/l10n/l10n_et.dart
@@ -88,6 +88,9 @@ class AppLocalizationsEt extends AppLocalizations {
   String get mobileOverTheBoard => 'Üle laua';
 
   @override
+  String get mobileNbOfflinePuzzles => 'Offline puzzles';
+
+  @override
   String mobilePlayersMatchingSearchTerm(String param) {
     return 'Kasutajad sisuga \"$param\"';
   }

--- a/lib/l10n/l10n_et.dart
+++ b/lib/l10n/l10n_et.dart
@@ -70,6 +70,9 @@ class AppLocalizationsEt extends AppLocalizations {
   String get mobileMustBeLoggedIn => 'Selle lehe vaatamiseks peab olema sisse logitud.';
 
   @override
+  String get mobileNbOfflinePuzzles => 'Offline puzzles';
+
+  @override
   String get mobileNewGame => 'Uus mäng';
 
   @override
@@ -86,9 +89,6 @@ class AppLocalizationsEt extends AppLocalizations {
 
   @override
   String get mobileOverTheBoard => 'Üle laua';
-
-  @override
-  String get mobileNbOfflinePuzzles => 'Offline puzzles';
 
   @override
   String mobilePlayersMatchingSearchTerm(String param) {

--- a/lib/l10n/l10n_eu.dart
+++ b/lib/l10n/l10n_eu.dart
@@ -88,6 +88,9 @@ class AppLocalizationsEu extends AppLocalizations {
   String get mobileOverTheBoard => 'Taula gainean';
 
   @override
+  String get mobileNbOfflinePuzzles => 'Offline puzzles';
+
+  @override
   String mobilePlayersMatchingSearchTerm(String param) {
     return '\"$param\" duten jokalariak';
   }

--- a/lib/l10n/l10n_eu.dart
+++ b/lib/l10n/l10n_eu.dart
@@ -70,6 +70,9 @@ class AppLocalizationsEu extends AppLocalizations {
   String get mobileMustBeLoggedIn => 'Sartu egin behar zara orri hau ikusteko.';
 
   @override
+  String get mobileNbOfflinePuzzles => 'Offline puzzles';
+
+  @override
   String get mobileNewGame => 'Partida berria';
 
   @override
@@ -86,9 +89,6 @@ class AppLocalizationsEu extends AppLocalizations {
 
   @override
   String get mobileOverTheBoard => 'Taula gainean';
-
-  @override
-  String get mobileNbOfflinePuzzles => 'Offline puzzles';
 
   @override
   String mobilePlayersMatchingSearchTerm(String param) {

--- a/lib/l10n/l10n_fa.dart
+++ b/lib/l10n/l10n_fa.dart
@@ -88,6 +88,9 @@ class AppLocalizationsFa extends AppLocalizations {
   String get mobileOverTheBoard => 'سَرِ میز';
 
   @override
+  String get mobileNbOfflinePuzzles => 'Offline puzzles';
+
+  @override
   String mobilePlayersMatchingSearchTerm(String param) {
     return 'بازیکنانِ «$param»';
   }

--- a/lib/l10n/l10n_fa.dart
+++ b/lib/l10n/l10n_fa.dart
@@ -70,6 +70,9 @@ class AppLocalizationsFa extends AppLocalizations {
   String get mobileMustBeLoggedIn => 'برای دیدن این برگه باید وارد شده باشید.';
 
   @override
+  String get mobileNbOfflinePuzzles => 'Offline puzzles';
+
+  @override
   String get mobileNewGame => 'بازی جدید';
 
   @override
@@ -86,9 +89,6 @@ class AppLocalizationsFa extends AppLocalizations {
 
   @override
   String get mobileOverTheBoard => 'سَرِ میز';
-
-  @override
-  String get mobileNbOfflinePuzzles => 'Offline puzzles';
 
   @override
   String mobilePlayersMatchingSearchTerm(String param) {

--- a/lib/l10n/l10n_fi.dart
+++ b/lib/l10n/l10n_fi.dart
@@ -88,6 +88,9 @@ class AppLocalizationsFi extends AppLocalizations {
   String get mobileOverTheBoard => 'Kaveria vastaan offline-tilassa';
 
   @override
+  String get mobileNbOfflinePuzzles => 'Offline puzzles';
+
+  @override
   String mobilePlayersMatchingSearchTerm(String param) {
     return 'Pelaajat, joiden tunnuksesta löytyy \"$param\"';
   }

--- a/lib/l10n/l10n_fi.dart
+++ b/lib/l10n/l10n_fi.dart
@@ -70,6 +70,9 @@ class AppLocalizationsFi extends AppLocalizations {
   String get mobileMustBeLoggedIn => 'Sinun täytyy olla kirjautuneena nähdäksesi tämän sivun.';
 
   @override
+  String get mobileNbOfflinePuzzles => 'Offline puzzles';
+
+  @override
   String get mobileNewGame => 'Uusi peli';
 
   @override
@@ -86,9 +89,6 @@ class AppLocalizationsFi extends AppLocalizations {
 
   @override
   String get mobileOverTheBoard => 'Kaveria vastaan offline-tilassa';
-
-  @override
-  String get mobileNbOfflinePuzzles => 'Offline puzzles';
 
   @override
   String mobilePlayersMatchingSearchTerm(String param) {

--- a/lib/l10n/l10n_fr.dart
+++ b/lib/l10n/l10n_fr.dart
@@ -88,6 +88,9 @@ class AppLocalizationsFr extends AppLocalizations {
   String get mobileOverTheBoard => 'Jouer hors ligne avec un ami';
 
   @override
+  String get mobileNbOfflinePuzzles => 'Offline puzzles';
+
+  @override
   String mobilePlayersMatchingSearchTerm(String param) {
     return 'Joueurs – \"$param\"';
   }

--- a/lib/l10n/l10n_fr.dart
+++ b/lib/l10n/l10n_fr.dart
@@ -70,6 +70,9 @@ class AppLocalizationsFr extends AppLocalizations {
   String get mobileMustBeLoggedIn => 'Vous devez être connecté pour voir cette page.';
 
   @override
+  String get mobileNbOfflinePuzzles => 'Offline puzzles';
+
+  @override
   String get mobileNewGame => 'Nouvelle partie';
 
   @override
@@ -86,9 +89,6 @@ class AppLocalizationsFr extends AppLocalizations {
 
   @override
   String get mobileOverTheBoard => 'Jouer hors ligne avec un ami';
-
-  @override
-  String get mobileNbOfflinePuzzles => 'Offline puzzles';
 
   @override
   String mobilePlayersMatchingSearchTerm(String param) {

--- a/lib/l10n/l10n_gl.dart
+++ b/lib/l10n/l10n_gl.dart
@@ -88,6 +88,9 @@ class AppLocalizationsGl extends AppLocalizations {
   String get mobileOverTheBoard => 'Xogar nun taboleiro virtual';
 
   @override
+  String get mobileNbOfflinePuzzles => 'Offline puzzles';
+
+  @override
   String mobilePlayersMatchingSearchTerm(String param) {
     return 'O nome de usuario contén \"$param\"';
   }

--- a/lib/l10n/l10n_gl.dart
+++ b/lib/l10n/l10n_gl.dart
@@ -70,6 +70,9 @@ class AppLocalizationsGl extends AppLocalizations {
   String get mobileMustBeLoggedIn => 'Debes iniciar sesión para ver esta páxina.';
 
   @override
+  String get mobileNbOfflinePuzzles => 'Offline puzzles';
+
+  @override
   String get mobileNewGame => 'Nova partida';
 
   @override
@@ -86,9 +89,6 @@ class AppLocalizationsGl extends AppLocalizations {
 
   @override
   String get mobileOverTheBoard => 'Xogar nun taboleiro virtual';
-
-  @override
-  String get mobileNbOfflinePuzzles => 'Offline puzzles';
 
   @override
   String mobilePlayersMatchingSearchTerm(String param) {

--- a/lib/l10n/l10n_gsw.dart
+++ b/lib/l10n/l10n_gsw.dart
@@ -88,6 +88,9 @@ class AppLocalizationsGsw extends AppLocalizations {
   String get mobileOverTheBoard => 'Schpill offline gäge en Mänsch';
 
   @override
+  String get mobileNbOfflinePuzzles => 'Offline puzzles';
+
+  @override
   String mobilePlayersMatchingSearchTerm(String param) {
     return 'Schpiller mit \"$param%';
   }

--- a/lib/l10n/l10n_gsw.dart
+++ b/lib/l10n/l10n_gsw.dart
@@ -70,6 +70,9 @@ class AppLocalizationsGsw extends AppLocalizations {
   String get mobileMustBeLoggedIn => 'Du muesch igloggt si, um die Site z\'gseh.';
 
   @override
+  String get mobileNbOfflinePuzzles => 'Offline puzzles';
+
+  @override
   String get mobileNewGame => 'Neus Schpiel';
 
   @override
@@ -86,9 +89,6 @@ class AppLocalizationsGsw extends AppLocalizations {
 
   @override
   String get mobileOverTheBoard => 'Schpill offline gäge en Mänsch';
-
-  @override
-  String get mobileNbOfflinePuzzles => 'Offline puzzles';
 
   @override
   String mobilePlayersMatchingSearchTerm(String param) {

--- a/lib/l10n/l10n_he.dart
+++ b/lib/l10n/l10n_he.dart
@@ -88,6 +88,9 @@ class AppLocalizationsHe extends AppLocalizations {
   String get mobileOverTheBoard => 'שח-חי (על גבי לוח!)';
 
   @override
+  String get mobileNbOfflinePuzzles => 'Offline puzzles';
+
+  @override
   String mobilePlayersMatchingSearchTerm(String param) {
     return 'שחקנים עם ״$param״';
   }

--- a/lib/l10n/l10n_he.dart
+++ b/lib/l10n/l10n_he.dart
@@ -70,6 +70,9 @@ class AppLocalizationsHe extends AppLocalizations {
   String get mobileMustBeLoggedIn => 'יש להתחבר כדי לצפות בדף זה.';
 
   @override
+  String get mobileNbOfflinePuzzles => 'Offline puzzles';
+
+  @override
   String get mobileNewGame => 'New game';
 
   @override
@@ -86,9 +89,6 @@ class AppLocalizationsHe extends AppLocalizations {
 
   @override
   String get mobileOverTheBoard => 'שח-חי (על גבי לוח!)';
-
-  @override
-  String get mobileNbOfflinePuzzles => 'Offline puzzles';
 
   @override
   String mobilePlayersMatchingSearchTerm(String param) {

--- a/lib/l10n/l10n_hi.dart
+++ b/lib/l10n/l10n_hi.dart
@@ -88,6 +88,9 @@ class AppLocalizationsHi extends AppLocalizations {
   String get mobileOverTheBoard => 'बोर्ड पर';
 
   @override
+  String get mobileNbOfflinePuzzles => 'Offline puzzles';
+
+  @override
   String mobilePlayersMatchingSearchTerm(String param) {
     return '\"$param\" नाम वाले खिलाड़ी';
   }

--- a/lib/l10n/l10n_hi.dart
+++ b/lib/l10n/l10n_hi.dart
@@ -70,6 +70,9 @@ class AppLocalizationsHi extends AppLocalizations {
   String get mobileMustBeLoggedIn => 'इस पेज को देखने के लिए आपको लॉगिन करना होगा।';
 
   @override
+  String get mobileNbOfflinePuzzles => 'Offline puzzles';
+
+  @override
   String get mobileNewGame => 'New game';
 
   @override
@@ -86,9 +89,6 @@ class AppLocalizationsHi extends AppLocalizations {
 
   @override
   String get mobileOverTheBoard => 'बोर्ड पर';
-
-  @override
-  String get mobileNbOfflinePuzzles => 'Offline puzzles';
 
   @override
   String mobilePlayersMatchingSearchTerm(String param) {

--- a/lib/l10n/l10n_hr.dart
+++ b/lib/l10n/l10n_hr.dart
@@ -88,6 +88,9 @@ class AppLocalizationsHr extends AppLocalizations {
   String get mobileOverTheBoard => 'Igraj bez mreže, preko uređaja';
 
   @override
+  String get mobileNbOfflinePuzzles => 'Offline puzzles';
+
+  @override
   String mobilePlayersMatchingSearchTerm(String param) {
     return 'Igrači s \"$param\"';
   }

--- a/lib/l10n/l10n_hr.dart
+++ b/lib/l10n/l10n_hr.dart
@@ -70,6 +70,9 @@ class AppLocalizationsHr extends AppLocalizations {
   String get mobileMustBeLoggedIn => 'Morate biti prijavljeni kako bi vidjeli ovu stranicu.';
 
   @override
+  String get mobileNbOfflinePuzzles => 'Offline puzzles';
+
+  @override
   String get mobileNewGame => 'Nova partija';
 
   @override
@@ -86,9 +89,6 @@ class AppLocalizationsHr extends AppLocalizations {
 
   @override
   String get mobileOverTheBoard => 'Igraj bez mreže, preko uređaja';
-
-  @override
-  String get mobileNbOfflinePuzzles => 'Offline puzzles';
 
   @override
   String mobilePlayersMatchingSearchTerm(String param) {

--- a/lib/l10n/l10n_hu.dart
+++ b/lib/l10n/l10n_hu.dart
@@ -88,6 +88,9 @@ class AppLocalizationsHu extends AppLocalizations {
   String get mobileOverTheBoard => 'Asztali játék';
 
   @override
+  String get mobileNbOfflinePuzzles => 'Offline puzzles';
+
+  @override
   String mobilePlayersMatchingSearchTerm(String param) {
     return 'Játékosok \"$param\"felhasználónévvel';
   }

--- a/lib/l10n/l10n_hu.dart
+++ b/lib/l10n/l10n_hu.dart
@@ -70,6 +70,9 @@ class AppLocalizationsHu extends AppLocalizations {
   String get mobileMustBeLoggedIn => 'Az oldal megtekintéséhez be kell jelentkezned.';
 
   @override
+  String get mobileNbOfflinePuzzles => 'Offline puzzles';
+
+  @override
   String get mobileNewGame => 'Új játék';
 
   @override
@@ -86,9 +89,6 @@ class AppLocalizationsHu extends AppLocalizations {
 
   @override
   String get mobileOverTheBoard => 'Asztali játék';
-
-  @override
-  String get mobileNbOfflinePuzzles => 'Offline puzzles';
 
   @override
   String mobilePlayersMatchingSearchTerm(String param) {

--- a/lib/l10n/l10n_hy.dart
+++ b/lib/l10n/l10n_hy.dart
@@ -88,6 +88,9 @@ class AppLocalizationsHy extends AppLocalizations {
   String get mobileOverTheBoard => 'Երկուսով խաղատախտակի առջև';
 
   @override
+  String get mobileNbOfflinePuzzles => 'Offline puzzles';
+
+  @override
   String mobilePlayersMatchingSearchTerm(String param) {
     return 'Players with \"$param\"';
   }

--- a/lib/l10n/l10n_hy.dart
+++ b/lib/l10n/l10n_hy.dart
@@ -70,6 +70,9 @@ class AppLocalizationsHy extends AppLocalizations {
   String get mobileMustBeLoggedIn => 'You must be logged in to view this page.';
 
   @override
+  String get mobileNbOfflinePuzzles => 'Offline puzzles';
+
+  @override
   String get mobileNewGame => 'New game';
 
   @override
@@ -86,9 +89,6 @@ class AppLocalizationsHy extends AppLocalizations {
 
   @override
   String get mobileOverTheBoard => 'Երկուսով խաղատախտակի առջև';
-
-  @override
-  String get mobileNbOfflinePuzzles => 'Offline puzzles';
 
   @override
   String mobilePlayersMatchingSearchTerm(String param) {

--- a/lib/l10n/l10n_id.dart
+++ b/lib/l10n/l10n_id.dart
@@ -88,6 +88,9 @@ class AppLocalizationsId extends AppLocalizations {
   String get mobileOverTheBoard => 'Di atas papan';
 
   @override
+  String get mobileNbOfflinePuzzles => 'Offline puzzles';
+
+  @override
   String mobilePlayersMatchingSearchTerm(String param) {
     return 'Pengguna dengan sebutan \"$param\"';
   }

--- a/lib/l10n/l10n_id.dart
+++ b/lib/l10n/l10n_id.dart
@@ -70,6 +70,9 @@ class AppLocalizationsId extends AppLocalizations {
   String get mobileMustBeLoggedIn => 'Anda harus masuk untuk melihat halaman ini.';
 
   @override
+  String get mobileNbOfflinePuzzles => 'Offline puzzles';
+
+  @override
   String get mobileNewGame => 'New game';
 
   @override
@@ -86,9 +89,6 @@ class AppLocalizationsId extends AppLocalizations {
 
   @override
   String get mobileOverTheBoard => 'Di atas papan';
-
-  @override
-  String get mobileNbOfflinePuzzles => 'Offline puzzles';
 
   @override
   String mobilePlayersMatchingSearchTerm(String param) {

--- a/lib/l10n/l10n_it.dart
+++ b/lib/l10n/l10n_it.dart
@@ -88,6 +88,9 @@ class AppLocalizationsIt extends AppLocalizations {
   String get mobileOverTheBoard => 'Gioca offline';
 
   @override
+  String get mobileNbOfflinePuzzles => 'Offline puzzles';
+
+  @override
   String mobilePlayersMatchingSearchTerm(String param) {
     return 'Giocatori con \"$param\"';
   }

--- a/lib/l10n/l10n_it.dart
+++ b/lib/l10n/l10n_it.dart
@@ -70,6 +70,9 @@ class AppLocalizationsIt extends AppLocalizations {
   String get mobileMustBeLoggedIn => 'Devi aver effettuato l\'accesso per visualizzare questa pagina.';
 
   @override
+  String get mobileNbOfflinePuzzles => 'Offline puzzles';
+
+  @override
   String get mobileNewGame => 'Nuova partita';
 
   @override
@@ -86,9 +89,6 @@ class AppLocalizationsIt extends AppLocalizations {
 
   @override
   String get mobileOverTheBoard => 'Gioca offline';
-
-  @override
-  String get mobileNbOfflinePuzzles => 'Offline puzzles';
 
   @override
   String mobilePlayersMatchingSearchTerm(String param) {

--- a/lib/l10n/l10n_ja.dart
+++ b/lib/l10n/l10n_ja.dart
@@ -88,6 +88,9 @@ class AppLocalizationsJa extends AppLocalizations {
   String get mobileOverTheBoard => 'オフライン（2人対戦）';
 
   @override
+  String get mobileNbOfflinePuzzles => 'Offline puzzles';
+
+  @override
   String mobilePlayersMatchingSearchTerm(String param) {
     return '「$param」を含むプレイヤー';
   }

--- a/lib/l10n/l10n_ja.dart
+++ b/lib/l10n/l10n_ja.dart
@@ -70,6 +70,9 @@ class AppLocalizationsJa extends AppLocalizations {
   String get mobileMustBeLoggedIn => 'このページを見るにはログインが必要です。';
 
   @override
+  String get mobileNbOfflinePuzzles => 'Offline puzzles';
+
+  @override
   String get mobileNewGame => '新しい対局';
 
   @override
@@ -86,9 +89,6 @@ class AppLocalizationsJa extends AppLocalizations {
 
   @override
   String get mobileOverTheBoard => 'オフライン（2人対戦）';
-
-  @override
-  String get mobileNbOfflinePuzzles => 'Offline puzzles';
 
   @override
   String mobilePlayersMatchingSearchTerm(String param) {

--- a/lib/l10n/l10n_kk.dart
+++ b/lib/l10n/l10n_kk.dart
@@ -88,6 +88,9 @@ class AppLocalizationsKk extends AppLocalizations {
   String get mobileOverTheBoard => 'Тақтаны жаю';
 
   @override
+  String get mobileNbOfflinePuzzles => 'Offline puzzles';
+
+  @override
   String mobilePlayersMatchingSearchTerm(String param) {
     return 'Атауында \"$param\" бар ойыншылар';
   }

--- a/lib/l10n/l10n_kk.dart
+++ b/lib/l10n/l10n_kk.dart
@@ -70,6 +70,9 @@ class AppLocalizationsKk extends AppLocalizations {
   String get mobileMustBeLoggedIn => 'Бұл бетті көру үшін тіркелгіге кіріңіз.';
 
   @override
+  String get mobileNbOfflinePuzzles => 'Offline puzzles';
+
+  @override
   String get mobileNewGame => 'Жаңа ойын';
 
   @override
@@ -86,9 +89,6 @@ class AppLocalizationsKk extends AppLocalizations {
 
   @override
   String get mobileOverTheBoard => 'Тақтаны жаю';
-
-  @override
-  String get mobileNbOfflinePuzzles => 'Offline puzzles';
 
   @override
   String mobilePlayersMatchingSearchTerm(String param) {

--- a/lib/l10n/l10n_ko.dart
+++ b/lib/l10n/l10n_ko.dart
@@ -88,6 +88,9 @@ class AppLocalizationsKo extends AppLocalizations {
   String get mobileOverTheBoard => '로컬 게임';
 
   @override
+  String get mobileNbOfflinePuzzles => 'Offline puzzles';
+
+  @override
   String mobilePlayersMatchingSearchTerm(String param) {
     return '닉네임에 \"$param\"가 포함된 플레이어';
   }

--- a/lib/l10n/l10n_ko.dart
+++ b/lib/l10n/l10n_ko.dart
@@ -70,6 +70,9 @@ class AppLocalizationsKo extends AppLocalizations {
   String get mobileMustBeLoggedIn => '이 페이지를 보려면 로그인해야 합니다.';
 
   @override
+  String get mobileNbOfflinePuzzles => 'Offline puzzles';
+
+  @override
   String get mobileNewGame => '새 게임';
 
   @override
@@ -86,9 +89,6 @@ class AppLocalizationsKo extends AppLocalizations {
 
   @override
   String get mobileOverTheBoard => '로컬 게임';
-
-  @override
-  String get mobileNbOfflinePuzzles => 'Offline puzzles';
 
   @override
   String mobilePlayersMatchingSearchTerm(String param) {

--- a/lib/l10n/l10n_lt.dart
+++ b/lib/l10n/l10n_lt.dart
@@ -88,6 +88,9 @@ class AppLocalizationsLt extends AppLocalizations {
   String get mobileOverTheBoard => 'Žaidimas lentoje';
 
   @override
+  String get mobileNbOfflinePuzzles => 'Offline puzzles';
+
+  @override
   String mobilePlayersMatchingSearchTerm(String param) {
     return 'Players with \"$param\"';
   }

--- a/lib/l10n/l10n_lt.dart
+++ b/lib/l10n/l10n_lt.dart
@@ -70,6 +70,9 @@ class AppLocalizationsLt extends AppLocalizations {
   String get mobileMustBeLoggedIn => 'You must be logged in to view this page.';
 
   @override
+  String get mobileNbOfflinePuzzles => 'Offline puzzles';
+
+  @override
   String get mobileNewGame => 'New game';
 
   @override
@@ -86,9 +89,6 @@ class AppLocalizationsLt extends AppLocalizations {
 
   @override
   String get mobileOverTheBoard => 'Žaidimas lentoje';
-
-  @override
-  String get mobileNbOfflinePuzzles => 'Offline puzzles';
 
   @override
   String mobilePlayersMatchingSearchTerm(String param) {

--- a/lib/l10n/l10n_lv.dart
+++ b/lib/l10n/l10n_lv.dart
@@ -88,6 +88,9 @@ class AppLocalizationsLv extends AppLocalizations {
   String get mobileOverTheBoard => 'Šaha galdiņš';
 
   @override
+  String get mobileNbOfflinePuzzles => 'Offline puzzles';
+
+  @override
   String mobilePlayersMatchingSearchTerm(String param) {
     return 'Players with \"$param\"';
   }

--- a/lib/l10n/l10n_lv.dart
+++ b/lib/l10n/l10n_lv.dart
@@ -70,6 +70,9 @@ class AppLocalizationsLv extends AppLocalizations {
   String get mobileMustBeLoggedIn => 'You must be logged in to view this page.';
 
   @override
+  String get mobileNbOfflinePuzzles => 'Offline puzzles';
+
+  @override
   String get mobileNewGame => 'New game';
 
   @override
@@ -86,9 +89,6 @@ class AppLocalizationsLv extends AppLocalizations {
 
   @override
   String get mobileOverTheBoard => 'Šaha galdiņš';
-
-  @override
-  String get mobileNbOfflinePuzzles => 'Offline puzzles';
 
   @override
   String mobilePlayersMatchingSearchTerm(String param) {

--- a/lib/l10n/l10n_mk.dart
+++ b/lib/l10n/l10n_mk.dart
@@ -88,6 +88,9 @@ class AppLocalizationsMk extends AppLocalizations {
   String get mobileOverTheBoard => 'Игра за двајца';
 
   @override
+  String get mobileNbOfflinePuzzles => 'Offline puzzles';
+
+  @override
   String mobilePlayersMatchingSearchTerm(String param) {
     return 'Играчи со \"$param\"';
   }

--- a/lib/l10n/l10n_mk.dart
+++ b/lib/l10n/l10n_mk.dart
@@ -70,6 +70,9 @@ class AppLocalizationsMk extends AppLocalizations {
   String get mobileMustBeLoggedIn => 'Мора да сте најавени за да ја видите оваа страница.';
 
   @override
+  String get mobileNbOfflinePuzzles => 'Offline puzzles';
+
+  @override
   String get mobileNewGame => 'New game';
 
   @override
@@ -86,9 +89,6 @@ class AppLocalizationsMk extends AppLocalizations {
 
   @override
   String get mobileOverTheBoard => 'Игра за двајца';
-
-  @override
-  String get mobileNbOfflinePuzzles => 'Offline puzzles';
 
   @override
   String mobilePlayersMatchingSearchTerm(String param) {

--- a/lib/l10n/l10n_nb.dart
+++ b/lib/l10n/l10n_nb.dart
@@ -88,6 +88,9 @@ class AppLocalizationsNb extends AppLocalizations {
   String get mobileOverTheBoard => 'Over brettet';
 
   @override
+  String get mobileNbOfflinePuzzles => 'Offline puzzles';
+
+  @override
   String mobilePlayersMatchingSearchTerm(String param) {
     return 'Spillere med «$param»';
   }

--- a/lib/l10n/l10n_nb.dart
+++ b/lib/l10n/l10n_nb.dart
@@ -70,6 +70,9 @@ class AppLocalizationsNb extends AppLocalizations {
   String get mobileMustBeLoggedIn => 'Du må være logget inn for å vise denne siden.';
 
   @override
+  String get mobileNbOfflinePuzzles => 'Offline puzzles';
+
+  @override
   String get mobileNewGame => 'Nytt parti';
 
   @override
@@ -86,9 +89,6 @@ class AppLocalizationsNb extends AppLocalizations {
 
   @override
   String get mobileOverTheBoard => 'Over brettet';
-
-  @override
-  String get mobileNbOfflinePuzzles => 'Offline puzzles';
 
   @override
   String mobilePlayersMatchingSearchTerm(String param) {

--- a/lib/l10n/l10n_nl.dart
+++ b/lib/l10n/l10n_nl.dart
@@ -88,6 +88,9 @@ class AppLocalizationsNl extends AppLocalizations {
   String get mobileOverTheBoard => 'Op virtueel bord';
 
   @override
+  String get mobileNbOfflinePuzzles => 'Offline puzzles';
+
+  @override
   String mobilePlayersMatchingSearchTerm(String param) {
     return 'Spelers met \"$param\"';
   }

--- a/lib/l10n/l10n_nl.dart
+++ b/lib/l10n/l10n_nl.dart
@@ -70,6 +70,9 @@ class AppLocalizationsNl extends AppLocalizations {
   String get mobileMustBeLoggedIn => 'Je moet ingelogd zijn om deze pagina te bekijken.';
 
   @override
+  String get mobileNbOfflinePuzzles => 'Offline puzzles';
+
+  @override
   String get mobileNewGame => 'Nieuwe partij';
 
   @override
@@ -86,9 +89,6 @@ class AppLocalizationsNl extends AppLocalizations {
 
   @override
   String get mobileOverTheBoard => 'Op virtueel bord';
-
-  @override
-  String get mobileNbOfflinePuzzles => 'Offline puzzles';
 
   @override
   String mobilePlayersMatchingSearchTerm(String param) {

--- a/lib/l10n/l10n_pl.dart
+++ b/lib/l10n/l10n_pl.dart
@@ -88,6 +88,9 @@ class AppLocalizationsPl extends AppLocalizations {
   String get mobileOverTheBoard => 'Ze znajomym';
 
   @override
+  String get mobileNbOfflinePuzzles => 'Offline puzzles';
+
+  @override
   String mobilePlayersMatchingSearchTerm(String param) {
     return 'Gracze pasujący do \"$param\"';
   }

--- a/lib/l10n/l10n_pl.dart
+++ b/lib/l10n/l10n_pl.dart
@@ -70,6 +70,9 @@ class AppLocalizationsPl extends AppLocalizations {
   String get mobileMustBeLoggedIn => 'Musisz być zalogowany, aby wyświetlić tę stronę.';
 
   @override
+  String get mobileNbOfflinePuzzles => 'Offline puzzles';
+
+  @override
   String get mobileNewGame => 'Nowa partia';
 
   @override
@@ -86,9 +89,6 @@ class AppLocalizationsPl extends AppLocalizations {
 
   @override
   String get mobileOverTheBoard => 'Ze znajomym';
-
-  @override
-  String get mobileNbOfflinePuzzles => 'Offline puzzles';
 
   @override
   String mobilePlayersMatchingSearchTerm(String param) {

--- a/lib/l10n/l10n_pt.dart
+++ b/lib/l10n/l10n_pt.dart
@@ -88,6 +88,9 @@ class AppLocalizationsPt extends AppLocalizations {
   String get mobileOverTheBoard => 'Jogar offline contra um amigo';
 
   @override
+  String get mobileNbOfflinePuzzles => 'Offline puzzles';
+
+  @override
   String mobilePlayersMatchingSearchTerm(String param) {
     return 'Jogadores com \"$param\"';
   }

--- a/lib/l10n/l10n_pt.dart
+++ b/lib/l10n/l10n_pt.dart
@@ -70,6 +70,9 @@ class AppLocalizationsPt extends AppLocalizations {
   String get mobileMustBeLoggedIn => 'Tens de iniciar sessão para visualizar esta página.';
 
   @override
+  String get mobileNbOfflinePuzzles => 'Offline puzzles';
+
+  @override
   String get mobileNewGame => 'Novo jogo';
 
   @override
@@ -86,9 +89,6 @@ class AppLocalizationsPt extends AppLocalizations {
 
   @override
   String get mobileOverTheBoard => 'Jogar offline contra um amigo';
-
-  @override
-  String get mobileNbOfflinePuzzles => 'Offline puzzles';
 
   @override
   String mobilePlayersMatchingSearchTerm(String param) {

--- a/lib/l10n/l10n_ro.dart
+++ b/lib/l10n/l10n_ro.dart
@@ -88,6 +88,9 @@ class AppLocalizationsRo extends AppLocalizations {
   String get mobileOverTheBoard => 'Deasupra tablei';
 
   @override
+  String get mobileNbOfflinePuzzles => 'Offline puzzles';
+
+  @override
   String mobilePlayersMatchingSearchTerm(String param) {
     return 'Jucători cu \"$param\"';
   }

--- a/lib/l10n/l10n_ro.dart
+++ b/lib/l10n/l10n_ro.dart
@@ -70,6 +70,9 @@ class AppLocalizationsRo extends AppLocalizations {
   String get mobileMustBeLoggedIn => 'Trebuie să te autentifici pentru a accesa această pagină.';
 
   @override
+  String get mobileNbOfflinePuzzles => 'Offline puzzles';
+
+  @override
   String get mobileNewGame => 'Joc nou';
 
   @override
@@ -86,9 +89,6 @@ class AppLocalizationsRo extends AppLocalizations {
 
   @override
   String get mobileOverTheBoard => 'Deasupra tablei';
-
-  @override
-  String get mobileNbOfflinePuzzles => 'Offline puzzles';
 
   @override
   String mobilePlayersMatchingSearchTerm(String param) {

--- a/lib/l10n/l10n_ru.dart
+++ b/lib/l10n/l10n_ru.dart
@@ -88,6 +88,9 @@ class AppLocalizationsRu extends AppLocalizations {
   String get mobileOverTheBoard => 'Офлайн игра';
 
   @override
+  String get mobileNbOfflinePuzzles => 'Offline puzzles';
+
+  @override
   String mobilePlayersMatchingSearchTerm(String param) {
     return 'Игроки, содержащие «$param»';
   }

--- a/lib/l10n/l10n_ru.dart
+++ b/lib/l10n/l10n_ru.dart
@@ -70,6 +70,9 @@ class AppLocalizationsRu extends AppLocalizations {
   String get mobileMustBeLoggedIn => 'Вы должны войти для просмотра этой страницы.';
 
   @override
+  String get mobileNbOfflinePuzzles => 'Offline puzzles';
+
+  @override
   String get mobileNewGame => 'Новая игра';
 
   @override
@@ -86,9 +89,6 @@ class AppLocalizationsRu extends AppLocalizations {
 
   @override
   String get mobileOverTheBoard => 'Офлайн игра';
-
-  @override
-  String get mobileNbOfflinePuzzles => 'Offline puzzles';
 
   @override
   String mobilePlayersMatchingSearchTerm(String param) {

--- a/lib/l10n/l10n_sk.dart
+++ b/lib/l10n/l10n_sk.dart
@@ -88,6 +88,9 @@ class AppLocalizationsSk extends AppLocalizations {
   String get mobileOverTheBoard => 'Hrať offline, na jednom zariadení';
 
   @override
+  String get mobileNbOfflinePuzzles => 'Offline puzzles';
+
+  @override
   String mobilePlayersMatchingSearchTerm(String param) {
     return 'Hráči s \"$param\"';
   }

--- a/lib/l10n/l10n_sk.dart
+++ b/lib/l10n/l10n_sk.dart
@@ -70,6 +70,9 @@ class AppLocalizationsSk extends AppLocalizations {
   String get mobileMustBeLoggedIn => 'Na zobrazenie tejto stránky musíte byť prihlásený.';
 
   @override
+  String get mobileNbOfflinePuzzles => 'Offline puzzles';
+
+  @override
   String get mobileNewGame => 'Nová hra';
 
   @override
@@ -86,9 +89,6 @@ class AppLocalizationsSk extends AppLocalizations {
 
   @override
   String get mobileOverTheBoard => 'Hrať offline, na jednom zariadení';
-
-  @override
-  String get mobileNbOfflinePuzzles => 'Offline puzzles';
 
   @override
   String mobilePlayersMatchingSearchTerm(String param) {

--- a/lib/l10n/l10n_sl.dart
+++ b/lib/l10n/l10n_sl.dart
@@ -88,6 +88,9 @@ class AppLocalizationsSl extends AppLocalizations {
   String get mobileOverTheBoard => 'Proti človeku';
 
   @override
+  String get mobileNbOfflinePuzzles => 'Offline puzzles';
+
+  @override
   String mobilePlayersMatchingSearchTerm(String param) {
     return 'Igralci z \"$param\"';
   }

--- a/lib/l10n/l10n_sl.dart
+++ b/lib/l10n/l10n_sl.dart
@@ -70,6 +70,9 @@ class AppLocalizationsSl extends AppLocalizations {
   String get mobileMustBeLoggedIn => 'Prijavite se za ogled te strani.';
 
   @override
+  String get mobileNbOfflinePuzzles => 'Offline puzzles';
+
+  @override
   String get mobileNewGame => 'Nova igra';
 
   @override
@@ -86,9 +89,6 @@ class AppLocalizationsSl extends AppLocalizations {
 
   @override
   String get mobileOverTheBoard => 'Proti človeku';
-
-  @override
-  String get mobileNbOfflinePuzzles => 'Offline puzzles';
 
   @override
   String mobilePlayersMatchingSearchTerm(String param) {

--- a/lib/l10n/l10n_sq.dart
+++ b/lib/l10n/l10n_sq.dart
@@ -88,6 +88,9 @@ class AppLocalizationsSq extends AppLocalizations {
   String get mobileOverTheBoard => 'Mbi tabelën';
 
   @override
+  String get mobileNbOfflinePuzzles => 'Offline puzzles';
+
+  @override
   String mobilePlayersMatchingSearchTerm(String param) {
     return 'Lojtarët me \"$param\"';
   }

--- a/lib/l10n/l10n_sq.dart
+++ b/lib/l10n/l10n_sq.dart
@@ -70,6 +70,9 @@ class AppLocalizationsSq extends AppLocalizations {
   String get mobileMustBeLoggedIn => 'Që të shihni këtë faqe, duhet të keni bërë hyrjen në llogari.';
 
   @override
+  String get mobileNbOfflinePuzzles => 'Offline puzzles';
+
+  @override
   String get mobileNewGame => 'Lojë e re';
 
   @override
@@ -86,9 +89,6 @@ class AppLocalizationsSq extends AppLocalizations {
 
   @override
   String get mobileOverTheBoard => 'Mbi tabelën';
-
-  @override
-  String get mobileNbOfflinePuzzles => 'Offline puzzles';
 
   @override
   String mobilePlayersMatchingSearchTerm(String param) {

--- a/lib/l10n/l10n_sr.dart
+++ b/lib/l10n/l10n_sr.dart
@@ -88,6 +88,9 @@ class AppLocalizationsSr extends AppLocalizations {
   String get mobileOverTheBoard => 'Преко табле';
 
   @override
+  String get mobileNbOfflinePuzzles => 'Offline puzzles';
+
+  @override
   String mobilePlayersMatchingSearchTerm(String param) {
     return 'Играчи са \"$param\"';
   }

--- a/lib/l10n/l10n_sr.dart
+++ b/lib/l10n/l10n_sr.dart
@@ -70,6 +70,9 @@ class AppLocalizationsSr extends AppLocalizations {
   String get mobileMustBeLoggedIn => 'Морате се пријавити да бисте видели ову страницу.';
 
   @override
+  String get mobileNbOfflinePuzzles => 'Offline puzzles';
+
+  @override
   String get mobileNewGame => 'New game';
 
   @override
@@ -86,9 +89,6 @@ class AppLocalizationsSr extends AppLocalizations {
 
   @override
   String get mobileOverTheBoard => 'Преко табле';
-
-  @override
-  String get mobileNbOfflinePuzzles => 'Offline puzzles';
 
   @override
   String mobilePlayersMatchingSearchTerm(String param) {

--- a/lib/l10n/l10n_sv.dart
+++ b/lib/l10n/l10n_sv.dart
@@ -88,6 +88,9 @@ class AppLocalizationsSv extends AppLocalizations {
   String get mobileOverTheBoard => 'Spela 2 på samma enhet';
 
   @override
+  String get mobileNbOfflinePuzzles => 'Offline puzzles';
+
+  @override
   String mobilePlayersMatchingSearchTerm(String param) {
     return 'Spelare med \"$param\"';
   }

--- a/lib/l10n/l10n_sv.dart
+++ b/lib/l10n/l10n_sv.dart
@@ -70,6 +70,9 @@ class AppLocalizationsSv extends AppLocalizations {
   String get mobileMustBeLoggedIn => 'Du måste vara inloggad för att se denna sida.';
 
   @override
+  String get mobileNbOfflinePuzzles => 'Offline puzzles';
+
+  @override
   String get mobileNewGame => 'New game';
 
   @override
@@ -86,9 +89,6 @@ class AppLocalizationsSv extends AppLocalizations {
 
   @override
   String get mobileOverTheBoard => 'Spela 2 på samma enhet';
-
-  @override
-  String get mobileNbOfflinePuzzles => 'Offline puzzles';
 
   @override
   String mobilePlayersMatchingSearchTerm(String param) {

--- a/lib/l10n/l10n_tr.dart
+++ b/lib/l10n/l10n_tr.dart
@@ -88,6 +88,9 @@ class AppLocalizationsTr extends AppLocalizations {
   String get mobileOverTheBoard => 'Tahta üzerinde çevrimdışı oyna';
 
   @override
+  String get mobileNbOfflinePuzzles => 'Offline puzzles';
+
+  @override
   String mobilePlayersMatchingSearchTerm(String param) {
     return '\"$param\" ile başlayan oyuncularla';
   }

--- a/lib/l10n/l10n_tr.dart
+++ b/lib/l10n/l10n_tr.dart
@@ -70,6 +70,9 @@ class AppLocalizationsTr extends AppLocalizations {
   String get mobileMustBeLoggedIn => 'Bu sayfayı görüntülemek için giriş yapmalısınız.';
 
   @override
+  String get mobileNbOfflinePuzzles => 'Offline puzzles';
+
+  @override
   String get mobileNewGame => 'Yeni oyun';
 
   @override
@@ -86,9 +89,6 @@ class AppLocalizationsTr extends AppLocalizations {
 
   @override
   String get mobileOverTheBoard => 'Tahta üzerinde çevrimdışı oyna';
-
-  @override
-  String get mobileNbOfflinePuzzles => 'Offline puzzles';
 
   @override
   String mobilePlayersMatchingSearchTerm(String param) {

--- a/lib/l10n/l10n_uk.dart
+++ b/lib/l10n/l10n_uk.dart
@@ -88,6 +88,9 @@ class AppLocalizationsUk extends AppLocalizations {
   String get mobileOverTheBoard => 'За дошкою';
 
   @override
+  String get mobileNbOfflinePuzzles => 'Offline puzzles';
+
+  @override
   String mobilePlayersMatchingSearchTerm(String param) {
     return 'Гравці з «$param»';
   }

--- a/lib/l10n/l10n_uk.dart
+++ b/lib/l10n/l10n_uk.dart
@@ -70,6 +70,9 @@ class AppLocalizationsUk extends AppLocalizations {
   String get mobileMustBeLoggedIn => 'Ви повинні ввійти, аби переглянути цю сторінку.';
 
   @override
+  String get mobileNbOfflinePuzzles => 'Offline puzzles';
+
+  @override
   String get mobileNewGame => 'Нова гра';
 
   @override
@@ -86,9 +89,6 @@ class AppLocalizationsUk extends AppLocalizations {
 
   @override
   String get mobileOverTheBoard => 'За дошкою';
-
-  @override
-  String get mobileNbOfflinePuzzles => 'Offline puzzles';
 
   @override
   String mobilePlayersMatchingSearchTerm(String param) {

--- a/lib/l10n/l10n_uz.dart
+++ b/lib/l10n/l10n_uz.dart
@@ -88,6 +88,9 @@ class AppLocalizationsUz extends AppLocalizations {
   String get mobileOverTheBoard => 'Oflayn oʻyin';
 
   @override
+  String get mobileNbOfflinePuzzles => 'Offline puzzles';
+
+  @override
   String mobilePlayersMatchingSearchTerm(String param) {
     return 'Ismida “$param” bor oʻyinchilar';
   }

--- a/lib/l10n/l10n_uz.dart
+++ b/lib/l10n/l10n_uz.dart
@@ -70,6 +70,9 @@ class AppLocalizationsUz extends AppLocalizations {
   String get mobileMustBeLoggedIn => 'Ushbu sahifani koʻrish uchun tizimga kirishingiz kerak.';
 
   @override
+  String get mobileNbOfflinePuzzles => 'Offline puzzles';
+
+  @override
   String get mobileNewGame => 'Yangi oʻyin';
 
   @override
@@ -86,9 +89,6 @@ class AppLocalizationsUz extends AppLocalizations {
 
   @override
   String get mobileOverTheBoard => 'Oflayn oʻyin';
-
-  @override
-  String get mobileNbOfflinePuzzles => 'Offline puzzles';
 
   @override
   String mobilePlayersMatchingSearchTerm(String param) {

--- a/lib/l10n/l10n_vi.dart
+++ b/lib/l10n/l10n_vi.dart
@@ -88,6 +88,9 @@ class AppLocalizationsVi extends AppLocalizations {
   String get mobileOverTheBoard => 'Trên bàn cờ';
 
   @override
+  String get mobileNbOfflinePuzzles => 'Offline puzzles';
+
+  @override
   String mobilePlayersMatchingSearchTerm(String param) {
     return 'chơi với \"$param\"';
   }

--- a/lib/l10n/l10n_vi.dart
+++ b/lib/l10n/l10n_vi.dart
@@ -70,6 +70,9 @@ class AppLocalizationsVi extends AppLocalizations {
   String get mobileMustBeLoggedIn => 'Bạn phải đăng nhập để xem trang này.';
 
   @override
+  String get mobileNbOfflinePuzzles => 'Offline puzzles';
+
+  @override
   String get mobileNewGame => 'Ván cờ mới';
 
   @override
@@ -86,9 +89,6 @@ class AppLocalizationsVi extends AppLocalizations {
 
   @override
   String get mobileOverTheBoard => 'Trên bàn cờ';
-
-  @override
-  String get mobileNbOfflinePuzzles => 'Offline puzzles';
 
   @override
   String mobilePlayersMatchingSearchTerm(String param) {

--- a/lib/l10n/l10n_zh.dart
+++ b/lib/l10n/l10n_zh.dart
@@ -88,6 +88,9 @@ class AppLocalizationsZh extends AppLocalizations {
   String get mobileOverTheBoard => '离线棋盘';
 
   @override
+  String get mobileNbOfflinePuzzles => 'Offline puzzles';
+
+  @override
   String mobilePlayersMatchingSearchTerm(String param) {
     return '用户名包含“$param”的棋手';
   }

--- a/lib/l10n/l10n_zh.dart
+++ b/lib/l10n/l10n_zh.dart
@@ -70,6 +70,9 @@ class AppLocalizationsZh extends AppLocalizations {
   String get mobileMustBeLoggedIn => '您需要登录才能浏览此页面';
 
   @override
+  String get mobileNbOfflinePuzzles => 'Offline puzzles';
+
+  @override
   String get mobileNewGame => '新的对局';
 
   @override
@@ -86,9 +89,6 @@ class AppLocalizationsZh extends AppLocalizations {
 
   @override
   String get mobileOverTheBoard => '离线棋盘';
-
-  @override
-  String get mobileNbOfflinePuzzles => 'Offline puzzles';
 
   @override
   String mobilePlayersMatchingSearchTerm(String param) {

--- a/lib/src/model/puzzle/puzzle_controller.dart
+++ b/lib/src/model/puzzle/puzzle_controller.dart
@@ -15,6 +15,7 @@ import 'package:lichess_mobile/src/model/common/uci.dart';
 import 'package:lichess_mobile/src/model/puzzle/puzzle.dart';
 import 'package:lichess_mobile/src/model/puzzle/puzzle_difficulty.dart';
 import 'package:lichess_mobile/src/model/puzzle/puzzle_preferences.dart';
+import 'package:lichess_mobile/src/model/puzzle/puzzle_queue_filler.dart';
 import 'package:lichess_mobile/src/model/puzzle/puzzle_repository.dart';
 import 'package:lichess_mobile/src/model/puzzle/puzzle_service.dart';
 import 'package:lichess_mobile/src/model/puzzle/puzzle_session.dart';
@@ -204,6 +205,15 @@ class PuzzleController extends Notifier<PuzzleState> {
     );
 
     state = state.copyWith(isChangingDifficulty: false);
+
+    // Difficulty invalidates the queue, so resetBatch only refetched one batch
+    // (capped at 50 by the server). Top the queue back up to the configured
+    // count in the background, matching the settings-change behaviour.
+    unawaited(
+      ref
+          .read(puzzleQueueFillerProvider.notifier)
+          .fill(userId: initialContext.userId, angle: initialContext.angle),
+    );
 
     return nextPuzzle;
   }

--- a/lib/src/model/puzzle/puzzle_controller.dart
+++ b/lib/src/model/puzzle/puzzle_controller.dart
@@ -40,8 +40,9 @@ class PuzzleController extends Notifier<PuzzleState> {
   Timer? _viewSolutionTimer;
   IList<PuzzleId>? _replayRemaining;
 
-  Future<PuzzleService> get _service =>
-      ref.read(puzzleServiceFactoryProvider)(queueLength: kPuzzleLocalQueueLength);
+  Future<PuzzleService> get _service => ref.read(puzzleServiceFactoryProvider)(
+    queueLength: ref.read(puzzlePreferencesProvider).nbOfflinePuzzles,
+  );
 
   @override
   PuzzleState build() {

--- a/lib/src/model/puzzle/puzzle_controller.dart
+++ b/lib/src/model/puzzle/puzzle_controller.dart
@@ -199,21 +199,30 @@ class PuzzleController extends Notifier<PuzzleState> {
 
     await ref.read(puzzlePreferencesProvider.notifier).setDifficulty(difficulty);
 
-    final nextPuzzle = (await _service).resetBatch(
+    final nextPuzzleFuture = (await _service).resetBatch(
       userId: initialContext.userId,
       angle: initialContext.angle,
     );
 
     state = state.copyWith(isChangingDifficulty: false);
 
+    // Wait for the reset to land before topping the queue back up: [resetBatch]
+    // saves a batch built from a snapshot taken before its own request, without
+    // merging, so a fill running concurrently would see its writes overwritten,
+    // and its "the queue did not grow" check would then stop it early, below
+    // the configured count.
+    final nextPuzzle = await nextPuzzleFuture;
+
     // Difficulty invalidates the queue, so resetBatch only refetched one batch
     // (capped at 50 by the server). Top the queue back up to the configured
     // count in the background, matching the settings-change behaviour.
-    unawaited(
-      ref
-          .read(puzzleQueueFillerProvider.notifier)
-          .fill(userId: initialContext.userId, angle: initialContext.angle),
-    );
+    if (ref.mounted) {
+      unawaited(
+        ref
+            .read(puzzleQueueFillerProvider.notifier)
+            .fill(userId: initialContext.userId, angle: initialContext.angle),
+      );
+    }
 
     return nextPuzzle;
   }

--- a/lib/src/model/puzzle/puzzle_controller.dart
+++ b/lib/src/model/puzzle/puzzle_controller.dart
@@ -42,7 +42,10 @@ class PuzzleController extends Notifier<PuzzleState> {
   IList<PuzzleId>? _replayRemaining;
 
   Future<PuzzleService> get _service => ref.read(puzzleServiceFactoryProvider)(
-    queueLength: ref.read(puzzlePreferencesProvider).nbOfflinePuzzles,
+    queueLength: offlineQueueLengthForAngle(
+      initialContext.angle,
+      ref.read(puzzlePreferencesProvider).nbOfflinePuzzles,
+    ),
   );
 
   @override

--- a/lib/src/model/puzzle/puzzle_preferences.dart
+++ b/lib/src/model/puzzle/puzzle_preferences.dart
@@ -34,20 +34,20 @@ class PuzzlePreferences extends Notifier<PuzzlePrefs> with SessionPreferencesSto
     return clamped == prefs.nbOfflinePuzzles ? prefs : prefs.copyWith(nbOfflinePuzzles: clamped);
   }
 
-  Future<void> setDifficulty(PuzzleDifficulty difficulty) async {
-    save(state.copyWith(difficulty: difficulty));
+  Future<void> setDifficulty(PuzzleDifficulty difficulty) {
+    return save(state.copyWith(difficulty: difficulty));
   }
 
-  Future<void> setAutoNext(bool autoNext) async {
-    save(state.copyWith(autoNext: autoNext));
+  Future<void> setAutoNext(bool autoNext) {
+    return save(state.copyWith(autoNext: autoNext));
   }
 
-  Future<void> setRated(bool rated) async {
-    save(state.copyWith(rated: rated));
+  Future<void> setRated(bool rated) {
+    return save(state.copyWith(rated: rated));
   }
 
-  Future<void> setNbOfflinePuzzles(int nbOfflinePuzzles) async {
-    save(
+  Future<void> setNbOfflinePuzzles(int nbOfflinePuzzles) {
+    return save(
       state.copyWith(
         nbOfflinePuzzles: nbOfflinePuzzles.clamp(kMinOfflinePuzzles, kMaxOfflinePuzzles),
       ),

--- a/lib/src/model/puzzle/puzzle_preferences.dart
+++ b/lib/src/model/puzzle/puzzle_preferences.dart
@@ -40,7 +40,24 @@ class PuzzlePreferences extends Notifier<PuzzlePrefs> with SessionPreferencesSto
   Future<void> setRated(bool rated) async {
     save(state.copyWith(rated: rated));
   }
+
+  Future<void> setNbOfflinePuzzles(int nbOfflinePuzzles) async {
+    save(
+      state.copyWith(
+        nbOfflinePuzzles: nbOfflinePuzzles.clamp(kMinOfflinePuzzles, kMaxOfflinePuzzles),
+      ),
+    );
+  }
 }
+
+/// Minimum number of puzzles kept in the offline queue.
+const kMinOfflinePuzzles = 50;
+
+/// Maximum number of puzzles kept in the offline queue.
+const kMaxOfflinePuzzles = 500;
+
+/// Available choices for the size of the offline puzzle queue.
+const kOfflinePuzzlesChoices = [50, 100, 150, 200, 300, 500];
 
 @Freezed(fromJson: true, toJson: true)
 sealed class PuzzlePrefs with _$PuzzlePrefs implements Serializable {
@@ -56,10 +73,19 @@ sealed class PuzzlePrefs with _$PuzzlePrefs implements Serializable {
     /// If `true`, the puzzle will be rated for logged in users.
     /// Defaults to `true`.
     @Default(true) bool rated,
+
+    /// Number of puzzles to keep downloaded in the offline queue.
+    /// Defaults to `50`.
+    @Default(50) int nbOfflinePuzzles,
   }) = _PuzzlePrefs;
 
-  factory PuzzlePrefs.defaults({UserId? id}) =>
-      PuzzlePrefs(id: id, difficulty: PuzzleDifficulty.normal, autoNext: false, rated: true);
+  factory PuzzlePrefs.defaults({UserId? id}) => PuzzlePrefs(
+    id: id,
+    difficulty: PuzzleDifficulty.normal,
+    autoNext: false,
+    rated: true,
+    nbOfflinePuzzles: 50,
+  );
 
   factory PuzzlePrefs.fromJson(Map<String, dynamic> json) => _$PuzzlePrefsFromJson(json);
 }

--- a/lib/src/model/puzzle/puzzle_preferences.dart
+++ b/lib/src/model/puzzle/puzzle_preferences.dart
@@ -26,7 +26,12 @@ class PuzzlePreferences extends Notifier<PuzzlePrefs> with SessionPreferencesSto
 
   @override
   PuzzlePrefs build() {
-    return fetch();
+    final prefs = fetch();
+    // Clamp the offline queue length loaded from storage: corrupted or
+    // manually edited prefs could otherwise bypass the bounds enforced by
+    // [setNbOfflinePuzzles] and trigger very large downloads.
+    final clamped = prefs.nbOfflinePuzzles.clamp(kMinOfflinePuzzles, kMaxOfflinePuzzles);
+    return clamped == prefs.nbOfflinePuzzles ? prefs : prefs.copyWith(nbOfflinePuzzles: clamped);
   }
 
   Future<void> setDifficulty(PuzzleDifficulty difficulty) async {

--- a/lib/src/model/puzzle/puzzle_preferences.dart
+++ b/lib/src/model/puzzle/puzzle_preferences.dart
@@ -59,10 +59,10 @@ class PuzzlePreferences extends Notifier<PuzzlePrefs> with SessionPreferencesSto
 const kMinOfflinePuzzles = 100;
 
 /// Maximum number of puzzles kept in the offline queue.
-const kMaxOfflinePuzzles = 500;
+const kMaxOfflinePuzzles = 300;
 
 /// Available choices for the size of the offline puzzle queue.
-const kOfflinePuzzlesChoices = [100, 150, 200, 300, 500];
+const kOfflinePuzzlesChoices = [100, 150, 200, 250, 300];
 
 @Freezed(fromJson: true, toJson: true)
 sealed class PuzzlePrefs with _$PuzzlePrefs implements Serializable {

--- a/lib/src/model/puzzle/puzzle_preferences.dart
+++ b/lib/src/model/puzzle/puzzle_preferences.dart
@@ -56,13 +56,13 @@ class PuzzlePreferences extends Notifier<PuzzlePrefs> with SessionPreferencesSto
 }
 
 /// Minimum number of puzzles kept in the offline queue.
-const kMinOfflinePuzzles = 50;
+const kMinOfflinePuzzles = 100;
 
 /// Maximum number of puzzles kept in the offline queue.
 const kMaxOfflinePuzzles = 500;
 
 /// Available choices for the size of the offline puzzle queue.
-const kOfflinePuzzlesChoices = [50, 100, 150, 200, 300, 500];
+const kOfflinePuzzlesChoices = [100, 150, 200, 300, 500];
 
 @Freezed(fromJson: true, toJson: true)
 sealed class PuzzlePrefs with _$PuzzlePrefs implements Serializable {
@@ -80,8 +80,8 @@ sealed class PuzzlePrefs with _$PuzzlePrefs implements Serializable {
     @Default(true) bool rated,
 
     /// Number of puzzles to keep downloaded in the offline queue.
-    /// Defaults to `50`.
-    @Default(50) int nbOfflinePuzzles,
+    /// Defaults to `100`.
+    @Default(100) int nbOfflinePuzzles,
   }) = _PuzzlePrefs;
 
   factory PuzzlePrefs.defaults({UserId? id}) => PuzzlePrefs(
@@ -89,7 +89,7 @@ sealed class PuzzlePrefs with _$PuzzlePrefs implements Serializable {
     difficulty: PuzzleDifficulty.normal,
     autoNext: false,
     rated: true,
-    nbOfflinePuzzles: 50,
+    nbOfflinePuzzles: 100,
   );
 
   factory PuzzlePrefs.fromJson(Map<String, dynamic> json) => _$PuzzlePrefsFromJson(json);

--- a/lib/src/model/puzzle/puzzle_preferences.dart
+++ b/lib/src/model/puzzle/puzzle_preferences.dart
@@ -1,7 +1,9 @@
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:freezed_annotation/freezed_annotation.dart';
 import 'package:lichess_mobile/src/model/common/id.dart';
+import 'package:lichess_mobile/src/model/puzzle/puzzle_angle.dart';
 import 'package:lichess_mobile/src/model/puzzle/puzzle_difficulty.dart';
+import 'package:lichess_mobile/src/model/puzzle/puzzle_theme.dart';
 import 'package:lichess_mobile/src/model/settings/preferences_storage.dart';
 import 'package:lichess_mobile/src/model/user/user.dart';
 
@@ -63,6 +65,17 @@ const kMaxOfflinePuzzles = 300;
 
 /// Available choices for the size of the offline puzzle queue.
 const kOfflinePuzzlesChoices = [100, 150, 200, 250, 300];
+
+/// Whether the configurable offline-queue size ([PuzzlePrefs.nbOfflinePuzzles])
+/// applies to [angle]. Where it doesn't, the queue stays at [kMinOfflinePuzzles].
+bool isConfigurableOfflineQueueAngle(PuzzleAngle angle) =>
+    angle == const PuzzleTheme(PuzzleThemeKey.mix);
+
+/// The offline-queue length for [angle]: the configurable [nbOfflinePuzzles]
+/// where [isConfigurableOfflineQueueAngle] allows it, otherwise the fixed
+/// [kMinOfflinePuzzles].
+int offlineQueueLengthForAngle(PuzzleAngle angle, int nbOfflinePuzzles) =>
+    isConfigurableOfflineQueueAngle(angle) ? nbOfflinePuzzles : kMinOfflinePuzzles;
 
 @Freezed(fromJson: true, toJson: true)
 sealed class PuzzlePrefs with _$PuzzlePrefs implements Serializable {

--- a/lib/src/model/puzzle/puzzle_providers.dart
+++ b/lib/src/model/puzzle/puzzle_providers.dart
@@ -21,9 +21,13 @@ final nextPuzzleProvider = FutureProvider.autoDispose.family<PuzzleContext?, Puz
   PuzzleAngle angle,
 ) async {
   final authUser = ref.watch(authControllerProvider);
-  final nbOfflinePuzzles = ref.watch(
-    puzzlePreferencesProvider.select((prefs) => prefs.nbOfflinePuzzles),
-  );
+  // Read, don't watch: rebuilding this provider runs a queue sync, which saves
+  // a batch built from a snapshot taken before its own request, without
+  // merging. Watching the offline queue length would make a change of that
+  // setting start such a sync at the very moment [PuzzleQueueFiller] starts
+  // filling the queue up to the new length, and the two writers would overwrite
+  // each other. The value is picked up again on the next rebuild anyway.
+  final nbOfflinePuzzles = ref.read(puzzlePreferencesProvider).nbOfflinePuzzles;
   final puzzleService = await ref.read(puzzleServiceFactoryProvider)(queueLength: nbOfflinePuzzles);
   // useful for for preview puzzle list in puzzle tab (providers in a list can
   // be invalidated multiple times when the user scrolls the list)

--- a/lib/src/model/puzzle/puzzle_providers.dart
+++ b/lib/src/model/puzzle/puzzle_providers.dart
@@ -6,6 +6,7 @@ import 'package:lichess_mobile/src/model/puzzle/puzzle.dart';
 import 'package:lichess_mobile/src/model/puzzle/puzzle_angle.dart';
 import 'package:lichess_mobile/src/model/puzzle/puzzle_batch_storage.dart';
 import 'package:lichess_mobile/src/model/puzzle/puzzle_opening.dart';
+import 'package:lichess_mobile/src/model/puzzle/puzzle_preferences.dart';
 import 'package:lichess_mobile/src/model/puzzle/puzzle_repository.dart';
 import 'package:lichess_mobile/src/model/puzzle/puzzle_service.dart';
 import 'package:lichess_mobile/src/model/puzzle/puzzle_storage.dart';
@@ -20,9 +21,10 @@ final nextPuzzleProvider = FutureProvider.autoDispose.family<PuzzleContext?, Puz
   PuzzleAngle angle,
 ) async {
   final authUser = ref.watch(authControllerProvider);
-  final puzzleService = await ref.read(puzzleServiceFactoryProvider)(
-    queueLength: kPuzzleLocalQueueLength,
+  final nbOfflinePuzzles = ref.watch(
+    puzzlePreferencesProvider.select((prefs) => prefs.nbOfflinePuzzles),
   );
+  final puzzleService = await ref.read(puzzleServiceFactoryProvider)(queueLength: nbOfflinePuzzles);
   // useful for for preview puzzle list in puzzle tab (providers in a list can
   // be invalidated multiple times when the user scrolls the list)
   ref.cacheFor(const Duration(minutes: 1));

--- a/lib/src/model/puzzle/puzzle_providers.dart
+++ b/lib/src/model/puzzle/puzzle_providers.dart
@@ -28,7 +28,9 @@ final nextPuzzleProvider = FutureProvider.autoDispose.family<PuzzleContext?, Puz
   // filling the queue up to the new length, and the two writers would overwrite
   // each other. The value is picked up again on the next rebuild anyway.
   final nbOfflinePuzzles = ref.read(puzzlePreferencesProvider).nbOfflinePuzzles;
-  final puzzleService = await ref.read(puzzleServiceFactoryProvider)(queueLength: nbOfflinePuzzles);
+  final puzzleService = await ref.read(puzzleServiceFactoryProvider)(
+    queueLength: offlineQueueLengthForAngle(angle, nbOfflinePuzzles),
+  );
   // useful for for preview puzzle list in puzzle tab (providers in a list can
   // be invalidated multiple times when the user scrolls the list)
   ref.cacheFor(const Duration(minutes: 1));

--- a/lib/src/model/puzzle/puzzle_queue_filler.dart
+++ b/lib/src/model/puzzle/puzzle_queue_filler.dart
@@ -39,14 +39,20 @@ class PuzzleQueueFiller extends Notifier<bool> {
   /// This is a one-time, select-only action triggered when the offline puzzle
   /// count or the difficulty changes. It never submits solves, so it can't race
   /// with the solve/sync path over the stored `solved` list. Re-reads storage
-  /// on every pass and merges by puzzle id so a solve made while the fill runs
-  /// is never clobbered. Guarded by [state] so overlapping calls can't
-  /// double-fetch. Never throws: network and storage failures stop the fill.
+  /// *after* each network request and merges by puzzle id, so a solve made
+  /// while a request is in flight is never clobbered. Guarded by [state] so
+  /// overlapping calls can't double-fetch. No-op for anonymous users: the
+  /// configurable queue length is a logged-in-only feature. Never throws:
+  /// network and storage failures stop the fill.
   Future<void> fill({
     required UserId? userId,
     PuzzleAngle angle = const PuzzleTheme(PuzzleThemeKey.mix),
     @visibleForTesting int? queueLengthOverride,
   }) async {
+    // The larger offline queue is a logged-in-only feature: anonymous players
+    // face a much higher server rate limit for fetching puzzles, so the fill is
+    // a no-op for them.
+    if (userId == null) return;
     if (state) return;
     state = true;
     try {
@@ -87,9 +93,16 @@ class PuzzleQueueFiller extends Notifier<bool> {
         // unreachable `queueLength`.
         if (response.puzzles.isEmpty) break;
 
-        // Skip ids already stored so a re-read after a mid-fill solve can't
-        // reintroduce a duplicate.
-        final existingIds = unsolved.map((p) => p.puzzle.id).toISet();
+        // Re-read storage AFTER the network round-trip: a solve made while the
+        // request was in flight moves a puzzle unsolved->solved on this same
+        // row. Merging into the pre-request snapshot would restore it to
+        // unsolved and drop its solution. Merge into the fresh read instead.
+        final fresh = await batchStorage.fetch(userId: userId, angle: angle);
+        final freshUnsolved = fresh?.unsolved ?? IList(const []);
+
+        // Skip ids already stored (in the fresh read) so a re-read after a
+        // mid-fill solve can't reintroduce a duplicate.
+        final existingIds = freshUnsolved.map((p) => p.puzzle.id).toISet();
         final additions = response.puzzles.where((p) => !existingIds.contains(p.puzzle.id));
         if (additions.isEmpty) break;
 
@@ -97,8 +110,8 @@ class PuzzleQueueFiller extends Notifier<bool> {
           userId: userId,
           angle: angle,
           data: PuzzleBatch(
-            solved: current?.solved ?? IList(const []),
-            unsolved: IList([...unsolved, ...additions]),
+            solved: fresh?.solved ?? IList(const []),
+            unsolved: IList([...freshUnsolved, ...additions]),
           ),
         );
       }

--- a/lib/src/model/puzzle/puzzle_queue_filler.dart
+++ b/lib/src/model/puzzle/puzzle_queue_filler.dart
@@ -1,0 +1,109 @@
+import 'dart:math' show max;
+
+import 'package:fast_immutable_collections/fast_immutable_collections.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:lichess_mobile/src/model/common/id.dart';
+import 'package:lichess_mobile/src/model/puzzle/puzzle_angle.dart';
+import 'package:lichess_mobile/src/model/puzzle/puzzle_batch_storage.dart';
+import 'package:lichess_mobile/src/model/puzzle/puzzle_preferences.dart';
+import 'package:lichess_mobile/src/model/puzzle/puzzle_repository.dart';
+import 'package:lichess_mobile/src/model/puzzle/puzzle_theme.dart';
+import 'package:lichess_mobile/src/network/http.dart';
+import 'package:logging/logging.dart';
+import 'package:meta/meta.dart';
+
+/// The server caps each batch request at 50 puzzles regardless of the requested
+/// `nb` (`nb.atMost(50)` in lila's `Puzzle` controller), so a queue larger than
+/// this is filled with several sequential requests, each asking for the current
+/// deficit and receiving at most 50.
+
+/// Whether a one-time offline-queue fill is currently running.
+///
+/// This is a top-level (stable) provider, not per-[PuzzleService] state, so the
+/// single-flight guard actually holds: the puzzle service factory builds a fresh
+/// service on every read, but this notifier is a single instance.
+final puzzleQueueFillerProvider = NotifierProvider<PuzzleQueueFiller, bool>(
+  PuzzleQueueFiller.new,
+  name: 'PuzzleQueueFillerProvider',
+);
+
+class PuzzleQueueFiller extends Notifier<bool> {
+  final Logger _log = Logger('PuzzleQueueFiller');
+
+  @override
+  bool build() => false;
+
+  /// Fills the offline queue for [angle] up to the configured
+  /// `nbOfflinePuzzles`, one server batch at a time.
+  ///
+  /// This is a one-time, select-only action triggered when the offline puzzle
+  /// count or the difficulty changes. It never submits solves, so it can't race
+  /// with the solve/sync path over the stored `solved` list. Re-reads storage
+  /// on every pass and merges by puzzle id so a solve made while the fill runs
+  /// is never clobbered. Guarded by [state] so overlapping calls can't
+  /// double-fetch. Never throws: network and storage failures stop the fill.
+  Future<void> fill({
+    required UserId? userId,
+    PuzzleAngle angle = const PuzzleTheme(PuzzleThemeKey.mix),
+    @visibleForTesting int? queueLengthOverride,
+  }) async {
+    if (state) return;
+    state = true;
+    try {
+      final queueLength =
+          queueLengthOverride ?? ref.read(puzzlePreferencesProvider).nbOfflinePuzzles;
+      final difficulty = ref.read(puzzlePreferencesProvider).difficulty;
+      final batchStorage = await ref.read(puzzleBatchStorageProvider.future);
+
+      // Tracks the stored queue length across passes. Stop when a pass fails to
+      // grow the queue (server exhausted or a silent no-op write), not when it
+      // shrinks: a solve made mid-fill lowers the count and legitimately widens
+      // the deficit, so that pass should still top up.
+      int lastLength = -1;
+      while (true) {
+        final current = await batchStorage.fetch(userId: userId, angle: angle);
+        final unsolved = current?.unsolved ?? IList(const []);
+
+        if (unsolved.length == lastLength) break;
+        lastLength = unsolved.length;
+
+        final deficit = max(0, queueLength - unsolved.length);
+        if (deficit <= 0) break;
+
+        final PuzzleBatchResponse response;
+        try {
+          response = await ref.withClient(
+            (client) => PuzzleRepository(
+              client,
+            ).selectBatch(nb: deficit, angle: angle, difficulty: difficulty),
+          );
+        } catch (e, st) {
+          // Offline or server error: stop the fill, keep what we have.
+          _log.warning('Offline puzzle queue fill failed', e, st);
+          break;
+        }
+
+        // Server has no more puzzles: stop rather than spin forever below an
+        // unreachable `queueLength`.
+        if (response.puzzles.isEmpty) break;
+
+        // Skip ids already stored so a re-read after a mid-fill solve can't
+        // reintroduce a duplicate.
+        final existingIds = unsolved.map((p) => p.puzzle.id).toISet();
+        final additions = response.puzzles.where((p) => !existingIds.contains(p.puzzle.id));
+        if (additions.isEmpty) break;
+
+        await batchStorage.save(
+          userId: userId,
+          angle: angle,
+          data: PuzzleBatch(
+            solved: current?.solved ?? IList(const []),
+            unsolved: IList([...unsolved, ...additions]),
+          ),
+        );
+      }
+    } finally {
+      state = false;
+    }
+  }
+}

--- a/lib/src/model/puzzle/puzzle_queue_filler.dart
+++ b/lib/src/model/puzzle/puzzle_queue_filler.dart
@@ -67,7 +67,14 @@ class PuzzleQueueFiller extends Notifier<bool> {
       // the deficit, so that pass should still top up.
       int lastLength = -1;
       while (true) {
-        final current = await batchStorage.fetch(userId: userId, angle: angle);
+        final PuzzleBatch? current;
+        try {
+          current = await batchStorage.fetch(userId: userId, angle: angle);
+        } catch (e, st) {
+          // Corrupted prefs, decode error, or sqflite failure: stop the fill.
+          _log.warning('Offline puzzle queue fill: storage read failed', e, st);
+          break;
+        }
         final unsolved = current?.unsolved ?? IList(const []);
 
         if (unsolved.length == lastLength) break;
@@ -97,23 +104,30 @@ class PuzzleQueueFiller extends Notifier<bool> {
         // request was in flight moves a puzzle unsolved->solved on this same
         // row. Merging into the pre-request snapshot would restore it to
         // unsolved and drop its solution. Merge into the fresh read instead.
-        final fresh = await batchStorage.fetch(userId: userId, angle: angle);
-        final freshUnsolved = fresh?.unsolved ?? IList(const []);
+        try {
+          final fresh = await batchStorage.fetch(userId: userId, angle: angle);
+          final freshUnsolved = fresh?.unsolved ?? IList(const []);
 
-        // Skip ids already stored (in the fresh read) so a re-read after a
-        // mid-fill solve can't reintroduce a duplicate.
-        final existingIds = freshUnsolved.map((p) => p.puzzle.id).toISet();
-        final additions = response.puzzles.where((p) => !existingIds.contains(p.puzzle.id));
-        if (additions.isEmpty) break;
+          // Skip ids already stored (in the fresh read) so a re-read after a
+          // mid-fill solve can't reintroduce a duplicate.
+          final existingIds = freshUnsolved.map((p) => p.puzzle.id).toISet();
+          final additions = response.puzzles.where((p) => !existingIds.contains(p.puzzle.id));
+          if (additions.isEmpty) break;
 
-        await batchStorage.save(
-          userId: userId,
-          angle: angle,
-          data: PuzzleBatch(
-            solved: fresh?.solved ?? IList(const []),
-            unsolved: IList([...freshUnsolved, ...additions]),
-          ),
-        );
+          await batchStorage.save(
+            userId: userId,
+            angle: angle,
+            data: PuzzleBatch(
+              solved: fresh?.solved ?? IList(const []),
+              unsolved: IList([...freshUnsolved, ...additions]),
+            ),
+          );
+        } catch (e, st) {
+          // sqflite I/O or serialization failure on the merge read/write:
+          // stop the fill rather than surface an unhandled async error.
+          _log.warning('Offline puzzle queue fill: storage write failed', e, st);
+          break;
+        }
       }
     } finally {
       state = false;

--- a/lib/src/model/puzzle/puzzle_queue_filler.dart
+++ b/lib/src/model/puzzle/puzzle_queue_filler.dart
@@ -56,8 +56,9 @@ class PuzzleQueueFiller extends Notifier<bool> {
     if (state) return;
     state = true;
     try {
-      final queueLength =
+      final configured =
           queueLengthOverride ?? ref.read(puzzlePreferencesProvider).nbOfflinePuzzles;
+      final queueLength = offlineQueueLengthForAngle(angle, configured);
       final difficulty = ref.read(puzzlePreferencesProvider).difficulty;
       final batchStorage = await ref.read(puzzleBatchStorageProvider.future);
 

--- a/lib/src/model/puzzle/puzzle_queue_filler.dart
+++ b/lib/src/model/puzzle/puzzle_queue_filler.dart
@@ -17,11 +17,7 @@ import 'package:meta/meta.dart';
 /// this is filled with several sequential requests, each asking for the current
 /// deficit and receiving at most 50.
 
-/// Whether a one-time offline-queue fill is currently running.
-///
-/// This is a top-level (stable) provider, not per-[PuzzleService] state, so the
-/// single-flight guard actually holds: the puzzle service factory builds a fresh
-/// service on every read, but this notifier is a single instance.
+/// Whether a one-time offline-queue background fill is currently running.
 final puzzleQueueFillerProvider = NotifierProvider<PuzzleQueueFiller, bool>(
   PuzzleQueueFiller.new,
   name: 'PuzzleQueueFillerProvider',

--- a/lib/src/model/puzzle/puzzle_queue_filler.dart
+++ b/lib/src/model/puzzle/puzzle_queue_filler.dart
@@ -16,6 +16,10 @@ import 'package:logging/logging.dart';
 /// this is filled with several sequential requests, each asking for the current
 /// deficit and receiving at most 50.
 
+/// Delay between successive fill requests, to spread the burst rather than fire
+/// it all at the server at once.
+const _kFillRequestDelay = Duration(milliseconds: 200);
+
 /// Whether a one-time offline-queue background fill is currently running.
 final puzzleQueueFillerProvider = NotifierProvider<PuzzleQueueFiller, bool>(
   PuzzleQueueFiller.new,
@@ -60,6 +64,7 @@ class PuzzleQueueFiller extends Notifier<bool> {
       // shrinks: a solve made mid-fill lowers the count and legitimately widens
       // the deficit, so that pass should still top up.
       int lastLength = -1;
+      bool isFirstRequest = true;
       while (true) {
         final PuzzleBatch? current;
         try {
@@ -82,6 +87,12 @@ class PuzzleQueueFiller extends Notifier<bool> {
 
         final deficit = max(0, queueLength - unsolved.length);
         if (deficit <= 0) break;
+
+        // Throttle: space out successive requests (no delay before the first).
+        if (!isFirstRequest) {
+          await Future<void>.delayed(_kFillRequestDelay);
+        }
+        isFirstRequest = false;
 
         final PuzzleBatchResponse response;
         try {

--- a/lib/src/model/puzzle/puzzle_queue_filler.dart
+++ b/lib/src/model/puzzle/puzzle_queue_filler.dart
@@ -10,7 +10,6 @@ import 'package:lichess_mobile/src/model/puzzle/puzzle_repository.dart';
 import 'package:lichess_mobile/src/model/puzzle/puzzle_theme.dart';
 import 'package:lichess_mobile/src/network/http.dart';
 import 'package:logging/logging.dart';
-import 'package:meta/meta.dart';
 
 /// The server caps each batch request at 50 puzzles regardless of the requested
 /// `nb` (`nb.atMost(50)` in lila's `Puzzle` controller), so a queue larger than
@@ -43,7 +42,6 @@ class PuzzleQueueFiller extends Notifier<bool> {
   Future<void> fill({
     required UserId? userId,
     PuzzleAngle angle = const PuzzleTheme(PuzzleThemeKey.mix),
-    @visibleForTesting int? queueLengthOverride,
   }) async {
     // The larger offline queue is a logged-in-only feature: anonymous players
     // face a much higher server rate limit for fetching puzzles, so the fill is
@@ -52,8 +50,7 @@ class PuzzleQueueFiller extends Notifier<bool> {
     if (state) return;
     state = true;
     try {
-      final configured =
-          queueLengthOverride ?? ref.read(puzzlePreferencesProvider).nbOfflinePuzzles;
+      final configured = ref.read(puzzlePreferencesProvider).nbOfflinePuzzles;
       final queueLength = offlineQueueLengthForAngle(angle, configured);
       final difficulty = ref.read(puzzlePreferencesProvider).difficulty;
       final batchStorage = await ref.read(puzzleBatchStorageProvider.future);

--- a/lib/src/model/puzzle/puzzle_queue_filler.dart
+++ b/lib/src/model/puzzle/puzzle_queue_filler.dart
@@ -78,6 +78,12 @@ class PuzzleQueueFiller extends Notifier<bool> {
         }
         final unsolved = current?.unsolved ?? IList(const []);
 
+        // Don't grow the unsolved queue while there are solves we still owe the
+        // server: fetching more only enlarges a backlog we can't flush yet.
+        // Solving is the binding constraint (lila caps solves at 400/h, far
+        // tighter than puzzle fetching), so nothing else throttles this refill.
+        if (current != null && current.solved.isNotEmpty) break;
+
         if (unsolved.length == lastLength) break;
         lastLength = unsolved.length;
 

--- a/lib/src/model/puzzle/puzzle_service.dart
+++ b/lib/src/model/puzzle/puzzle_service.dart
@@ -18,12 +18,16 @@ import 'package:result_extensions/result_extensions.dart';
 
 part 'puzzle_service.freezed.dart';
 
-/// Size of puzzle local cache
+/// Default size of puzzle local cache. Used as a fallback; the effective
+/// queue length is user-configurable via [PuzzlePrefs.nbOfflinePuzzles].
 const kPuzzleLocalQueueLength = 50;
 
 /// A provider for [PuzzleService].
 final puzzleServiceProvider = FutureProvider<PuzzleService>((Ref ref) {
-  return ref.read(puzzleServiceFactoryProvider)(queueLength: kPuzzleLocalQueueLength);
+  final nbOfflinePuzzles = ref.watch(
+    puzzlePreferencesProvider.select((prefs) => prefs.nbOfflinePuzzles),
+  );
+  return ref.read(puzzleServiceFactoryProvider)(queueLength: nbOfflinePuzzles);
 }, name: 'PuzzleServiceProvider');
 
 /// A provider for [PuzzleServiceFactory].

--- a/lib/src/model/puzzle/puzzle_service.dart
+++ b/lib/src/model/puzzle/puzzle_service.dart
@@ -1,3 +1,4 @@
+import 'dart:async' show unawaited;
 import 'dart:math' show max;
 
 import 'package:async/async.dart';
@@ -8,6 +9,7 @@ import 'package:lichess_mobile/src/model/common/id.dart';
 import 'package:lichess_mobile/src/model/puzzle/puzzle.dart';
 import 'package:lichess_mobile/src/model/puzzle/puzzle_angle.dart';
 import 'package:lichess_mobile/src/model/puzzle/puzzle_batch_storage.dart';
+import 'package:lichess_mobile/src/model/puzzle/puzzle_difficulty.dart';
 import 'package:lichess_mobile/src/model/puzzle/puzzle_preferences.dart';
 import 'package:lichess_mobile/src/model/puzzle/puzzle_repository.dart';
 import 'package:lichess_mobile/src/model/puzzle/puzzle_storage.dart';
@@ -82,6 +84,10 @@ class PuzzleService {
   final PuzzleStorage puzzleStorage;
   final Logger _log = Logger('PuzzleService');
 
+  /// Guards [_backgroundFill] against overlapping runs issuing duplicate
+  /// requests.
+  bool _isFilling = false;
+
   /// Loads the next puzzle from database and the glicko rating if available.
   ///
   /// Will sync with server if necessary.
@@ -145,9 +151,10 @@ class PuzzleService {
 
   /// Synchronize offline puzzle queue with server and gets latest data.
   ///
-  /// This task will fetch missing puzzles so the queue length is always equal to
-  /// `queueLength`.
-  /// It will call [PuzzleRepository.solveBatch] if necessary.
+  /// Does a single request so the next puzzle is available without blocking.
+  /// A large offline queue can't be filled in one call (the server caps each
+  /// batch at 50), so any remaining deficit is filled by [_backgroundFill]
+  /// rather than making the user wait.
   ///
   /// This method should never fail, as if the network is down it will fallback
   /// to the local database.
@@ -162,48 +169,114 @@ class PuzzleService {
 
     final deficit = max(0, queueLength - unsolved.length);
 
-    if (deficit > 0 || solved.isNotEmpty) {
-      _log.fine('Will sync puzzles with lichess (deficit: $deficit, solved: ${solved.length})');
-
-      final difficulty = _ref.read(puzzlePreferencesProvider).difficulty;
-
-      // anonymous users can't solve puzzles so we just download the deficit
-      final batchResponse = _ref.withClient(
-        (client) => Result.capture(
-          solved.isNotEmpty && userId != null
-              ? PuzzleRepository(
-                  client,
-                ).solveBatch(nb: deficit, solved: solved, angle: angle, difficulty: difficulty)
-              : PuzzleRepository(
-                  client,
-                ).selectBatch(nb: deficit, angle: angle, difficulty: difficulty),
-        ),
-      );
-
-      return batchResponse
-          .fold(
-            (value) => Result.value((
-              PuzzleBatch(
-                solved: IList(const []),
-                unsolved: IList([...unsolved, ...value.puzzles]),
-              ),
-              value.glicko,
-              value.rounds,
-              true, // should save the batch
-            )),
-
-            // we don't need to save the batch if the request failed
-            (_, _) => Result.value((data, null, null, false)),
-          )
-          .flatMap((tuple) async {
-            final (newBatch, glicko, rounds, shouldSave) = tuple;
-            if (newBatch != null && shouldSave) {
-              await batchStorage.save(userId: userId, angle: angle, data: newBatch);
-            }
-            return Result.value((newBatch, glicko, rounds));
-          });
+    if (deficit <= 0 && solved.isEmpty) {
+      return Result.value((data, null, null));
     }
 
-    return Result.value((data, null, null));
+    final difficulty = _ref.read(puzzlePreferencesProvider).difficulty;
+
+    // One request keeps the next puzzle responsive; the rest fills in the
+    // background.
+    final batchResult = await _fetchBatch(
+      userId: userId,
+      angle: angle,
+      difficulty: difficulty,
+      nb: deficit,
+      solved: solved,
+    );
+
+    if (batchResult.isError) {
+      // Offline: fall back to the local database.
+      return Result.value((data, null, null));
+    }
+
+    final value = batchResult.asValue!.value;
+    final newBatch = PuzzleBatch(
+      solved: IList(const []),
+      unsolved: IList([...unsolved, ...value.puzzles]),
+    );
+    await batchStorage.save(userId: userId, angle: angle, data: newBatch);
+
+    // Fill the rest without blocking so a large queue is cached before the
+    // user goes offline.
+    if (value.puzzles.isNotEmpty && newBatch.unsolved.length < queueLength) {
+      unawaited(_backgroundFill(userId, angle, difficulty));
+    }
+
+    return Result.value((newBatch, value.glicko, value.rounds));
+  }
+
+  /// Downloads a single batch, submitting [solved] if there is anything to
+  /// report (and the user is logged in), otherwise just fetching new puzzles.
+  FutureResult<PuzzleBatchResponse> _fetchBatch({
+    required UserId? userId,
+    required PuzzleAngle angle,
+    required PuzzleDifficulty difficulty,
+    required int nb,
+    IList<PuzzleSolution> solved = const IListConst([]),
+  }) {
+    _log.fine('Will sync puzzles with lichess (nb: $nb, solved: ${solved.length})');
+    // anonymous users can't solve puzzles so we just download the deficit.
+    return _ref.withClient(
+      (client) => Result.capture(
+        solved.isNotEmpty && userId != null
+            ? PuzzleRepository(
+                client,
+              ).solveBatch(nb: nb, solved: solved, angle: angle, difficulty: difficulty)
+            : PuzzleRepository(client).selectBatch(nb: nb, angle: angle, difficulty: difficulty),
+      ),
+    );
+  }
+
+  /// Tops up the offline queue to `queueLength` in the background.
+  ///
+  /// Re-reads storage each pass and merges by puzzle id so a solve made while
+  /// the fill runs is never clobbered. Guarded by [_isFilling] so overlapping
+  /// calls can't double-fetch.
+  Future<void> _backgroundFill(
+    UserId? userId,
+    PuzzleAngle angle,
+    PuzzleDifficulty difficulty,
+  ) async {
+    if (_isFilling) return;
+    _isFilling = true;
+    try {
+      while (true) {
+        final current = await batchStorage.fetch(userId: userId, angle: angle);
+        final unsolved = current?.unsolved ?? IList(const []);
+        final deficit = max(0, queueLength - unsolved.length);
+        if (deficit <= 0) break;
+
+        final batchResult = await _fetchBatch(
+          userId: userId,
+          angle: angle,
+          difficulty: difficulty,
+          nb: deficit,
+        );
+        if (batchResult.isError) break;
+
+        final value = batchResult.asValue!.value;
+        // Server has no more puzzles: stop rather than spin forever below
+        // an unreachable `queueLength`.
+        if (value.puzzles.isEmpty) break;
+
+        // Skip ids already stored so a re-read after a mid-fill solve can't
+        // reintroduce a duplicate.
+        final existingIds = unsolved.map((p) => p.puzzle.id).toISet();
+        final additions = value.puzzles.where((p) => !existingIds.contains(p.puzzle.id));
+        if (additions.isEmpty) break;
+
+        await batchStorage.save(
+          userId: userId,
+          angle: angle,
+          data: PuzzleBatch(
+            solved: current?.solved ?? IList(const []),
+            unsolved: IList([...unsolved, ...additions]),
+          ),
+        );
+      }
+    } finally {
+      _isFilling = false;
+    }
   }
 }

--- a/lib/src/model/puzzle/puzzle_service.dart
+++ b/lib/src/model/puzzle/puzzle_service.dart
@@ -1,4 +1,3 @@
-import 'dart:async' show unawaited;
 import 'dart:math' show max;
 
 import 'package:async/async.dart';
@@ -9,7 +8,6 @@ import 'package:lichess_mobile/src/model/common/id.dart';
 import 'package:lichess_mobile/src/model/puzzle/puzzle.dart';
 import 'package:lichess_mobile/src/model/puzzle/puzzle_angle.dart';
 import 'package:lichess_mobile/src/model/puzzle/puzzle_batch_storage.dart';
-import 'package:lichess_mobile/src/model/puzzle/puzzle_difficulty.dart';
 import 'package:lichess_mobile/src/model/puzzle/puzzle_preferences.dart';
 import 'package:lichess_mobile/src/model/puzzle/puzzle_repository.dart';
 import 'package:lichess_mobile/src/model/puzzle/puzzle_storage.dart';
@@ -19,12 +17,6 @@ import 'package:logging/logging.dart';
 import 'package:result_extensions/result_extensions.dart';
 
 part 'puzzle_service.freezed.dart';
-
-/// The server caps each batch request at 50 puzzles regardless of the
-/// requested `nb` (`nb.atMost(50)` in lila's `Puzzle` controller). A deficit
-/// larger than this can't be filled in a single request, so the remainder is
-/// topped up sequentially in the background.
-const _kServerBatchCap = 50;
 
 /// A provider for [PuzzleService].
 final puzzleServiceProvider = FutureProvider<PuzzleService>((Ref ref) {
@@ -44,16 +36,12 @@ class PuzzleServiceFactory {
 
   final Ref _ref;
 
-  Future<PuzzleService> call({
-    required int queueLength,
-    int serverBatchCap = _kServerBatchCap,
-  }) async {
+  Future<PuzzleService> call({required int queueLength}) async {
     return PuzzleService(
       _ref,
       batchStorage: await _ref.read(puzzleBatchStorageProvider.future),
       puzzleStorage: await _ref.read(puzzleStorageProvider.future),
       queueLength: queueLength,
-      serverBatchCap: serverBatchCap,
     );
   }
 }
@@ -86,22 +74,13 @@ class PuzzleService {
     required this.batchStorage,
     required this.puzzleStorage,
     required this.queueLength,
-    this.serverBatchCap = _kServerBatchCap,
   });
 
   final Ref _ref;
   final int queueLength;
-
-  /// Max puzzles the server returns per batch request. Injectable so tests can
-  /// exercise the background-fill loop with a small simulated cap.
-  final int serverBatchCap;
   final PuzzleBatchStorage batchStorage;
   final PuzzleStorage puzzleStorage;
   final Logger _log = Logger('PuzzleService');
-
-  /// Guards [_backgroundFill] against overlapping runs issuing duplicate
-  /// requests.
-  bool _isFilling = false;
 
   /// Loads the next puzzle from database and the glicko rating if available.
   ///
@@ -166,10 +145,9 @@ class PuzzleService {
 
   /// Synchronize offline puzzle queue with server and gets latest data.
   ///
-  /// Does a single request so the next puzzle is available without blocking.
-  /// A large offline queue can't be filled in one call (the server caps each
-  /// batch at 50), so any remaining deficit is filled by [_backgroundFill]
-  /// rather than making the user wait.
+  /// This task will fetch missing puzzles so the queue length is always equal to
+  /// `queueLength`.
+  /// It will call [PuzzleRepository.solveBatch] if necessary.
   ///
   /// This method should never fail, as if the network is down it will fallback
   /// to the local database.
@@ -184,129 +162,48 @@ class PuzzleService {
 
     final deficit = max(0, queueLength - unsolved.length);
 
-    if (deficit <= 0 && solved.isEmpty) {
-      return Result.value((data, null, null));
-    }
+    if (deficit > 0 || solved.isNotEmpty) {
+      _log.fine('Will sync puzzles with lichess (deficit: $deficit, solved: ${solved.length})');
 
-    final difficulty = _ref.read(puzzlePreferencesProvider).difficulty;
+      final difficulty = _ref.read(puzzlePreferencesProvider).difficulty;
 
-    // One request keeps the next puzzle responsive; the rest fills in the
-    // background.
-    final batchResult = await _fetchBatch(
-      userId: userId,
-      angle: angle,
-      difficulty: difficulty,
-      nb: deficit,
-      solved: solved,
-    );
-
-    if (batchResult.isError) {
-      // Offline: fall back to the local database.
-      return Result.value((data, null, null));
-    }
-
-    final value = batchResult.asValue!.value;
-    final newBatch = PuzzleBatch(
-      solved: IList(const []),
-      unsolved: IList([...unsolved, ...value.puzzles]),
-    );
-    await batchStorage.save(userId: userId, angle: angle, data: newBatch);
-
-    // A single fetch returns at most one server batch (capped at 50). If it
-    // came back cap-sized the server likely truncated a larger deficit, so top
-    // up the remainder in the background; a short batch already satisfied the
-    // deficit (or exhausted the server), so there is nothing left to fetch.
-    if (value.puzzles.length >= serverBatchCap && newBatch.unsolved.length < queueLength) {
-      unawaited(
-        _backgroundFill(userId, angle, difficulty).catchError((Object e, StackTrace st) {
-          // Fire-and-forget: swallow so a background fill failure (e.g. storage
-          // I/O) never surfaces as an unhandled async error.
-          _log.warning('Background puzzle fill failed', e, st);
-        }),
+      // anonymous users can't solve puzzles so we just download the deficit
+      final batchResponse = _ref.withClient(
+        (client) => Result.capture(
+          solved.isNotEmpty && userId != null
+              ? PuzzleRepository(
+                  client,
+                ).solveBatch(nb: deficit, solved: solved, angle: angle, difficulty: difficulty)
+              : PuzzleRepository(
+                  client,
+                ).selectBatch(nb: deficit, angle: angle, difficulty: difficulty),
+        ),
       );
+
+      return batchResponse
+          .fold(
+            (value) => Result.value((
+              PuzzleBatch(
+                solved: IList(const []),
+                unsolved: IList([...unsolved, ...value.puzzles]),
+              ),
+              value.glicko,
+              value.rounds,
+              true, // should save the batch
+            )),
+
+            // we don't need to save the batch if the request failed
+            (_, _) => Result.value((data, null, null, false)),
+          )
+          .flatMap((tuple) async {
+            final (newBatch, glicko, rounds, shouldSave) = tuple;
+            if (newBatch != null && shouldSave) {
+              await batchStorage.save(userId: userId, angle: angle, data: newBatch);
+            }
+            return Result.value((newBatch, glicko, rounds));
+          });
     }
 
-    return Result.value((newBatch, value.glicko, value.rounds));
-  }
-
-  /// Downloads a single batch, submitting [solved] if there is anything to
-  /// report (and the user is logged in), otherwise just fetching new puzzles.
-  FutureResult<PuzzleBatchResponse> _fetchBatch({
-    required UserId? userId,
-    required PuzzleAngle angle,
-    required PuzzleDifficulty difficulty,
-    required int nb,
-    IList<PuzzleSolution> solved = const IListConst([]),
-  }) {
-    _log.fine('Will sync puzzles with lichess (nb: $nb, solved: ${solved.length})');
-    // anonymous users can't solve puzzles so we just download the deficit.
-    return _ref.withClient(
-      (client) => Result.capture(
-        solved.isNotEmpty && userId != null
-            ? PuzzleRepository(
-                client,
-              ).solveBatch(nb: nb, solved: solved, angle: angle, difficulty: difficulty)
-            : PuzzleRepository(client).selectBatch(nb: nb, angle: angle, difficulty: difficulty),
-      ),
-    );
-  }
-
-  /// Tops up the offline queue to `queueLength` in the background.
-  ///
-  /// Re-reads storage each pass and merges by puzzle id so a solve made while
-  /// the fill runs is never clobbered. Guarded by [_isFilling] so overlapping
-  /// calls can't double-fetch.
-  Future<void> _backgroundFill(
-    UserId? userId,
-    PuzzleAngle angle,
-    PuzzleDifficulty difficulty,
-  ) async {
-    if (_isFilling) return;
-    _isFilling = true;
-    try {
-      // Tracks the stored queue length across passes. Stop only when a pass
-      // fails to grow the queue (e.g. the write silently no-ops), not when it
-      // shrinks: a solve made mid-fill lowers the count and legitimately
-      // widens the deficit, so that pass should still top up.
-      int lastLength = -1;
-      while (true) {
-        final current = await batchStorage.fetch(userId: userId, angle: angle);
-        final unsolved = current?.unsolved ?? IList(const []);
-        if (unsolved.length == lastLength) break;
-        lastLength = unsolved.length;
-        final deficit = max(0, queueLength - unsolved.length);
-        if (deficit <= 0) break;
-
-        final batchResult = await _fetchBatch(
-          userId: userId,
-          angle: angle,
-          difficulty: difficulty,
-          nb: deficit,
-        );
-        if (batchResult.isError) break;
-
-        final value = batchResult.asValue!.value;
-        // Server has no more puzzles: stop rather than spin forever below
-        // an unreachable `queueLength`.
-        if (value.puzzles.isEmpty) break;
-
-        // Skip ids already stored so a re-read after a mid-fill solve can't
-        // reintroduce a duplicate.
-        final existingIds = unsolved.map((p) => p.puzzle.id).toISet();
-        final additions = value.puzzles.where((p) => !existingIds.contains(p.puzzle.id));
-        if (additions.isEmpty) break;
-
-        await batchStorage.save(
-          userId: userId,
-          angle: angle,
-          data: PuzzleBatch(
-            solved: current?.solved ?? IList(const []),
-            unsolved: IList([...unsolved, ...additions]),
-          ),
-        );
-      }
-    } finally {
-      _isFilling = false;
-    }
+    return Result.value((data, null, null));
   }
 }

--- a/lib/src/model/puzzle/puzzle_service.dart
+++ b/lib/src/model/puzzle/puzzle_service.dart
@@ -18,10 +18,6 @@ import 'package:result_extensions/result_extensions.dart';
 
 part 'puzzle_service.freezed.dart';
 
-/// Default size of puzzle local cache. Used as a fallback; the effective
-/// queue length is user-configurable via [PuzzlePrefs.nbOfflinePuzzles].
-const kPuzzleLocalQueueLength = 50;
-
 /// A provider for [PuzzleService].
 final puzzleServiceProvider = FutureProvider<PuzzleService>((Ref ref) {
   final nbOfflinePuzzles = ref.watch(

--- a/lib/src/model/puzzle/puzzle_service.dart
+++ b/lib/src/model/puzzle/puzzle_service.dart
@@ -212,11 +212,18 @@ class PuzzleService {
     );
     await batchStorage.save(userId: userId, angle: angle, data: newBatch);
 
-    // The server caps each batch at 50, so a single fetch already covers any
-    // deficit up to that cap. Only spin up a background fill when the remaining
-    // deficit still exceeds one batch (i.e. the user raised the offline limit).
-    if (value.puzzles.isNotEmpty && queueLength - newBatch.unsolved.length >= serverBatchCap) {
-      unawaited(_backgroundFill(userId, angle, difficulty));
+    // A single fetch returns at most one server batch (capped at 50). If it
+    // came back cap-sized the server likely truncated a larger deficit, so top
+    // up the remainder in the background; a short batch already satisfied the
+    // deficit (or exhausted the server), so there is nothing left to fetch.
+    if (value.puzzles.length >= serverBatchCap && newBatch.unsolved.length < queueLength) {
+      unawaited(
+        _backgroundFill(userId, angle, difficulty).catchError((Object e, StackTrace st) {
+          // Fire-and-forget: swallow so a background fill failure (e.g. storage
+          // I/O) never surfaces as an unhandled async error.
+          _log.warning('Background puzzle fill failed', e, st);
+        }),
+      );
     }
 
     return Result.value((newBatch, value.glicko, value.rounds));
@@ -257,14 +264,15 @@ class PuzzleService {
     if (_isFilling) return;
     _isFilling = true;
     try {
-      // Tracks the stored queue length across passes. If a save doesn't grow
-      // the queue (e.g. the write silently no-ops), stop instead of looping
-      // forever re-requesting the same deficit.
+      // Tracks the stored queue length across passes. Stop only when a pass
+      // fails to grow the queue (e.g. the write silently no-ops), not when it
+      // shrinks: a solve made mid-fill lowers the count and legitimately
+      // widens the deficit, so that pass should still top up.
       int lastLength = -1;
       while (true) {
         final current = await batchStorage.fetch(userId: userId, angle: angle);
         final unsolved = current?.unsolved ?? IList(const []);
-        if (unsolved.length <= lastLength) break;
+        if (unsolved.length == lastLength) break;
         lastLength = unsolved.length;
         final deficit = max(0, queueLength - unsolved.length);
         if (deficit <= 0) break;

--- a/lib/src/model/puzzle/puzzle_service.dart
+++ b/lib/src/model/puzzle/puzzle_service.dart
@@ -20,6 +20,12 @@ import 'package:result_extensions/result_extensions.dart';
 
 part 'puzzle_service.freezed.dart';
 
+/// The server caps each batch request at 50 puzzles regardless of the
+/// requested `nb` (`nb.atMost(50)` in lila's `Puzzle` controller). A deficit
+/// larger than this can't be filled in a single request, so the remainder is
+/// topped up sequentially in the background.
+const _kServerBatchCap = 50;
+
 /// A provider for [PuzzleService].
 final puzzleServiceProvider = FutureProvider<PuzzleService>((Ref ref) {
   final nbOfflinePuzzles = ref.watch(
@@ -38,12 +44,16 @@ class PuzzleServiceFactory {
 
   final Ref _ref;
 
-  Future<PuzzleService> call({required int queueLength}) async {
+  Future<PuzzleService> call({
+    required int queueLength,
+    int serverBatchCap = _kServerBatchCap,
+  }) async {
     return PuzzleService(
       _ref,
       batchStorage: await _ref.read(puzzleBatchStorageProvider.future),
       puzzleStorage: await _ref.read(puzzleStorageProvider.future),
       queueLength: queueLength,
+      serverBatchCap: serverBatchCap,
     );
   }
 }
@@ -76,10 +86,15 @@ class PuzzleService {
     required this.batchStorage,
     required this.puzzleStorage,
     required this.queueLength,
+    this.serverBatchCap = _kServerBatchCap,
   });
 
   final Ref _ref;
   final int queueLength;
+
+  /// Max puzzles the server returns per batch request. Injectable so tests can
+  /// exercise the background-fill loop with a small simulated cap.
+  final int serverBatchCap;
   final PuzzleBatchStorage batchStorage;
   final PuzzleStorage puzzleStorage;
   final Logger _log = Logger('PuzzleService');
@@ -197,9 +212,10 @@ class PuzzleService {
     );
     await batchStorage.save(userId: userId, angle: angle, data: newBatch);
 
-    // Fill the rest without blocking so a large queue is cached before the
-    // user goes offline.
-    if (value.puzzles.isNotEmpty && newBatch.unsolved.length < queueLength) {
+    // The server caps each batch at 50, so a single fetch already covers any
+    // deficit up to that cap. Only spin up a background fill when the remaining
+    // deficit still exceeds one batch (i.e. the user raised the offline limit).
+    if (value.puzzles.isNotEmpty && queueLength - newBatch.unsolved.length >= serverBatchCap) {
       unawaited(_backgroundFill(userId, angle, difficulty));
     }
 
@@ -241,9 +257,15 @@ class PuzzleService {
     if (_isFilling) return;
     _isFilling = true;
     try {
+      // Tracks the stored queue length across passes. If a save doesn't grow
+      // the queue (e.g. the write silently no-ops), stop instead of looping
+      // forever re-requesting the same deficit.
+      int lastLength = -1;
       while (true) {
         final current = await batchStorage.fetch(userId: userId, angle: angle);
         final unsolved = current?.unsolved ?? IList(const []);
+        if (unsolved.length <= lastLength) break;
+        lastLength = unsolved.length;
         final deficit = max(0, queueLength - unsolved.length);
         if (deficit <= 0) break;
 

--- a/lib/src/model/puzzle/puzzle_service.dart
+++ b/lib/src/model/puzzle/puzzle_service.dart
@@ -10,6 +10,7 @@ import 'package:lichess_mobile/src/model/puzzle/puzzle_angle.dart';
 import 'package:lichess_mobile/src/model/puzzle/puzzle_batch_storage.dart';
 import 'package:lichess_mobile/src/model/puzzle/puzzle_preferences.dart';
 import 'package:lichess_mobile/src/model/puzzle/puzzle_repository.dart';
+import 'package:lichess_mobile/src/model/puzzle/puzzle_solve_limit.dart';
 import 'package:lichess_mobile/src/model/puzzle/puzzle_storage.dart';
 import 'package:lichess_mobile/src/model/puzzle/puzzle_theme.dart';
 import 'package:lichess_mobile/src/network/http.dart';
@@ -162,15 +163,26 @@ class PuzzleService {
 
     final deficit = max(0, queueLength - unsolved.length);
 
+    // anonymous users can't solve puzzles, so their sync only ever downloads
+    final isSolving = solved.isNotEmpty && userId != null;
+
+    // Back off while the server is rate-limiting solves: keep serving from the
+    // local unsolved queue instead of firing another solveBatch that will 429
+    // again. This also stops the queue from refilling (solveBatch is the only
+    // refill path once there are pending solves), so the solved backlog can't
+    // grow past the current unsolved queue.
+    if (isSolving && _ref.read(puzzleSolveLimiterProvider.notifier).isLimited) {
+      return Result.value((data, null, null));
+    }
+
     if (deficit > 0 || solved.isNotEmpty) {
       _log.fine('Will sync puzzles with lichess (deficit: $deficit, solved: ${solved.length})');
 
       final difficulty = _ref.read(puzzlePreferencesProvider).difficulty;
 
-      // anonymous users can't solve puzzles so we just download the deficit
       final batchResponse = _ref.withClient(
         (client) => Result.capture(
-          solved.isNotEmpty && userId != null
+          isSolving
               ? PuzzleRepository(
                   client,
                 ).solveBatch(nb: deficit, solved: solved, angle: angle, difficulty: difficulty)
@@ -193,7 +205,14 @@ class PuzzleService {
             )),
 
             // we don't need to save the batch if the request failed
-            (_, _) => Result.value((data, null, null, false)),
+            (error, _) {
+              // Arm the back-off when the server rejects a solve flush with 429,
+              // so later solves stop hammering it and the UI can warn the user.
+              if (isSolving && error is ServerException && error.statusCode == 429) {
+                _ref.read(puzzleSolveLimiterProvider.notifier).markLimited(solved.length);
+              }
+              return Result.value((data, null, null, false));
+            },
           )
           .flatMap((tuple) async {
             final (newBatch, glicko, rounds, shouldSave) = tuple;

--- a/lib/src/model/puzzle/puzzle_solve_limit.dart
+++ b/lib/src/model/puzzle/puzzle_solve_limit.dart
@@ -18,8 +18,7 @@ typedef PuzzleSolveLimit = ({DateTime since, int solvedCount});
 /// tell the user to wait.
 ///
 /// Global, not per-angle: the solve rate limit is account-wide, so hitting it on
-/// one angle means every angle is limited. In-memory only: after a restart the
-/// first flush re-hits the limit and re-arms this, so persistence buys little.
+/// one angle means every angle is limited.
 class PuzzleSolveLimiter extends Notifier<PuzzleSolveLimit?> {
   @override
   PuzzleSolveLimit? build() => null;

--- a/lib/src/model/puzzle/puzzle_solve_limit.dart
+++ b/lib/src/model/puzzle/puzzle_solve_limit.dart
@@ -1,0 +1,49 @@
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:meta/meta.dart';
+
+/// How long the app backs off from submitting solves after the server answers a
+/// solve batch with 429 Too Many Requests.
+///
+/// The puzzle solve rate limit is a rolling window on the server, so this fixed
+/// duration is a heuristic: if a flush attempted after it expires is limited
+/// again, the back-off simply re-arms itself.
+const kPuzzleSolveLimitDuration = Duration(hours: 1);
+
+/// The last time the server rate-limited solve submissions, and how many pending
+/// solves were rejected then. `null` when the limit has never been hit.
+typedef PuzzleSolveLimit = ({DateTime since, int solvedCount});
+
+/// Tracks whether the server is currently rate-limiting puzzle solve
+/// submissions (HTTP 429), so the sync path can stop hammering it and the UI can
+/// tell the user to wait.
+///
+/// Global, not per-angle: the solve rate limit is account-wide, so hitting it on
+/// one angle means every angle is limited. In-memory only: after a restart the
+/// first flush re-hits the limit and re-arms this, so persistence buys little.
+class PuzzleSolveLimiter extends Notifier<PuzzleSolveLimit?> {
+  @override
+  PuzzleSolveLimit? build() => null;
+
+  /// Whether solve submissions are currently backed off.
+  bool get isLimited {
+    final current = state;
+    return current != null && DateTime.now().isBefore(current.since.add(kPuzzleSolveLimitDuration));
+  }
+
+  /// Records that the server rejected a flush of [solvedCount] pending solves.
+  void markLimited(int solvedCount) {
+    state = (since: DateTime.now(), solvedCount: solvedCount);
+  }
+
+  /// Like [markLimited] but with an explicit timestamp, to simulate an expired
+  /// back-off in tests.
+  @visibleForTesting
+  void markLimitedAt(DateTime since, int solvedCount) {
+    state = (since: since, solvedCount: solvedCount);
+  }
+}
+
+final puzzleSolveLimiterProvider = NotifierProvider<PuzzleSolveLimiter, PuzzleSolveLimit?>(
+  PuzzleSolveLimiter.new,
+  name: 'PuzzleSolveLimiterProvider',
+);

--- a/lib/src/network/http.dart
+++ b/lib/src/network/http.dart
@@ -149,18 +149,35 @@ final defaultClientProvider = Provider<DefaultClient>((Ref ref) {
 /// Only one instance of this client is created and kept alive for the whole app.
 final lichessClientProvider = Provider<LichessClient>((Ref ref) {
   final client = LichessClient(
-    // Retry just once, after 500ms, on 429 Too Many Requests.
+    // Retry just once on 429 Too Many Requests.
     RetryClient(
       ref.read(httpClientFactoryProvider)(),
       retries: 1,
       delay: _defaultDelay,
-      when: (response) => response.statusCode == 429,
+      when: shouldRetryOn429,
     ),
     ref,
   );
   ref.onDispose(() => client.close());
   return client;
 }, name: 'LichessHttpClientProvider');
+
+/// Whether a response should be retried once by [lichessClientProvider].
+///
+/// Retries on 429 Too Many Requests, except for puzzle solve submissions
+/// (`POST /api/puzzle/batch/…`): those are rate-limited deliberately and handled
+/// with a back-off by `PuzzleSolveLimiter`, so retrying here only burns a request
+/// and delays arming the back-off.
+@visibleForTesting
+bool shouldRetryOn429(BaseResponse response) {
+  if (response.statusCode != 429) return false;
+  final request = response.request;
+  final isPuzzleSolve =
+      request != null &&
+      request.method == 'POST' &&
+      request.url.path.startsWith('/api/puzzle/batch/');
+  return !isPuzzleSolve;
+}
 
 Duration _defaultDelay(int retryCount) =>
     const Duration(milliseconds: 900) * math.pow(1.5, retryCount);

--- a/lib/src/view/puzzle/puzzle_screen.dart
+++ b/lib/src/view/puzzle/puzzle_screen.dart
@@ -17,6 +17,7 @@ import 'package:lichess_mobile/src/model/puzzle/puzzle_controller.dart';
 import 'package:lichess_mobile/src/model/puzzle/puzzle_difficulty.dart';
 import 'package:lichess_mobile/src/model/puzzle/puzzle_preferences.dart';
 import 'package:lichess_mobile/src/model/puzzle/puzzle_providers.dart';
+import 'package:lichess_mobile/src/model/puzzle/puzzle_queue_filler.dart';
 import 'package:lichess_mobile/src/model/puzzle/puzzle_service.dart';
 import 'package:lichess_mobile/src/model/puzzle/puzzle_theme.dart';
 import 'package:lichess_mobile/src/model/settings/board_preferences.dart';
@@ -932,6 +933,7 @@ class _PuzzleSettingsBottomSheet extends ConsumerWidget {
     final ctrlProvider = puzzleControllerProvider(initialPuzzleContext);
     final puzzleState = ref.watch(ctrlProvider);
     final difficulty = ref.watch(puzzlePreferencesProvider.select((state) => state.difficulty));
+    final isFillingQueue = ref.watch(puzzleQueueFillerProvider);
     final isOnline = ref.watch(onlineStatusProvider).value ?? false;
     return BottomSheetScrollableContainer(
       padding: const EdgeInsets.only(bottom: 16),
@@ -988,21 +990,52 @@ class _PuzzleSettingsBottomSheet extends ConsumerWidget {
               },
             ),
             SettingsListTile(
+              icon: isFillingQueue
+                  ? const SizedBox(
+                      width: 24,
+                      height: 24,
+                      child: Center(
+                        child: SizedBox(
+                          width: 18,
+                          height: 18,
+                          child: CircularProgressIndicator.adaptive(strokeWidth: 2),
+                        ),
+                      ),
+                    )
+                  : null,
               settingsLabel: Text(context.l10n.mobileNbOfflinePuzzles),
               settingsValue: nbOfflinePuzzles.toString(),
-              onTap: () {
-                showChoicePicker(
-                  context,
-                  choices: kOfflinePuzzlesChoices,
-                  selectedItem: nbOfflinePuzzles,
-                  labelBuilder: (t) => Text(t.toString()),
-                  onSelectedItemChanged: (int? nb) {
-                    if (nb != null) {
-                      ref.read(puzzlePreferencesProvider.notifier).setNbOfflinePuzzles(nb);
-                    }
-                  },
-                );
-              },
+              enabled: !isFillingQueue,
+              onTap: isFillingQueue
+                  ? null
+                  : () {
+                      showChoicePicker(
+                        context,
+                        choices: kOfflinePuzzlesChoices,
+                        selectedItem: nbOfflinePuzzles,
+                        labelBuilder: (t) => Text(t.toString()),
+                        onSelectedItemChanged: (int? nb) {
+                          if (nb != null) {
+                            ref.read(puzzlePreferencesProvider.notifier).setNbOfflinePuzzles(nb);
+                          }
+                        },
+                      ).then((_) {
+                        if (nbOfflinePuzzles ==
+                            ref.read(puzzlePreferencesProvider).nbOfflinePuzzles) {
+                          return;
+                        }
+                        // Fill the offline queue up to the new count now, rather
+                        // than trickling in via the solve path. The setting is
+                        // the "about to go offline" signal, so the puzzles need
+                        // to be there before the user leaves the screen.
+                        ref
+                            .read(puzzleQueueFillerProvider.notifier)
+                            .fill(
+                              userId: initialPuzzleContext.userId,
+                              angle: initialPuzzleContext.angle,
+                            );
+                      });
+                    },
             ),
             if (authUser != null && initialPuzzleContext.replayRemaining == null)
               SwitchSettingTile(

--- a/lib/src/view/puzzle/puzzle_screen.dart
+++ b/lib/src/view/puzzle/puzzle_screen.dart
@@ -925,6 +925,9 @@ class _PuzzleSettingsBottomSheet extends ConsumerWidget {
   Widget build(BuildContext context, WidgetRef ref) {
     final authUser = ref.watch(authControllerProvider);
     final autoNext = ref.watch(puzzlePreferencesProvider.select((value) => value.autoNext));
+    final nbOfflinePuzzles = ref.watch(
+      puzzlePreferencesProvider.select((value) => value.nbOfflinePuzzles),
+    );
     final rated = ref.watch(puzzlePreferencesProvider.select((value) => value.rated));
     final ctrlProvider = puzzleControllerProvider(initialPuzzleContext);
     final puzzleState = ref.watch(ctrlProvider);
@@ -982,6 +985,23 @@ class _PuzzleSettingsBottomSheet extends ConsumerWidget {
               value: autoNext,
               onChanged: (value) {
                 ref.read(puzzlePreferencesProvider.notifier).setAutoNext(value);
+              },
+            ),
+            SettingsListTile(
+              settingsLabel: Text(context.l10n.mobileNbOfflinePuzzles),
+              settingsValue: nbOfflinePuzzles.toString(),
+              onTap: () {
+                showChoicePicker(
+                  context,
+                  choices: kOfflinePuzzlesChoices,
+                  selectedItem: nbOfflinePuzzles,
+                  labelBuilder: (t) => Text(t.toString()),
+                  onSelectedItemChanged: (int? nb) {
+                    if (nb != null) {
+                      ref.read(puzzlePreferencesProvider.notifier).setNbOfflinePuzzles(nb);
+                    }
+                  },
+                );
               },
             ),
             if (authUser != null && initialPuzzleContext.replayRemaining == null)

--- a/lib/src/view/puzzle/puzzle_screen.dart
+++ b/lib/src/view/puzzle/puzzle_screen.dart
@@ -1013,6 +1013,7 @@ class _PuzzleSettingsBottomSheet extends ConsumerWidget {
                 onTap: isFillingQueue
                     ? null
                     : () {
+                        int selectedNb = nbOfflinePuzzles;
                         showChoicePicker(
                           context,
                           choices: kOfflinePuzzlesChoices,
@@ -1020,24 +1021,32 @@ class _PuzzleSettingsBottomSheet extends ConsumerWidget {
                           labelBuilder: (t) => Text(t.toString()),
                           onSelectedItemChanged: (int? nb) {
                             if (nb != null) {
-                              ref.read(puzzlePreferencesProvider.notifier).setNbOfflinePuzzles(nb);
+                              selectedNb = nb;
                             }
                           },
-                        ).then((_) {
-                          if (nbOfflinePuzzles ==
-                              ref.read(puzzlePreferencesProvider).nbOfflinePuzzles) {
+                        ).then((_) async {
+                          if (selectedNb == nbOfflinePuzzles) {
                             return;
                           }
+                          // Await the save: the fill reads the count from the
+                          // preferences state, so it must be up to date before
+                          // the fill starts, or it would be a silent no-op.
+                          await ref
+                              .read(puzzlePreferencesProvider.notifier)
+                              .setNbOfflinePuzzles(selectedNb);
+                          if (!context.mounted) return;
                           // Fill the offline queue up to the new count now, rather
                           // than trickling in via the solve path. The setting is
                           // the "about to go offline" signal, so the puzzles need
                           // to be there before the user leaves the screen.
-                          ref
-                              .read(puzzleQueueFillerProvider.notifier)
-                              .fill(
-                                userId: initialPuzzleContext.userId,
-                                angle: initialPuzzleContext.angle,
-                              );
+                          unawaited(
+                            ref
+                                .read(puzzleQueueFillerProvider.notifier)
+                                .fill(
+                                  userId: initialPuzzleContext.userId,
+                                  angle: initialPuzzleContext.angle,
+                                ),
+                          );
                         });
                       },
               ),

--- a/lib/src/view/puzzle/puzzle_screen.dart
+++ b/lib/src/view/puzzle/puzzle_screen.dart
@@ -989,54 +989,58 @@ class _PuzzleSettingsBottomSheet extends ConsumerWidget {
                 ref.read(puzzlePreferencesProvider.notifier).setAutoNext(value);
               },
             ),
-            SettingsListTile(
-              icon: isFillingQueue
-                  ? const SizedBox(
-                      width: 24,
-                      height: 24,
-                      child: Center(
-                        child: SizedBox(
-                          width: 18,
-                          height: 18,
-                          child: CircularProgressIndicator.adaptive(strokeWidth: 2),
+            // Offline queue length is a logged-in-only feature: anonymous
+            // players face a much higher server rate limit for fetching
+            // puzzles, so the setting is hidden for them.
+            if (initialPuzzleContext.userId != null)
+              SettingsListTile(
+                icon: isFillingQueue
+                    ? const SizedBox(
+                        width: 24,
+                        height: 24,
+                        child: Center(
+                          child: SizedBox(
+                            width: 18,
+                            height: 18,
+                            child: CircularProgressIndicator.adaptive(strokeWidth: 2),
+                          ),
                         ),
-                      ),
-                    )
-                  : null,
-              settingsLabel: Text(context.l10n.mobileNbOfflinePuzzles),
-              settingsValue: nbOfflinePuzzles.toString(),
-              enabled: !isFillingQueue,
-              onTap: isFillingQueue
-                  ? null
-                  : () {
-                      showChoicePicker(
-                        context,
-                        choices: kOfflinePuzzlesChoices,
-                        selectedItem: nbOfflinePuzzles,
-                        labelBuilder: (t) => Text(t.toString()),
-                        onSelectedItemChanged: (int? nb) {
-                          if (nb != null) {
-                            ref.read(puzzlePreferencesProvider.notifier).setNbOfflinePuzzles(nb);
+                      )
+                    : null,
+                settingsLabel: Text(context.l10n.mobileNbOfflinePuzzles),
+                settingsValue: nbOfflinePuzzles.toString(),
+                enabled: !isFillingQueue,
+                onTap: isFillingQueue
+                    ? null
+                    : () {
+                        showChoicePicker(
+                          context,
+                          choices: kOfflinePuzzlesChoices,
+                          selectedItem: nbOfflinePuzzles,
+                          labelBuilder: (t) => Text(t.toString()),
+                          onSelectedItemChanged: (int? nb) {
+                            if (nb != null) {
+                              ref.read(puzzlePreferencesProvider.notifier).setNbOfflinePuzzles(nb);
+                            }
+                          },
+                        ).then((_) {
+                          if (nbOfflinePuzzles ==
+                              ref.read(puzzlePreferencesProvider).nbOfflinePuzzles) {
+                            return;
                           }
-                        },
-                      ).then((_) {
-                        if (nbOfflinePuzzles ==
-                            ref.read(puzzlePreferencesProvider).nbOfflinePuzzles) {
-                          return;
-                        }
-                        // Fill the offline queue up to the new count now, rather
-                        // than trickling in via the solve path. The setting is
-                        // the "about to go offline" signal, so the puzzles need
-                        // to be there before the user leaves the screen.
-                        ref
-                            .read(puzzleQueueFillerProvider.notifier)
-                            .fill(
-                              userId: initialPuzzleContext.userId,
-                              angle: initialPuzzleContext.angle,
-                            );
-                      });
-                    },
-            ),
+                          // Fill the offline queue up to the new count now, rather
+                          // than trickling in via the solve path. The setting is
+                          // the "about to go offline" signal, so the puzzles need
+                          // to be there before the user leaves the screen.
+                          ref
+                              .read(puzzleQueueFillerProvider.notifier)
+                              .fill(
+                                userId: initialPuzzleContext.userId,
+                                angle: initialPuzzleContext.angle,
+                              );
+                        });
+                      },
+              ),
             if (authUser != null && initialPuzzleContext.replayRemaining == null)
               SwitchSettingTile(
                 title: Text(context.l10n.rated),

--- a/lib/src/view/puzzle/puzzle_screen.dart
+++ b/lib/src/view/puzzle/puzzle_screen.dart
@@ -991,8 +991,10 @@ class _PuzzleSettingsBottomSheet extends ConsumerWidget {
             ),
             // Offline queue length is a logged-in-only feature: anonymous
             // players face a much higher server rate limit for fetching
-            // puzzles, so the setting is hidden for them.
-            if (initialPuzzleContext.userId != null)
+            // puzzles, so the setting is hidden for them. It is also limited to
+            // the mix angle (see [isConfigurableOfflineQueueAngle]).
+            if (initialPuzzleContext.userId != null &&
+                isConfigurableOfflineQueueAngle(initialPuzzleContext.angle))
               SettingsListTile(
                 icon: isFillingQueue
                     ? const SizedBox(

--- a/lib/src/view/puzzle/puzzle_screen.dart
+++ b/lib/src/view/puzzle/puzzle_screen.dart
@@ -1009,17 +1009,11 @@ class _PuzzleSettingsBottomSheet extends ConsumerWidget {
             if (initialPuzzleContext.userId != null &&
                 isConfigurableOfflineQueueAngle(initialPuzzleContext.angle))
               SettingsListTile(
-                icon: isFillingQueue
+                trailing: isFillingQueue
                     ? const SizedBox(
-                        width: 24,
-                        height: 24,
-                        child: Center(
-                          child: SizedBox(
-                            width: 18,
-                            height: 18,
-                            child: CircularProgressIndicator.adaptive(strokeWidth: 2),
-                          ),
-                        ),
+                        width: 20,
+                        height: 20,
+                        child: CircularProgressIndicator.adaptive(strokeWidth: 2),
                       )
                     : null,
                 settingsLabel: Text(context.l10n.mobileNbOfflinePuzzles),

--- a/lib/src/view/puzzle/puzzle_screen.dart
+++ b/lib/src/view/puzzle/puzzle_screen.dart
@@ -1044,10 +1044,6 @@ class _PuzzleSettingsBottomSheet extends ConsumerWidget {
                               .read(puzzlePreferencesProvider.notifier)
                               .setNbOfflinePuzzles(selectedNb);
                           if (!context.mounted) return;
-                          // Fill the offline queue up to the new count now, rather
-                          // than trickling in via the solve path. The setting is
-                          // the "about to go offline" signal, so the puzzles need
-                          // to be there before the user leaves the screen.
                           unawaited(
                             ref
                                 .read(puzzleQueueFillerProvider.notifier)

--- a/lib/src/view/puzzle/puzzle_screen.dart
+++ b/lib/src/view/puzzle/puzzle_screen.dart
@@ -19,6 +19,7 @@ import 'package:lichess_mobile/src/model/puzzle/puzzle_preferences.dart';
 import 'package:lichess_mobile/src/model/puzzle/puzzle_providers.dart';
 import 'package:lichess_mobile/src/model/puzzle/puzzle_queue_filler.dart';
 import 'package:lichess_mobile/src/model/puzzle/puzzle_service.dart';
+import 'package:lichess_mobile/src/model/puzzle/puzzle_solve_limit.dart';
 import 'package:lichess_mobile/src/model/puzzle/puzzle_theme.dart';
 import 'package:lichess_mobile/src/model/settings/board_preferences.dart';
 import 'package:lichess_mobile/src/network/connectivity.dart';
@@ -440,6 +441,18 @@ class _BodyState extends ConsumerState<_Body> {
     final boardPreferences = ref.watch(boardPreferencesProvider);
     final ctrlProvider = puzzleControllerProvider(widget.initialPuzzleContext);
     final puzzleState = ref.watch(ctrlProvider);
+
+    // Warn the user when the server starts rate-limiting solve submissions.
+    ref.listen(puzzleSolveLimiterProvider, (previous, next) {
+      if (next != null && next != previous) {
+        showSnackBar(
+          context,
+          'You solved ${next.solvedCount} puzzles very quickly. Please wait a while before '
+          'solving more so your results can be saved.',
+          type: SnackBarType.error,
+        );
+      }
+    });
 
     // Drive the board on position/interactivity changes without rebuilding it.
     ref.listen(

--- a/lib/src/widgets/settings.dart
+++ b/lib/src/widgets/settings.dart
@@ -12,6 +12,7 @@ class SettingsListTile extends StatelessWidget {
     required this.settingsValue,
     required this.onTap,
     this.explanation,
+    this.trailing,
     this.enabled = true,
     super.key,
   });
@@ -30,6 +31,10 @@ class SettingsListTile extends StatelessWidget {
 
   /// The optional explanation of the settings.
   final String? explanation;
+
+  /// Optional widget shown in the trailing slot instead of [settingsValue],
+  /// e.g. a progress indicator while the value is being applied.
+  final Widget? trailing;
 
   @override
   Widget build(BuildContext context) {
@@ -52,16 +57,18 @@ class SettingsListTile extends StatelessWidget {
             : null,
         enabled: enabled,
         onTap: onTap,
-        trailing: ConstrainedBox(
-          constraints: BoxConstraints(maxWidth: MediaQuery.widthOf(context) * 0.25),
-          child: Text(
-            settingsValue,
-            overflow: TextOverflow.ellipsis,
-            textAlign: TextAlign.end,
-            maxLines: kSettingsTileTitleMaxLines,
-            style: TextStyle(color: textShade(context, Styles.subtitleOpacity)),
-          ),
-        ),
+        trailing:
+            trailing ??
+            ConstrainedBox(
+              constraints: BoxConstraints(maxWidth: MediaQuery.widthOf(context) * 0.25),
+              child: Text(
+                settingsValue,
+                overflow: TextOverflow.ellipsis,
+                textAlign: TextAlign.end,
+                maxLines: kSettingsTileTitleMaxLines,
+                style: TextStyle(color: textShade(context, Styles.subtitleOpacity)),
+              ),
+            ),
       ),
     );
   }

--- a/test/binding.dart
+++ b/test/binding.dart
@@ -78,6 +78,13 @@ class TestLichessBinding extends LichessBinding {
     return _sharedPreferences ??= FakeSharedPreferences();
   }
 
+  /// Replaces the shared preferences fake, to test how a slow write behaves.
+  ///
+  /// Must be called before anything reads [sharedPreferences]. Reset by [reset].
+  set sharedPreferences(FakeSharedPreferences prefs) {
+    _sharedPreferences = prefs;
+  }
+
   /// Reset the binding instance.
   ///
   /// Should be called using [addTearDown] in tests.
@@ -366,4 +373,22 @@ class FakeFirebaseMessaging extends Fake implements FirebaseMessaging {
   /// Call [StreamController.add] to simulate a message received from FCM while
   /// the application is in background.
   StreamController<RemoteMessage> onBackgroundMessage = StreamController.broadcast();
+}
+
+/// A [FakeSharedPreferences] whose writes complete on the event queue, like the
+/// real ones do: [SharedPreferencesWithCache] goes through a platform channel,
+/// so its futures never complete in a microtask.
+///
+/// Use it to check that code awaiting a preference write actually observes the
+/// new value. Set [writeDelay] to exaggerate the latency.
+class SlowFakeSharedPreferences extends FakeSharedPreferences {
+  SlowFakeSharedPreferences({this.writeDelay = Duration.zero});
+
+  final Duration writeDelay;
+
+  @override
+  Future<bool> setString(String key, String value) async {
+    await Future<void>.delayed(writeDelay);
+    return super.setString(key, value);
+  }
 }

--- a/test/model/puzzle/puzzle_controller_test.dart
+++ b/test/model/puzzle/puzzle_controller_test.dart
@@ -1,0 +1,151 @@
+import 'dart:math' show max;
+
+import 'package:dartchess/dartchess.dart';
+import 'package:fast_immutable_collections/fast_immutable_collections.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:http/testing.dart';
+import 'package:lichess_mobile/src/model/common/id.dart';
+import 'package:lichess_mobile/src/model/common/perf.dart';
+import 'package:lichess_mobile/src/model/puzzle/puzzle.dart';
+import 'package:lichess_mobile/src/model/puzzle/puzzle_angle.dart';
+import 'package:lichess_mobile/src/model/puzzle/puzzle_batch_storage.dart';
+import 'package:lichess_mobile/src/model/puzzle/puzzle_controller.dart';
+import 'package:lichess_mobile/src/model/puzzle/puzzle_difficulty.dart';
+import 'package:lichess_mobile/src/model/puzzle/puzzle_queue_filler.dart';
+import 'package:lichess_mobile/src/model/puzzle/puzzle_service.dart';
+import 'package:lichess_mobile/src/model/puzzle/puzzle_theme.dart';
+import 'package:lichess_mobile/src/network/http.dart';
+
+import '../../test_container.dart';
+import '../../test_helpers.dart';
+import '../auth/fake_auth_storage.dart';
+
+final _userId = fakeAuthUser.user.id;
+
+void main() {
+  group('PuzzleController.changeDifficulty', () {
+    test('does not start the offline queue fill while resetBatch is in flight', () async {
+      // Regression test: `resetBatch` saves a batch built from a snapshot taken
+      // before its own request and does not merge, so a fill running
+      // concurrently would have its writes overwritten, and would then stop
+      // early on its "the queue did not grow" check, leaving the offline queue
+      // below the configured count.
+      int nbBatchReq = 0;
+      int inFlight = 0;
+      int maxInFlight = 0;
+      final mockClient = MockClient((request) async {
+        if (request.url.path == '/api/puzzle/batch/mix') {
+          // the rating probe made on controller build asks for nb=0
+          if (request.url.queryParameters['nb'] == '0') {
+            return mockResponse(_emptyBatch, 200);
+          }
+          nbBatchReq++;
+          inFlight++;
+          maxInFlight = max(maxInFlight, inFlight);
+          // keep the request in flight long enough for an overlapping fill to
+          // start before the response is stored
+          await Future<void>.delayed(const Duration(milliseconds: 20));
+          inFlight--;
+          return mockResponse(_batchOf2, 200);
+        }
+        return mockResponse('', 404);
+      });
+
+      final container = await makeContainer(
+        authUser: fakeAuthUser,
+        overrides: {
+          lichessClientProvider: lichessClientProvider.overrideWith((ref) {
+            return LichessClient(mockClient, ref);
+          }),
+        },
+      );
+      final storage = await container.read(puzzleBatchStorageProvider.future);
+
+      final ctrlProvider = puzzleControllerProvider(_initialContext);
+      // keep the autoDispose controller alive for the duration of the test
+      final sub = container.listen(ctrlProvider, (_, _) {});
+      addTearDown(sub.close);
+
+      await container.read(ctrlProvider.notifier).changeDifficulty(PuzzleDifficulty.harder);
+      await _waitForFill(container);
+
+      expect(maxInFlight, equals(1), reason: 'the fill must not overlap the resetBatch request');
+      expect(nbBatchReq, equals(2), reason: 'one reset request, then one fill request');
+
+      // The reset batch survived the fill: the two puzzles of the new difficulty
+      // are still queued, and the fill did not restore any of the pre-reset ones.
+      final data = await storage.fetch(userId: _userId);
+      expect(
+        data?.unsolved.map((p) => p.puzzle.id).toList(),
+        equals(const [PuzzleId('20yWT'), PuzzleId('7H5EV')]),
+      );
+    });
+
+    test('is a no-op for the fill when the user is anonymous', () async {
+      int nbBatchReq = 0;
+      final mockClient = MockClient((request) {
+        if (request.url.path == '/api/puzzle/batch/mix') {
+          nbBatchReq++;
+          return mockResponse(_batchOf2, 200);
+        }
+        return mockResponse('', 404);
+      });
+
+      final container = await makeContainer(
+        overrides: {
+          lichessClientProvider: lichessClientProvider.overrideWith((ref) {
+            return LichessClient(mockClient, ref);
+          }),
+        },
+      );
+
+      final ctrlProvider = puzzleControllerProvider(_initialContext.copyWith(userId: null));
+      final sub = container.listen(ctrlProvider, (_, _) {});
+      addTearDown(sub.close);
+
+      await container.read(ctrlProvider.notifier).changeDifficulty(PuzzleDifficulty.harder);
+      await _waitForFill(container);
+
+      expect(nbBatchReq, equals(1), reason: 'only the resetBatch request, no fill');
+      expect(container.read(puzzleQueueFillerProvider), isFalse);
+    });
+  });
+}
+
+/// Waits for the fire-and-forget queue fill kicked off by the controller.
+Future<void> _waitForFill(ProviderContainer container) async {
+  for (int i = 0; i < 200 && container.read(puzzleQueueFillerProvider); i++) {
+    await Future<void>.delayed(const Duration(milliseconds: 10));
+  }
+  expect(container.read(puzzleQueueFillerProvider), isFalse, reason: 'the fill should be done');
+}
+
+final _initialContext = PuzzleContext(
+  puzzle: Puzzle(
+    puzzle: PuzzleData(
+      id: const PuzzleId('pId3'),
+      rating: 1988,
+      plays: 5,
+      initialPly: 23,
+      solution: IList(const ['a6a7', 'b2a2', 'c4c2']),
+      themes: ISet(const ['endgame', 'advantage']),
+    ),
+    game: const PuzzleGame(
+      id: GameId('PrlkCqOv'),
+      perf: Perf.blitz,
+      rated: true,
+      white: PuzzleGamePlayer(side: Side.white, name: 'user1'),
+      black: PuzzleGamePlayer(side: Side.black, name: 'user2'),
+      pgn: 'e4 Nc6 Bc4 e6 a3 g6 Nf3 Bg7 c3 Nge7 d3 O-O Be3 Na5 Ba2 b6 Qd2',
+    ),
+  ),
+  angle: const PuzzleTheme(PuzzleThemeKey.mix),
+  userId: _userId,
+);
+
+const _emptyBatch = '{"puzzles":[]}';
+
+const _batchOf2 = '''
+{"puzzles":[{"game":{"id":"PrlkCqOv","perf":{"key":"rapid","name":"Rapid"},"rated":true,"players":[{"userId":"silverjo","name":"silverjo (1777)","color":"white"},{"userId":"robyarchitetto","name":"Robyarchitetto (1742)","color":"black"}],"pgn":"e4 Nc6 Bc4 e6 a3 g6 Nf3 Bg7 c3 Nge7 d3 O-O Be3 Na5 Ba2 b6 Qd2","clock":"5+8"},"puzzle":{"id":"20yWT","rating":1859,"plays":551,"initialPly":93,"solution":["a6a7","b2a2","c4c2","a2a7","d7a7"],"themes":["endgame","long","advantage","advancedPawn"]}},{"game":{"id":"0lwkiJbZ","perf":{"key":"classical","name":"Classical"},"rated":true,"players":[{"userId":"nirdosh","name":"nirdosh (2035)","color":"white"},{"userId":"burn_it_down","name":"burn_it_down (2139)","color":"black"}],"pgn":"d4 Nf6 Nf3 c5 e3 g6 Bd3 Bg7 c3 Qc7 O-O O-O","clock":"15+15"},"puzzle":{"id":"7H5EV","rating":1852,"plays":410,"initialPly":84,"solution":["e8c8","d7d4","e4d4"],"themes":["endgame","short","advantage"]}}]}
+''';

--- a/test/model/puzzle/puzzle_preferences_test.dart
+++ b/test/model/puzzle/puzzle_preferences_test.dart
@@ -1,0 +1,47 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:lichess_mobile/src/model/puzzle/puzzle_preferences.dart';
+
+import '../../model/auth/fake_auth_storage.dart';
+import '../../test_container.dart';
+
+void main() {
+  group('PuzzlePreferences', () {
+    test('offline queue length is session-scoped: anon reads the default after a '
+        'logged-in user increased it', () async {
+      // Logged-in user bumps the offline queue length above the default.
+      final loggedIn = await makeContainer(authUser: fakeAuthUser);
+      await loggedIn
+          .read(puzzlePreferencesProvider.notifier)
+          .setNbOfflinePuzzles(kMaxOfflinePuzzles);
+      expect(loggedIn.read(puzzlePreferencesProvider).nbOfflinePuzzles, equals(kMaxOfflinePuzzles));
+
+      // A new anonymous session shares the same SharedPreferences store but a
+      // different (per-user) key, so it must fall back to the default rather
+      // than inherit the logged-in user's larger queue.
+      final anon = await makeContainer();
+      expect(
+        anon.read(puzzlePreferencesProvider).nbOfflinePuzzles,
+        equals(PuzzlePrefs.defaults().nbOfflinePuzzles),
+      );
+    });
+
+    test('clamps an out-of-bounds stored value on load', () async {
+      final container = await makeContainer(authUser: fakeAuthUser);
+      final notifier = container.read(puzzlePreferencesProvider.notifier);
+
+      // Above the max is clamped down...
+      await notifier.setNbOfflinePuzzles(9999);
+      expect(
+        container.read(puzzlePreferencesProvider).nbOfflinePuzzles,
+        equals(kMaxOfflinePuzzles),
+      );
+
+      // ...and below the min is clamped up.
+      await notifier.setNbOfflinePuzzles(1);
+      expect(
+        container.read(puzzlePreferencesProvider).nbOfflinePuzzles,
+        equals(kMinOfflinePuzzles),
+      );
+    });
+  });
+}

--- a/test/model/puzzle/puzzle_preferences_test.dart
+++ b/test/model/puzzle/puzzle_preferences_test.dart
@@ -1,11 +1,48 @@
 import 'package:flutter_test/flutter_test.dart';
+import 'package:lichess_mobile/src/model/puzzle/puzzle_difficulty.dart';
 import 'package:lichess_mobile/src/model/puzzle/puzzle_preferences.dart';
 
+import '../../binding.dart';
 import '../../model/auth/fake_auth_storage.dart';
 import '../../test_container.dart';
 
 void main() {
   group('PuzzlePreferences', () {
+    test('setNbOfflinePuzzles completes only once the new value is visible', () async {
+      // A real preferences write goes through a platform channel, so its future
+      // never completes in a microtask: awaiting the setter must still leave the
+      // state up to date. The offline queue fill reads the count from there, so
+      // a setter that returns early makes the fill top up to the *old* count —
+      // a silent no-op when the count was raised.
+      TestLichessBinding.ensureInitialized().sharedPreferences = SlowFakeSharedPreferences();
+
+      final container = await makeContainer(authUser: fakeAuthUser);
+      // materialize the notifier before the write
+      container.read(puzzlePreferencesProvider);
+
+      await container.read(puzzlePreferencesProvider.notifier).setNbOfflinePuzzles(200);
+
+      expect(container.read(puzzlePreferencesProvider).nbOfflinePuzzles, equals(200));
+    });
+
+    test('setDifficulty completes only once the new value is visible', () async {
+      // Same contract: [PuzzleController.changeDifficulty] awaits this and then
+      // refetches the queue, and the batch request reads the difficulty from
+      // the state. A setter returning before the state is updated makes that
+      // ordering a race against the preferences write.
+      TestLichessBinding.ensureInitialized().sharedPreferences = SlowFakeSharedPreferences();
+
+      final container = await makeContainer(authUser: fakeAuthUser);
+      container.read(puzzlePreferencesProvider);
+
+      await container.read(puzzlePreferencesProvider.notifier).setDifficulty(.hardest);
+
+      expect(
+        container.read(puzzlePreferencesProvider).difficulty,
+        equals(PuzzleDifficulty.hardest),
+      );
+    });
+
     test('offline queue length is session-scoped: anon reads the default after a '
         'logged-in user increased it', () async {
       // Logged-in user bumps the offline queue length above the default.

--- a/test/model/puzzle/puzzle_preferences_test.dart
+++ b/test/model/puzzle/puzzle_preferences_test.dart
@@ -1,12 +1,38 @@
 import 'package:flutter_test/flutter_test.dart';
+import 'package:lichess_mobile/src/model/puzzle/puzzle_angle.dart';
 import 'package:lichess_mobile/src/model/puzzle/puzzle_difficulty.dart';
 import 'package:lichess_mobile/src/model/puzzle/puzzle_preferences.dart';
+import 'package:lichess_mobile/src/model/puzzle/puzzle_theme.dart';
 
 import '../../binding.dart';
 import '../../model/auth/fake_auth_storage.dart';
 import '../../test_container.dart';
 
 void main() {
+  group('offlineQueueLengthForAngle', () {
+    const mix = PuzzleTheme(PuzzleThemeKey.mix);
+
+    test('applies the configured count to the mix angle', () {
+      expect(isConfigurableOfflineQueueAngle(mix), isTrue);
+      expect(offlineQueueLengthForAngle(mix, 250), equals(250));
+    });
+
+    test('caps every non-mix angle at kMinOfflinePuzzles', () {
+      for (final angle in const <PuzzleAngle>[
+        PuzzleTheme(PuzzleThemeKey.advancedPawn),
+        PuzzleTheme(PuzzleThemeKey.opening),
+        PuzzleOpening('A00'),
+      ]) {
+        expect(isConfigurableOfflineQueueAngle(angle), isFalse, reason: '$angle');
+        expect(
+          offlineQueueLengthForAngle(angle, 300),
+          equals(kMinOfflinePuzzles),
+          reason: '$angle',
+        );
+      }
+    });
+  });
+
   group('PuzzlePreferences', () {
     test('setNbOfflinePuzzles completes only once the new value is visible', () async {
       // A real preferences write goes through a platform channel, so its future

--- a/test/model/puzzle/puzzle_queue_filler_test.dart
+++ b/test/model/puzzle/puzzle_queue_filler_test.dart
@@ -15,6 +15,10 @@ import 'package:lichess_mobile/src/network/http.dart';
 import '../../test_container.dart';
 import '../../test_helpers.dart';
 
+// The offline queue length is a logged-in-only feature, so the fill runs for a
+// real user id. Anonymous behaviour is covered by its own no-op test.
+const _user = UserId('testUser');
+
 void main() {
   Future<ProviderContainer> makeTestContainer(MockClient mockClient) {
     return makeContainer(
@@ -46,10 +50,10 @@ void main() {
 
       await container
           .read(puzzleQueueFillerProvider.notifier)
-          .fill(userId: null, queueLengthOverride: 3);
+          .fill(userId: _user, queueLengthOverride: 3);
 
       expect(nbReq, equals(3), reason: 'three GET requests to reach a queue of 3');
-      final data = await storage.fetch(userId: null);
+      final data = await storage.fetch(userId: _user);
       expect(data?.unsolved.length, equals(3));
       expect(data?.solved, equals(IList(const [])));
     });
@@ -67,14 +71,17 @@ void main() {
 
       final container = await makeTestContainer(mockClient);
       final storage = await container.read(puzzleBatchStorageProvider.future);
-      await storage.save(userId: null, data: _makePuzzleBatch(unsolved: [const PuzzleId('pId3')]));
+      await storage.save(
+        userId: _user,
+        data: _makePuzzleBatch(unsolved: [const PuzzleId('pId3')]),
+      );
 
       await container
           .read(puzzleQueueFillerProvider.notifier)
-          .fill(userId: null, queueLengthOverride: 3);
+          .fill(userId: _user, queueLengthOverride: 3);
 
       expect(nbReq, equals(1));
-      final data = await storage.fetch(userId: null);
+      final data = await storage.fetch(userId: _user);
       expect(data?.unsolved.length, equals(3));
     });
 
@@ -87,14 +94,17 @@ void main() {
 
       final container = await makeTestContainer(mockClient);
       final storage = await container.read(puzzleBatchStorageProvider.future);
-      await storage.save(userId: null, data: _makePuzzleBatch(unsolved: [const PuzzleId('pId3')]));
+      await storage.save(
+        userId: _user,
+        data: _makePuzzleBatch(unsolved: [const PuzzleId('pId3')]),
+      );
 
       await container
           .read(puzzleQueueFillerProvider.notifier)
-          .fill(userId: null, queueLengthOverride: 1);
+          .fill(userId: _user, queueLengthOverride: 1);
 
       expect(nbReq, equals(0), reason: 'no request when there is no deficit');
-      final data = await storage.fetch(userId: null);
+      final data = await storage.fetch(userId: _user);
       expect(data?.unsolved.length, equals(1));
     });
 
@@ -114,10 +124,10 @@ void main() {
 
       await container
           .read(puzzleQueueFillerProvider.notifier)
-          .fill(userId: null, queueLengthOverride: 10);
+          .fill(userId: _user, queueLengthOverride: 10);
 
       expect(nbReq, equals(2), reason: 'one filling request, one empty response, then stop');
-      final data = await storage.fetch(userId: null);
+      final data = await storage.fetch(userId: _user);
       expect(data?.unsolved.length, equals(1));
     });
 
@@ -130,15 +140,18 @@ void main() {
 
       final container = await makeTestContainer(mockClient);
       final storage = await container.read(puzzleBatchStorageProvider.future);
-      await storage.save(userId: null, data: _makePuzzleBatch(unsolved: [const PuzzleId('pId3')]));
+      await storage.save(
+        userId: _user,
+        data: _makePuzzleBatch(unsolved: [const PuzzleId('pId3')]),
+      );
 
       // must not throw
       await container
           .read(puzzleQueueFillerProvider.notifier)
-          .fill(userId: null, queueLengthOverride: 5);
+          .fill(userId: _user, queueLengthOverride: 5);
 
       expect(nbReq, equals(1));
-      final data = await storage.fetch(userId: null);
+      final data = await storage.fetch(userId: _user);
       expect(data?.unsolved.length, equals(1));
     });
 
@@ -156,7 +169,7 @@ void main() {
       final storage = await container.read(puzzleBatchStorageProvider.future);
       // storage already holds a solved entry: the filler must not report it
       await storage.save(
-        userId: const UserId('u1'),
+        userId: _user,
         data: _makePuzzleBatch(
           unsolved: const [],
           solved: [const PuzzleSolution(id: PuzzleId('old'), win: true, rated: true)],
@@ -165,10 +178,10 @@ void main() {
 
       await container
           .read(puzzleQueueFillerProvider.notifier)
-          .fill(userId: const UserId('u1'), queueLengthOverride: 2);
+          .fill(userId: _user, queueLengthOverride: 2);
 
       expect(nbPost, equals(0), reason: 'fill must only GET, never POST solves');
-      final data = await storage.fetch(userId: const UserId('u1'));
+      final data = await storage.fetch(userId: _user);
       // pre-existing solved list is preserved untouched
       expect(data?.solved.length, equals(1));
       expect(data?.unsolved.length, equals(2));
@@ -190,14 +203,77 @@ void main() {
       final notifier = container.read(puzzleQueueFillerProvider.notifier);
 
       // fire two overlapping fills; the second must return immediately
-      final first = notifier.fill(userId: null, queueLengthOverride: 2);
-      final second = notifier.fill(userId: null);
+      final first = notifier.fill(userId: _user, queueLengthOverride: 2);
+      final second = notifier.fill(userId: _user);
       await Future.wait([first, second]);
 
       // only the first fill ran: exactly 2 requests to reach a queue of 2
       expect(nbReq, equals(2));
-      final data = await storage.fetch(userId: null);
+      final data = await storage.fetch(userId: _user);
       expect(data?.unsolved.length, equals(2));
+    });
+
+    test('is a no-op for anonymous users', () async {
+      int nbReq = 0;
+      final mockClient = MockClient((request) {
+        nbReq++;
+        return mockResponse('', 404);
+      });
+
+      final container = await makeTestContainer(mockClient);
+      final storage = await container.read(puzzleBatchStorageProvider.future);
+
+      await container
+          .read(puzzleQueueFillerProvider.notifier)
+          .fill(userId: null, queueLengthOverride: 5);
+
+      expect(nbReq, equals(0), reason: 'anonymous fill must never hit the server');
+      final data = await storage.fetch(userId: null);
+      expect(data, isNull, reason: 'no queue is written for an anonymous user');
+    });
+
+    test('a solve during an in-flight fetch is not clobbered (lost-update)', () async {
+      // Seed one unsolved puzzle. During the network request the filler must
+      // tolerate a concurrent solve that moves that puzzle unsolved -> solved
+      // on the same storage row. If the fill merged into its pre-request
+      // snapshot it would restore the solved puzzle to unsolved and drop its
+      // solution: the exact silent data loss this test guards against.
+      late final ProviderContainer container;
+      container = await makeTestContainer(
+        MockClient((request) async {
+          if (request.method == 'GET' && request.url.path == '/api/puzzle/batch/mix') {
+            // Simulate a solve landing while the request is in flight: the
+            // seeded puzzle 'seed' is now solved, unsolved is emptied.
+            final storage = await container.read(puzzleBatchStorageProvider.future);
+            await storage.save(
+              userId: _user,
+              data: PuzzleBatch(
+                solved: IList(const [PuzzleSolution(id: PuzzleId('seed'), win: true, rated: true)]),
+                unsolved: IList(const []),
+              ),
+            );
+            return mockResponse(_batchOf1, 200);
+          }
+          return mockResponse('', 404);
+        }),
+      );
+      final storage = await container.read(puzzleBatchStorageProvider.future);
+      await storage.save(
+        userId: _user,
+        data: _makePuzzleBatch(unsolved: [const PuzzleId('seed')]),
+      );
+
+      await container
+          .read(puzzleQueueFillerProvider.notifier)
+          .fill(userId: _user, queueLengthOverride: 3);
+
+      final data = await storage.fetch(userId: _user);
+      // The mid-fill solve survives: 'seed' stays in solved, its solution intact.
+      expect(data?.solved.map((s) => s.id).toList(), equals(const [PuzzleId('seed')]));
+      // The freshly fetched puzzle is appended to the post-solve unsolved list.
+      expect(data?.unsolved.any((p) => p.puzzle.id == const PuzzleId('20yWT')), isTrue);
+      // 'seed' was NOT restored to unsolved.
+      expect(data?.unsolved.any((p) => p.puzzle.id == const PuzzleId('seed')), isFalse);
     });
   });
 }

--- a/test/model/puzzle/puzzle_queue_filler_test.dart
+++ b/test/model/puzzle/puzzle_queue_filler_test.dart
@@ -1,0 +1,241 @@
+import 'dart:io';
+
+import 'package:dartchess/dartchess.dart';
+import 'package:fast_immutable_collections/fast_immutable_collections.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:http/testing.dart';
+import 'package:lichess_mobile/src/model/common/id.dart';
+import 'package:lichess_mobile/src/model/common/perf.dart';
+import 'package:lichess_mobile/src/model/puzzle/puzzle.dart';
+import 'package:lichess_mobile/src/model/puzzle/puzzle_batch_storage.dart';
+import 'package:lichess_mobile/src/model/puzzle/puzzle_queue_filler.dart';
+import 'package:lichess_mobile/src/network/http.dart';
+
+import '../../test_container.dart';
+import '../../test_helpers.dart';
+
+void main() {
+  Future<ProviderContainer> makeTestContainer(MockClient mockClient) {
+    return makeContainer(
+      overrides: {
+        lichessClientProvider: lichessClientProvider.overrideWith((ref) {
+          return LichessClient(mockClient, ref);
+        }),
+      },
+    );
+  }
+
+  group('PuzzleQueueFiller', () {
+    test('fills an empty queue up to the configured count over multiple requests', () async {
+      // Each server batch is capped (50 in prod, 1 here), so a queue larger than
+      // the cap must be filled with several sequential select requests.
+      int nbReq = 0;
+      final mockClient = MockClient((request) {
+        if (request.method == 'GET' && request.url.path == '/api/puzzle/batch/mix') {
+          nbReq++;
+          // distinct id per request so each pass appends a new puzzle
+          return mockResponse(_batchOf1.replaceFirst('"20yWT"', '"pz$nbReq"'), 200);
+        }
+        // The filler must never POST solves.
+        return mockResponse('', 404);
+      });
+
+      final container = await makeTestContainer(mockClient);
+      final storage = await container.read(puzzleBatchStorageProvider.future);
+
+      await container
+          .read(puzzleQueueFillerProvider.notifier)
+          .fill(userId: null, queueLengthOverride: 3);
+
+      expect(nbReq, equals(3), reason: 'three GET requests to reach a queue of 3');
+      final data = await storage.fetch(userId: null);
+      expect(data?.unsolved.length, equals(3));
+      expect(data?.solved, equals(IList(const [])));
+    });
+
+    test('only fetches the deficit when the queue is partially full', () async {
+      int nbReq = 0;
+      final mockClient = MockClient((request) {
+        if (request.method == 'GET' && request.url.path == '/api/puzzle/batch/mix') {
+          nbReq++;
+          // request 1 needs nb=2 (queue 1 -> 3); serve two new puzzles at once
+          return mockResponse(_batchOf2, 200);
+        }
+        return mockResponse('', 404);
+      });
+
+      final container = await makeTestContainer(mockClient);
+      final storage = await container.read(puzzleBatchStorageProvider.future);
+      await storage.save(userId: null, data: _makePuzzleBatch(unsolved: [const PuzzleId('pId3')]));
+
+      await container
+          .read(puzzleQueueFillerProvider.notifier)
+          .fill(userId: null, queueLengthOverride: 3);
+
+      expect(nbReq, equals(1));
+      final data = await storage.fetch(userId: null);
+      expect(data?.unsolved.length, equals(3));
+    });
+
+    test('does nothing when the queue is already full', () async {
+      int nbReq = 0;
+      final mockClient = MockClient((request) {
+        nbReq++;
+        return mockResponse('', 404);
+      });
+
+      final container = await makeTestContainer(mockClient);
+      final storage = await container.read(puzzleBatchStorageProvider.future);
+      await storage.save(userId: null, data: _makePuzzleBatch(unsolved: [const PuzzleId('pId3')]));
+
+      await container
+          .read(puzzleQueueFillerProvider.notifier)
+          .fill(userId: null, queueLengthOverride: 1);
+
+      expect(nbReq, equals(0), reason: 'no request when there is no deficit');
+      final data = await storage.fetch(userId: null);
+      expect(data?.unsolved.length, equals(1));
+    });
+
+    test('stops when the server runs out of puzzles', () async {
+      int nbReq = 0;
+      final mockClient = MockClient((request) {
+        if (request.url.path == '/api/puzzle/batch/mix') {
+          nbReq++;
+          // first request yields one puzzle, then the server is exhausted
+          return mockResponse(nbReq == 1 ? _batchOf1 : '{"puzzles":[]}', 200);
+        }
+        return mockResponse('', 404);
+      });
+
+      final container = await makeTestContainer(mockClient);
+      final storage = await container.read(puzzleBatchStorageProvider.future);
+
+      await container
+          .read(puzzleQueueFillerProvider.notifier)
+          .fill(userId: null, queueLengthOverride: 10);
+
+      expect(nbReq, equals(2), reason: 'one filling request, one empty response, then stop');
+      final data = await storage.fetch(userId: null);
+      expect(data?.unsolved.length, equals(1));
+    });
+
+    test('stops and keeps existing puzzles when offline', () async {
+      int nbReq = 0;
+      final mockClient = MockClient((request) {
+        nbReq++;
+        throw const SocketException('offline');
+      });
+
+      final container = await makeTestContainer(mockClient);
+      final storage = await container.read(puzzleBatchStorageProvider.future);
+      await storage.save(userId: null, data: _makePuzzleBatch(unsolved: [const PuzzleId('pId3')]));
+
+      // must not throw
+      await container
+          .read(puzzleQueueFillerProvider.notifier)
+          .fill(userId: null, queueLengthOverride: 5);
+
+      expect(nbReq, equals(1));
+      final data = await storage.fetch(userId: null);
+      expect(data?.unsolved.length, equals(1));
+    });
+
+    test('never submits a solve request (select-only)', () async {
+      int nbPost = 0;
+      final mockClient = MockClient((request) {
+        if (request.method == 'POST') nbPost++;
+        if (request.method == 'GET' && request.url.path == '/api/puzzle/batch/mix') {
+          return mockResponse(_batchOf2, 200);
+        }
+        return mockResponse('', 404);
+      });
+
+      final container = await makeTestContainer(mockClient);
+      final storage = await container.read(puzzleBatchStorageProvider.future);
+      // storage already holds a solved entry: the filler must not report it
+      await storage.save(
+        userId: const UserId('u1'),
+        data: _makePuzzleBatch(
+          unsolved: const [],
+          solved: [const PuzzleSolution(id: PuzzleId('old'), win: true, rated: true)],
+        ),
+      );
+
+      await container
+          .read(puzzleQueueFillerProvider.notifier)
+          .fill(userId: const UserId('u1'), queueLengthOverride: 2);
+
+      expect(nbPost, equals(0), reason: 'fill must only GET, never POST solves');
+      final data = await storage.fetch(userId: const UserId('u1'));
+      // pre-existing solved list is preserved untouched
+      expect(data?.solved.length, equals(1));
+      expect(data?.unsolved.length, equals(2));
+    });
+
+    test('single-flight: a second concurrent fill is a no-op', () async {
+      int nbReq = 0;
+      final mockClient = MockClient((request) async {
+        if (request.method == 'GET' && request.url.path == '/api/puzzle/batch/mix') {
+          nbReq++;
+          await Future<void>.delayed(const Duration(milliseconds: 20));
+          return mockResponse(_batchOf1.replaceFirst('"20yWT"', '"pz$nbReq"'), 200);
+        }
+        return mockResponse('', 404);
+      });
+
+      final container = await makeTestContainer(mockClient);
+      final storage = await container.read(puzzleBatchStorageProvider.future);
+      final notifier = container.read(puzzleQueueFillerProvider.notifier);
+
+      // fire two overlapping fills; the second must return immediately
+      final first = notifier.fill(userId: null, queueLengthOverride: 2);
+      final second = notifier.fill(userId: null);
+      await Future.wait([first, second]);
+
+      // only the first fill ran: exactly 2 requests to reach a queue of 2
+      expect(nbReq, equals(2));
+      final data = await storage.fetch(userId: null);
+      expect(data?.unsolved.length, equals(2));
+    });
+  });
+}
+
+const _batchOf1 = '''
+{"puzzles":[{"game":{"id":"PrlkCqOv","perf":{"key":"rapid","name":"Rapid"},"rated":true,"players":[{"userId":"silverjo","name":"silverjo (1777)","color":"white"},{"userId":"robyarchitetto","name":"Robyarchitetto (1742)","color":"black"}],"pgn":"e4 Nc6","clock":"5+8"},"puzzle":{"id":"20yWT","rating":1859,"plays":551,"initialPly":93,"solution":["a6a7","b2a2","c4c2","a2a7","d7a7"],"themes":["endgame","long","advantage","advancedPawn"]}}]}
+''';
+
+const _batchOf2 = '''
+{"puzzles":[{"game":{"id":"PrlkCqOv","perf":{"key":"rapid","name":"Rapid"},"rated":true,"players":[{"userId":"silverjo","name":"silverjo (1777)","color":"white"},{"userId":"robyarchitetto","name":"Robyarchitetto (1742)","color":"black"}],"pgn":"e4 Nc6","clock":"5+8"},"puzzle":{"id":"20yWT","rating":1859,"plays":551,"initialPly":93,"solution":["a6a7","b2a2","c4c2","a2a7","d7a7"],"themes":["endgame"]}},{"game":{"id":"0lwkiJbZ","perf":{"key":"classical","name":"Classical"},"rated":true,"players":[{"userId":"nirdosh","name":"nirdosh (2035)","color":"white"},{"userId":"burn_it_down","name":"burn_it_down (2139)","color":"black"}],"pgn":"d4 Nf6","clock":"15+15"},"puzzle":{"id":"7H5EV","rating":1852,"plays":410,"initialPly":84,"solution":["e8c8","d7d4","e4d4"],"themes":["endgame","short","advantage"]}}]}
+''';
+
+PuzzleBatch _makePuzzleBatch({
+  required List<PuzzleId> unsolved,
+  List<PuzzleSolution> solved = const [],
+}) {
+  return PuzzleBatch(
+    solved: IList([for (final solution in solved) solution]),
+    unsolved: IList([
+      for (final id in unsolved)
+        Puzzle(
+          puzzle: PuzzleData(
+            id: id,
+            rating: 1988,
+            plays: 5,
+            initialPly: 23,
+            solution: IList(const ['a6a7', 'b2a2', 'c4c2']),
+            themes: ISet(const ['endgame', 'advantage']),
+          ),
+          game: const PuzzleGame(
+            id: GameId('PrlkCqOv'),
+            perf: Perf.blitz,
+            rated: true,
+            white: PuzzleGamePlayer(side: Side.white, name: 'user1'),
+            black: PuzzleGamePlayer(side: Side.black, name: 'user2'),
+            pgn: 'e4 Nc6 Bc4 e6 a3 g6 Nf3 Bg7 c3 Nge7 d3 O-O Be3 Na5 Ba2 b6 Qd2',
+          ),
+        ),
+    ]),
+  );
+}

--- a/test/model/puzzle/puzzle_queue_filler_test.dart
+++ b/test/model/puzzle/puzzle_queue_filler_test.dart
@@ -8,9 +8,12 @@ import 'package:http/testing.dart';
 import 'package:lichess_mobile/src/model/common/id.dart';
 import 'package:lichess_mobile/src/model/common/perf.dart';
 import 'package:lichess_mobile/src/model/puzzle/puzzle.dart';
+import 'package:lichess_mobile/src/model/puzzle/puzzle_angle.dart';
 import 'package:lichess_mobile/src/model/puzzle/puzzle_batch_storage.dart';
 import 'package:lichess_mobile/src/model/puzzle/puzzle_queue_filler.dart';
+import 'package:lichess_mobile/src/model/puzzle/puzzle_theme.dart';
 import 'package:lichess_mobile/src/network/http.dart';
+import 'package:mocktail/mocktail.dart';
 
 import '../../test_container.dart';
 import '../../test_helpers.dart';
@@ -19,7 +22,13 @@ import '../../test_helpers.dart';
 // real user id. Anonymous behaviour is covered by its own no-op test.
 const _user = UserId('testUser');
 
+class _MockPuzzleBatchStorage extends Mock implements PuzzleBatchStorage {}
+
 void main() {
+  setUpAll(() {
+    registerFallbackValue(const PuzzleTheme(PuzzleThemeKey.mix));
+  });
+
   Future<ProviderContainer> makeTestContainer(MockClient mockClient) {
     return makeContainer(
       overrides: {
@@ -274,6 +283,37 @@ void main() {
       expect(data?.unsolved.any((p) => p.puzzle.id == const PuzzleId('20yWT')), isTrue);
       // 'seed' was NOT restored to unsolved.
       expect(data?.unsolved.any((p) => p.puzzle.id == const PuzzleId('seed')), isFalse);
+    });
+
+    test('never throws when storage read fails (best-effort contract)', () async {
+      // fill() is documented "Never throws". A storage read failure (corrupt
+      // prefs, sqflite I/O) must stop the fill quietly, not surface an
+      // unhandled async error to the fire-and-forget caller.
+      final throwingStorage = _MockPuzzleBatchStorage();
+      when(
+        () => throwingStorage.fetch(
+          userId: any(named: 'userId'),
+          angle: any(named: 'angle'),
+        ),
+      ).thenThrow(const FormatException('corrupt puzzle batch'));
+
+      final container = await makeContainer(
+        overrides: {
+          puzzleBatchStorageProvider: puzzleBatchStorageProvider.overrideWith(
+            (ref) => Future.value(throwingStorage),
+          ),
+        },
+      );
+
+      // Must complete normally rather than throw.
+      await expectLater(
+        container
+            .read(puzzleQueueFillerProvider.notifier)
+            .fill(userId: _user, queueLengthOverride: 5),
+        completes,
+      );
+      // The single-flight guard is released so a later fill can run.
+      expect(container.read(puzzleQueueFillerProvider), isFalse);
     });
   });
 }

--- a/test/model/puzzle/puzzle_queue_filler_test.dart
+++ b/test/model/puzzle/puzzle_queue_filler_test.dart
@@ -177,23 +177,15 @@ void main() {
 
       final container = await makeTestContainer(mockClient);
       final storage = await container.read(puzzleBatchStorageProvider.future);
-      // storage already holds a solved entry: the filler must not report it
-      await storage.save(
-        userId: _user,
-        data: _makePuzzleBatch(
-          unsolved: const [],
-          solved: [const PuzzleSolution(id: PuzzleId('old'), win: true, rated: true)],
-        ),
-      );
 
+      // fills a queue with no pending solves: must download via GET, never POST
       await container
           .read(puzzleQueueFillerProvider.notifier)
           .fill(userId: _user, queueLengthOverride: 2);
 
       expect(nbPost, equals(0), reason: 'fill must only GET, never POST solves');
       final data = await storage.fetch(userId: _user);
-      // pre-existing solved list is preserved untouched
-      expect(data?.solved.length, equals(1));
+      expect(data?.solved, equals(IList(const [])));
       expect(data?.unsolved.length, equals(2));
     });
 
@@ -260,6 +252,36 @@ void main() {
       );
       final data = await storage.fetch(userId: _user, angle: nonMixAngle);
       expect(data?.unsolved.length, equals(kMinOfflinePuzzles));
+    });
+
+    test('does not refill while there are pending (unflushed) solves', () async {
+      // Solving is the binding constraint (lila caps solves at 400/h, far
+      // tighter than puzzle fetching), so while a solved backlog waits to flush
+      // the filler must not keep growing the unsolved queue.
+      int nbReq = 0;
+      final mockClient = MockClient((request) {
+        nbReq++;
+        return mockResponse('', 404);
+      });
+
+      final container = await makeTestContainer(mockClient);
+      final storage = await container.read(puzzleBatchStorageProvider.future);
+      await storage.save(
+        userId: _user,
+        data: _makePuzzleBatch(
+          unsolved: [const PuzzleId('pId3')],
+          solved: [const PuzzleSolution(id: PuzzleId('done'), win: true, rated: true)],
+        ),
+      );
+
+      await container
+          .read(puzzleQueueFillerProvider.notifier)
+          .fill(userId: _user, queueLengthOverride: 5);
+
+      expect(nbReq, equals(0), reason: 'no download while solves are pending flush');
+      final data = await storage.fetch(userId: _user);
+      expect(data?.unsolved.length, equals(1));
+      expect(data?.solved.length, equals(1));
     });
 
     test('is a no-op for anonymous users', () async {

--- a/test/model/puzzle/puzzle_queue_filler_test.dart
+++ b/test/model/puzzle/puzzle_queue_filler_test.dart
@@ -10,6 +10,7 @@ import 'package:lichess_mobile/src/model/common/perf.dart';
 import 'package:lichess_mobile/src/model/puzzle/puzzle.dart';
 import 'package:lichess_mobile/src/model/puzzle/puzzle_angle.dart';
 import 'package:lichess_mobile/src/model/puzzle/puzzle_batch_storage.dart';
+import 'package:lichess_mobile/src/model/puzzle/puzzle_preferences.dart';
 import 'package:lichess_mobile/src/model/puzzle/puzzle_queue_filler.dart';
 import 'package:lichess_mobile/src/model/puzzle/puzzle_theme.dart';
 import 'package:lichess_mobile/src/network/http.dart';
@@ -220,6 +221,45 @@ void main() {
       expect(nbReq, equals(2));
       final data = await storage.fetch(userId: _user);
       expect(data?.unsolved.length, equals(2));
+    });
+
+    test('caps a non-mix angle at kMinOfflinePuzzles regardless of the setting', () async {
+      // The configurable count applies only to the mix angle. A non-mix angle
+      // must never grow past kMinOfflinePuzzles, even when the setting (here the
+      // override) asks for more: per-angle queues would otherwise multiply into
+      // enough offline solves to blow the server's solve rate limit.
+      const nonMixAngle = PuzzleTheme(PuzzleThemeKey.advancedPawn);
+      int nbReq = 0;
+      final mockClient = MockClient((request) {
+        if (request.method == 'GET' && request.url.path == '/api/puzzle/batch/advancedPawn') {
+          nbReq++;
+          return mockResponse(_batchOf1.replaceFirst('"20yWT"', '"pz$nbReq"'), 200);
+        }
+        return mockResponse('', 404);
+      });
+
+      final container = await makeTestContainer(mockClient);
+      final storage = await container.read(puzzleBatchStorageProvider.future);
+      // one short of the cap, so a correct fill tops up by exactly one
+      await storage.save(
+        userId: _user,
+        angle: nonMixAngle,
+        data: _makePuzzleBatch(
+          unsolved: [for (var i = 0; i < kMinOfflinePuzzles - 1; i++) PuzzleId('p$i')],
+        ),
+      );
+
+      await container
+          .read(puzzleQueueFillerProvider.notifier)
+          .fill(userId: _user, angle: nonMixAngle, queueLengthOverride: 300);
+
+      expect(
+        nbReq,
+        equals(1),
+        reason: 'fills up to kMinOfflinePuzzles (one request), not to the requested 300',
+      );
+      final data = await storage.fetch(userId: _user, angle: nonMixAngle);
+      expect(data?.unsolved.length, equals(kMinOfflinePuzzles));
     });
 
     test('is a no-op for anonymous users', () async {

--- a/test/model/puzzle/puzzle_queue_filler_test.dart
+++ b/test/model/puzzle/puzzle_queue_filler_test.dart
@@ -10,6 +10,7 @@ import 'package:lichess_mobile/src/model/common/perf.dart';
 import 'package:lichess_mobile/src/model/puzzle/puzzle.dart';
 import 'package:lichess_mobile/src/model/puzzle/puzzle_angle.dart';
 import 'package:lichess_mobile/src/model/puzzle/puzzle_batch_storage.dart';
+import 'package:lichess_mobile/src/model/puzzle/puzzle_difficulty.dart';
 import 'package:lichess_mobile/src/model/puzzle/puzzle_preferences.dart';
 import 'package:lichess_mobile/src/model/puzzle/puzzle_queue_filler.dart';
 import 'package:lichess_mobile/src/model/puzzle/puzzle_theme.dart';
@@ -25,17 +26,36 @@ const _user = UserId('testUser');
 
 class _MockPuzzleBatchStorage extends Mock implements PuzzleBatchStorage {}
 
+/// A [PuzzlePreferences] that returns a fixed, unclamped offline queue length,
+/// so tests can drive the fill with small (cheap) values that the real,
+/// [kMinOfflinePuzzles]-clamped preference could never produce.
+class _FakePuzzlePreferences extends PuzzlePreferences {
+  _FakePuzzlePreferences(this._nbOfflinePuzzles);
+
+  final int _nbOfflinePuzzles;
+
+  @override
+  PuzzlePrefs build() => PuzzlePrefs(
+    id: null,
+    difficulty: PuzzleDifficulty.normal,
+    nbOfflinePuzzles: _nbOfflinePuzzles,
+  );
+}
+
 void main() {
   setUpAll(() {
     registerFallbackValue(const PuzzleTheme(PuzzleThemeKey.mix));
   });
 
-  Future<ProviderContainer> makeTestContainer(MockClient mockClient) {
+  Future<ProviderContainer> makeTestContainer(MockClient mockClient, {int nbOfflinePuzzles = 100}) {
     return makeContainer(
       overrides: {
         lichessClientProvider: lichessClientProvider.overrideWith((ref) {
           return LichessClient(mockClient, ref);
         }),
+        puzzlePreferencesProvider: puzzlePreferencesProvider.overrideWith(
+          () => _FakePuzzlePreferences(nbOfflinePuzzles),
+        ),
       },
     );
   }
@@ -55,12 +75,10 @@ void main() {
         return mockResponse('', 404);
       });
 
-      final container = await makeTestContainer(mockClient);
+      final container = await makeTestContainer(mockClient, nbOfflinePuzzles: 3);
       final storage = await container.read(puzzleBatchStorageProvider.future);
 
-      await container
-          .read(puzzleQueueFillerProvider.notifier)
-          .fill(userId: _user, queueLengthOverride: 3);
+      await container.read(puzzleQueueFillerProvider.notifier).fill(userId: _user);
 
       expect(nbReq, equals(3), reason: 'three GET requests to reach a queue of 3');
       final data = await storage.fetch(userId: _user);
@@ -79,16 +97,14 @@ void main() {
         return mockResponse('', 404);
       });
 
-      final container = await makeTestContainer(mockClient);
+      final container = await makeTestContainer(mockClient, nbOfflinePuzzles: 3);
       final storage = await container.read(puzzleBatchStorageProvider.future);
       await storage.save(
         userId: _user,
         data: _makePuzzleBatch(unsolved: [const PuzzleId('pId3')]),
       );
 
-      await container
-          .read(puzzleQueueFillerProvider.notifier)
-          .fill(userId: _user, queueLengthOverride: 3);
+      await container.read(puzzleQueueFillerProvider.notifier).fill(userId: _user);
 
       expect(nbReq, equals(1));
       final data = await storage.fetch(userId: _user);
@@ -102,16 +118,14 @@ void main() {
         return mockResponse('', 404);
       });
 
-      final container = await makeTestContainer(mockClient);
+      final container = await makeTestContainer(mockClient, nbOfflinePuzzles: 1);
       final storage = await container.read(puzzleBatchStorageProvider.future);
       await storage.save(
         userId: _user,
         data: _makePuzzleBatch(unsolved: [const PuzzleId('pId3')]),
       );
 
-      await container
-          .read(puzzleQueueFillerProvider.notifier)
-          .fill(userId: _user, queueLengthOverride: 1);
+      await container.read(puzzleQueueFillerProvider.notifier).fill(userId: _user);
 
       expect(nbReq, equals(0), reason: 'no request when there is no deficit');
       final data = await storage.fetch(userId: _user);
@@ -129,12 +143,10 @@ void main() {
         return mockResponse('', 404);
       });
 
-      final container = await makeTestContainer(mockClient);
+      final container = await makeTestContainer(mockClient, nbOfflinePuzzles: 10);
       final storage = await container.read(puzzleBatchStorageProvider.future);
 
-      await container
-          .read(puzzleQueueFillerProvider.notifier)
-          .fill(userId: _user, queueLengthOverride: 10);
+      await container.read(puzzleQueueFillerProvider.notifier).fill(userId: _user);
 
       expect(nbReq, equals(2), reason: 'one filling request, one empty response, then stop');
       final data = await storage.fetch(userId: _user);
@@ -148,7 +160,7 @@ void main() {
         throw const SocketException('offline');
       });
 
-      final container = await makeTestContainer(mockClient);
+      final container = await makeTestContainer(mockClient, nbOfflinePuzzles: 5);
       final storage = await container.read(puzzleBatchStorageProvider.future);
       await storage.save(
         userId: _user,
@@ -156,9 +168,7 @@ void main() {
       );
 
       // must not throw
-      await container
-          .read(puzzleQueueFillerProvider.notifier)
-          .fill(userId: _user, queueLengthOverride: 5);
+      await container.read(puzzleQueueFillerProvider.notifier).fill(userId: _user);
 
       expect(nbReq, equals(1));
       final data = await storage.fetch(userId: _user);
@@ -175,13 +185,11 @@ void main() {
         return mockResponse('', 404);
       });
 
-      final container = await makeTestContainer(mockClient);
+      final container = await makeTestContainer(mockClient, nbOfflinePuzzles: 2);
       final storage = await container.read(puzzleBatchStorageProvider.future);
 
       // fills a queue with no pending solves: must download via GET, never POST
-      await container
-          .read(puzzleQueueFillerProvider.notifier)
-          .fill(userId: _user, queueLengthOverride: 2);
+      await container.read(puzzleQueueFillerProvider.notifier).fill(userId: _user);
 
       expect(nbPost, equals(0), reason: 'fill must only GET, never POST solves');
       final data = await storage.fetch(userId: _user);
@@ -200,12 +208,12 @@ void main() {
         return mockResponse('', 404);
       });
 
-      final container = await makeTestContainer(mockClient);
+      final container = await makeTestContainer(mockClient, nbOfflinePuzzles: 2);
       final storage = await container.read(puzzleBatchStorageProvider.future);
       final notifier = container.read(puzzleQueueFillerProvider.notifier);
 
       // fire two overlapping fills; the second must return immediately
-      final first = notifier.fill(userId: _user, queueLengthOverride: 2);
+      final first = notifier.fill(userId: _user);
       final second = notifier.fill(userId: _user);
       await Future.wait([first, second]);
 
@@ -230,7 +238,7 @@ void main() {
         return mockResponse('', 404);
       });
 
-      final container = await makeTestContainer(mockClient);
+      final container = await makeTestContainer(mockClient, nbOfflinePuzzles: 300);
       final storage = await container.read(puzzleBatchStorageProvider.future);
       // one short of the cap, so a correct fill tops up by exactly one
       await storage.save(
@@ -243,7 +251,7 @@ void main() {
 
       await container
           .read(puzzleQueueFillerProvider.notifier)
-          .fill(userId: _user, angle: nonMixAngle, queueLengthOverride: 300);
+          .fill(userId: _user, angle: nonMixAngle);
 
       expect(
         nbReq,
@@ -274,9 +282,7 @@ void main() {
         ),
       );
 
-      await container
-          .read(puzzleQueueFillerProvider.notifier)
-          .fill(userId: _user, queueLengthOverride: 5);
+      await container.read(puzzleQueueFillerProvider.notifier).fill(userId: _user);
 
       expect(nbReq, equals(0), reason: 'no download while solves are pending flush');
       final data = await storage.fetch(userId: _user);
@@ -294,9 +300,7 @@ void main() {
       final container = await makeTestContainer(mockClient);
       final storage = await container.read(puzzleBatchStorageProvider.future);
 
-      await container
-          .read(puzzleQueueFillerProvider.notifier)
-          .fill(userId: null, queueLengthOverride: 5);
+      await container.read(puzzleQueueFillerProvider.notifier).fill(userId: null);
 
       expect(nbReq, equals(0), reason: 'anonymous fill must never hit the server');
       final data = await storage.fetch(userId: null);
@@ -311,6 +315,7 @@ void main() {
       // solution: the exact silent data loss this test guards against.
       late final ProviderContainer container;
       container = await makeTestContainer(
+        nbOfflinePuzzles: 3,
         MockClient((request) async {
           if (request.method == 'GET' && request.url.path == '/api/puzzle/batch/mix') {
             // Simulate a solve landing while the request is in flight: the
@@ -334,9 +339,7 @@ void main() {
         data: _makePuzzleBatch(unsolved: [const PuzzleId('seed')]),
       );
 
-      await container
-          .read(puzzleQueueFillerProvider.notifier)
-          .fill(userId: _user, queueLengthOverride: 3);
+      await container.read(puzzleQueueFillerProvider.notifier).fill(userId: _user);
 
       final data = await storage.fetch(userId: _user);
       // The mid-fill solve survives: 'seed' stays in solved, its solution intact.
@@ -369,9 +372,7 @@ void main() {
 
       // Must complete normally rather than throw.
       await expectLater(
-        container
-            .read(puzzleQueueFillerProvider.notifier)
-            .fill(userId: _user, queueLengthOverride: 5),
+        container.read(puzzleQueueFillerProvider.notifier).fill(userId: _user),
         completes,
       );
       // The single-flight guard is released so a later fill can run.

--- a/test/model/puzzle/puzzle_service_test.dart
+++ b/test/model/puzzle/puzzle_service_test.dart
@@ -356,6 +356,75 @@ void main() {
       expect(data?.unsolved[0].puzzle.id, equals(const PuzzleId('20yWT')));
       expect(data?.unsolved[1].puzzle.id, equals(const PuzzleId('7H5EV')));
     });
+
+    test(
+      'fills queue in the background over multiple requests when server caps each batch',
+      () async {
+        // The server caps each batch at 50 puzzles, so a large queueLength is
+        // filled over several requests. The first request runs in the foreground
+        // (so the next puzzle shows immediately) and the rest fill in the
+        // background. Simulate the cap by returning one puzzle per request.
+        int nbReq = 0;
+        final mockClient = MockClient((request) {
+          if (request.url.path == '/api/puzzle/batch/mix') {
+            nbReq++;
+            // each request yields a single puzzle with a distinct id, so the
+            // background merge keeps appending until the queue reaches 3
+            return mockResponse(batchOf1.replaceFirst('"20yWT"', '"pz$nbReq"'), 200);
+          }
+          return mockResponse('', 404);
+        });
+
+        final container = await makeTestContainer(mockClient);
+        final storage = await container.read(puzzleBatchStorageProvider.future);
+        final service = await container.read(puzzleServiceFactoryProvider)(queueLength: 3);
+
+        final next = await service.nextPuzzle(userId: null);
+
+        // the first puzzle is available immediately after the foreground request
+        expect(next?.puzzle.puzzle.id, equals(const PuzzleId('pz1')));
+
+        // the background fill tops the queue up to queueLength
+        await _waitUntil(() async {
+          final data = await storage.fetch(userId: null);
+          return (data?.unsolved.length ?? 0) >= 3;
+        });
+
+        expect(nbReq, equals(3));
+        final data = await storage.fetch(userId: null);
+        expect(data?.unsolved.length, equals(3));
+      },
+    );
+
+    test('background fill stops when server returns no more puzzles', () async {
+      // If the server runs out of puzzles before the queue is full, the fill
+      // must stop instead of looping forever.
+      int nbReq = 0;
+      final mockClient = MockClient((request) {
+        if (request.url.path == '/api/puzzle/batch/mix') {
+          nbReq++;
+          // first request returns 1 puzzle, subsequent requests return none
+          return mockResponse(nbReq == 1 ? batchOf1 : '{"puzzles":[]}', 200);
+        }
+        return mockResponse('', 404);
+      });
+
+      final container = await makeTestContainer(mockClient);
+      final storage = await container.read(puzzleBatchStorageProvider.future);
+      final service = await container.read(puzzleServiceFactoryProvider)(queueLength: 10);
+
+      final next = await service.nextPuzzle(userId: null);
+      expect(next?.puzzle.puzzle.id, equals(const PuzzleId('20yWT')));
+
+      // wait for the background fill to make its (empty) second request and stop
+      await _waitUntil(() async => nbReq >= 2);
+      // give the loop a tick to settle after the empty response
+      await Future<void>.delayed(const Duration(milliseconds: 20));
+
+      expect(nbReq, equals(2));
+      final data = await storage.fetch(userId: null);
+      expect(data?.unsolved.length, equals(1));
+    });
   });
 }
 
@@ -422,4 +491,18 @@ PuzzleBatch _makePuzzleBatch({
         ),
     ]),
   );
+}
+
+/// Polls [condition] until it returns true or [timeout] elapses. Used to wait
+/// for the background queue fill, which runs after `nextPuzzle` returns.
+Future<void> _waitUntil(
+  Future<bool> Function() condition, {
+  Duration timeout = const Duration(seconds: 2),
+}) async {
+  final deadline = DateTime.now().add(timeout);
+  while (DateTime.now().isBefore(deadline)) {
+    if (await condition()) return;
+    await Future<void>.delayed(const Duration(milliseconds: 5));
+  }
+  throw StateError('Timed out waiting for condition');
 }

--- a/test/model/puzzle/puzzle_service_test.dart
+++ b/test/model/puzzle/puzzle_service_test.dart
@@ -356,84 +356,6 @@ void main() {
       expect(data?.unsolved[0].puzzle.id, equals(const PuzzleId('20yWT')));
       expect(data?.unsolved[1].puzzle.id, equals(const PuzzleId('7H5EV')));
     });
-
-    test(
-      'fills queue in the background over multiple requests when server caps each batch',
-      () async {
-        // The server caps each batch at 50 puzzles, so a large queueLength is
-        // filled over several requests. The first request runs in the foreground
-        // (so the next puzzle shows immediately) and the rest fill in the
-        // background. Simulate the cap by returning one puzzle per request.
-        int nbReq = 0;
-        final mockClient = MockClient((request) {
-          if (request.url.path == '/api/puzzle/batch/mix') {
-            nbReq++;
-            // each request yields a single puzzle with a distinct id, so the
-            // background merge keeps appending until the queue reaches 3
-            return mockResponse(batchOf1.replaceFirst('"20yWT"', '"pz$nbReq"'), 200);
-          }
-          return mockResponse('', 404);
-        });
-
-        final container = await makeTestContainer(mockClient);
-        final storage = await container.read(puzzleBatchStorageProvider.future);
-        // Simulate a server cap of 1 puzzle per request so the loop must run.
-        final service = await container.read(puzzleServiceFactoryProvider)(
-          queueLength: 3,
-          serverBatchCap: 1,
-        );
-
-        final next = await service.nextPuzzle(userId: null);
-
-        // the first puzzle is available immediately after the foreground request
-        expect(next?.puzzle.puzzle.id, equals(const PuzzleId('pz1')));
-
-        // the background fill tops the queue up to queueLength
-        await _waitUntil(() async {
-          final data = await storage.fetch(userId: null);
-          return (data?.unsolved.length ?? 0) >= 3;
-        });
-
-        expect(nbReq, equals(3));
-        final data = await storage.fetch(userId: null);
-        expect(data?.unsolved.length, equals(3));
-      },
-    );
-
-    test('background fill stops when server returns no more puzzles', () async {
-      // If the server runs out of puzzles before the queue is full, the fill
-      // must stop instead of looping forever.
-      int nbReq = 0;
-      final mockClient = MockClient((request) {
-        if (request.url.path == '/api/puzzle/batch/mix') {
-          nbReq++;
-          // first request returns 1 puzzle, subsequent requests return none
-          return mockResponse(nbReq == 1 ? batchOf1 : '{"puzzles":[]}', 200);
-        }
-        return mockResponse('', 404);
-      });
-
-      final container = await makeTestContainer(mockClient);
-      final storage = await container.read(puzzleBatchStorageProvider.future);
-      // Simulate a server cap of 1 so the background fill loop runs and must
-      // stop when the server returns no more puzzles.
-      final service = await container.read(puzzleServiceFactoryProvider)(
-        queueLength: 10,
-        serverBatchCap: 1,
-      );
-
-      final next = await service.nextPuzzle(userId: null);
-      expect(next?.puzzle.puzzle.id, equals(const PuzzleId('20yWT')));
-
-      // wait for the background fill to make its (empty) second request and stop
-      await _waitUntil(() async => nbReq >= 2);
-      // give the loop a tick to settle after the empty response
-      await Future<void>.delayed(const Duration(milliseconds: 20));
-
-      expect(nbReq, equals(2));
-      final data = await storage.fetch(userId: null);
-      expect(data?.unsolved.length, equals(1));
-    });
   });
 }
 
@@ -500,18 +422,4 @@ PuzzleBatch _makePuzzleBatch({
         ),
     ]),
   );
-}
-
-/// Polls [condition] until it returns true or [timeout] elapses. Used to wait
-/// for the background queue fill, which runs after `nextPuzzle` returns.
-Future<void> _waitUntil(
-  Future<bool> Function() condition, {
-  Duration timeout = const Duration(seconds: 2),
-}) async {
-  final deadline = DateTime.now().add(timeout);
-  while (DateTime.now().isBefore(deadline)) {
-    if (await condition()) return;
-    await Future<void>.delayed(const Duration(milliseconds: 5));
-  }
-  throw StateError('Timed out waiting for condition');
 }

--- a/test/model/puzzle/puzzle_service_test.dart
+++ b/test/model/puzzle/puzzle_service_test.dart
@@ -377,7 +377,11 @@ void main() {
 
         final container = await makeTestContainer(mockClient);
         final storage = await container.read(puzzleBatchStorageProvider.future);
-        final service = await container.read(puzzleServiceFactoryProvider)(queueLength: 3);
+        // Simulate a server cap of 1 puzzle per request so the loop must run.
+        final service = await container.read(puzzleServiceFactoryProvider)(
+          queueLength: 3,
+          serverBatchCap: 1,
+        );
 
         final next = await service.nextPuzzle(userId: null);
 
@@ -411,7 +415,12 @@ void main() {
 
       final container = await makeTestContainer(mockClient);
       final storage = await container.read(puzzleBatchStorageProvider.future);
-      final service = await container.read(puzzleServiceFactoryProvider)(queueLength: 10);
+      // Simulate a server cap of 1 so the background fill loop runs and must
+      // stop when the server returns no more puzzles.
+      final service = await container.read(puzzleServiceFactoryProvider)(
+        queueLength: 10,
+        serverBatchCap: 1,
+      );
 
       final next = await service.nextPuzzle(userId: null);
       expect(next?.puzzle.puzzle.id, equals(const PuzzleId('20yWT')));

--- a/test/model/puzzle/puzzle_service_test.dart
+++ b/test/model/puzzle/puzzle_service_test.dart
@@ -11,6 +11,7 @@ import 'package:lichess_mobile/src/model/puzzle/puzzle.dart';
 import 'package:lichess_mobile/src/model/puzzle/puzzle_angle.dart';
 import 'package:lichess_mobile/src/model/puzzle/puzzle_batch_storage.dart';
 import 'package:lichess_mobile/src/model/puzzle/puzzle_service.dart';
+import 'package:lichess_mobile/src/model/puzzle/puzzle_solve_limit.dart';
 import 'package:lichess_mobile/src/model/puzzle/puzzle_theme.dart';
 import 'package:lichess_mobile/src/network/http.dart';
 
@@ -131,6 +132,100 @@ void main() {
       final data = await storage.fetch(userId: const UserId('testUserId'));
       expect(data?.unsolved.length, equals(1));
       expect(data?.solved.length, equals(0));
+    });
+
+    test('a 429 on a solve flush arms the back-off and preserves the solved list', () async {
+      int nbPOSTReq = 0;
+      final mockClient = MockClient((request) {
+        if (request.method == 'POST' && request.url.path == '/api/puzzle/batch/mix') {
+          nbPOSTReq++;
+          return mockResponse('', 429);
+        }
+        return mockResponse('', 404);
+      });
+
+      final container = await makeTestContainer(mockClient);
+      final storage = await container.read(puzzleBatchStorageProvider.future);
+      final service = await container.read(puzzleServiceFactoryProvider)(queueLength: 1);
+      await storage.save(
+        userId: const UserId('testUserId'),
+        data: _makePuzzleBatch(
+          unsolved: [const PuzzleId('pId3')],
+          solved: [const PuzzleSolution(id: PuzzleId('soAw'), win: true, rated: true)],
+        ),
+      );
+
+      final next = await service.nextPuzzle(userId: const UserId('testUserId'));
+
+      expect(nbPOSTReq, equals(1));
+      // still serves the next puzzle from the local unsolved queue
+      expect(next?.puzzle.puzzle.id, equals(const PuzzleId('pId3')));
+      // the solved list is preserved, not lost
+      final data = await storage.fetch(userId: const UserId('testUserId'));
+      expect(data?.solved.length, equals(1));
+      // the back-off is armed, carrying the rejected count
+      expect(container.read(puzzleSolveLimiterProvider.notifier).isLimited, isTrue);
+      expect(container.read(puzzleSolveLimiterProvider)?.solvedCount, equals(1));
+    });
+
+    test('does not attempt a solve flush while the back-off is armed', () async {
+      int nbPOSTReq = 0;
+      final mockClient = MockClient((request) {
+        if (request.method == 'POST') nbPOSTReq++;
+        return mockResponse('', 404);
+      });
+
+      final container = await makeTestContainer(mockClient);
+      final storage = await container.read(puzzleBatchStorageProvider.future);
+      final service = await container.read(puzzleServiceFactoryProvider)(queueLength: 1);
+      container.read(puzzleSolveLimiterProvider.notifier).markLimited(3);
+      await storage.save(
+        userId: const UserId('testUserId'),
+        data: _makePuzzleBatch(
+          unsolved: [const PuzzleId('pId3')],
+          solved: [const PuzzleSolution(id: PuzzleId('soAw'), win: true, rated: true)],
+        ),
+      );
+
+      final next = await service.nextPuzzle(userId: const UserId('testUserId'));
+
+      expect(nbPOSTReq, equals(0), reason: 'no solve flush is attempted while limited');
+      expect(next?.puzzle.puzzle.id, equals(const PuzzleId('pId3')));
+      // the pending solves are kept for a later flush
+      final data = await storage.fetch(userId: const UserId('testUserId'));
+      expect(data?.solved.length, equals(1));
+    });
+
+    test('attempts a solve flush again once the back-off has expired', () async {
+      int nbPOSTReq = 0;
+      final mockClient = MockClient((request) {
+        if (request.method == 'POST' && request.url.path == '/api/puzzle/batch/mix') {
+          nbPOSTReq++;
+          return mockResponse(emptyBatch, 200);
+        }
+        return mockResponse('', 404);
+      });
+
+      final container = await makeTestContainer(mockClient);
+      final storage = await container.read(puzzleBatchStorageProvider.future);
+      final service = await container.read(puzzleServiceFactoryProvider)(queueLength: 1);
+      // an expired back-off (its timestamp is well past the duration)
+      container
+          .read(puzzleSolveLimiterProvider.notifier)
+          .markLimitedAt(DateTime.now().subtract(kPuzzleSolveLimitDuration * 2), 3);
+      await storage.save(
+        userId: const UserId('testUserId'),
+        data: _makePuzzleBatch(
+          unsolved: [const PuzzleId('pId3')],
+          solved: [const PuzzleSolution(id: PuzzleId('soAw'), win: true, rated: true)],
+        ),
+      );
+
+      await service.nextPuzzle(userId: const UserId('testUserId'));
+
+      expect(nbPOSTReq, equals(1), reason: 'the flush is attempted again after expiry');
+      final data = await storage.fetch(userId: const UserId('testUserId'));
+      expect(data?.solved.length, equals(0), reason: 'the flush succeeded and cleared solved');
     });
 
     test('nextPuzzle will always get the first puzzle of unsolved queue', () async {

--- a/test/network/http_test.dart
+++ b/test/network/http_test.dart
@@ -19,6 +19,39 @@ void main() {
     FakeClient.reset();
   });
 
+  group('shouldRetryOn429', () {
+    http.Response response(int status, {String method = 'GET', String path = '/api/test'}) {
+      return http.Response(
+        '',
+        status,
+        request: http.Request(method, Uri.parse('https://lichess.org$path')),
+      );
+    }
+
+    test('retries a generic 429', () {
+      expect(shouldRetryOn429(response(429)), isTrue);
+      expect(shouldRetryOn429(response(429, method: 'POST')), isTrue);
+    });
+
+    test('does not retry non-429 responses', () {
+      expect(shouldRetryOn429(response(200)), isFalse);
+      expect(shouldRetryOn429(response(503)), isFalse);
+    });
+
+    test('does not retry a puzzle solve submission (POST /api/puzzle/batch)', () {
+      // solveBatch handles 429 with a back-off, so the retry only wastes a call
+      expect(
+        shouldRetryOn429(response(429, method: 'POST', path: '/api/puzzle/batch/mix')),
+        isFalse,
+      );
+    });
+
+    test('still retries a puzzle batch download (GET /api/puzzle/batch)', () {
+      // selectBatch is a plain download, not the rate-limited solve path
+      expect(shouldRetryOn429(response(429, method: 'GET', path: '/api/puzzle/batch/mix')), isTrue);
+    });
+  });
+
   group('LichessClient', () {
     test('sends requests to lichess host when only path is provided', () async {
       final container = await makeContainer(

--- a/test/view/puzzle/puzzle_screen_test.dart
+++ b/test/view/puzzle/puzzle_screen_test.dart
@@ -53,6 +53,7 @@ void main() {
   setUpAll(() {
     registerFallbackValue(PuzzleBatch(solved: IList(const []), unsolved: IList([puzzle])));
     registerFallbackValue(puzzle);
+    registerFallbackValue(const PuzzleTheme(PuzzleThemeKey.mix));
   });
 
   final mockBatchStorage = MockPuzzleBatchStorage();
@@ -124,9 +125,26 @@ void main() {
     });
 
     testWidgets(
-      'Changing the offline puzzles setting updates the displayed value',
+      'Changing the offline puzzles setting updates the displayed value and fills the queue',
       variant: kPlatformVariant,
       (tester) async {
+        // The offline-puzzles setting change triggers a one-time queue fill, so
+        // the mocks must serve the fill's storage reads/writes and a batch
+        // response for the deficit request.
+        int nbSelectReq = 0;
+        final mockClient = MockClient((request) {
+          if (request.method == 'GET' && request.url.path == '/api/puzzle/batch/mix') {
+            nbSelectReq++;
+            return mockResponse(batchOf1, 200);
+          }
+          return mockResponse('', 404);
+        });
+
+        // Use fresh mocks local to this test so the fill's `any`-matcher stubs
+        // don't leak into other tests sharing the module-level mocks.
+        final batchStorage = MockPuzzleBatchStorage();
+        final historyStorage = MockPuzzleStorage();
+
         final app = await makeTestProviderScopeApp(
           tester,
           home: PuzzleScreen(
@@ -135,15 +153,32 @@ void main() {
           ),
           overrides: {
             puzzleBatchStorageProvider: puzzleBatchStorageProvider.overrideWith(
-              (ref) => mockBatchStorage,
+              (ref) => batchStorage,
             ),
-            puzzleStorageProvider: puzzleStorageProvider.overrideWith((ref) => mockHistoryStorage),
+            puzzleStorageProvider: puzzleStorageProvider.overrideWith((ref) => historyStorage),
+            lichessClientProvider: lichessClientProvider.overrideWith(
+              (ref) => LichessClient(mockClient, ref),
+            ),
           },
         );
 
         when(
-          () => mockHistoryStorage.fetch(puzzleId: puzzle.puzzle.id),
+          () => historyStorage.fetch(puzzleId: puzzle.puzzle.id),
         ).thenAnswer((_) async => puzzle);
+        // Queue starts full enough for the deficit fetch to append once.
+        when(
+          () => batchStorage.fetch(
+            userId: any(named: 'userId'),
+            angle: any(named: 'angle'),
+          ),
+        ).thenAnswer((_) async => PuzzleBatch(solved: IList(const []), unsolved: IList([puzzle])));
+        when(
+          () => batchStorage.save(
+            userId: any(named: 'userId'),
+            angle: any(named: 'angle'),
+            data: any(named: 'data'),
+          ),
+        ).thenAnswer((_) async {});
 
         await tester.pumpWidget(app);
 
@@ -157,7 +192,7 @@ void main() {
         // the offline puzzles tile shows the default value
         final tileFinder = find.widgetWithText(SettingsListTile, 'Offline puzzles');
         expect(tileFinder, findsOneWidget);
-        expect(tester.widget<SettingsListTile>(tileFinder).settingsValue, '50');
+        expect(tester.widget<SettingsListTile>(tileFinder).settingsValue, '100');
 
         // open the choice picker and select a larger value
         await tester.tap(tileFinder);
@@ -167,6 +202,9 @@ void main() {
 
         // the tile reflects the new value
         expect(tester.widget<SettingsListTile>(tileFinder).settingsValue, '200');
+
+        // the change triggered the offline queue fill
+        expect(nbSelectReq, greaterThan(0));
       },
     );
 

--- a/test/view/puzzle/puzzle_screen_test.dart
+++ b/test/view/puzzle/puzzle_screen_test.dart
@@ -160,6 +160,9 @@ void main() {
               (ref) => LichessClient(mockClient, ref),
             ),
           },
+          // The offline-puzzles setting is a logged-in-only feature, so the
+          // tile is only rendered for an authenticated user.
+          authUser: fakeAuthUser,
         );
 
         when(
@@ -205,6 +208,51 @@ void main() {
 
         // the change triggered the offline queue fill
         expect(nbSelectReq, greaterThan(0));
+      },
+    );
+
+    testWidgets(
+      'Offline puzzles setting is hidden for anonymous players',
+      variant: kPlatformVariant,
+      (tester) async {
+        final batchStorage = MockPuzzleBatchStorage();
+        final historyStorage = MockPuzzleStorage();
+
+        final app = await makeTestProviderScopeApp(
+          tester,
+          home: PuzzleScreen(
+            angle: const PuzzleTheme(PuzzleThemeKey.mix),
+            puzzleId: puzzle.puzzle.id,
+          ),
+          overrides: {
+            puzzleBatchStorageProvider: puzzleBatchStorageProvider.overrideWith(
+              (ref) => batchStorage,
+            ),
+            puzzleStorageProvider: puzzleStorageProvider.overrideWith((ref) => historyStorage),
+          },
+          // No authUser: an anonymous player must not see the setting, because
+          // the larger offline queue is a logged-in-only feature.
+        );
+
+        when(
+          () => historyStorage.fetch(puzzleId: puzzle.puzzle.id),
+        ).thenAnswer((_) async => puzzle);
+        when(
+          () => batchStorage.fetch(
+            userId: any(named: 'userId'),
+            angle: any(named: 'angle'),
+          ),
+        ).thenAnswer((_) async => PuzzleBatch(solved: IList(const []), unsolved: IList([puzzle])));
+
+        await tester.pumpWidget(app);
+        await tester.pump(const Duration(milliseconds: 200));
+
+        // open settings
+        await tester.tap(find.byIcon(Icons.settings));
+        await tester.pumpAndSettle();
+
+        // the offline puzzles tile is not shown for an anonymous player
+        expect(find.widgetWithText(SettingsListTile, 'Offline puzzles'), findsNothing);
       },
     );
 

--- a/test/view/puzzle/puzzle_screen_test.dart
+++ b/test/view/puzzle/puzzle_screen_test.dart
@@ -123,6 +123,53 @@ void main() {
       expect(find.text('Your turn'), findsOneWidget);
     });
 
+    testWidgets(
+      'Changing the offline puzzles setting updates the displayed value',
+      variant: kPlatformVariant,
+      (tester) async {
+        final app = await makeTestProviderScopeApp(
+          tester,
+          home: PuzzleScreen(
+            angle: const PuzzleTheme(PuzzleThemeKey.mix),
+            puzzleId: puzzle.puzzle.id,
+          ),
+          overrides: {
+            puzzleBatchStorageProvider: puzzleBatchStorageProvider.overrideWith(
+              (ref) => mockBatchStorage,
+            ),
+            puzzleStorageProvider: puzzleStorageProvider.overrideWith((ref) => mockHistoryStorage),
+          },
+        );
+
+        when(
+          () => mockHistoryStorage.fetch(puzzleId: puzzle.puzzle.id),
+        ).thenAnswer((_) async => puzzle);
+
+        await tester.pumpWidget(app);
+
+        // wait for the puzzle to load
+        await tester.pump(const Duration(milliseconds: 200));
+
+        // open settings
+        await tester.tap(find.byIcon(Icons.settings));
+        await tester.pumpAndSettle();
+
+        // the offline puzzles tile shows the default value
+        final tileFinder = find.widgetWithText(SettingsListTile, 'Offline puzzles');
+        expect(tileFinder, findsOneWidget);
+        expect(tester.widget<SettingsListTile>(tileFinder).settingsValue, '50');
+
+        // open the choice picker and select a larger value
+        await tester.tap(tileFinder);
+        await tester.pumpAndSettle();
+        await tester.tap(find.text('200').last);
+        await tester.pumpAndSettle();
+
+        // the tile reflects the new value
+        expect(tester.widget<SettingsListTile>(tileFinder).settingsValue, '200');
+      },
+    );
+
     testWidgets('Loads next puzzle when no puzzleId is passed', (tester) async {
       final app = await makeTestProviderScopeApp(
         tester,

--- a/test/view/puzzle/puzzle_screen_test.dart
+++ b/test/view/puzzle/puzzle_screen_test.dart
@@ -3,6 +3,7 @@ import 'package:dartchess/dartchess.dart';
 import 'package:fast_immutable_collections/fast_immutable_collections.dart';
 import 'package:flutter/cupertino.dart';
 import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:http/testing.dart';
 import 'package:lichess_mobile/src/model/account/account_preferences.dart';
@@ -15,6 +16,7 @@ import 'package:lichess_mobile/src/model/puzzle/puzzle_difficulty.dart';
 import 'package:lichess_mobile/src/model/puzzle/puzzle_preferences.dart';
 import 'package:lichess_mobile/src/model/puzzle/puzzle_providers.dart';
 import 'package:lichess_mobile/src/model/puzzle/puzzle_service.dart';
+import 'package:lichess_mobile/src/model/puzzle/puzzle_solve_limit.dart';
 import 'package:lichess_mobile/src/model/puzzle/puzzle_storage.dart';
 import 'package:lichess_mobile/src/model/puzzle/puzzle_theme.dart';
 import 'package:lichess_mobile/src/network/http.dart';
@@ -122,6 +124,38 @@ void main() {
 
       expect(find.byType(Chessboard), findsOneWidget);
       expect(find.text('Your turn'), findsOneWidget);
+    });
+
+    testWidgets('Warns the user when the server rate-limits solve submissions', (tester) async {
+      final app = await makeTestProviderScopeApp(
+        tester,
+        home: PuzzleScreen(
+          angle: const PuzzleTheme(PuzzleThemeKey.mix),
+          puzzleId: puzzle.puzzle.id,
+        ),
+        overrides: {
+          puzzleBatchStorageProvider: puzzleBatchStorageProvider.overrideWith(
+            (ref) => mockBatchStorage,
+          ),
+          puzzleStorageProvider: puzzleStorageProvider.overrideWith((ref) => mockHistoryStorage),
+        },
+        authUser: fakeAuthUser,
+      );
+
+      when(
+        () => mockHistoryStorage.fetch(puzzleId: puzzle.puzzle.id),
+      ).thenAnswer((_) async => puzzle);
+
+      await tester.pumpWidget(app);
+      await tester.pump(const Duration(milliseconds: 200));
+
+      // arm the solve back-off, as a 429 on a solve flush would; the screen
+      // watches it and warns the user with the rejected count.
+      final container = ProviderScope.containerOf(tester.element(find.byType(PuzzleScreen)));
+      container.read(puzzleSolveLimiterProvider.notifier).markLimited(7);
+      await tester.pump();
+
+      expect(find.textContaining('You solved 7 puzzles'), findsOneWidget);
     });
 
     testWidgets(

--- a/test/view/puzzle/puzzle_screen_test.dart
+++ b/test/view/puzzle/puzzle_screen_test.dart
@@ -256,6 +256,50 @@ void main() {
       },
     );
 
+    testWidgets('Offline puzzles setting is hidden for non-mix angles', variant: kPlatformVariant, (
+      tester,
+    ) async {
+      // Enter through the puzzle-stream path (no puzzleId) so the loaded context
+      // keeps the requested angle; loading a puzzle by id always tags the
+      // context as mix. The configurable queue is limited to mix, so the tile
+      // must not show for an opening angle, even for a logged-in user.
+      final batchStorage = MockPuzzleBatchStorage();
+      final historyStorage = MockPuzzleStorage();
+
+      // stored queue already covers the non-mix cap, so nextPuzzle needs no fetch
+      final fullQueue = PuzzleBatch(
+        solved: IList(const []),
+        unsolved: IList([for (var i = 0; i < kMinOfflinePuzzles; i++) puzzle]),
+      );
+
+      final app = await makeTestProviderScopeApp(
+        tester,
+        home: const PuzzleScreen(angle: PuzzleOpening('A00')),
+        overrides: {
+          puzzleBatchStorageProvider: puzzleBatchStorageProvider.overrideWith(
+            (ref) => batchStorage,
+          ),
+          puzzleStorageProvider: puzzleStorageProvider.overrideWith((ref) => historyStorage),
+        },
+        authUser: fakeAuthUser,
+      );
+
+      when(
+        () => batchStorage.fetch(
+          userId: any(named: 'userId'),
+          angle: any(named: 'angle'),
+        ),
+      ).thenAnswer((_) async => fullQueue);
+
+      await tester.pumpWidget(app);
+      await tester.pump(const Duration(milliseconds: 200));
+
+      await tester.tap(find.byIcon(Icons.settings));
+      await tester.pumpAndSettle();
+
+      expect(find.widgetWithText(SettingsListTile, 'Offline puzzles'), findsNothing);
+    });
+
     testWidgets('Loads next puzzle when no puzzleId is passed', (tester) async {
       final app = await makeTestProviderScopeApp(
         tester,

--- a/test/view/puzzle/puzzle_tab_screen_test.dart
+++ b/test/view/puzzle/puzzle_tab_screen_test.dart
@@ -1,8 +1,11 @@
 import 'dart:convert';
+import 'dart:math' show max;
 
 import 'package:chessground/chessground.dart';
 import 'package:dartchess/dartchess.dart';
 import 'package:fast_immutable_collections/fast_immutable_collections.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_slidable/flutter_slidable.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:http/testing.dart';
@@ -15,10 +18,13 @@ import 'package:lichess_mobile/src/model/puzzle/puzzle_batch_storage.dart';
 import 'package:lichess_mobile/src/model/puzzle/puzzle_theme.dart';
 import 'package:lichess_mobile/src/model/puzzle/streak_storage.dart';
 import 'package:lichess_mobile/src/network/http.dart';
+import 'package:lichess_mobile/src/view/puzzle/puzzle_screen.dart';
 import 'package:lichess_mobile/src/view/puzzle/puzzle_tab_screen.dart';
+import 'package:lichess_mobile/src/widgets/settings.dart';
 import 'package:mocktail/mocktail.dart';
 import 'package:sqflite_common_ffi/sqflite_ffi.dart';
 
+import '../../model/auth/fake_auth_storage.dart';
 import '../../model/puzzle/mock_server_responses.dart';
 import '../../network/fake_http_client_factory.dart';
 import '../../test_helpers.dart';
@@ -293,7 +299,136 @@ void main() {
       expect(find.widgetWithText(PuzzleAnglePreview, 'A00'), findsNothing);
     });
   });
+
+  testWidgets('changing the offline puzzles setting does not start a concurrent queue sync', (
+    WidgetTester tester,
+  ) async {
+    // Regression test: the puzzle tab stays mounted under the pushed
+    // [PuzzleScreen] and keeps watching [nextPuzzleProvider]. If that provider
+    // watched the offline queue length, changing the setting would rebuild it
+    // and run a queue sync — a writer that saves a batch built from a snapshot
+    // taken before its own request, without merging — at the very moment
+    // [PuzzleQueueFiller] starts filling the queue up to the new length. The
+    // two overwrite each other: puzzles are downloaded and thrown away, and
+    // depending on the interleaving the fill stops early on its "the queue did
+    // not grow" check, below the configured count. The fill must be the only
+    // writer.
+    int nbBatchReq = 0;
+    int inFlight = 0;
+    int maxInFlight = 0;
+    int nextPuzzleNumber = 0;
+
+    final client = MockClient((request) async {
+      if (request.url.path == '/api/puzzle/daily') {
+        return mockResponse(mockDailyPuzzleResponse, 200);
+      }
+      if (request.url.path == '/api/puzzle/batch/mix') {
+        // the rating probe made on puzzle controller build asks for nb=0
+        if (request.url.queryParameters['nb'] == '0') {
+          return mockResponse('{"puzzles":[]}', 200);
+        }
+        nbBatchReq++;
+        inFlight++;
+        maxInFlight = max(maxInFlight, inFlight);
+        // keep the request in flight long enough for an overlapping sync to
+        // start before the response is stored
+        await Future<void>.delayed(const Duration(milliseconds: 20));
+        inFlight--;
+        // the server caps each batch at 50 puzzles, whatever `nb` asks for
+        return mockResponse(_batchResponse(50, () => nextPuzzleNumber++), 200);
+      }
+      return mockResponse('', 404);
+    });
+
+    final testDb = await openAppDatabase(databaseFactoryFfiNoIsolate, inMemoryDatabasePath);
+
+    final app = await makeTestProviderScopeApp(
+      tester,
+      home: const PuzzleTabScreen(),
+      overrides: {
+        databaseProvider: databaseProvider.overrideWith((ref) {
+          ref.onDispose(testDb.close);
+          return testDb;
+        }),
+        httpClientFactoryProvider: httpClientFactoryProvider.overrideWith((ref) {
+          return FakeHttpClientFactory(() => client);
+        }),
+      },
+      // the offline puzzles setting is a logged-in-only feature
+      authUser: fakeAuthUser,
+    );
+
+    await tester.pumpWidget(app);
+    await tester.pumpAndSettle(const Duration(milliseconds: 100));
+
+    // the tab preview synced the queue once, up to the server cap
+    expect(nbBatchReq, equals(1));
+
+    final container = ProviderScope.containerOf(tester.element(find.byType(PuzzleTabScreen)));
+    Future<int> queueLength() async {
+      final storage = await container.read(puzzleBatchStorageProvider.future);
+      final data = await storage.fetch(userId: fakeAuthUser.user.id);
+      return data?.unsolved.length ?? 0;
+    }
+
+    expect(await queueLength(), equals(50));
+
+    // open the puzzle screen from the tab: the tab screen stays mounted below it
+    await tester.ensureVisible(find.widgetWithText(PuzzleAnglePreview, 'Healthy mix'));
+    await tester.pumpAndSettle();
+    await tester.tap(find.widgetWithText(PuzzleAnglePreview, 'Healthy mix'));
+    await tester.pumpAndSettle(const Duration(milliseconds: 100));
+    expect(find.byType(PuzzleScreen), findsOneWidget);
+
+    // open the puzzle settings and raise the offline puzzles count
+    await tester.tap(
+      find.descendant(of: find.byType(PuzzleScreen), matching: find.byIcon(Icons.settings)),
+    );
+    await tester.pumpAndSettle();
+    await tester.tap(find.widgetWithText(SettingsListTile, 'Offline puzzles'));
+    await tester.pumpAndSettle();
+    await tester.tap(find.text('200').last);
+    await tester.pumpAndSettle(const Duration(milliseconds: 100));
+
+    expect(
+      maxInFlight,
+      equals(1),
+      reason: 'the queue fill must be the only writer: no sync may run alongside it',
+    );
+    // the fill reached the newly configured count: 50 -> 200 in three batches,
+    // and nothing overwrote what it stored on the way.
+    expect(await queueLength(), equals(200));
+    expect(nbBatchReq, equals(4), reason: 'the initial sync, then three fill batches');
+  });
 }
+
+/// Builds a batch response of [count] puzzles with distinct ids.
+String _batchResponse(int count, int Function() nextPuzzleNumber) => jsonEncode({
+  'puzzles': [
+    for (int i = 0; i < count; i++)
+      {
+        'game': {
+          'id': 'PrlkCqOv',
+          'perf': const {'key': 'rapid', 'name': 'Rapid'},
+          'rated': true,
+          'players': const [
+            {'userId': 'silverjo', 'name': 'silverjo (1777)', 'color': 'white'},
+            {'userId': 'robyarchitetto', 'name': 'Robyarchitetto (1742)', 'color': 'black'},
+          ],
+          'pgn': 'e4 Nc6 Bc4 e6 a3 g6 Nf3 Bg7 c3 Nge7 d3 O-O Be3 Na5 Ba2 b6 Qd2',
+          'clock': '5+8',
+        },
+        'puzzle': {
+          'id': 'p${nextPuzzleNumber()}',
+          'rating': 1859,
+          'plays': 551,
+          'initialPly': 10,
+          'solution': const ['a6a7', 'b2a2'],
+          'themes': const ['endgame'],
+        },
+      },
+  ],
+});
 
 final onePuzzleBatch = PuzzleBatch(
   solved: IList(const [

--- a/translation/source/mobile.xml
+++ b/translation/source/mobile.xml
@@ -25,6 +25,7 @@
   <string name="notFollowingAnyUser" comment="This is shown in the list that contains user followed by the user. Displayed if the user does not follow any users.">You are not following any users.</string>
   <string name="okButton" comment="This is used in varius confirmations dialogs. Translation should be short.">OK</string>
   <string name="overTheBoard" comment="Used in the main play menu to launch the Over the board game mode.">Over the board</string>
+  <string name="nbOfflinePuzzles" comment="Label for the puzzle setting that controls how many puzzles are downloaded and kept available for offline play.">Offline puzzles</string>
   <string name="playersMatchingSearchTerm" comment="This is shown when searching for a player. %s is the string that user entered in the search bar">Players with "%s"</string>
   <string name="positionLeft" comment="Appears in the board settings screen to indicate clock position.">Left</string>
   <string name="positionRight" comment="Appears in the board settings screen to indicate clock position.">Right</string>

--- a/translation/source/mobile.xml
+++ b/translation/source/mobile.xml
@@ -19,13 +19,13 @@
   <string name="homeTab" comment="The tab in bottom navigation bar. Must be very short (10 characters max) to avoid ugly text shifting issues." maxLength="10">Home</string>
   <string name="liveStreamers" comment="This is shown as a heading in the streamer screen">Live streamers</string>
   <string name="mustBeLoggedIn" comment="This is shown when the user tries to access a feature that requires login.">You must be logged in to view this page.</string>
+  <string name="nbOfflinePuzzles" comment="Label for the puzzle setting that controls how many puzzles are downloaded and kept available for offline play.">Offline puzzles</string>
   <string name="newGame" comment="New game button in OTB and play against offline computer features">New game</string>
   <string name="noSearchResults" comment="This is shown when the search did not return any results.">No results</string>
   <string name="notAllFeaturesAreAvailable" comment="This is shown in the welcome message when the app is first installed">Please note that not all features from the old app or the website are currently available, but we are adding features all the time.</string>
   <string name="notFollowingAnyUser" comment="This is shown in the list that contains user followed by the user. Displayed if the user does not follow any users.">You are not following any users.</string>
   <string name="okButton" comment="This is used in varius confirmations dialogs. Translation should be short.">OK</string>
   <string name="overTheBoard" comment="Used in the main play menu to launch the Over the board game mode.">Over the board</string>
-  <string name="nbOfflinePuzzles" comment="Label for the puzzle setting that controls how many puzzles are downloaded and kept available for offline play.">Offline puzzles</string>
   <string name="playersMatchingSearchTerm" comment="This is shown when searching for a player. %s is the string that user entered in the search bar">Players with "%s"</string>
   <string name="positionLeft" comment="Appears in the board settings screen to indicate clock position.">Left</string>
   <string name="positionRight" comment="Appears in the board settings screen to indicate clock position.">Right</string>


### PR DESCRIPTION
Closes #926

## What

Make the number of offline puzzles configurable, and fill the offline queue reliably when the setting changes.

- Adds an **Offline puzzles** setting on the puzzle screen (100 / 150 / 200 / 300), default and minimum **100**.
- Fills the offline queue up to the configured count as a **one-time action** triggered on the setting change and on difficulty change, rather than trickling puzzles in via the solve path.

## How

The offline queue can exceed the server's 50-per-request batch cap, so it is filled with several sequential requests. Following review, the fill is kept out of the solve/sync loop entirely:

- **Sync path reverted** to the original single-request logic, unchanged. Offline solves still reconcile in one shot.
- **`PuzzleQueueFiller`** is a stable `NotifierProvider` that fills the queue to the configured count with sequential, single-flight, **select-only** requests. It re-reads storage each pass, dedups by id, never submits solves, and is safe offline. Being a stable provider (not a per-call service instance), its single-flight guard actually holds.
- The settings tile shows a spinner while a fill is running.

This removes the concurrency hazards raised in review: the inert `_isFilling` guard (a fresh `PuzzleService` was built per call) and the within-pass stale-solve race are both gone, because no `solved` list is ever in flight during a fill.

## Tests

- `PuzzleQueueFiller` covered in isolation: fill-to-count over multiple requests, deficit-only fetch, no-op when full, stop when the server is exhausted, offline-safe, select-only (never POSTs solves), and single-flight.
- Puzzle screen test asserts the setting change triggers the fill.
- Removed the obsolete background-fill service tests.