### PR TITLE
feat: Add same side mode for OTB/local play (#3076)

### DIFF
--- a/lib/src/model/over_the_board/over_the_board_preferences.dart
+++ b/lib/src/model/over_the_board/over_the_board_preferences.dart
@@ -46,6 +46,10 @@ class OverTheBoardPreferencesNotifier extends Notifier<OverTheBoardPrefs>
     return save(state.copyWith(symmetricPieces: !state.symmetricPieces));
   }
 
+  Future<void> toggleSameSideMode() {
+    return save(state.copyWith(sameSideMode: !state.sameSideMode));
+  }
+
   Future<void> setTimeControlType(TimeControlType type) {
     return save(state.copyWith(timeControlType: type));
   }
@@ -78,6 +82,7 @@ sealed class OverTheBoardPrefs with _$OverTheBoardPrefs implements Serializable 
   const factory OverTheBoardPrefs({
     required bool flipPiecesAfterMove,
     required bool symmetricPieces,
+    @Default(false) bool sameSideMode,
     @Default(TimeControlType.clock) TimeControlType timeControlType,
     @Default(OverTheBoardPrefs._defaultTimeIncrement) TimeIncrement timeIncrement,
   }) = _OverTheBoardPrefs;
@@ -85,6 +90,7 @@ sealed class OverTheBoardPrefs with _$OverTheBoardPrefs implements Serializable 
   static const defaults = OverTheBoardPrefs(
     flipPiecesAfterMove: false,
     symmetricPieces: false,
+    sameSideMode: false,
     timeControlType: TimeControlType.clock,
     timeIncrement: _defaultTimeIncrement,
   );

--- a/lib/src/view/over_the_board/configure_over_the_board_game.dart
+++ b/lib/src/view/over_the_board/configure_over_the_board_game.dart
@@ -285,6 +285,11 @@ class OverTheBoardDisplaySettings extends ConsumerWidget {
     return BottomSheetScrollableContainer(
       children: [
         SwitchSettingTile(
+          title: const Text('Same side mode'),
+          value: prefs.sameSideMode,
+          onChanged: (_) => ref.read(overTheBoardPreferencesProvider.notifier).toggleSameSideMode(),
+        ),
+        SwitchSettingTile(
           title: const Text('Use symmetric pieces'),
           value: prefs.symmetricPieces,
           onChanged: (_) =>

--- a/lib/src/view/over_the_board/over_the_board_screen.dart
+++ b/lib/src/view/over_the_board/over_the_board_screen.dart
@@ -242,13 +242,15 @@ class _BodyState extends ConsumerState<_Body> {
                       clockKey: const ValueKey('topClock'),
                     ),
                     topTableUpsideDown:
-                        !overTheBoardPrefs.flipPiecesAfterMove || orientation != gameState.turn,
+                        !overTheBoardPrefs.sameSideMode &&
+                        (!overTheBoardPrefs.flipPiecesAfterMove || orientation != gameState.turn),
                     bottomTable: _Player(
                       side: orientation,
                       clockKey: const ValueKey('bottomClock'),
                     ),
                     bottomTableUpsideDown:
-                        overTheBoardPrefs.flipPiecesAfterMove && orientation != gameState.turn,
+                        !overTheBoardPrefs.sameSideMode &&
+                        (overTheBoardPrefs.flipPiecesAfterMove && orientation != gameState.turn),
                     orientation: orientation,
                     explosionSquares: gameState.stepCursor > 0
                         ? atomicExplosionSquares(
@@ -279,7 +281,9 @@ class _BodyState extends ConsumerState<_Body> {
                     currentMoveIndex: gameState.stepCursor,
                     boardSettingsOverrides: BoardSettingsOverrides(
                       drawShape: const DrawShapeOptions(enable: false),
-                      pieceOrientationBehavior: overTheBoardPrefs.flipPiecesAfterMove
+                      pieceOrientationBehavior: overTheBoardPrefs.sameSideMode
+                          ? PieceOrientationBehavior.facingUser
+                          : overTheBoardPrefs.flipPiecesAfterMove
                           ? PieceOrientationBehavior.sideToPlay
                           : PieceOrientationBehavior.opponentUpsideDown,
                       pieceAssets: overTheBoardPrefs.symmetricPieces

--- a/test/view/over_the_board/over_the_board_screen_test.dart
+++ b/test/view/over_the_board/over_the_board_screen_test.dart
@@ -18,9 +18,11 @@ import 'package:lichess_mobile/src/model/game/over_the_board_game.dart';
 import 'package:lichess_mobile/src/model/over_the_board/over_the_board_clock.dart';
 import 'package:lichess_mobile/src/model/over_the_board/over_the_board_game_controller.dart';
 import 'package:lichess_mobile/src/model/over_the_board/over_the_board_game_storage.dart';
+import 'package:lichess_mobile/src/model/over_the_board/over_the_board_preferences.dart';
 import 'package:lichess_mobile/src/utils/navigation.dart';
 import 'package:lichess_mobile/src/view/over_the_board/over_the_board_screen.dart';
 import 'package:lichess_mobile/src/widgets/clock.dart';
+import 'package:lichess_mobile/src/widgets/game_layout.dart';
 import 'package:mocktail/mocktail.dart';
 
 import '../../test_helpers.dart';
@@ -743,6 +745,49 @@ void main() {
       expect(gameState.game.steps.length, 1);
       expect(boardHasPiece(tester, Square.e4, Piece.whitePawn), isTrue);
       expect(boardHasPiece(tester, Square.e5, Piece.blackPawn), isTrue);
+    });
+
+    testWidgets('Same side mode configures GameLayout and board settings correctly', (
+      tester,
+    ) async {
+      await initOverTheBoardGame(tester, const TimeIncrement(60, 5));
+
+      final element = tester.element(find.byType(Chessboard));
+      final container = ProviderScope.containerOf(element);
+
+      // Verify sameSideMode is false by default
+      expect(container.read(overTheBoardPreferencesProvider).sameSideMode, isFalse);
+
+      // Open Display Settings Sheet
+      await tester.tap(find.byIcon(Icons.settings));
+      await tester.pumpAndSettle();
+
+      expect(find.text('Same side mode'), findsOneWidget);
+
+      // Toggle Same side mode on
+      final sameSideTile = find.ancestor(
+        of: find.text('Same side mode'),
+        matching: find.byType(ListTile),
+      );
+      await tester.tap(find.descendant(of: sameSideTile, matching: find.byType(Switch)));
+      await tester.pumpAndSettle();
+
+      expect(container.read(overTheBoardPreferencesProvider).sameSideMode, isTrue);
+
+      // Dismiss the bottom sheet
+      await tester.tapAt(const Offset(10, 10));
+      await tester.pumpAndSettle();
+
+      // Verify that topTableUpsideDown and bottomTableUpsideDown are both false in GameLayout
+      final gameLayout = tester.widget<GameLayout>(find.byType(GameLayout));
+      expect(gameLayout.topTableUpsideDown, isFalse);
+      expect(gameLayout.bottomTableUpsideDown, isFalse);
+
+      // Verify piece orientation behavior is facingUser
+      expect(
+        gameLayout.boardSettingsOverrides?.pieceOrientationBehavior,
+        PieceOrientationBehavior.facingUser,
+      );
     });
   });
 }


### PR DESCRIPTION
Implements feature #3076: Add 'same side' mode for OTB/local play. Both players can now view the board and clocks from the same perspective.