### PR TITLE
fix(game): display PGN player name fallback for imported games (#3485)

### DIFF
--- a/lib/src/view/analysis/analysis_screen.dart
+++ b/lib/src/view/analysis/analysis_screen.dart
@@ -418,6 +418,7 @@ class _PlayerWidget extends StatelessWidget {
             Expanded(
               child: UserFullNameWidget.player(
                 user: player.user,
+                name: player.name,
                 rating: player.rating,
                 provisional: player.provisional,
                 aiLevel: player.aiLevel,

--- a/lib/src/view/game/game_list_detail_tile.dart
+++ b/lib/src/view/game/game_list_detail_tile.dart
@@ -57,6 +57,7 @@ class GameListDetailTile extends ConsumerWidget {
           builder: (context) => GameContextMenu(
             opponentTitle: UserFullNameWidget.player(
               user: opponent.user,
+              name: opponent.name,
               aiLevel: opponent.aiLevel,
               rating: opponent.rating,
             ),

--- a/lib/src/view/game/game_list_tile.dart
+++ b/lib/src/view/game/game_list_tile.dart
@@ -59,6 +59,7 @@ class GameListTile extends ConsumerWidget {
 
     final opponentTitle = UserFullNameWidget.player(
       user: opponent.user,
+      name: opponent.name,
       aiLevel: opponent.aiLevel,
       rating: opponent.rating,
     );

--- a/lib/src/widgets/user.dart
+++ b/lib/src/widgets/user.dart
@@ -127,6 +127,7 @@ class PatronIcon extends StatelessWidget {
 class UserFullNameWidget extends ConsumerWidget {
   const UserFullNameWidget({
     required this.user,
+    this.name,
     this.aiLevel,
     this.rating,
     this.provisional,
@@ -140,6 +141,7 @@ class UserFullNameWidget extends ConsumerWidget {
 
   const UserFullNameWidget.player({
     required this.user,
+    this.name,
     required this.aiLevel,
     this.rating,
     this.provisional,
@@ -152,6 +154,7 @@ class UserFullNameWidget extends ConsumerWidget {
   });
 
   final LightUser? user;
+  final String? name;
   final int? rating;
 
   /// The AI level, if the user is lichess AI.
@@ -185,6 +188,7 @@ class UserFullNameWidget extends ConsumerWidget {
 
     final displayName =
         user?.name ??
+        name ??
         (aiLevel != null
             ? context.l10n.aiNameLevelAiLevel('Stockfish', aiLevel.toString())
             : context.l10n.anonymous);

--- a/test/widgets/user_test.dart
+++ b/test/widgets/user_test.dart
@@ -1,0 +1,35 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:lichess_mobile/src/widgets/user.dart';
+
+import '../test_provider_scope.dart';
+
+void main() {
+  group('UserFullNameWidget', () {
+    testWidgets('displays fallback name when user is null', (WidgetTester tester) async {
+      final app = await makeTestProviderScopeApp(
+        tester,
+        home: const Scaffold(
+          body: UserFullNameWidget.player(user: null, name: 'Kasparov, Garry', aiLevel: null),
+        ),
+      );
+      await tester.pumpWidget(app);
+
+      expect(find.text('Kasparov, Garry'), findsOneWidget);
+    });
+
+    testWidgets('displays Anonymous when neither user nor name is available', (
+      WidgetTester tester,
+    ) async {
+      final app = await makeTestProviderScopeApp(
+        tester,
+        home: const Scaffold(
+          body: UserFullNameWidget.player(user: null, name: null, aiLevel: null),
+        ),
+      );
+      await tester.pumpWidget(app);
+
+      expect(find.text('Anonymous'), findsOneWidget);
+    });
+  });
+}


### PR DESCRIPTION
Fixes #3485

### Description
For imported/bookmarked PGN games, no `LightUser` object is present because the players are not linked to Lichess user accounts. However, the player names from the PGN header tags are parsed into `Player.name`. 
Previously, `UserFullNameWidget` did not accept a `name` parameter and computed `displayName` as `user?.name ?? (aiLevel != null ? ... : l10n.anonymous)`, causing imported games to always display "Anonymous".

### Changes Made
- **`lib/src/widgets/user.dart`**: Added `name` property to `UserFullNameWidget` (and constructor `.player`), and updated `displayName` to check `user?.name ?? name ?? ...`.
- **Call sites (`game_list_tile.dart`, `game_list_detail_tile.dart`, `analysis_screen.dart`)**: Passed `name: opponent.name` / `name: player.name` to `UserFullNameWidget.player`.
- **`test/widgets/user_test.dart`**: Added widget tests for `UserFullNameWidget.player` fallback behavior.