### PR TITLE
fix: ensure opponent's pieces cannot be moved in interactive studies

### DIFF
--- a/lib/src/view/study/study_screen.dart
+++ b/lib/src/view/study/study_screen.dart
@@ -599,6 +599,10 @@ class _StudyAnalysisBoardState
   StudyState get analysisState => ref.watch(studyControllerProvider(widget.options)).requireValue;
 
   @override
+  bool computeInteractive(StudyState state) =>
+      !state.gamebookActive || state.currentPosition?.turn == state.pov;
+
+  @override
   StudyPrefs get analysisPrefs => ref.watch(studyPreferencesProvider);
 
   @override

--- a/test/view/study/study_screen_test.dart
+++ b/test/view/study/study_screen_test.dart
@@ -453,6 +453,11 @@ void main() {
       // Verify this by waiting the same duration as above
       await tester.pump(const Duration(seconds: 1));
 
+      // Regression test: there was a bug where the opponent's piece could be moved in this state:
+      await playMove(tester, 'c4', 'c7');
+      expect(boardHasPiece(tester, Square.c4, Piece.blackQueen), isTrue);
+      expect(boardHasPiece(tester, Square.c7, Piece.blackQueen), isFalse);
+
       expect(find.text('Not much to say after ...Qc7.'), findsOneWidget);
       expect(find.text(introText), findsNothing);
 


### PR DESCRIPTION
In interactive (gamebook) studies the board was incorrectly interactive for both sides.

This went unnoticed for a long time, because the opponents moves are usually played automatically. However, when there's an explicit comment on a move, you have to tap "Next" to trigger the opponent move. In this state. it was possible to move the opponents pieces. 

Fix this by overriding the already existing `computeInteractive()` method. Added a regression test. 