### PR TITLE
docs: fix two broken links

### DIFF
--- a/COPYING.md
+++ b/COPYING.md
@@ -3,7 +3,7 @@ Copying Lichess Mobile
 
 Any file in this project that does not state otherwise and is not listed as an
 exception below is part of *Lichess Mobile*, the mobile app for
-[lichess.org](lichess.org/mobile), and copyright (c) 2022-2023 Lichess Mobile
+[lichess.org](https://lichess.org/mobile), and copyright (c) 2022-2023 Lichess Mobile
 contributors.
 
 For a list of the authors see the commit log or

--- a/docs/internationalisation.md
+++ b/docs/internationalisation.md
@@ -26,7 +26,7 @@ All three steps are combined in a single script:
 
 ## How to add new translations
 
-[Translations in Crowdin](../translation/sources) are organised by module.
+[Translations in Crowdin](../translation/source) are organised by module.
 
 There is one module for the mobile app: [mobile.xml](../translation/source/mobile.xml).
 

--- a/docs/publish_fdroid.md
+++ b/docs/publish_fdroid.md
@@ -11,7 +11,7 @@ Finally, tag the release and push, this will automatically trigger a new version
 git checkout fdroid
 git merge v<new-version>
 
-# If neccessary, update the flutter-version file
+# If necessary, update the flutter-version file
 
 # Any tag that ends with ".fdroid" will be picked up by the f-droid server as a new release
 git push


### PR DESCRIPTION
Two broken links in the docs:

- **`COPYING.md`** links `[lichess.org](lichess.org/mobile)` — with no scheme, Markdown treats `lichess.org/mobile` as a repository-relative path, so it 404s instead of going to the site. Fixed to `https://lichess.org/mobile` (verified 200).
- **`docs/internationalisation.md`** links `[Translations in Crowdin](../translation/sources)`, but the directory is `translation/source` (singular) — the very next line already links `../translation/source/mobile.xml`. Fixed to `../translation/source`.

Docs-only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)