### PR TITLE
Edit clock tool to allow time and increment change to one player while paused

### DIFF
--- a/lib/src/model/clock/clock_tool_controller.dart
+++ b/lib/src/model/clock/clock_tool_controller.dart
@@ -141,35 +141,49 @@ class ClockToolController extends Notifier<ClockState> {
   }
 
   void updateOptionsCustom(TimeIncrement clock, ClockSide player) {
+    Duration topTime = state.options.topTime;
+    Duration bottomTime = state.options.bottomTime;
+    Duration topIncrement = state.options.topIncrement;
+    Duration bottomIncrement = state.options.bottomIncrement;
+    if (player == ClockSide.top) {
+      topIncrement = Duration(seconds: clock.increment);
+      // Update stored preferences only if the clock hasn't started yet
+      if (state.activeSide == null) {
+        topTime = Duration(seconds: clock.time);
+        ref.read(clockToolPreferencesProvider.notifier).setTopTimeIncrement(clock);
+      }
+      _clock.setTimes(
+        blackTime: Duration(seconds: clock.time),
+        whiteTime: state.bottomTime.value,
+      );
+    } else {
+      bottomIncrement = Duration(seconds: clock.increment);
+      // Update stored preferences only if the clock hasn't started yet
+      if (state.activeSide == null) {
+        bottomTime = Duration(seconds: clock.time);
+        ref.read(clockToolPreferencesProvider.notifier).setBottomTimeIncrement(clock);
+      }
+      _clock.setTimes(
+        blackTime: state.topTime.value,
+        whiteTime: Duration(seconds: clock.time),
+      );
+    }
+
     final options = ClockOptions(
       type: state.options.type,
-      topTime: player == ClockSide.top ? Duration(seconds: clock.time) : state.options.topTime,
-      bottomTime: player == ClockSide.bottom
-          ? Duration(seconds: clock.time)
-          : state.options.bottomTime,
-      topIncrement: player == ClockSide.top
-          ? Duration(seconds: clock.increment)
-          : state.options.topIncrement,
-      bottomIncrement: player == ClockSide.bottom
-          ? Duration(seconds: clock.increment)
-          : state.options.bottomIncrement,
+      topTime: topTime,
+      bottomTime: bottomTime,
+      topIncrement: topIncrement,
+      bottomIncrement: bottomIncrement,
     );
     _emergencyThresholds[player] = _calculateEmergencyThreshold(Duration(seconds: clock.time));
     _hasPlayedLowTimeSound[player] = false;
-    _clock.setTimes(blackTime: options.topTime, whiteTime: options.bottomTime);
-    state = ClockState(
+
+    state = state.copyWith(
       options: options,
       topTime: _clock.blackTime,
       bottomTime: _clock.whiteTime,
-      activeSide: state.activeSide,
-      clockOrientation: state.clockOrientation,
     );
-
-    if (player == ClockSide.top) {
-      ref.read(clockToolPreferencesProvider.notifier).setTopTimeIncrement(clock);
-    } else {
-      ref.read(clockToolPreferencesProvider.notifier).setBottomTimeIncrement(clock);
-    }
   }
 
   void updateClockType(ClockTimeControlType type) {

--- a/lib/src/model/clock/clock_tool_controller.dart
+++ b/lib/src/model/clock/clock_tool_controller.dart
@@ -148,7 +148,7 @@ class ClockToolController extends Notifier<ClockState> {
     if (player == ClockSide.top) {
       topIncrement = Duration(seconds: clock.increment);
       // Update stored preferences only if the clock hasn't started yet
-      if (state.activeSide == null) {
+      if (!state.started) {
         topTime = Duration(seconds: clock.time);
         ref.read(clockToolPreferencesProvider.notifier).setTopTimeIncrement(clock);
       }
@@ -159,7 +159,7 @@ class ClockToolController extends Notifier<ClockState> {
     } else {
       bottomIncrement = Duration(seconds: clock.increment);
       // Update stored preferences only if the clock hasn't started yet
-      if (state.activeSide == null) {
+      if (!state.started) {
         bottomTime = Duration(seconds: clock.time);
         ref.read(clockToolPreferencesProvider.notifier).setBottomTimeIncrement(clock);
       }

--- a/lib/src/view/clock/clock_tool_screen.dart
+++ b/lib/src/view/clock/clock_tool_screen.dart
@@ -288,9 +288,9 @@ class _ClockTileState extends ConsumerState<ClockTile> with SingleTickerProvider
                 Positioned(
                   bottom: MediaQuery.paddingOf(context).bottom + 48.0,
                   child: IgnorePointer(
-                    ignoring: clockState.started,
+                    ignoring: clockState.started && !clockState.paused,
                     child: AnimatedOpacity(
-                      opacity: clockState.started ? 0 : 1.0,
+                      opacity: (clockState.started && !clockState.paused) ? 0 : 1.0,
                       duration: const Duration(milliseconds: 300),
                       child: Row(
                         mainAxisSize: MainAxisSize.min,
@@ -300,7 +300,7 @@ class _ClockTileState extends ConsumerState<ClockTile> with SingleTickerProvider
                             iconSize: 32,
                             icon: const Icon(Icons.tune),
                             color: clockStyle.textColor,
-                            onPressed: clockState.started
+                            onPressed: (clockState.started && !clockState.paused)
                                 ? null
                                 : () => showModalBottomSheet<void>(
                                     context: context,

--- a/lib/src/view/clock/custom_clock_settings.dart
+++ b/lib/src/view/clock/custom_clock_settings.dart
@@ -100,9 +100,22 @@ class _CustomClockSettingsState extends State<CustomClockSettings> {
         ),
         Padding(
           padding: Styles.horizontalBodyPadding,
-          child: FilledButton(
-            onPressed: () => _submit(context),
-            child: Text(context.l10n.mobileOkButton, style: Styles.bold),
+          child: Row(
+            children: [
+              Expanded(
+                child: FilledButton(
+                  onPressed: () => _submit(context),
+                  child: Text(context.l10n.mobileOkButton, style: Styles.bold),
+                ),
+              ),
+              const SizedBox(width: 16),
+              Expanded(
+                child: FilledButton(
+                  onPressed: () => Navigator.of(context).pop(),
+                  child: Text(context.l10n.cancel, style: Styles.bold),
+                ),
+              ),
+            ],
           ),
         ),
       ],


### PR DESCRIPTION
Allow users to modify the time and increment settings while the clock is paused.
Previously, the per-player settings UI became unavailable when the clock started.

New behaviour:
<img height="480" alt="output2" src="https://github.com/user-attachments/assets/df0b6f8a-b2cf-4694-baed-641034916d94" />

Old behaviour:
<img height="480" alt="output3" src="https://github.com/user-attachments/assets/611696cf-effc-4018-8644-d0495b5edf94" />

Solves issue #1788  as time can now be edited during a game