### PR TITLE
Moved colors to lichess_color and added color to game analysis summary.

### DIFF
--- a/lib/src/styles/lichess_colors.dart
+++ b/lib/src/styles/lichess_colors.dart
@@ -87,4 +87,8 @@ class LichessColors {
   static const cyan = Color(0xFF56B4E9);
   static const blue = Color(0xFF0072B2);
   static const purple = Color(0xFF8572ff);
+
+  static const inaccuracy = cyan;
+  static const mistake = Color(0xFFe69f00);
+  static const blunder = Color(0xFFdf5353);
 }

--- a/lib/src/view/offline_computer/offline_computer_game_screen.dart
+++ b/lib/src/view/offline_computer/offline_computer_game_screen.dart
@@ -16,6 +16,7 @@ import 'package:lichess_mobile/src/model/offline_computer/offline_computer_game_
 import 'package:lichess_mobile/src/model/offline_computer/offline_computer_game_storage.dart';
 import 'package:lichess_mobile/src/model/offline_computer/practice_comment.dart';
 import 'package:lichess_mobile/src/model/settings/board_preferences.dart';
+import 'package:lichess_mobile/src/styles/lichess_colors.dart';
 import 'package:lichess_mobile/src/styles/styles.dart';
 import 'package:lichess_mobile/src/utils/chessboard.dart';
 import 'package:lichess_mobile/src/utils/focus_detector.dart';
@@ -35,7 +36,6 @@ import 'package:lichess_mobile/src/widgets/list.dart';
 import 'package:lichess_mobile/src/widgets/material_diff.dart';
 import 'package:lichess_mobile/src/widgets/misc.dart';
 import 'package:lichess_mobile/src/widgets/non_linear_slider.dart';
-import 'package:lichess_mobile/src/widgets/pgn.dart';
 import 'package:lichess_mobile/src/widgets/settings.dart';
 import 'package:lichess_mobile/src/widgets/variant_app_bar_title.dart';
 import 'package:lichess_mobile/src/widgets/yes_no_dialog.dart';
@@ -51,9 +51,9 @@ extension _MoveVerdictDisplay on MoveVerdict {
 
   Color get color => switch (this) {
     .goodMove || .notBest => Colors.lightGreen,
-    .inaccuracy => inaccuracyColor,
-    .mistake => mistakeColor,
-    .blunder => blunderColor,
+    .inaccuracy => LichessColors.inaccuracy,
+    .mistake => LichessColors.mistake,
+    .blunder => LichessColors.blunder,
   };
 }
 

--- a/lib/src/widgets/game_summary_table.dart
+++ b/lib/src/widgets/game_summary_table.dart
@@ -4,8 +4,11 @@ import 'package:dartchess/dartchess.dart';
 import 'package:fast_immutable_collections/fast_immutable_collections.dart';
 import 'package:flutter/cupertino.dart';
 import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:lichess_mobile/src/model/game/player.dart';
+import 'package:lichess_mobile/src/model/settings/general_preferences.dart';
 import 'package:lichess_mobile/src/model/user/user.dart';
+import 'package:lichess_mobile/src/styles/lichess_colors.dart';
 import 'package:lichess_mobile/src/styles/styles.dart';
 import 'package:lichess_mobile/src/utils/l10n_context.dart';
 import 'package:lichess_mobile/src/view/user/user_or_profile_screen.dart';
@@ -15,7 +18,7 @@ import 'package:url_launcher/url_launcher.dart';
 ///
 /// Shows player names, game result, accuracy, inaccuracies, mistakes, blunders, and ACPL
 /// in a formatted table layout.
-class GameSummaryTable extends StatelessWidget {
+class GameSummaryTable extends ConsumerWidget {
   const GameSummaryTable({
     required this.pgnHeaders,
     required this.playersAnalysis,
@@ -37,11 +40,17 @@ class GameSummaryTable extends StatelessWidget {
   final LightUser? blackUser;
 
   @override
-  Widget build(BuildContext context) {
+  Widget build(BuildContext context, WidgetRef ref) {
     final result = pgnHeaders.get('Result') ?? '';
 
     final whiteAnalysis = playersAnalysis.white;
     final blackAnalysis = playersAnalysis.black;
+
+    final bool usingCustomBackground = ref.watch(
+      generalPreferencesProvider.select(
+        (prefs) => prefs.backgroundImage != null || prefs.backgroundColor != null,
+      ),
+    );
 
     return Center(
       child: SizedBox(
@@ -103,47 +112,65 @@ class GameSummaryTable extends StatelessWidget {
                     _SummaryNumber('${blackAnalysis.accuracy}%'),
                   ],
                 ),
-              for (final item in [
-                (
-                  whiteAnalysis.inaccuracies.toString(),
-                  context.l10n.numberInaccuracies(2).replaceAll('2', '').trim(),
-                  blackAnalysis.inaccuracies.toString(),
-                ),
-                (
-                  whiteAnalysis.mistakes.toString(),
-                  context.l10n.numberMistakes(2).replaceAll('2', '').trim(),
-                  blackAnalysis.mistakes.toString(),
-                ),
-                (
-                  whiteAnalysis.blunders.toString(),
-                  context.l10n.numberBlunders(2).replaceAll('2', '').trim(),
-                  blackAnalysis.blunders.toString(),
-                ),
+              for (final (whiteText, whiteTextColor, label, blackText, blackTextColor) in [
                 if (whiteAnalysis.phases?.opening != null && blackAnalysis.phases?.opening != null)
                   (
                     '${whiteAnalysis.phases!.opening}%',
+                    _accuracyColor(whiteAnalysis.phases!.opening!, context),
                     context.l10n.opening,
                     '${blackAnalysis.phases!.opening}%',
+                    _accuracyColor(blackAnalysis.phases!.opening!, context),
                   ),
                 if (whiteAnalysis.phases?.middlegame != null &&
                     blackAnalysis.phases?.middlegame != null)
                   (
                     '${whiteAnalysis.phases!.middlegame}%',
+                    _accuracyColor(whiteAnalysis.phases!.middlegame!, context),
                     context.l10n.middlegame,
                     '${blackAnalysis.phases!.middlegame}%',
+                    _accuracyColor(blackAnalysis.phases!.middlegame!, context),
                   ),
                 if (whiteAnalysis.phases?.endgame != null && blackAnalysis.phases?.endgame != null)
                   (
                     '${whiteAnalysis.phases!.endgame}%',
+                    _accuracyColor(whiteAnalysis.phases!.endgame!, context),
                     context.l10n.endgame,
                     '${blackAnalysis.phases!.endgame}%',
+                    _accuracyColor(blackAnalysis.phases!.endgame!, context),
                   ),
               ])
                 TableRow(
                   children: [
-                    _SummaryNumber(item.$1),
-                    Center(heightFactor: 1.2, child: Text(item.$2, softWrap: true)),
-                    _SummaryNumber(item.$3),
+                    _SummaryNumber(whiteText, color: usingCustomBackground ? null : whiteTextColor),
+                    Center(heightFactor: 1.2, child: Text(label, softWrap: true)),
+                    _SummaryNumber(blackText, color: usingCustomBackground ? null : blackTextColor),
+                  ],
+                ),
+              for (final (whiteText, label, blackText, color) in [
+                (
+                  whiteAnalysis.inaccuracies.toString(),
+                  context.l10n.numberInaccuracies(2).replaceAll('2', '').trim(),
+                  blackAnalysis.inaccuracies.toString(),
+                  LichessColors.inaccuracy,
+                ),
+                (
+                  whiteAnalysis.mistakes.toString(),
+                  context.l10n.numberMistakes(2).replaceAll('2', '').trim(),
+                  blackAnalysis.mistakes.toString(),
+                  LichessColors.mistake,
+                ),
+                (
+                  whiteAnalysis.blunders.toString(),
+                  context.l10n.numberBlunders(2).replaceAll('2', '').trim(),
+                  blackAnalysis.blunders.toString(),
+                  LichessColors.blunder,
+                ),
+              ])
+                TableRow(
+                  children: [
+                    _SummaryNumber(whiteText, color: usingCustomBackground ? null : color),
+                    Center(heightFactor: 1.2, child: Text(label, softWrap: true)),
+                    _SummaryNumber(blackText, color: usingCustomBackground ? null : color),
                   ],
                 ),
               if (whiteAnalysis.acpl != null && blackAnalysis.acpl != null)
@@ -170,12 +197,15 @@ class GameSummaryTable extends StatelessWidget {
 }
 
 class _SummaryNumber extends StatelessWidget {
-  const _SummaryNumber(this.data);
+  const _SummaryNumber(this.data, {this.color});
   final String data;
+  final Color? color;
 
   @override
   Widget build(BuildContext context) {
-    return Center(child: Text(data, softWrap: true));
+    return Center(
+      child: Text(data, softWrap: true, style: TextStyle(color: color)),
+    );
   }
 }
 
@@ -249,4 +279,18 @@ class _SummaryPlayerName extends StatelessWidget {
       ),
     );
   }
+}
+
+Color _accuracyColor(int accuracy, BuildContext context) {
+  if (accuracy >= 85) {
+    return LichessColors.good;
+  }
+  if (accuracy >= 70) {
+    return LichessColors.inaccuracy;
+  }
+
+  if (accuracy >= 55) {
+    return LichessColors.mistake;
+  }
+  return LichessColors.blunder;
 }

--- a/lib/src/widgets/pgn.dart
+++ b/lib/src/widgets/pgn.dart
@@ -16,9 +16,6 @@ import 'package:lichess_mobile/src/utils/rate_limit.dart';
 import 'package:lichess_mobile/src/widgets/adaptive_bottom_sheet.dart';
 import 'package:lichess_mobile/src/widgets/list.dart';
 
-const inaccuracyColor = LichessColors.cyan;
-const mistakeColor = Color(0xFFe69f00);
-const blunderColor = Color(0xFFdf5353);
 const kInlineMovePadding = EdgeInsets.symmetric(horizontal: 6.0, vertical: 2.0);
 const kIndexOpacity = 0.6;
 
@@ -86,9 +83,9 @@ Annotation? makeAnnotation(Iterable<int>? nags) {
     1 => const Annotation(symbol: '!', color: Colors.lightGreen),
     3 => const Annotation(symbol: '!!', color: Colors.teal),
     5 => const Annotation(symbol: '!?', color: Colors.purple),
-    6 => const Annotation(symbol: '?!', color: LichessColors.cyan),
-    2 => const Annotation(symbol: '?', color: mistakeColor),
-    4 => const Annotation(symbol: '??', color: blunderColor),
+    6 => const Annotation(symbol: '?!', color: LichessColors.inaccuracy),
+    2 => const Annotation(symbol: '?', color: LichessColors.mistake),
+    4 => const Annotation(symbol: '??', color: LichessColors.blunder),
     8 => const Annotation(symbol: '□', color: Colors.grey),
     10 => const Annotation(symbol: '=', color: Colors.grey),
     11 => const Annotation(symbol: '=', color: Colors.grey),

--- a/test/view/offline_computer/offline_computer_game_screen_test.dart
+++ b/test/view/offline_computer/offline_computer_game_screen_test.dart
@@ -19,11 +19,11 @@ import 'package:lichess_mobile/src/model/offline_computer/offline_computer_game_
 import 'package:lichess_mobile/src/model/offline_computer/offline_computer_game_preferences.dart';
 import 'package:lichess_mobile/src/model/offline_computer/offline_computer_game_storage.dart';
 import 'package:lichess_mobile/src/model/offline_computer/practice_comment.dart';
+import 'package:lichess_mobile/src/styles/lichess_colors.dart';
 import 'package:lichess_mobile/src/utils/navigation.dart';
 import 'package:lichess_mobile/src/view/offline_computer/offline_computer_game_screen.dart';
 import 'package:lichess_mobile/src/widgets/bottom_bar.dart';
 import 'package:lichess_mobile/src/widgets/move_list.dart';
-import 'package:lichess_mobile/src/widgets/pgn.dart';
 import 'package:lichess_mobile/src/widgets/pockets.dart';
 import 'package:lichess_mobile/src/widgets/settings.dart';
 import 'package:mocktail/mocktail.dart';
@@ -1475,19 +1475,28 @@ void main() {
     testWidgets('inaccuracy card background is inaccuracyColor with low alpha', (tester) async {
       await pumpWithComment(tester, makeComment(.inaccuracy));
       final card = _findCommentCardContainer(tester, Icons.help);
-      expect((card.decoration! as BoxDecoration).color, inaccuracyColor.withValues(alpha: 0.1));
+      expect(
+        (card.decoration! as BoxDecoration).color,
+        LichessColors.inaccuracy.withValues(alpha: 0.1),
+      );
     });
 
     testWidgets('mistake card background is mistakeColor with low alpha', (tester) async {
       await pumpWithComment(tester, makeComment(.mistake));
       final card = _findCommentCardContainer(tester, Icons.error);
-      expect((card.decoration! as BoxDecoration).color, mistakeColor.withValues(alpha: 0.1));
+      expect(
+        (card.decoration! as BoxDecoration).color,
+        LichessColors.mistake.withValues(alpha: 0.1),
+      );
     });
 
     testWidgets('blunder card background is blunderColor with low alpha', (tester) async {
       await pumpWithComment(tester, makeComment(.blunder));
       final card = _findCommentCardContainer(tester, Icons.cancel);
-      expect((card.decoration! as BoxDecoration).color, blunderColor.withValues(alpha: 0.1));
+      expect(
+        (card.decoration! as BoxDecoration).color,
+        LichessColors.blunder.withValues(alpha: 0.1),
+      );
     });
 
     // --- suggested moves ---


### PR DESCRIPTION
<img width="1080" height="2424" alt="Screenshot_1784747176" src="https://github.com/user-attachments/assets/bf1a5a20-5011-461c-9a7f-01e60949adc3" />

Based on https://github.com/lichess-org/mobile/pull/1499

As discussed in https://github.com/lichess-org/mobile/pull/3464 we only show the colors if no custom background is used for now.