### PR TITLE
Add animated app bar gradients to remaining settings menus

### DIFF
--- a/lib/src/view/settings/background_theme_choice_screen.dart
+++ b/lib/src/view/settings/background_theme_choice_screen.dart
@@ -32,7 +32,7 @@ class BackgroundChoiceScreen extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     return Scaffold(
-      appBar: AppBar(title: Text(context.l10n.background)),
+      appBar: AppBar(title: Text(context.l10n.background), animateColor: true),
       body: _Body(),
     );
   }

--- a/lib/src/view/settings/background_theme_choice_screen.dart
+++ b/lib/src/view/settings/background_theme_choice_screen.dart
@@ -18,6 +18,7 @@ import 'package:lichess_mobile/src/utils/l10n_context.dart';
 import 'package:lichess_mobile/src/utils/navigation.dart';
 import 'package:lichess_mobile/src/widgets/background.dart';
 import 'package:lichess_mobile/src/widgets/list.dart';
+import 'package:lichess_mobile/src/widgets/platform.dart';
 import 'package:lichess_mobile/src/widgets/settings.dart';
 import 'package:material_color_utilities/score/score.dart';
 import 'package:path/path.dart';
@@ -31,8 +32,8 @@ class BackgroundChoiceScreen extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    return Scaffold(
-      appBar: AppBar(title: Text(context.l10n.background), animateColor: true),
+    return PlatformScaffold(
+      appBar: PlatformAppBar(title: Text(context.l10n.background)),
       body: _Body(),
     );
   }

--- a/lib/src/view/settings/board_choice_screen.dart
+++ b/lib/src/view/settings/board_choice_screen.dart
@@ -5,6 +5,7 @@ import 'package:lichess_mobile/src/utils/color_palette.dart';
 import 'package:lichess_mobile/src/utils/l10n_context.dart';
 import 'package:lichess_mobile/src/utils/navigation.dart';
 import 'package:lichess_mobile/src/widgets/list.dart';
+import 'package:lichess_mobile/src/widgets/platform.dart';
 
 class BoardChoiceScreen extends StatelessWidget {
   const BoardChoiceScreen({super.key});
@@ -15,8 +16,8 @@ class BoardChoiceScreen extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    return Scaffold(
-      appBar: AppBar(title: Text(context.l10n.board), animateColor: true),
+    return PlatformScaffold(
+      appBar: PlatformAppBar(title: Text(context.l10n.board)),
       body: const _Body(),
     );
   }

--- a/lib/src/view/settings/board_choice_screen.dart
+++ b/lib/src/view/settings/board_choice_screen.dart
@@ -16,7 +16,7 @@ class BoardChoiceScreen extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     return Scaffold(
-      appBar: AppBar(title: Text(context.l10n.board)),
+      appBar: AppBar(title: Text(context.l10n.board), animateColor: true),
       body: const _Body(),
     );
   }

--- a/lib/src/view/settings/engine_settings_screen.dart
+++ b/lib/src/view/settings/engine_settings_screen.dart
@@ -67,7 +67,7 @@ class _EngineSettingsScreenState extends ConsumerState<EngineSettingsScreen> {
     final prefs = ref.watch(engineEvaluationPreferencesProvider);
 
     return Scaffold(
-      appBar: AppBar(title: const Text('Chess engine')),
+      appBar: AppBar(title: const Text('Chess engine'), animateColor: true),
       body: ListView(
         children: [
           if (_hasVerifiedNNUEFiles == null)

--- a/lib/src/view/settings/engine_settings_screen.dart
+++ b/lib/src/view/settings/engine_settings_screen.dart
@@ -10,6 +10,7 @@ import 'package:lichess_mobile/src/view/analysis/engine_settings_widget.dart';
 import 'package:lichess_mobile/src/widgets/adaptive_choice_picker.dart';
 import 'package:lichess_mobile/src/widgets/buttons.dart';
 import 'package:lichess_mobile/src/widgets/list.dart';
+import 'package:lichess_mobile/src/widgets/platform.dart';
 import 'package:lichess_mobile/src/widgets/platform_alert_dialog.dart';
 import 'package:lichess_mobile/src/widgets/settings.dart';
 import 'package:lichess_mobile/src/widgets/shimmer.dart';
@@ -66,8 +67,8 @@ class _EngineSettingsScreenState extends ConsumerState<EngineSettingsScreen> {
   Widget build(BuildContext context) {
     final prefs = ref.watch(engineEvaluationPreferencesProvider);
 
-    return Scaffold(
-      appBar: AppBar(title: const Text('Chess engine'), animateColor: true),
+    return PlatformScaffold(
+      appBar: PlatformAppBar(title: const Text('Chess engine')),
       body: ListView(
         children: [
           if (_hasVerifiedNNUEFiles == null)

--- a/lib/src/view/settings/piece_set_screen.dart
+++ b/lib/src/view/settings/piece_set_screen.dart
@@ -59,6 +59,7 @@ class _PieceSetScreenState extends ConsumerState<PieceSetScreen> {
     return Scaffold(
       appBar: AppBar(
         title: Text(context.l10n.pieceSet),
+        animateColor: true,
         actions: [if (isLoading) const PlatformAppBarLoadingIndicator()],
       ),
       body: SafeArea(

--- a/lib/src/view/settings/piece_set_screen.dart
+++ b/lib/src/view/settings/piece_set_screen.dart
@@ -56,10 +56,9 @@ class _PieceSetScreenState extends ConsumerState<PieceSetScreen> {
   Widget build(BuildContext context) {
     final boardPrefs = ref.watch(boardPreferencesProvider);
 
-    return Scaffold(
-      appBar: AppBar(
+    return PlatformScaffold(
+      appBar: PlatformAppBar(
         title: Text(context.l10n.pieceSet),
-        animateColor: true,
         actions: [if (isLoading) const PlatformAppBarLoadingIndicator()],
       ),
       body: SafeArea(

--- a/lib/src/view/settings/sound_settings_screen.dart
+++ b/lib/src/view/settings/sound_settings_screen.dart
@@ -5,6 +5,7 @@ import 'package:lichess_mobile/src/model/settings/general_preferences.dart';
 import 'package:lichess_mobile/src/utils/l10n_context.dart';
 import 'package:lichess_mobile/src/utils/navigation.dart';
 import 'package:lichess_mobile/src/widgets/list.dart';
+import 'package:lichess_mobile/src/widgets/platform.dart';
 import 'package:lichess_mobile/src/widgets/settings.dart';
 
 const kMasterVolumeValues = [0.0, 0.1, 0.2, 0.3, 0.4, 0.5, 0.6, 0.7, 0.8, 0.9, 1.0];
@@ -18,8 +19,8 @@ class SoundSettingsScreen extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    return Scaffold(
-      appBar: AppBar(title: Text(context.l10n.sound), animateColor: true),
+    return PlatformScaffold(
+      appBar: PlatformAppBar(title: Text(context.l10n.sound)),
       body: _Body(),
     );
   }

--- a/lib/src/view/settings/sound_settings_screen.dart
+++ b/lib/src/view/settings/sound_settings_screen.dart
@@ -19,7 +19,7 @@ class SoundSettingsScreen extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     return Scaffold(
-      appBar: AppBar(title: Text(context.l10n.sound)),
+      appBar: AppBar(title: Text(context.l10n.sound), animateColor: true),
       body: _Body(),
     );
   }


### PR DESCRIPTION
## Description

This updates the remaining settings menu screens that were still using plain `AppBar`s without the sliding gradient animation.

Covered screens:

- Background theme choice
- Board style choice
- Piece set choice
- Sound settings
- Chess engine settings

`PlatformAppBar`-based screens were already covered, and `ThemeSettingsScreen` already had `animateColor: true`, so this patch only fills the missing direct `AppBar` usages in the settings/menu flow.
