### PR TITLE
Add blindfold mode to offline computer and over-the-board games

### DIFF
--- a/lib/src/model/offline_computer/offline_computer_game_preferences.dart
+++ b/lib/src/model/offline_computer/offline_computer_game_preferences.dart
@@ -59,6 +59,10 @@ class OfflineComputerGamePreferences extends Notifier<OfflineComputerGamePrefs>
   Future<void> toggleHideEvaluation() {
     return save(state.copyWith(hideEvaluation: !state.hideEvaluation));
   }
+
+  Future<void> toggleBlindfoldMode() {
+    return save(state.copyWith(blindfoldMode: !state.blindfoldMode));
+  }
 }
 
 /// Represents the player's color choice for offline computer games.
@@ -98,6 +102,7 @@ sealed class OfflineComputerGamePrefs with _$OfflineComputerGamePrefs implements
     @Default(false) bool practiceMode,
     @Default(false) bool hideBestMove,
     @Default(false) bool hideEvaluation,
+    @Default(false) bool blindfoldMode,
   }) = _OfflineComputerGamePrefs;
 
   static const defaults = OfflineComputerGamePrefs(
@@ -108,6 +113,7 @@ sealed class OfflineComputerGamePrefs with _$OfflineComputerGamePrefs implements
     practiceMode: false,
     hideBestMove: false,
     hideEvaluation: false,
+    blindfoldMode: false,
   );
 
   factory OfflineComputerGamePrefs.fromJson(Map<String, dynamic> json) {

--- a/lib/src/model/over_the_board/over_the_board_preferences.dart
+++ b/lib/src/model/over_the_board/over_the_board_preferences.dart
@@ -53,6 +53,10 @@ class OverTheBoardPreferencesNotifier extends Notifier<OverTheBoardPrefs>
   Future<void> setTimeIncrement(TimeIncrement timeIncrement) {
     return save(state.copyWith(timeIncrement: timeIncrement));
   }
+
+  Future<void> toggleBlindfoldMode() {
+    return save(state.copyWith(blindfoldMode: !state.blindfoldMode));
+  }
 }
 
 enum TimeControlType {
@@ -80,6 +84,7 @@ sealed class OverTheBoardPrefs with _$OverTheBoardPrefs implements Serializable 
     required bool symmetricPieces,
     @Default(TimeControlType.clock) TimeControlType timeControlType,
     @Default(OverTheBoardPrefs._defaultTimeIncrement) TimeIncrement timeIncrement,
+    @Default(false) bool blindfoldMode,
   }) = _OverTheBoardPrefs;
 
   static const defaults = OverTheBoardPrefs(
@@ -87,6 +92,7 @@ sealed class OverTheBoardPrefs with _$OverTheBoardPrefs implements Serializable 
     symmetricPieces: false,
     timeControlType: TimeControlType.clock,
     timeIncrement: _defaultTimeIncrement,
+    blindfoldMode: false,
   );
 
   factory OverTheBoardPrefs.fromJson(Map<String, dynamic> json) {

--- a/lib/src/view/offline_computer/offline_computer_game_screen.dart
+++ b/lib/src/view/offline_computer/offline_computer_game_screen.dart
@@ -92,17 +92,16 @@ class OfflineComputerGameScreen extends ConsumerWidget {
       appBar: AppBar(
         title: AppBarTitleText(title),
         actions: [
-          if (practiceMode)
-            IconButton(
-              icon: const Icon(Icons.settings),
-              tooltip: 'Practice settings',
-              onPressed: () {
-                showModalBottomSheet<void>(
-                  context: context,
-                  builder: (_) => const _PracticeSettingsSheet(),
-                );
-              },
-            ),
+          IconButton(
+            icon: const Icon(Icons.settings),
+            tooltip: context.l10n.settingsSettings,
+            onPressed: () {
+              showModalBottomSheet<void>(
+                context: context,
+                builder: (_) => const _OfflineComputerGameSettingsSheet(),
+              );
+            },
+          ),
         ],
       ),
       body: _Body(initialVariant: initialVariant, initialFen: initialFen),
@@ -204,6 +203,10 @@ class _BodyState extends ConsumerState<_Body> {
     final orientation = gameState.game.playerSide;
     final isPlayerTurn = gameState.turn == orientation && !gameState.isEngineThinking;
 
+    final blindfoldMode = ref.watch(
+      offlineComputerGamePreferencesProvider.select((p) => p.blindfoldMode),
+    );
+
     return WakelockWidget(
       child: PopScope(
         canPop: false,
@@ -260,7 +263,10 @@ class _BodyState extends ConsumerState<_Body> {
                           )
                         : null,
                     shapes: _buildBoardShapes(gameState, boardColorScheme),
-                    boardSettingsOverrides: const BoardSettingsOverrides(enablePremoves: false),
+                    boardSettingsOverrides: BoardSettingsOverrides(
+                      enablePremoves: false,
+                      blindfoldMode: blindfoldMode,
+                    ),
                     boardParams: GameBoardParams.interactive(
                       variant: gameState.game.meta.variant,
                       position: gameState.currentPosition,
@@ -956,31 +962,48 @@ class _NewGameSheetState extends ConsumerState<_NewGameSheet> {
       (_fromPositionFen != null && _fromPositionFen!.isNotEmpty);
 }
 
-class _PracticeSettingsSheet extends ConsumerWidget {
-  const _PracticeSettingsSheet();
+class _OfflineComputerGameSettingsSheet extends ConsumerWidget {
+  const _OfflineComputerGameSettingsSheet();
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
     final prefs = ref.watch(offlineComputerGamePreferencesProvider);
+    final practiceMode = ref.watch(
+      offlineComputerGameControllerProvider.select((s) => s.game.practiceMode),
+    );
 
     return BottomSheetScrollableContainer(
       children: [
+        if (practiceMode)
+          ListSection(
+            header: const Text('Practice settings'),
+            materialFilledCard: true,
+            children: [
+              SwitchSettingTile(
+                title: Text(context.l10n.hideBestMove),
+                value: prefs.hideBestMove,
+                onChanged: (_) {
+                  ref.read(offlineComputerGamePreferencesProvider.notifier).toggleHideBestMove();
+                },
+              ),
+              SwitchSettingTile(
+                title: const Text('Hide evaluation'),
+                value: prefs.hideEvaluation,
+                onChanged: (_) {
+                  ref.read(offlineComputerGamePreferencesProvider.notifier).toggleHideEvaluation();
+                },
+              ),
+            ],
+          ),
         ListSection(
-          header: const Text('Practice settings'),
+          header: Text(context.l10n.settingsSettings),
           materialFilledCard: true,
           children: [
             SwitchSettingTile(
-              title: Text(context.l10n.hideBestMove),
-              value: prefs.hideBestMove,
+              title: Text(context.l10n.preferencesBlindfold),
+              value: prefs.blindfoldMode,
               onChanged: (_) {
-                ref.read(offlineComputerGamePreferencesProvider.notifier).toggleHideBestMove();
-              },
-            ),
-            SwitchSettingTile(
-              title: const Text('Hide evaluation'),
-              value: prefs.hideEvaluation,
-              onChanged: (_) {
-                ref.read(offlineComputerGamePreferencesProvider.notifier).toggleHideEvaluation();
+                ref.read(offlineComputerGamePreferencesProvider.notifier).toggleBlindfoldMode();
               },
             ),
           ],

--- a/lib/src/view/over_the_board/configure_over_the_board_game.dart
+++ b/lib/src/view/over_the_board/configure_over_the_board_game.dart
@@ -296,6 +296,12 @@ class OverTheBoardDisplaySettings extends ConsumerWidget {
           onChanged: (_) =>
               ref.read(overTheBoardPreferencesProvider.notifier).toggleFlipPiecesAfterMove(),
         ),
+        SwitchSettingTile(
+          title: Text(context.l10n.preferencesBlindfold),
+          value: prefs.blindfoldMode,
+          onChanged: (_) =>
+              ref.read(overTheBoardPreferencesProvider.notifier).toggleBlindfoldMode(),
+        ),
       ],
     );
   }

--- a/lib/src/view/over_the_board/over_the_board_screen.dart
+++ b/lib/src/view/over_the_board/over_the_board_screen.dart
@@ -191,6 +191,8 @@ class _BodyState extends ConsumerState<_Body> {
       }
     });
 
+    final blindfoldMode = overTheBoardPrefs.blindfoldMode;
+
     return WakelockWidget(
       child: PopScope(
         canPop: false,
@@ -286,6 +288,7 @@ class _BodyState extends ConsumerState<_Body> {
                           ? PieceSet.symmetric.assets
                           : null,
                       enablePremoves: false,
+                      blindfoldMode: blindfoldMode,
                     ),
                     userActionsBar: _BottomBar(
                       onFlipBoard: () {

--- a/test/view/offline_computer/offline_computer_game_screen_test.dart
+++ b/test/view/offline_computer/offline_computer_game_screen_test.dart
@@ -273,6 +273,44 @@ void main() {
       expect(find.text('New game'), findsWidgets);
     });
 
+    testWidgets(
+      'Settings icon in app bar is visible and opens unified settings sheet in standard mode',
+      (tester) async {
+        await initOfflineComputerGame(tester);
+
+        // Verify settings icon is present in app bar
+        final settingsIcon = find.byIcon(Icons.settings);
+        expect(settingsIcon, findsOneWidget);
+
+        await tester.tap(settingsIcon);
+        await tester.pumpAndSettle();
+
+        // In standard mode, only general settings (blindfold mode) are shown
+        expect(find.text('Blindfold'), findsOneWidget);
+        expect(find.text('Practice settings'), findsNothing);
+        expect(find.text('Hide best move'), findsNothing);
+      },
+    );
+
+    testWidgets(
+      'Settings icon opens unified settings sheet with practice settings in practice mode',
+      (tester) async {
+        await initPracticeModeGame(tester);
+        await tester.pumpAndSettle();
+
+        // Verify settings icon is visible
+        final settingsIcon = find.byIcon(Icons.settings);
+        expect(settingsIcon, findsOneWidget);
+
+        await tester.tap(settingsIcon);
+        await tester.pumpAndSettle();
+
+        // In practice mode, practice settings appear before general settings (blindfold mode)
+        expect(find.text('Practice settings'), findsOneWidget);
+        expect(find.text('Blindfold'), findsOneWidget);
+      },
+    );
+
     testWidgets('Playing as black shows board from black perspective', (tester) async {
       await initOfflineComputerGame(tester, side: Side.black);
 

--- a/test/view/over_the_board/over_the_board_screen_test.dart
+++ b/test/view/over_the_board/over_the_board_screen_test.dart
@@ -744,6 +744,32 @@ void main() {
       expect(boardHasPiece(tester, Square.e4, Piece.whitePawn), isTrue);
       expect(boardHasPiece(tester, Square.e5, Piece.blackPawn), isTrue);
     });
+
+    testWidgets('Blindfold option is shown in display settings sheet', (tester) async {
+      final gameStorage = MockOverTheBoardGameStorage();
+      when(() => gameStorage.fetchOngoingGame()).thenAnswer((_) async => null);
+
+      final app = await makeTestProviderScopeApp(
+        tester,
+        home: const OverTheBoardScreen(),
+        overrides: {
+          overTheBoardGameStorageProvider: overTheBoardGameStorageProvider.overrideWith(
+            (_) => gameStorage,
+          ),
+        },
+      );
+      await tester.pumpWidget(app);
+      await tester.pumpAndSettle();
+
+      await tester.tap(find.text('Play'));
+      await tester.pumpAndSettle();
+
+      await tester.tap(find.byIcon(Icons.settings));
+      await tester.pumpAndSettle();
+
+      // Verify Blindfold setting tile is present in display settings bottom sheet
+      expect(find.text('Blindfold'), findsOneWidget);
+    });
   });
 }
 


### PR DESCRIPTION
## Summary

This PR adds blindfold mode support to both offline computer games and over-the-board games.
Fixes: #3502

## Changes

- Offline computer games now include a general settings sheet that is available in both standard and practice mode. This adds a blindfold toggle and keeps the existing practice-only options in the same place. The board now reads the saved blindfold preference and hides pieces during play.
- Over-the-board games now include a blindfold toggle in display settings. The board now reads that saved preference and applies blindfold mode during play.

## Testing

- Added & tested widget test coverage for the offline computer settings sheet in standard and practice mode
- Added & tested widget test coverage for the over-the-board display settings sheet

## Visuals
<img width="2580" height="4169" alt="image" src="https://github.com/user-attachments/assets/2a76d19c-edc6-4547-9f8f-c286d3b9c4e0" />
