### PR TITLE
feat: transparent, pass-through clock overlay for near-square screens…

### DIFF
--- a/lib/src/widgets/clock.dart
+++ b/lib/src/widgets/clock.dart
@@ -77,7 +77,7 @@ class Clock extends StatelessWidget {
       Shadow(offset: Offset(1.5, -1.5), color: Colors.black),
       Shadow(offset: Offset(-1.5, 1.5), color: Colors.black),
       Shadow(offset: Offset(1.5, 1.5), color: Colors.black),
-      Shadow(offset: Offset(0, 0), blurRadius: 6.0, color: Colors.black),
+      Shadow(offset: Offset.zero, blurRadius: 6.0, color: Colors.black),
     ];
 
     return LayoutBuilder(

--- a/lib/src/widgets/clock.dart
+++ b/lib/src/widgets/clock.dart
@@ -68,6 +68,18 @@ class Clock extends StatelessWidget {
     final effectiveClockStyle =
         clockStyle ?? ClockStyle.defaultStyle(brightness, colorScheme, context.lichessColors);
 
+    // Read whether we are running in overlay mode (foldable screens)
+    final isOverlay = ClockOverlayTheme.of(context);
+
+    // Black 360-degree outline shadow for overlay HUD mode
+    const hudClockShadows = [
+      Shadow(offset: Offset(-1.5, -1.5), color: Colors.black),
+      Shadow(offset: Offset(1.5, -1.5), color: Colors.black),
+      Shadow(offset: Offset(-1.5, 1.5), color: Colors.black),
+      Shadow(offset: Offset(1.5, 1.5), color: Colors.black),
+      Shadow(offset: Offset(0, 0), blurRadius: 6.0, color: Colors.black),
+    ];
+
     return LayoutBuilder(
       builder: (context, constraints) {
         final maxWidth = constraints.maxWidth;
@@ -76,13 +88,15 @@ class Clock extends StatelessWidget {
         return Container(
           decoration: BoxDecoration(
             borderRadius: const BorderRadius.all(Radius.circular(5.0)),
-            color: timeLeft > Duration.zero
-                ? active
-                      ? isEmergency
-                            ? effectiveClockStyle.emergencyBackgroundColor
-                            : effectiveClockStyle.activeBackgroundColor
-                      : effectiveClockStyle.backgroundColor
-                : effectiveClockStyle.emergencyBackgroundColor,
+            color: isOverlay
+                ? Colors.transparent
+                : (timeLeft > Duration.zero
+                      ? active
+                            ? isEmergency
+                                  ? effectiveClockStyle.emergencyBackgroundColor
+                                  : effectiveClockStyle.activeBackgroundColor
+                            : effectiveClockStyle.backgroundColor
+                      : effectiveClockStyle.emergencyBackgroundColor),
           ),
           child: Padding(
             padding: padding,
@@ -94,13 +108,16 @@ class Clock extends StatelessWidget {
                       ? '$hoursDisplay:${mins.toString().padLeft(2, '0')}:$secs'
                       : '$minsDisplay:$secs',
                   style: TextStyle(
-                    color: timeLeft > Duration.zero
-                        ? active
-                              ? isEmergency
-                                    ? effectiveClockStyle.emergencyTextColor
-                                    : effectiveClockStyle.activeTextColor
-                              : effectiveClockStyle.textColor
-                        : effectiveClockStyle.emergencyTextColor,
+                    color: isOverlay
+                        ? (isEmergency ? effectiveClockStyle.emergencyTextColor : Colors.white)
+                        : (timeLeft > Duration.zero
+                              ? active
+                                    ? isEmergency
+                                          ? effectiveClockStyle.emergencyTextColor
+                                          : effectiveClockStyle.activeTextColor
+                                    : effectiveClockStyle.textColor
+                              : effectiveClockStyle.emergencyTextColor),
+                    shadows: isOverlay ? hudClockShadows : null,
                     fontSize: _kClockFontSize * fontScaleFactor,
                     height: isShortVerticalScreen(context) ? 1.0 : null,
                     fontFeatures: const [FontFeature.tabularFigures()],
@@ -109,12 +126,20 @@ class Clock extends StatelessWidget {
                     if (showTenths)
                       TextSpan(
                         text: '.${timeLeft.inMilliseconds.remainder(1000) ~/ 100}',
-                        style: TextStyle(fontSize: _kClockTenthFontSize * fontScaleFactor),
+                        style: TextStyle(
+                          fontSize: _kClockTenthFontSize * fontScaleFactor,
+                          color: isOverlay ? Colors.white : null,
+                          shadows: isOverlay ? hudClockShadows : null,
+                        ),
                       ),
                     if (!active && timeLeft < const Duration(seconds: 1))
                       TextSpan(
                         text: '${timeLeft.inMilliseconds.remainder(1000) ~/ 10 % 10}',
-                        style: TextStyle(fontSize: _kClockHundredsFontSize * fontScaleFactor),
+                        style: TextStyle(
+                          fontSize: _kClockHundredsFontSize * fontScaleFactor,
+                          color: isOverlay ? Colors.white : null,
+                          shadows: isOverlay ? hudClockShadows : null,
+                        ),
                       ),
                   ],
                 ),
@@ -323,4 +348,18 @@ class _CountdownClockState extends State<CountdownClockBuilder> {
   Widget build(BuildContext context) {
     return RepaintBoundary(child: widget.builder(context, timeLeft));
   }
+}
+
+/// Scope flag to trigger transparent HUD clock styling on overlay screens (foldables)
+class ClockOverlayTheme extends InheritedWidget {
+  final bool isOverlay;
+
+  const ClockOverlayTheme({super.key, required this.isOverlay, required super.child});
+
+  static bool of(BuildContext context) {
+    return context.dependOnInheritedWidgetOfExactType<ClockOverlayTheme>()?.isOverlay ?? false;
+  }
+
+  @override
+  bool updateShouldNotify(ClockOverlayTheme oldWidget) => isOverlay != oldWidget.isOverlay;
 }

--- a/lib/src/widgets/game_layout.dart
+++ b/lib/src/widgets/game_layout.dart
@@ -13,6 +13,7 @@ import 'package:lichess_mobile/src/utils/screen.dart';
 import 'package:lichess_mobile/src/widgets/board.dart';
 import 'package:lichess_mobile/src/widgets/move_list.dart';
 import 'package:lichess_mobile/src/widgets/pockets.dart';
+import 'package:lichess_mobile/src/widgets/clock.dart';
 
 /// In crazyhouse, when displaying pockets above/below the board, add this much additional side padding to make the board smaller and avoid overflows.
 const _kAdditionalBoardSidePaddingForPockets = 70.0;
@@ -533,8 +534,50 @@ class _GameLayoutState extends ConsumerState<GameLayout> {
             ),
           );
 
-          // 3. IF NEAR-SQUARE: Overlay the clocks transparently on top of the board corners
+          // 3. IF NEAR-SQUARE: Floating HUD Overlay with Scope-Gated Clock Style
           if (isNearSquare) {
+            const hudShadows = [
+              Shadow(offset: Offset(-1.5, -1.5), color: Colors.black),
+              Shadow(offset: Offset(1.5, -1.5), color: Colors.black),
+              Shadow(offset: Offset(-1.5, 1.5), color: Colors.black),
+              Shadow(offset: Offset(1.5, 1.5), color: Colors.black),
+              Shadow(offset: Offset(0, 0), blurRadius: 6.0, color: Colors.black),
+            ];
+
+            const hudTextStyle = TextStyle(
+              color: Colors.white,
+              fontWeight: FontWeight.bold,
+              shadows: hudShadows,
+            );
+
+            final baseTheme = Theme.of(context);
+            final transparentHudTheme = baseTheme.copyWith(
+              cardColor: Colors.transparent,
+              canvasColor: Colors.transparent,
+              colorScheme: baseTheme.colorScheme.copyWith(
+                surface: Colors.transparent,
+                surfaceContainer: Colors.transparent,
+                onSurface: Colors.white,
+                onSurfaceVariant: Colors.white,
+              ),
+            );
+
+            Widget buildHudTable(Widget tableWidget) {
+              return IgnorePointer(
+                ignoring: true,
+                child: ClockOverlayTheme(
+                  isOverlay: true,
+                  child: Theme(
+                    data: transparentHudTheme,
+                    child: IconTheme.merge(
+                      data: const IconThemeData(color: Colors.white, shadows: hudShadows),
+                      child: DefaultTextStyle.merge(style: hudTextStyle, child: tableWidget),
+                    ),
+                  ),
+                ),
+              );
+            }
+
             return Column(
               mainAxisSize: MainAxisSize.max,
               mainAxisAlignment: MainAxisAlignment.center,
@@ -542,37 +585,21 @@ class _GameLayoutState extends ConsumerState<GameLayout> {
                 Stack(
                   alignment: Alignment.center,
                   children: [
-                    boardWidget, // The base layer: full size chessboard
-                    // Floating Top Clock/Player Bar
+                    boardWidget, // Base layer: full size chessboard
+                    // Floating Top Clock & Player Bar
                     Positioned(
-                      top: 6.0,
+                      top: 8.0,
                       left: 12.0,
                       right: 12.0,
-                      child: IgnorePointer(
-                        // 💡 ADD THIS WIDGET: Pass taps to the board
-                        ignoring: true,
-                        child: Opacity(
-                          opacity: 0.8,
-                          // 80% visible, pieces show through underneath
-                          child: topTable(boardSize: effectiveBoardSize),
-                        ),
-                      ),
+                      child: buildHudTable(topTable(boardSize: effectiveBoardSize)),
                     ),
 
-                    // Floating Bottom Clock/Player Bar
+                    // Floating Bottom Clock & Player Bar
                     Positioned(
-                      bottom: 6.0,
+                      bottom: 8.0,
                       left: 12.0,
                       right: 12.0,
-                      child: IgnorePointer(
-                        // 💡 ADD THIS WIDGET: Pass taps to the board
-                        ignoring: true,
-                        child: Opacity(
-                          opacity: 0.8,
-                          // 80% visible, pieces show through underneath
-                          child: bottomTable(boardSize: effectiveBoardSize),
-                        ),
-                      ),
+                      child: buildHudTable(bottomTable(boardSize: effectiveBoardSize)),
                     ),
                   ],
                 ),
@@ -580,7 +607,6 @@ class _GameLayoutState extends ConsumerState<GameLayout> {
               ],
             );
           }
-
           // 4. OTHERWISE (Normal phones): Fall back to the original vertical layout
           return Column(
             mainAxisSize: MainAxisSize.max,

--- a/lib/src/widgets/game_layout.dart
+++ b/lib/src/widgets/game_layout.dart
@@ -505,7 +505,7 @@ class _GameLayoutState extends ConsumerState<GameLayout> {
 
           double effectiveBoardSize =
               (isTablet ? defaultBoardSize - kTabletBoardTableSidePadding * 2 : defaultBoardSize) -
-                  pocketsPadding;
+              pocketsPadding;
 
           if (isShortScreen) {
             effectiveBoardSize -= 16;
@@ -533,7 +533,7 @@ class _GameLayoutState extends ConsumerState<GameLayout> {
             ),
           );
 
-// 3. IF NEAR-SQUARE: Overlay the clocks transparently on top of the board corners
+          // 3. IF NEAR-SQUARE: Overlay the clocks transparently on top of the board corners
           if (isNearSquare) {
             return Column(
               mainAxisSize: MainAxisSize.max,
@@ -543,16 +543,17 @@ class _GameLayoutState extends ConsumerState<GameLayout> {
                   alignment: Alignment.center,
                   children: [
                     boardWidget, // The base layer: full size chessboard
-
                     // Floating Top Clock/Player Bar
                     Positioned(
                       top: 6.0,
                       left: 12.0,
                       right: 12.0,
-                      child: IgnorePointer( // 💡 ADD THIS WIDGET: Pass taps to the board
+                      child: IgnorePointer(
+                        // 💡 ADD THIS WIDGET: Pass taps to the board
                         ignoring: true,
                         child: Opacity(
-                          opacity: 0.8, // 80% visible, pieces show through underneath
+                          opacity: 0.8,
+                          // 80% visible, pieces show through underneath
                           child: topTable(boardSize: effectiveBoardSize),
                         ),
                       ),
@@ -563,10 +564,12 @@ class _GameLayoutState extends ConsumerState<GameLayout> {
                       bottom: 6.0,
                       left: 12.0,
                       right: 12.0,
-                      child: IgnorePointer( // 💡 ADD THIS WIDGET: Pass taps to the board
+                      child: IgnorePointer(
+                        // 💡 ADD THIS WIDGET: Pass taps to the board
                         ignoring: true,
                         child: Opacity(
-                          opacity: 0.8, // 80% visible, pieces show through underneath
+                          opacity: 0.8,
+                          // 80% visible, pieces show through underneath
                           child: bottomTable(boardSize: effectiveBoardSize),
                         ),
                       ),

--- a/lib/src/widgets/game_layout.dart
+++ b/lib/src/widgets/game_layout.dart
@@ -11,9 +11,9 @@ import 'package:lichess_mobile/src/model/settings/board_preferences.dart';
 import 'package:lichess_mobile/src/styles/styles.dart';
 import 'package:lichess_mobile/src/utils/screen.dart';
 import 'package:lichess_mobile/src/widgets/board.dart';
+import 'package:lichess_mobile/src/widgets/clock.dart';
 import 'package:lichess_mobile/src/widgets/move_list.dart';
 import 'package:lichess_mobile/src/widgets/pockets.dart';
-import 'package:lichess_mobile/src/widgets/clock.dart';
 
 /// In crazyhouse, when displaying pockets above/below the board, add this much additional side padding to make the board smaller and avoid overflows.
 const _kAdditionalBoardSidePaddingForPockets = 70.0;
@@ -541,7 +541,7 @@ class _GameLayoutState extends ConsumerState<GameLayout> {
               Shadow(offset: Offset(1.5, -1.5), color: Colors.black),
               Shadow(offset: Offset(-1.5, 1.5), color: Colors.black),
               Shadow(offset: Offset(1.5, 1.5), color: Colors.black),
-              Shadow(offset: Offset(0, 0), blurRadius: 6.0, color: Colors.black),
+              Shadow(offset: Offset.zero, blurRadius: 6.0, color: Colors.black),
             ];
 
             const hudTextStyle = TextStyle(

--- a/lib/src/widgets/game_layout.dart
+++ b/lib/src/widgets/game_layout.dart
@@ -505,12 +505,80 @@ class _GameLayoutState extends ConsumerState<GameLayout> {
 
           double effectiveBoardSize =
               (isTablet ? defaultBoardSize - kTabletBoardTableSidePadding * 2 : defaultBoardSize) -
-              pocketsPadding;
+                  pocketsPadding;
 
           if (isShortScreen) {
             effectiveBoardSize -= 16;
           }
 
+          // 1. Calculate the aspect ratio to catch foldables/tablets
+          final double aspectRatio = constraints.maxWidth / constraints.maxHeight;
+          final bool isNearSquare = aspectRatio > 0.75;
+
+          // 2. Extract the BoardWidget so we can reuse it cleanly
+          final boardWidget = Padding(
+            padding: isTablet
+                ? const EdgeInsets.symmetric(horizontal: kTabletBoardTableSidePadding)
+                : EdgeInsets.zero,
+            child: BoardWidget(
+              size: effectiveBoardSize,
+              orientation: widget.orientation,
+              controller: _controller!,
+              onMove: rawOnMove,
+              shapes: shapes,
+              settings: settings,
+              boardKey: widget.boardKey,
+              boardOverlay: widget.boardOverlay,
+              error: widget.errorMessage,
+            ),
+          );
+
+// 3. IF NEAR-SQUARE: Overlay the clocks transparently on top of the board corners
+          if (isNearSquare) {
+            return Column(
+              mainAxisSize: MainAxisSize.max,
+              mainAxisAlignment: MainAxisAlignment.center,
+              children: [
+                Stack(
+                  alignment: Alignment.center,
+                  children: [
+                    boardWidget, // The base layer: full size chessboard
+
+                    // Floating Top Clock/Player Bar
+                    Positioned(
+                      top: 6.0,
+                      left: 12.0,
+                      right: 12.0,
+                      child: IgnorePointer( // 💡 ADD THIS WIDGET: Pass taps to the board
+                        ignoring: true,
+                        child: Opacity(
+                          opacity: 0.8, // 80% visible, pieces show through underneath
+                          child: topTable(boardSize: effectiveBoardSize),
+                        ),
+                      ),
+                    ),
+
+                    // Floating Bottom Clock/Player Bar
+                    Positioned(
+                      bottom: 6.0,
+                      left: 12.0,
+                      right: 12.0,
+                      child: IgnorePointer( // 💡 ADD THIS WIDGET: Pass taps to the board
+                        ignoring: true,
+                        child: Opacity(
+                          opacity: 0.8, // 80% visible, pieces show through underneath
+                          child: bottomTable(boardSize: effectiveBoardSize),
+                        ),
+                      ),
+                    ),
+                  ],
+                ),
+                if (widget.userActionsBar != null) widget.userActionsBar!,
+              ],
+            );
+          }
+
+          // 4. OTHERWISE (Normal phones): Fall back to the original vertical layout
           return Column(
             mainAxisSize: MainAxisSize.max,
             mainAxisAlignment: MainAxisAlignment.center,
@@ -520,7 +588,6 @@ class _GameLayoutState extends ConsumerState<GameLayout> {
                   !isShortScreen &&
                   !(isTablet && pockets != null))
                 if (widget.zenMode)
-                  // display empty move list to keep the layout consistent in zen mode
                   const MoveList(type: MoveListType.inline, slicedMoves: [], currentMoveIndex: 0)
                 else
                   _moveListContent(MoveListType.inline),
@@ -533,22 +600,7 @@ class _GameLayoutState extends ConsumerState<GameLayout> {
                   child: topTable(boardSize: effectiveBoardSize),
                 ),
               ),
-              Padding(
-                padding: isTablet
-                    ? const EdgeInsets.symmetric(horizontal: kTabletBoardTableSidePadding)
-                    : EdgeInsets.zero,
-                child: BoardWidget(
-                  size: effectiveBoardSize,
-                  orientation: widget.orientation,
-                  controller: _controller!,
-                  onMove: rawOnMove,
-                  shapes: shapes,
-                  settings: settings,
-                  boardKey: widget.boardKey,
-                  boardOverlay: widget.boardOverlay,
-                  error: widget.errorMessage,
-                ),
-              ),
+              boardWidget, // Uses the extracted widget here
               Expanded(
                 flex: widget.bottomTableFlex,
                 child: Padding(


### PR DESCRIPTION
… like foldables

This PR introduces a layout optimization for near-square screens (like the Galaxy Z Fold 5 when unfolded) in portrait mode where the standard layout can result in unexpected timers mostly hidden by the board.

    Changes: Implemented a Stack overlay for the top and bottom tables/clocks when isNearSquare evaluates to true based on the aspect ratio.

    Usability Fix: Wrapped the floating clock elements in IgnorePointer widgets alongside Opacity. This ensures that even though the clocks are visually layered on top of the board corners, pointer events pass cleanly through to the underlying BoardWidget, allowing normal piece interaction.

    Testing: Verified on physical Galaxy Z Fold 5 hardware.