### PR TITLE
Use sentence case for messages and chat

### DIFF
--- a/lib/src/view/chat/chat_screen.dart
+++ b/lib/src/view/chat/chat_screen.dart
@@ -332,6 +332,7 @@ class _ChatBottomBarState extends ConsumerState<_ChatBottomBar> {
           ),
           controller: _textController,
           keyboardType: TextInputType.text,
+          textCapitalization: TextCapitalization.sentences,
           minLines: 1,
           maxLines: 4,
           enableSuggestions: true,

--- a/lib/src/view/message/conversation_screen.dart
+++ b/lib/src/view/message/conversation_screen.dart
@@ -535,6 +535,7 @@ class _MessageInputState extends ConsumerState<_MessageInput> {
           ),
           controller: controller,
           keyboardType: TextInputType.text,
+          textCapitalization: TextCapitalization.sentences,
           minLines: 1,
           maxLines: 4,
           enableSuggestions: true,

--- a/test/view/chat/chat_screen_test.dart
+++ b/test/view/chat/chat_screen_test.dart
@@ -118,6 +118,8 @@ void main() {
     // Chat content is displayed with its input field.
     expect(find.text('hello world'), findsOneWidget);
     expect(find.byType(TextField), findsOneWidget);
+    final textField = tester.widget<TextField>(find.byType(TextField));
+    expect(textField.textCapitalization, TextCapitalization.sentences);
 
     // Focus the input field: this opens the (fake) software keyboard.
     await tester.tap(find.byType(TextField));


### PR DESCRIPTION
Issue: https://github.com/lichess-org/mobile/issues/3476

### Description
Configures text inputs to use sentence-case capitalization (auto-capitalizing the first letter of each sentence) for the game chat and direct message screens.

### Changes
* **Chat Screen**: Set `textCapitalization: TextCapitalization.sentences` on the input `TextField` in `lib/src/view/chat/chat_screen.dart`.
* **Direct Messages**: Set `textCapitalization: TextCapitalization.sentences` on the input `TextField` in `lib/src/view/message/conversation_screen.dart`.
* **Tests**: Added assertion to `test/view/chat/chat_screen_test.dart` to verify text capitalization configuration.