### PR TITLE
Show the number of puzzles left in the queue when offline

### DIFF
--- a/lib/src/model/puzzle/puzzle_providers.dart
+++ b/lib/src/model/puzzle/puzzle_providers.dart
@@ -89,6 +89,20 @@ final savedBatchesProvider = FutureProvider.autoDispose<IList<(PuzzleAngle, int)
   return storage.fetchAll(userId: authUser?.user.id);
 }, name: 'SavedBatchesProvider');
 
+/// Fetches the number of unsolved puzzles saved locally for the given [PuzzleAngle].
+///
+/// Unlike [savedBatchesProvider], which is backed by [PuzzleBatchStorage.fetchAll] and skips the
+/// mix angle, this queries the batch of a single angle, so it also reports the mix count.
+final savedBatchCountProvider = FutureProvider.autoDispose.family<int, PuzzleAngle>((
+  Ref ref,
+  PuzzleAngle angle,
+) async {
+  final authUser = ref.watch(authControllerProvider);
+  final storage = await ref.watch(puzzleBatchStorageProvider.future);
+  final batch = await storage.fetch(userId: authUser?.user.id, angle: angle);
+  return batch?.unsolved.length ?? 0;
+}, name: 'SavedBatchCountProvider');
+
 /// Fetches saved puzzle theme batches for the current user.
 final savedThemeBatchesProvider = FutureProvider.autoDispose<IMap<PuzzleThemeKey, int>>((
   Ref ref,

--- a/lib/src/view/puzzle/puzzle_tab_screen.dart
+++ b/lib/src/view/puzzle/puzzle_tab_screen.dart
@@ -469,6 +469,10 @@ class PuzzleAnglePreview extends ConsumerWidget {
   Widget build(BuildContext context, WidgetRef ref) {
     final puzzle = ref.watch(nextPuzzleProvider(angle));
     final flatOpenings = ref.watch(flatOpeningsListProvider);
+    final isOnline = ref.watch(isDeviceOnlineProvider);
+    // Only useful offline: online the queue is refilled as puzzles are solved, so the number of
+    // puzzles left says nothing about what the user can still do.
+    final savedCount = ref.watch(savedBatchCountProvider(angle)).value ?? 0;
 
     Widget buildPuzzlePreview(Puzzle? puzzle, {bool loading = false}) {
       final preview = puzzle != null ? PuzzlePreview.fromPuzzle(puzzle) : null;
@@ -565,7 +569,7 @@ class PuzzleAnglePreview extends ConsumerWidget {
                           color: DefaultTextStyle.of(context).style.color?.withValues(alpha: 0.6),
                         ),
                         const SizedBox(width: 8),
-                        if (puzzle != null)
+                        if (puzzle != null) ...[
                           Flexible(
                             child: Text(
                               puzzle.puzzle.sideToMove == Side.white
@@ -574,8 +578,21 @@ class PuzzleAnglePreview extends ConsumerWidget {
                               style: TextStyle(color: textShade(context, 0.8)),
                               overflow: TextOverflow.ellipsis,
                             ),
-                          )
-                        else
+                          ),
+                          if (!isOnline && savedCount > 0) ...[
+                            const SizedBox(width: 8),
+                            Flexible(
+                              child: Text(
+                                savedCount == 1 ? '1 puzzle left' : '$savedCount puzzles left',
+                                style: TextStyle(
+                                  fontSize: 12,
+                                  color: textShade(context, Styles.subtitleOpacity),
+                                ),
+                                overflow: TextOverflow.ellipsis,
+                              ),
+                            ),
+                          ],
+                        ] else
                           const Flexible(
                             child: Text('No puzzles available, please go online to fetch them.'),
                           ),

--- a/test/view/puzzle/puzzle_tab_screen_test.dart
+++ b/test/view/puzzle/puzzle_tab_screen_test.dart
@@ -17,6 +17,7 @@ import 'package:lichess_mobile/src/model/puzzle/puzzle_angle.dart';
 import 'package:lichess_mobile/src/model/puzzle/puzzle_batch_storage.dart';
 import 'package:lichess_mobile/src/model/puzzle/puzzle_theme.dart';
 import 'package:lichess_mobile/src/model/puzzle/streak_storage.dart';
+import 'package:lichess_mobile/src/network/connectivity.dart';
 import 'package:lichess_mobile/src/network/http.dart';
 import 'package:lichess_mobile/src/view/puzzle/puzzle_screen.dart';
 import 'package:lichess_mobile/src/view/puzzle/puzzle_tab_screen.dart';
@@ -236,6 +237,71 @@ void main() {
       expect(find.widgetWithText(PuzzleAnglePreview, 'A00'), findsOneWidget);
     });
 
+    testWidgets('shows the number of remaining puzzles when offline', (WidgetTester tester) async {
+      when(
+        () => mockBatchStorage.fetch(userId: null, angle: const PuzzleTheme(PuzzleThemeKey.mix)),
+      ).thenAnswer((_) async => twoPuzzlesBatch);
+      when(() => mockBatchStorage.fetchAll(userId: null)).thenAnswer((_) async => IList(const []));
+
+      final app = await makeTestProviderScopeApp(
+        tester,
+        home: const PuzzleTabScreen(),
+        overrides: {
+          puzzleBatchStorageProvider: puzzleBatchStorageProvider.overrideWith(
+            (ref) => mockBatchStorage,
+          ),
+          httpClientFactoryProvider: httpClientFactoryProvider.overrideWith((ref) {
+            return FakeHttpClientFactory(() => mockClient);
+          }),
+          isDeviceOnlineProvider: isDeviceOnlineProvider.overrideWithValue(false),
+        },
+      );
+
+      await tester.pumpWidget(app);
+
+      // wait for connectivity and storage
+      await tester.pump(const Duration(milliseconds: 100));
+
+      // wait for the puzzles to load
+      await tester.pump(const Duration(milliseconds: 100));
+
+      expect(find.widgetWithText(PuzzleAnglePreview, '2 puzzles left'), findsOneWidget);
+    });
+
+    testWidgets('does not show the number of remaining puzzles when online', (
+      WidgetTester tester,
+    ) async {
+      when(
+        () => mockBatchStorage.fetch(userId: null, angle: const PuzzleTheme(PuzzleThemeKey.mix)),
+      ).thenAnswer((_) async => twoPuzzlesBatch);
+      when(() => mockBatchStorage.fetchAll(userId: null)).thenAnswer((_) async => IList(const []));
+
+      final app = await makeTestProviderScopeApp(
+        tester,
+        home: const PuzzleTabScreen(),
+        overrides: {
+          puzzleBatchStorageProvider: puzzleBatchStorageProvider.overrideWith(
+            (ref) => mockBatchStorage,
+          ),
+          httpClientFactoryProvider: httpClientFactoryProvider.overrideWith((ref) {
+            return FakeHttpClientFactory(() => mockClient);
+          }),
+          isDeviceOnlineProvider: isDeviceOnlineProvider.overrideWithValue(true),
+        },
+      );
+
+      await tester.pumpWidget(app);
+
+      // wait for connectivity and storage
+      await tester.pump(const Duration(milliseconds: 100));
+
+      // wait for the puzzles to load
+      await tester.pump(const Duration(milliseconds: 100));
+
+      expect(find.byType(PuzzleAnglePreview), findsOneWidget);
+      expect(find.text('2 puzzles left'), findsNothing);
+    });
+
     testWidgets('delete a saved puzzle batch', (WidgetTester tester) async {
       final testDb = await openAppDatabase(databaseFactoryFfiNoIsolate, inMemoryDatabasePath);
 
@@ -429,6 +495,8 @@ String _batchResponse(int count, int Function() nextPuzzleNumber) => jsonEncode(
       },
   ],
 });
+
+final twoPuzzlesBatch = PuzzleBatch(solved: IList(const []), unsolved: IList([puzzle, puzzle2]));
 
 final onePuzzleBatch = PuzzleBatch(
   solved: IList(const [


### PR DESCRIPTION
Closes #499

The puzzle tab previews already compute how many unsolved puzzles are cached for each angle, but the count is discarded --  `savedBatchesProvider` returns `IList<(PuzzleAngle, int)>` and `_MaterialTabBody` maps it down to `.$1`. Offline, that number is the only signal a user has about how much training is left before the queue runs dry.

Per @veloce's guidance in the issue thread, this adds a provider dedicated to this purpose rather than reusing `savedThemeBatchesProvider`. `savedBatchCountProvider` reads a single angle's batch via `PuzzleBatchStorage.fetch` -- deriving it from `savedBatchesProvider` wouldn't work, since `fetchAll` skips the mix angle, which is the entry most users see first.

`PuzzleAnglePreview` renders the count in its existing bottom row, gated on `isDeviceOnlineProvider`: online the queue is continuously refilled, so the number is noise.

The string is hardcoded English per `docs/internationalisation.md` .

2 tests added to the existing `tactical training preview` group (offline shows the count, online doesn't). `flutter analyze` is clean and the full suite passes.