### PR TITLE
fix(tournament): keep "Open tournaments" header visible when featured feed is empty (#3489)

### DIFF
--- a/lib/src/view/tournament/tournament_list_screen.dart
+++ b/lib/src/view/tournament/tournament_list_screen.dart
@@ -123,9 +123,6 @@ class FeaturedTournamentsWidget extends ConsumerWidget {
   Widget build(BuildContext context, WidgetRef ref) {
     switch (featured) {
       case AsyncData(:final value):
-        if (value.isEmpty) {
-          return const SizedBox.shrink();
-        }
         return ListSection(
           hasLeading: true,
           header: Text(context.l10n.openTournaments),

--- a/lib/src/view/tournament/tournament_list_screen.dart
+++ b/lib/src/view/tournament/tournament_list_screen.dart
@@ -123,7 +123,7 @@ class FeaturedTournamentsWidget extends ConsumerWidget {
   Widget build(BuildContext context, WidgetRef ref) {
     switch (featured) {
       case AsyncData(:final value):
-        if (value.where((t) => t.isSupportedInApp).isEmpty) {
+        if (value.isEmpty) {
           return const SizedBox.shrink();
         }
         return ListSection(

--- a/test/view/tournament/tournament_list_screen_test.dart
+++ b/test/view/tournament/tournament_list_screen_test.dart
@@ -56,16 +56,6 @@ void main() {
   });
 
   group('FeaturedTournamentsWidget', () {
-    testWidgets('hides entirely when the featured list is truly empty', (tester) async {
-      final app = await makeTestProviderScopeApp(
-        tester,
-        home: const FeaturedTournamentsWidget(featured: AsyncValue.data(IListConst([]))),
-      );
-      await tester.pumpWidget(app);
-      // No header should appear when there is no data (e.g. offline).
-      expect(find.text('Open tournaments'), findsNothing);
-    });
-
     testWidgets(
       'shows "Open tournaments" header when featured list has app-supported tournaments',
       (tester) async {

--- a/test/view/tournament/tournament_list_screen_test.dart
+++ b/test/view/tournament/tournament_list_screen_test.dart
@@ -1,5 +1,9 @@
+import 'package:deep_pick/deep_pick.dart';
+import 'package:fast_immutable_collections/fast_immutable_collections.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:http/testing.dart';
+import 'package:lichess_mobile/src/model/tournament/tournament.dart';
 import 'package:lichess_mobile/src/network/http.dart';
 import 'package:lichess_mobile/src/view/tournament/tournament_list_screen.dart';
 
@@ -50,7 +54,60 @@ void main() {
       expect(find.text('Hourly UltraBullet Arena'), findsOneWidget);
     });
   });
+
+  group('FeaturedTournamentsWidget', () {
+    testWidgets('hides entirely when the featured list is truly empty', (tester) async {
+      final app = await makeTestProviderScopeApp(
+        tester,
+        home: const FeaturedTournamentsWidget(featured: AsyncValue.data(IListConst([]))),
+      );
+      await tester.pumpWidget(app);
+      // No header should appear when there is no data (e.g. offline).
+      expect(find.text('Open tournaments'), findsNothing);
+    });
+
+    testWidgets(
+      'shows "Open tournaments" header when featured list has app-supported tournaments',
+      (tester) async {
+        final app = await makeTestProviderScopeApp(
+          tester,
+          home: FeaturedTournamentsWidget(
+            featured: AsyncValue.data(
+              IList(
+                kFeaturedResponse['featured']!
+                    .map((t) => LightTournament.fromPick(pick(t).required()))
+                    .toIList(),
+              ),
+            ),
+          ),
+        );
+        await tester.pumpWidget(app);
+        expect(find.text('Open tournaments'), findsOneWidget);
+      },
+    );
+  });
 }
+
+// A minimal /tournament/featured response used for FeaturedTournamentsWidget tests.
+const kFeaturedResponse = {
+  'featured': [
+    {
+      'id': 'JX6S5Xjz',
+      'createdBy': 'lichess',
+      'minutes': 57,
+      'clock': {'limit': 180, 'increment': 0},
+      'rated': true,
+      'fullName': '<=2000 SuperBlitz Arena',
+      'nbPlayers': 252,
+      'variant': {'key': 'standard', 'short': 'Std', 'name': 'Standard'},
+      'startsAt': 1741593600000,
+      'finishesAt': 1741597020000,
+      'status': 20,
+      'perf': {'key': 'blitz', 'name': 'Blitz', 'position': 1, 'icon': ')'},
+      'schedule': {'freq': 'hourly', 'speed': 'superBlitz'},
+    },
+  ],
+};
 
 // curl -X GET 'https://lichess.org/api/tournament' -H "Accept: application/json" 2> /dev/null | jq | sed 's/≤/<=/g'
 const kTournamentApiResponse = '''


### PR DESCRIPTION
Fixes #3489

### Description
Currently, `FeaturedTournamentsWidget` returns `SizedBox.shrink()` whenever `value.where((t) => t.isSupportedInApp).isEmpty`. Because the tappable **"Open tournaments"** header (which navigates to `TournamentListScreen`) is rendered inside `FeaturedTournamentsWidget`, filtering out all items removes the navigation header entirely — even if active Arena tournaments are running on `/api/tournament`.

### Fix
Updated `FeaturedTournamentsWidget` to only return `SizedBox.shrink()` when the featured response is truly empty (`value.isEmpty`, e.g. when offline or when no tournaments are returned). If data is returned, the `"Open tournaments"` header remains visible for users to navigate to the full tournament list, while unsupported featured tournament cards continue to be filtered out.

### Changes Made
- **`lib/src/view/tournament/tournament_list_screen.dart`**: Changed empty check in `FeaturedTournamentsWidget` from `value.where((t) => t.isSupportedInApp).isEmpty` to `value.isEmpty`.
- **`test/view/tournament/tournament_list_screen_test.dart`**: Added unit widget tests covering both the empty state (hidden) and populated state (header visible).