### PR TITLE
fix: use existing l10n strings for game history display mode options (#3479)

### DIFF
--- a/lib/src/view/user/game_history_screen.dart
+++ b/lib/src/view/user/game_history_screen.dart
@@ -100,7 +100,7 @@ class GameHistoryScreen extends ConsumerWidget {
       actions: [
         ContextMenuAction(
           icon: Icons.ballot_outlined,
-          label: 'Detailed view',
+          label: context.l10n.mobileDisplayModeDetailed,
           onPressed: () {
             ref
                 .read(gameHistoryPreferencesProvider.notifier)
@@ -109,7 +109,7 @@ class GameHistoryScreen extends ConsumerWidget {
         ),
         ContextMenuAction(
           icon: Icons.list_outlined,
-          label: 'Compact view',
+          label: context.l10n.mobileDisplayModeCompact,
           onPressed: () {
             ref
                 .read(gameHistoryPreferencesProvider.notifier)


### PR DESCRIPTION
Replace hardcoded 'Detailed view' and 'Compact view' strings with the existing mobileDisplayModeDetailed and mobileDisplayModeCompact translation keys, making the game history view options translatable.

Fixes #3479