### PR TITLE
Replace stalled flutter_linkify package

### DIFF
--- a/lib/src/app_links_service.dart
+++ b/lib/src/app_links_service.dart
@@ -420,7 +420,7 @@ class AppLinksService {
 
   static const kLichessLinkifiers = [UrlLinkifier(), EmailLinkifier(), UserTagLinkifier()];
 
-  /// Handles link clicks in Linkify widgets throughout the app.
+  /// Handles link clicks in RichLinkText widgets throughout the app.
   Future<void> onLinkifyOpen(BuildContext context, LinkableElement link) async {
     if (link is UrlElement && link.url.startsWith(RegExp('https?:\\/\\/$kLichessHost'))) {
       // Handle Lichess links specifically

--- a/lib/src/app_links_service.dart
+++ b/lib/src/app_links_service.dart
@@ -33,7 +33,7 @@ import 'package:lichess_mobile/src/view/tournament/tournament_screen.dart';
 import 'package:lichess_mobile/src/view/user/user_or_profile_screen.dart';
 import 'package:lichess_mobile/src/view/watch/tv_screen.dart';
 import 'package:lichess_mobile/src/widgets/feedback.dart';
-import 'package:linkify/linkify.dart';
+import 'package:lichess_mobile/src/widgets/rich_link_text.dart';
 import 'package:logging/logging.dart';
 import 'package:url_launcher/url_launcher.dart';
 

--- a/lib/src/view/chat/chat_screen.dart
+++ b/lib/src/view/chat/chat_screen.dart
@@ -235,7 +235,7 @@ class _MessageBubble extends ConsumerWidget {
                     onTap: () =>
                         Navigator.of(context).push(UserOrProfileScreen.buildRoute(message.user!)),
                   ),
-                Linkify(
+                RichLinkText(
                   onOpen: (link) async =>
                       await ref.read(appLinksServiceProvider).onLinkifyOpen(context, link),
                   linkifiers: AppLinksService.kLichessLinkifiers,

--- a/lib/src/view/chat/chat_screen.dart
+++ b/lib/src/view/chat/chat_screen.dart
@@ -1,4 +1,3 @@
-import 'package:flutter_linkify/flutter_linkify.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:lichess_mobile/src/app_links_service.dart';
 import 'package:lichess_mobile/src/model/auth/auth_controller.dart';
@@ -14,6 +13,7 @@ import 'package:lichess_mobile/src/view/user/user_or_profile_screen.dart';
 import 'package:lichess_mobile/src/widgets/adaptive_bottom_sheet.dart';
 import 'package:lichess_mobile/src/widgets/bottom_bar.dart';
 import 'package:lichess_mobile/src/widgets/buttons.dart';
+import 'package:lichess_mobile/src/widgets/rich_link_text.dart';
 import 'package:lichess_mobile/src/widgets/user.dart';
 import 'package:lichess_mobile/src/widgets/yes_no_dialog.dart';
 import 'package:material_ui/material_ui.dart';

--- a/lib/src/view/message/conversation_screen.dart
+++ b/lib/src/view/message/conversation_screen.dart
@@ -1,4 +1,3 @@
-import 'package:flutter_linkify/flutter_linkify.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:intl/intl.dart';
 import 'package:lichess_mobile/src/app_links_service.dart';
@@ -13,9 +12,9 @@ import 'package:lichess_mobile/src/utils/navigation.dart';
 import 'package:lichess_mobile/src/view/chat/chat_context_menu.dart';
 import 'package:lichess_mobile/src/view/user/user_or_profile_screen.dart';
 import 'package:lichess_mobile/src/widgets/platform.dart';
+import 'package:lichess_mobile/src/widgets/rich_link_text.dart';
 import 'package:lichess_mobile/src/widgets/user.dart';
 import 'package:lichess_mobile/src/widgets/yes_no_dialog.dart';
-import 'package:linkify/linkify.dart' show linkify;
 import 'package:material_ui/material_ui.dart';
 
 sealed class DisplayItem {}

--- a/lib/src/view/study/study_gamebook.dart
+++ b/lib/src/view/study/study_gamebook.dart
@@ -63,7 +63,7 @@ class _CommentState extends ConsumerState<_Comment> {
           controller: _scrollController,
           child: Padding(
             padding: const EdgeInsets.only(right: 5),
-            child: Linkify(
+            child: RichLinkText(
               text: comment,
               style: const TextStyle(fontSize: 16),
               onOpen: (link) {

--- a/lib/src/view/study/study_gamebook.dart
+++ b/lib/src/view/study/study_gamebook.dart
@@ -1,7 +1,7 @@
-import 'package:flutter_linkify/flutter_linkify.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:lichess_mobile/src/model/study/study_controller.dart';
 import 'package:lichess_mobile/src/utils/l10n_context.dart';
+import 'package:lichess_mobile/src/widgets/rich_link_text.dart';
 import 'package:material_ui/material_ui.dart';
 import 'package:url_launcher/url_launcher.dart';
 

--- a/lib/src/view/user/user_context_menu.dart
+++ b/lib/src/view/user/user_context_menu.dart
@@ -1,4 +1,3 @@
-import 'package:flutter_linkify/flutter_linkify.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:lichess_mobile/src/app_links_service.dart';
 import 'package:lichess_mobile/src/model/auth/auth_controller.dart';
@@ -14,6 +13,7 @@ import 'package:lichess_mobile/src/view/watch/tv_screen.dart';
 import 'package:lichess_mobile/src/widgets/adaptive_bottom_sheet.dart';
 import 'package:lichess_mobile/src/widgets/feedback.dart';
 import 'package:lichess_mobile/src/widgets/list.dart';
+import 'package:lichess_mobile/src/widgets/rich_link_text.dart';
 import 'package:lichess_mobile/src/widgets/user.dart';
 import 'package:material_ui/material_ui.dart';
 

--- a/lib/src/view/user/user_context_menu.dart
+++ b/lib/src/view/user/user_context_menu.dart
@@ -44,7 +44,7 @@ class UserContextMenu extends ConsumerWidget {
                   UserFullNameWidget(user: value.lightUser, style: Styles.title),
                   const SizedBox(height: 8.0),
                   if (value.profile?.bio != null)
-                    Linkify(
+                    RichLinkText(
                       onOpen: (link) async =>
                           await ref.read(appLinksServiceProvider).onLinkifyOpen(context, link),
                       linkifiers: AppLinksService.kLichessLinkifiers,

--- a/lib/src/view/user/user_profile.dart
+++ b/lib/src/view/user/user_profile.dart
@@ -1,4 +1,3 @@
-import 'package:flutter_linkify/flutter_linkify.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:intl/intl.dart';
 import 'package:lichess_mobile/l10n/l10n.dart';
@@ -14,6 +13,7 @@ import 'package:lichess_mobile/src/utils/lichess_assets.dart';
 import 'package:lichess_mobile/src/utils/string.dart';
 import 'package:lichess_mobile/src/view/user/countries.dart';
 import 'package:lichess_mobile/src/widgets/network_image.dart';
+import 'package:lichess_mobile/src/widgets/rich_link_text.dart';
 import 'package:material_ui/material_ui.dart';
 import 'package:url_launcher/url_launcher.dart';
 

--- a/lib/src/view/user/user_profile.dart
+++ b/lib/src/view/user/user_profile.dart
@@ -62,7 +62,7 @@ class UserProfileWidget extends ConsumerWidget {
             if (userFullName != null)
               Padding(padding: const EdgeInsets.only(bottom: 5), child: userFullName),
             if (user.profile?.bio != null)
-              Linkify(
+              RichLinkText(
                 onOpen: (link) async =>
                     await ref.read(appLinksServiceProvider).onLinkifyOpen(context, link),
                 linkifiers: AppLinksService.kLichessLinkifiers,

--- a/lib/src/widgets/rich_link_text.dart
+++ b/lib/src/widgets/rich_link_text.dart
@@ -1,0 +1,332 @@
+import 'package:flutter/gestures.dart';
+import 'package:flutter/material.dart';
+
+typedef LinkCallback = void Function(LinkableElement link);
+
+abstract class LinkifyElement {
+  final String text;
+  final String originText;
+
+  LinkifyElement(this.text, [String? originText]) : originText = originText ?? text;
+
+  @override
+  String toString() {
+    return '$runtimeType: "$text"';
+  }
+}
+
+class TextElement extends LinkifyElement {
+  TextElement(super.text);
+}
+
+class LinkableElement extends LinkifyElement {
+  final String url;
+
+  LinkableElement(String? text, this.url, [String? originText]) : super(text ?? url, originText);
+}
+
+class UrlElement extends LinkableElement {
+  UrlElement(String url, [String? text, String? originText]) : super(text, url, originText);
+}
+
+class EmailElement extends LinkableElement {
+  final String emailAddress;
+
+  EmailElement(this.emailAddress) : super(emailAddress, 'mailto:$emailAddress');
+}
+
+class UserTagElement extends LinkableElement {
+  final String userTag;
+
+  UserTagElement(this.userTag) : super(userTag, userTag);
+}
+
+class LinkifyOptions {
+  final bool humanize;
+  final bool defaultToHttps;
+  final bool excludeLastPeriod;
+
+  const LinkifyOptions({
+    this.humanize = true,
+    this.defaultToHttps = false,
+    this.excludeLastPeriod = true,
+  });
+}
+
+abstract class Linkifier {
+  const Linkifier();
+
+  List<LinkifyElement> parse(List<LinkifyElement> elements, LinkifyOptions options);
+}
+
+final _urlRegex = RegExp(r'^(.*?)(https?:\/\/\S+|www\.\S+)', caseSensitive: false, dotAll: true);
+
+final _protocolRegex = RegExp(r'^https?:\/\/', caseSensitive: false);
+
+class UrlLinkifier extends Linkifier {
+  const UrlLinkifier();
+
+  @override
+  List<LinkifyElement> parse(List<LinkifyElement> elements, LinkifyOptions options) {
+    final result = <LinkifyElement>[];
+
+    for (final element in elements) {
+      if (element is! TextElement) {
+        result.add(element);
+        continue;
+      }
+
+      final match = _urlRegex.firstMatch(element.text);
+      if (match == null) {
+        result.add(element);
+        continue;
+      }
+
+      var remaining = element.text.replaceFirst(match.group(0)!, '');
+
+      if (match.group(1)?.isNotEmpty ?? false) {
+        result.add(TextElement(match.group(1)!));
+      }
+
+      if (match.group(2)?.isNotEmpty ?? false) {
+        var matchedUrl = match.group(2)!;
+        var originText = matchedUrl;
+        var trailing = '';
+
+        if (options.excludeLastPeriod && matchedUrl.endsWith('.')) {
+          matchedUrl = matchedUrl.substring(0, matchedUrl.length - 1);
+          originText = originText.substring(0, originText.length - 1);
+          trailing = '.$remaining';
+          remaining = '';
+        } else {
+          while (true) {
+            final punct = RegExp(r'[.,;:!?)]$').firstMatch(matchedUrl);
+            if (punct != null) {
+              trailing = punct.group(0)! + trailing;
+              matchedUrl = matchedUrl.substring(0, matchedUrl.length - 1);
+            } else {
+              break;
+            }
+          }
+        }
+        var fullUrl = matchedUrl;
+        if (!fullUrl.startsWith(_protocolRegex)) {
+          fullUrl = '${options.defaultToHttps ? 'https' : 'http'}://$matchedUrl';
+        }
+
+        if (options.humanize) {
+          final displayText = fullUrl.replaceFirst(_protocolRegex, '');
+          result.add(UrlElement(fullUrl, displayText, originText));
+        } else {
+          result.add(UrlElement(fullUrl, null, originText));
+        }
+
+        if (trailing.isNotEmpty) {
+          result.add(TextElement(trailing));
+        }
+      }
+
+      if (remaining.isNotEmpty) {
+        result.addAll(parse([TextElement(remaining)], options));
+      }
+    }
+
+    return result;
+  }
+}
+
+final _emailRegex = RegExp(
+  r'^(.*?)((?:mailto:)?[A-Za-z0-9._%+-]+@[A-Za-z0-9.-]+\.[A-Za-z]{2,})',
+  caseSensitive: false,
+  dotAll: true,
+);
+
+class EmailLinkifier extends Linkifier {
+  const EmailLinkifier();
+
+  @override
+  List<LinkifyElement> parse(List<LinkifyElement> elements, LinkifyOptions options) {
+    final result = <LinkifyElement>[];
+
+    for (final element in elements) {
+      if (element is! TextElement) {
+        result.add(element);
+        continue;
+      }
+
+      final match = _emailRegex.firstMatch(element.text);
+      if (match == null) {
+        result.add(element);
+        continue;
+      }
+
+      final remaining = element.text.replaceFirst(match.group(0)!, '');
+
+      if (match.group(1)?.isNotEmpty ?? false) {
+        result.add(TextElement(match.group(1)!));
+      }
+
+      if (match.group(2)?.isNotEmpty ?? false) {
+        final email = match.group(2)!.replaceFirst(RegExp('^mailto:', caseSensitive: false), '');
+        result.add(EmailElement(email));
+      }
+
+      if (remaining.isNotEmpty) {
+        result.addAll(parse([TextElement(remaining)], options));
+      }
+    }
+
+    return result;
+  }
+}
+
+final _userTagRegex = RegExp(r'^(.*?)(@[\w@]+(?:[.!][\w@]+)*)', caseSensitive: false, dotAll: true);
+
+class UserTagLinkifier extends Linkifier {
+  const UserTagLinkifier();
+
+  @override
+  List<LinkifyElement> parse(List<LinkifyElement> elements, LinkifyOptions options) {
+    final result = <LinkifyElement>[];
+
+    for (final element in elements) {
+      if (element is! TextElement) {
+        result.add(element);
+        continue;
+      }
+
+      var match = _userTagRegex.firstMatch(element.text);
+      if (match == null) {
+        result.add(element);
+        continue;
+      }
+
+      var textRemaining = element.text.replaceFirst(match.group(0)!, '');
+      final preText = StringBuffer();
+
+      while (match?.group(1)?.contains(RegExp(r'[\w@]$')) ?? false) {
+        preText.write(match!.group(0));
+        match = _userTagRegex.firstMatch(textRemaining);
+        if (match == null) {
+          preText.write(textRemaining);
+          textRemaining = '';
+        } else {
+          textRemaining = textRemaining.replaceFirst(match.group(0)!, '');
+        }
+      }
+
+      if (preText.isNotEmpty || (match?.group(1)?.isNotEmpty ?? false)) {
+        result.add(TextElement(preText.toString() + (match?.group(1) ?? '')));
+      }
+
+      if (match?.group(2)?.isNotEmpty ?? false) {
+        result.add(UserTagElement(match!.group(2)!));
+      }
+
+      if (textRemaining.isNotEmpty) {
+        result.addAll(parse([TextElement(textRemaining)], options));
+      }
+    }
+
+    return result;
+  }
+}
+
+const List<Linkifier> defaultLinkifiers = [UrlLinkifier(), EmailLinkifier()];
+
+List<LinkifyElement> linkify(
+  String text, {
+  LinkifyOptions options = const LinkifyOptions(),
+  List<Linkifier> linkifiers = defaultLinkifiers,
+}) {
+  var elements = <LinkifyElement>[TextElement(text)];
+
+  if (text.isEmpty) {
+    return [];
+  }
+
+  for (final linkifier in linkifiers) {
+    elements = linkifier.parse(elements, options);
+  }
+
+  return elements;
+}
+
+TextSpan buildTextSpan(
+  List<LinkifyElement> elements, {
+  TextStyle? style,
+  TextStyle? linkStyle,
+  LinkCallback? onOpen,
+}) {
+  final children = <InlineSpan>[];
+
+  for (final element in elements) {
+    if (element is LinkableElement) {
+      children.add(
+        TextSpan(
+          text: element.text,
+          style: linkStyle,
+          recognizer: onOpen != null
+              ? (TapGestureRecognizer()..onTap = () => onOpen(element))
+              : null,
+        ),
+      );
+    } else {
+      children.add(TextSpan(text: element.text, style: style));
+    }
+  }
+
+  return TextSpan(children: children);
+}
+
+class Linkify extends StatelessWidget {
+  final String text;
+  final List<Linkifier> linkifiers;
+  final LinkCallback? onOpen;
+  final LinkifyOptions options;
+  final TextStyle? style;
+  final TextStyle? linkStyle;
+  final TextAlign textAlign;
+  final TextDirection? textDirection;
+  final int? maxLines;
+  final TextOverflow overflow;
+  final TextScaler? textScaler;
+
+  const Linkify({
+    super.key,
+    required this.text,
+    this.linkifiers = defaultLinkifiers,
+    this.onOpen,
+    this.options = const LinkifyOptions(),
+    this.style,
+    this.linkStyle,
+    this.textAlign = TextAlign.start,
+    this.textDirection,
+    this.maxLines,
+    this.overflow = TextOverflow.clip,
+    this.textScaler,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    final elements = linkify(text, options: options, linkifiers: linkifiers);
+
+    final defaultStyle = style ?? DefaultTextStyle.of(context).style;
+
+    return Text.rich(
+      buildTextSpan(
+        elements,
+        style: defaultStyle,
+        onOpen: onOpen,
+        linkStyle:
+            linkStyle ??
+            defaultStyle.copyWith(color: Colors.blueAccent, decoration: TextDecoration.underline),
+      ),
+      textAlign: textAlign,
+      textDirection: textDirection,
+      maxLines: maxLines,
+      overflow: overflow,
+      textScaler: textScaler,
+    );
+  }
+}

--- a/lib/src/widgets/rich_link_text.dart
+++ b/lib/src/widgets/rich_link_text.dart
@@ -3,6 +3,119 @@ import 'package:flutter/material.dart';
 
 typedef LinkCallback = void Function(LinkableElement link);
 
+/// A widget that renders [text] with URLs, email addresses and user tags
+/// turned into tappable links.
+class RichLinkText extends StatefulWidget {
+  final String text;
+  final List<Linkifier> linkifiers;
+  final LinkCallback? onOpen;
+  final TextStyle? style;
+  final TextStyle? linkStyle;
+  final TextAlign textAlign;
+  final TextDirection? textDirection;
+  final int? maxLines;
+  final TextOverflow overflow;
+  final TextScaler? textScaler;
+
+  const RichLinkText({
+    super.key,
+    required this.text,
+    this.linkifiers = defaultLinkifiers,
+    this.onOpen,
+    this.style,
+    this.linkStyle,
+    this.textAlign = TextAlign.start,
+    this.textDirection,
+    this.maxLines,
+    this.overflow = TextOverflow.clip,
+    this.textScaler,
+  });
+
+  @override
+  State<RichLinkText> createState() => _RichLinkTextState();
+}
+
+class _RichLinkTextState extends State<RichLinkText> {
+  late List<LinkifyElement> _elements;
+  final List<TapGestureRecognizer> _recognizers = [];
+
+  @override
+  void initState() {
+    super.initState();
+    _elements = linkify(widget.text, linkifiers: widget.linkifiers);
+    _createRecognizers();
+  }
+
+  @override
+  void didUpdateWidget(RichLinkText oldWidget) {
+    super.didUpdateWidget(oldWidget);
+    if (oldWidget.text != widget.text ||
+        oldWidget.linkifiers != widget.linkifiers ||
+        oldWidget.onOpen != widget.onOpen) {
+      _disposeRecognizers();
+      _elements = linkify(widget.text, linkifiers: widget.linkifiers);
+      _createRecognizers();
+    }
+  }
+
+  @override
+  void dispose() {
+    _disposeRecognizers();
+    super.dispose();
+  }
+
+  void _createRecognizers() {
+    if (widget.onOpen == null) return;
+    for (final element in _elements) {
+      if (element is LinkableElement) {
+        _recognizers.add(TapGestureRecognizer()..onTap = () => widget.onOpen!(element));
+      }
+    }
+  }
+
+  void _disposeRecognizers() {
+    for (final recognizer in _recognizers) {
+      recognizer.dispose();
+    }
+    _recognizers.clear();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final defaultStyle = widget.style ?? DefaultTextStyle.of(context).style;
+
+    final children = <InlineSpan>[];
+    var recognizerIndex = 0;
+    for (final element in _elements) {
+      if (element is LinkableElement) {
+        children.add(
+          TextSpan(
+            text: element.text,
+            style:
+                widget.linkStyle ??
+                defaultStyle.copyWith(
+                  color: Colors.blueAccent,
+                  decoration: TextDecoration.underline,
+                ),
+            recognizer: widget.onOpen != null ? _recognizers[recognizerIndex++] : null,
+          ),
+        );
+      } else {
+        children.add(TextSpan(text: element.text, style: defaultStyle));
+      }
+    }
+
+    return Text.rich(
+      TextSpan(children: children),
+      textAlign: widget.textAlign,
+      textDirection: widget.textDirection,
+      maxLines: widget.maxLines,
+      overflow: widget.overflow,
+      textScaler: widget.textScaler,
+    );
+  }
+}
+
 abstract class LinkifyElement {
   final String text;
   final String originText;
@@ -41,22 +154,10 @@ class UserTagElement extends LinkableElement {
   UserTagElement(this.userTag) : super(userTag, userTag);
 }
 
-class LinkifyOptions {
-  final bool humanize;
-  final bool defaultToHttps;
-  final bool excludeLastPeriod;
-
-  const LinkifyOptions({
-    this.humanize = true,
-    this.defaultToHttps = false,
-    this.excludeLastPeriod = true,
-  });
-}
-
 abstract class Linkifier {
   const Linkifier();
 
-  List<LinkifyElement> parse(List<LinkifyElement> elements, LinkifyOptions options);
+  List<LinkifyElement> parse(List<LinkifyElement> elements);
 }
 
 final _urlRegex = RegExp(r'^(.*?)(https?:\/\/\S+|www\.\S+)', caseSensitive: false, dotAll: true);
@@ -73,7 +174,7 @@ class UrlLinkifier extends Linkifier {
   const UrlLinkifier();
 
   @override
-  List<LinkifyElement> parse(List<LinkifyElement> elements, LinkifyOptions options) {
+  List<LinkifyElement> parse(List<LinkifyElement> elements) {
     final result = <LinkifyElement>[];
 
     for (final element in elements) {
@@ -88,7 +189,7 @@ class UrlLinkifier extends Linkifier {
         continue;
       }
 
-      var remaining = element.text.replaceFirst(match.group(0)!, '');
+      final remaining = element.text.replaceFirst(match.group(0)!, '');
 
       if (match.group(1)?.isNotEmpty ?? false) {
         result.add(TextElement(match.group(1)!));
@@ -96,36 +197,21 @@ class UrlLinkifier extends Linkifier {
 
       if (match.group(2)?.isNotEmpty ?? false) {
         var matchedUrl = match.group(2)!;
-        var originText = matchedUrl;
+        final originText = matchedUrl;
         var trailing = '';
 
-        if (options.excludeLastPeriod && matchedUrl.endsWith('.')) {
+        while (true) {
+          final punct = _trailingPunctRegex.firstMatch(matchedUrl);
+          if (punct == null) break;
+          if (punct.group(0)! == ')' && !_hasUnbalancedTrailingParens(matchedUrl)) break;
+          trailing = punct.group(0)! + trailing;
           matchedUrl = matchedUrl.substring(0, matchedUrl.length - 1);
-          originText = originText.substring(0, originText.length - 1);
-          trailing = '.$remaining';
-          remaining = '';
-        } else {
-          while (true) {
-            final punct = _trailingPunctRegex.firstMatch(matchedUrl);
-            if (punct != null) {
-              trailing = punct.group(0)! + trailing;
-              matchedUrl = matchedUrl.substring(0, matchedUrl.length - 1);
-            } else {
-              break;
-            }
-          }
-        }
-        var fullUrl = matchedUrl;
-        if (!fullUrl.startsWith(_protocolRegex)) {
-          fullUrl = '${options.defaultToHttps ? 'https' : 'http'}://$matchedUrl';
         }
 
-        if (options.humanize) {
-          final displayText = fullUrl.replaceFirst(_protocolRegex, '');
-          result.add(UrlElement(fullUrl, displayText, originText));
-        } else {
-          result.add(UrlElement(fullUrl, null, originText));
-        }
+        final fullUrl = matchedUrl.startsWith(_protocolRegex) ? matchedUrl : 'http://$matchedUrl';
+        final displayText = fullUrl.replaceFirst(_protocolRegex, '');
+
+        result.add(UrlElement(fullUrl, displayText, originText));
 
         if (trailing.isNotEmpty) {
           result.add(TextElement(trailing));
@@ -133,12 +219,24 @@ class UrlLinkifier extends Linkifier {
       }
 
       if (remaining.isNotEmpty) {
-        result.addAll(parse([TextElement(remaining)], options));
+        result.addAll(parse([TextElement(remaining)]));
       }
     }
 
     return result;
   }
+}
+
+bool _hasUnbalancedTrailingParens(String url) {
+  var balance = 0;
+  for (final char in url.split('')) {
+    if (char == '(') {
+      balance++;
+    } else if (char == ')') {
+      balance--;
+    }
+  }
+  return balance < 0;
 }
 
 final _emailRegex = RegExp(
@@ -151,7 +249,7 @@ class EmailLinkifier extends Linkifier {
   const EmailLinkifier();
 
   @override
-  List<LinkifyElement> parse(List<LinkifyElement> elements, LinkifyOptions options) {
+  List<LinkifyElement> parse(List<LinkifyElement> elements) {
     final result = <LinkifyElement>[];
 
     for (final element in elements) {
@@ -178,7 +276,7 @@ class EmailLinkifier extends Linkifier {
       }
 
       if (remaining.isNotEmpty) {
-        result.addAll(parse([TextElement(remaining)], options));
+        result.addAll(parse([TextElement(remaining)]));
       }
     }
 
@@ -192,7 +290,7 @@ class UserTagLinkifier extends Linkifier {
   const UserTagLinkifier();
 
   @override
-  List<LinkifyElement> parse(List<LinkifyElement> elements, LinkifyOptions options) {
+  List<LinkifyElement> parse(List<LinkifyElement> elements) {
     final result = <LinkifyElement>[];
 
     for (final element in elements) {
@@ -230,7 +328,7 @@ class UserTagLinkifier extends Linkifier {
       }
 
       if (textRemaining.isNotEmpty) {
-        result.addAll(parse([TextElement(textRemaining)], options));
+        result.addAll(parse([TextElement(textRemaining)]));
       }
     }
 
@@ -240,19 +338,15 @@ class UserTagLinkifier extends Linkifier {
 
 const List<Linkifier> defaultLinkifiers = [UrlLinkifier(), EmailLinkifier()];
 
-List<LinkifyElement> linkify(
-  String text, {
-  LinkifyOptions options = const LinkifyOptions(),
-  List<Linkifier> linkifiers = defaultLinkifiers,
-}) {
-  var elements = <LinkifyElement>[TextElement(text)];
-
+List<LinkifyElement> linkify(String text, {List<Linkifier> linkifiers = defaultLinkifiers}) {
   if (text.isEmpty) {
     return [];
   }
 
+  var elements = <LinkifyElement>[TextElement(text)];
+
   for (final linkifier in linkifiers) {
-    elements = linkifier.parse(elements, options);
+    elements = linkifier.parse(elements);
   }
 
   return elements;
@@ -283,56 +377,4 @@ TextSpan buildTextSpan(
   }
 
   return TextSpan(children: children);
-}
-
-class Linkify extends StatelessWidget {
-  final String text;
-  final List<Linkifier> linkifiers;
-  final LinkCallback? onOpen;
-  final LinkifyOptions options;
-  final TextStyle? style;
-  final TextStyle? linkStyle;
-  final TextAlign textAlign;
-  final TextDirection? textDirection;
-  final int? maxLines;
-  final TextOverflow overflow;
-  final TextScaler? textScaler;
-
-  const Linkify({
-    super.key,
-    required this.text,
-    this.linkifiers = defaultLinkifiers,
-    this.onOpen,
-    this.options = const LinkifyOptions(),
-    this.style,
-    this.linkStyle,
-    this.textAlign = TextAlign.start,
-    this.textDirection,
-    this.maxLines,
-    this.overflow = TextOverflow.clip,
-    this.textScaler,
-  });
-
-  @override
-  Widget build(BuildContext context) {
-    final elements = linkify(text, options: options, linkifiers: linkifiers);
-
-    final defaultStyle = style ?? DefaultTextStyle.of(context).style;
-
-    return Text.rich(
-      buildTextSpan(
-        elements,
-        style: defaultStyle,
-        onOpen: onOpen,
-        linkStyle:
-            linkStyle ??
-            defaultStyle.copyWith(color: Colors.blueAccent, decoration: TextDecoration.underline),
-      ),
-      textAlign: textAlign,
-      textDirection: textDirection,
-      maxLines: maxLines,
-      overflow: overflow,
-      textScaler: textScaler,
-    );
-  }
 }

--- a/lib/src/widgets/rich_link_text.dart
+++ b/lib/src/widgets/rich_link_text.dart
@@ -63,6 +63,12 @@ final _urlRegex = RegExp(r'^(.*?)(https?:\/\/\S+|www\.\S+)', caseSensitive: fals
 
 final _protocolRegex = RegExp(r'^https?:\/\/', caseSensitive: false);
 
+final _trailingPunctRegex = RegExp(r'[.,;:!?)]$');
+
+final _mailtoRegex = RegExp('^mailto:', caseSensitive: false);
+
+final _wordBoundaryRegex = RegExp(r'[\w@]$');
+
 class UrlLinkifier extends Linkifier {
   const UrlLinkifier();
 
@@ -100,7 +106,7 @@ class UrlLinkifier extends Linkifier {
           remaining = '';
         } else {
           while (true) {
-            final punct = RegExp(r'[.,;:!?)]$').firstMatch(matchedUrl);
+            final punct = _trailingPunctRegex.firstMatch(matchedUrl);
             if (punct != null) {
               trailing = punct.group(0)! + trailing;
               matchedUrl = matchedUrl.substring(0, matchedUrl.length - 1);
@@ -167,7 +173,7 @@ class EmailLinkifier extends Linkifier {
       }
 
       if (match.group(2)?.isNotEmpty ?? false) {
-        final email = match.group(2)!.replaceFirst(RegExp('^mailto:', caseSensitive: false), '');
+        final email = match.group(2)!.replaceFirst(_mailtoRegex, '');
         result.add(EmailElement(email));
       }
 
@@ -204,7 +210,7 @@ class UserTagLinkifier extends Linkifier {
       var textRemaining = element.text.replaceFirst(match.group(0)!, '');
       final preText = StringBuffer();
 
-      while (match?.group(1)?.contains(RegExp(r'[\w@]$')) ?? false) {
+      while (match?.group(1)?.contains(_wordBoundaryRegex) ?? false) {
         preText.write(match!.group(0));
         match = _userTagRegex.firstMatch(textRemaining);
         if (match == null) {

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -606,14 +606,6 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "2.0.8"
-  flutter_linkify:
-    dependency: "direct main"
-    description:
-      name: flutter_linkify
-      sha256: "74669e06a8f358fee4512b4320c0b80e51cffc496607931de68d28f099254073"
-      url: "https://pub.dev"
-    source: hosted
-    version: "6.0.0"
   flutter_local_notifications:
     dependency: "direct main"
     description:
@@ -1029,14 +1021,6 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "3.0.2"
-  linkify:
-    dependency: "direct main"
-    description:
-      name: linkify
-      sha256: "4139ea77f4651ab9c315b577da2dd108d9aa0bd84b5d03d33323f1970c645832"
-      url: "https://pub.dev"
-    source: hosted
-    version: "5.0.0"
   lint:
     dependency: "direct dev"
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -38,7 +38,6 @@ dependencies:
   flutter_appauth: ^12.0.2
   flutter_displaymode: ^0.7.0
   flutter_layout_grid: ^2.0.8
-  flutter_linkify: ^6.0.0
   flutter_local_notifications: ^22.3.0
   flutter_localizations:
     sdk: flutter
@@ -55,7 +54,6 @@ dependencies:
   intl: ^0.20.3
   json_annotation: ^4.12.0
   l10n_esperanto: ^3.0.0
-  linkify: ^5.0.0
   logging: ^1.3.0
   material_color_utilities: ^0.13.0
   material_symbols_icons: ^4.2960.0

--- a/test/widgets/rich_link_text_test.dart
+++ b/test/widgets/rich_link_text_test.dart
@@ -1,0 +1,272 @@
+import 'package:flutter/gestures.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:lichess_mobile/src/widgets/rich_link_text.dart';
+
+void main() {
+  group('linkify', () {
+    test('returns empty list for empty string', () {
+      expect(linkify(''), isEmpty);
+    });
+
+    test('returns single TextElement for plain text', () {
+      final result = linkify('hello world');
+      expect(result, hasLength(1));
+      expect(result[0], isA<TextElement>());
+      expect(result[0].text, 'hello world');
+    });
+
+    test('detects http URL', () {
+      final result = linkify('visit http://example.com now');
+      expect(result.any((e) => e is UrlElement), isTrue);
+      final url = result.firstWhere((e) => e is UrlElement) as UrlElement;
+      expect(url.url, 'http://example.com');
+    });
+
+    test('detects https URL', () {
+      final result = linkify('visit https://example.com now');
+      final url = result.firstWhere((e) => e is UrlElement) as UrlElement;
+      expect(url.url, 'https://example.com');
+    });
+
+    test('detects www URL and adds http protocol', () {
+      final result = linkify('visit www.example.com now');
+      final url = result.firstWhere((e) => e is UrlElement) as UrlElement;
+      expect(url.url, 'http://www.example.com');
+    });
+
+    test('www URL with defaultToHttps adds https', () {
+      final result = linkify(
+        'visit www.example.com now',
+        options: const LinkifyOptions(defaultToHttps: true),
+      );
+      final url = result.firstWhere((e) => e is UrlElement) as UrlElement;
+      expect(url.url, 'https://www.example.com');
+    });
+
+    test('humanizes URL display text', () {
+      final result = linkify(
+        'visit https://example.com/path now',
+        options: const LinkifyOptions(humanize: true),
+      );
+      final url = result.firstWhere((e) => e is UrlElement) as UrlElement;
+      expect(url.text, isNot(contains('https://')));
+      expect(url.url, contains('https://'));
+    });
+
+    test('does not humanize when humanize is false', () {
+      final result = linkify(
+        'visit https://example.com now',
+        options: const LinkifyOptions(humanize: false),
+      );
+      final url = result.firstWhere((e) => e is UrlElement) as UrlElement;
+      expect(url.text, equals(url.url));
+    });
+
+    test('excludeLastPeriod removes trailing dot from URL', () {
+      final result = linkify('visit https://example.com. now');
+      final url = result.firstWhere((e) => e is UrlElement) as UrlElement;
+      expect(url.url, isNot(endsWith('.')));
+    });
+
+    test('detects email address', () {
+      final result = linkify('contact me at user@example.com please');
+      final email = result.firstWhere((e) => e is EmailElement) as EmailElement;
+      expect(email.emailAddress, 'user@example.com');
+      expect(email.url, 'mailto:user@example.com');
+    });
+
+    test('detects email with mailto prefix', () {
+      final result = linkify('contact me at mailto:user@example.com please');
+      final email = result.firstWhere((e) => e is EmailElement) as EmailElement;
+      expect(email.emailAddress, 'user@example.com');
+    });
+
+    test('detects @username mention', () {
+      final result = linkify(
+        'hello @user123 how are you?',
+        linkifiers: const [UrlLinkifier(), EmailLinkifier(), UserTagLinkifier()],
+      );
+      final tag = result.firstWhere((e) => e is UserTagElement) as UserTagElement;
+      expect(tag.userTag, '@user123');
+      expect(tag.originText, '@user123');
+    });
+
+    test('detects multiple URLs in text', () {
+      final result = linkify('foo https://a.com bar https://b.com baz');
+      final urls = result.whereType<UrlElement>().toList();
+      expect(urls, hasLength(2));
+    });
+
+    test('detects URL at end of text', () {
+      final result = linkify('visit https://example.com');
+      expect(result.any((e) => e is UrlElement), isTrue);
+    });
+
+    test('detects URL at start of text', () {
+      final result = linkify('https://example.com is great');
+      expect(result.firstWhere((e) => e is UrlElement), isA<UrlElement>());
+    });
+
+    test('text with no links returns single TextElement', () {
+      final result = linkify('plain text without any links');
+      expect(result, hasLength(1));
+      expect(result[0], isA<TextElement>());
+    });
+
+    test('custom linkifiers only', () {
+      final result = linkify(
+        'email user@test.com and @mention',
+        linkifiers: const [EmailLinkifier()],
+      );
+      expect(result.any((e) => e is EmailElement), isTrue);
+      expect(result.any((e) => e is UserTagElement), isFalse);
+    });
+
+    test('no linkifiers returns original text', () {
+      final result = linkify('visit https://example.com', linkifiers: const []);
+      expect(result, hasLength(1));
+      expect(result[0], isA<TextElement>());
+      expect(result[0].text, 'visit https://example.com');
+    });
+
+    test('preserves text before and after URL', () {
+      final result = linkify('before https://example.com after');
+      final texts = result.whereType<TextElement>().toList();
+      expect(texts.any((t) => t.text == 'before '), isTrue);
+      expect(texts.any((t) => t.text == ' after'), isTrue);
+    });
+
+    test('preserves originText on UrlElement', () {
+      final result = linkify('foo www.example.com bar');
+      final url = result.firstWhere((e) => e is UrlElement) as UrlElement;
+      expect(url.originText, 'www.example.com');
+    });
+
+    test('LinkifyElement originText defaults to text', () {
+      final elem = TextElement('hello');
+      expect(elem.originText, 'hello');
+    });
+  });
+
+  group('buildTextSpan', () {
+    test('returns TextSpan with children for links and text', () {
+      final elements = linkify('hello https://example.com world');
+      final span = buildTextSpan(elements);
+      expect(span.children, isNotNull);
+      expect(span.children!.length, greaterThan(1));
+    });
+
+    test('applies linkStyle to link spans', () {
+      const linkStyle = TextStyle(color: Colors.red, fontWeight: FontWeight.bold);
+      final elements = linkify('hello https://example.com');
+      final span = buildTextSpan(elements, linkStyle: linkStyle, onOpen: (_) {});
+
+      final linkSpan =
+          span.children!.firstWhere((c) => (c as TextSpan).recognizer != null) as TextSpan;
+      expect(linkSpan.style, linkStyle);
+    });
+
+    test('applies style to text spans', () {
+      const style = TextStyle(color: Colors.green);
+      final elements = linkify('hello world');
+      final span = buildTextSpan(elements, style: style);
+
+      final textSpan =
+          span.children!.firstWhere((c) => c is TextSpan && c.recognizer == null) as TextSpan;
+      expect(textSpan.style, style);
+    });
+
+    test('onOpen adds TapGestureRecognizer to links', () {
+      LinkableElement? tappedLink;
+      final elements = linkify('hello https://example.com');
+      final span = buildTextSpan(elements, onOpen: (link) => tappedLink = link);
+
+      final linkSpan =
+          span.children!.firstWhere((c) => (c as TextSpan).recognizer != null) as TextSpan;
+      expect(linkSpan.recognizer, isA<TapGestureRecognizer>());
+      final tapRecognizer = linkSpan.recognizer! as TapGestureRecognizer;
+      expect(tapRecognizer, isNotNull);
+      tapRecognizer.onTap!();
+      expect(tappedLink, isNotNull);
+      expect(tappedLink!.url, 'https://example.com');
+    });
+
+    test('elements without links have no recognizer', () {
+      final elements = linkify('hello world');
+      final span = buildTextSpan(elements);
+
+      for (final child in span.children ?? <InlineSpan>[]) {
+        if (child is TextSpan) {
+          expect(child.recognizer, isNull);
+        }
+      }
+    });
+  });
+
+  group('Linkify widget', () {
+    testWidgets('renders plain text', (WidgetTester tester) async {
+      await tester.pumpWidget(const MaterialApp(home: Linkify(text: 'hello world')));
+      expect(find.text('hello world'), findsOneWidget);
+    });
+
+    testWidgets('renders multiple elements', (WidgetTester tester) async {
+      await tester.pumpWidget(const MaterialApp(home: Linkify(text: 'before https://a.com after')));
+      expect(find.byType(RichText), findsOneWidget);
+      final richText = tester.widget<RichText>(find.byType(RichText));
+      final plainText = richText.text.toPlainText();
+      expect(plainText, contains('before'));
+      expect(plainText, contains('after'));
+    });
+
+    testWidgets('onOpen callback is wired into TextSpan recognizer', (WidgetTester tester) async {
+      await tester.pumpWidget(
+        MaterialApp(
+          home: Linkify(text: 'tap https://example.com', onOpen: (_) {}),
+        ),
+      );
+
+      final richText = tester.widget<RichText>(find.byType(RichText));
+      final outer = richText.text as TextSpan;
+      final inner = outer.children!.first as TextSpan;
+      final hasRecognizer = inner.children!.any((c) => c is TextSpan && c.recognizer != null);
+      expect(hasRecognizer, isTrue);
+    });
+
+    testWidgets('passes maxLines and overflow', (WidgetTester tester) async {
+      await tester.pumpWidget(
+        const MaterialApp(
+          home: SizedBox(
+            width: 100,
+            child: Linkify(
+              text: 'very long text that should definitely overflow the given width',
+              maxLines: 1,
+              overflow: TextOverflow.ellipsis,
+            ),
+          ),
+        ),
+      );
+
+      final richText = tester.widget<RichText>(find.byType(RichText));
+      expect(richText.maxLines, 1);
+      expect(richText.overflow, TextOverflow.ellipsis);
+    });
+
+    testWidgets('applies custom style and linkStyle', (WidgetTester tester) async {
+      const customStyle = TextStyle(color: Colors.green, fontSize: 20.0);
+
+      await tester.pumpWidget(
+        const MaterialApp(
+          home: Linkify(text: 'plain text no links', style: customStyle),
+        ),
+      );
+
+      final richText = tester.widget<RichText>(find.byType(RichText));
+      final outer = richText.text as TextSpan;
+      final inner = outer.children!.first as TextSpan;
+      expect(inner.children, isNotEmpty);
+      final child = inner.children!.first as TextSpan;
+      expect(child.style, isNotNull);
+    });
+  });
+}

--- a/test/widgets/rich_link_text_test.dart
+++ b/test/widgets/rich_link_text_test.dart
@@ -246,8 +246,9 @@ void main() {
 
       final richText = tester.widget<RichText>(find.byType(RichText));
       final outer = richText.text as TextSpan;
-      final inner = outer.children!.first as TextSpan;
-      final hasRecognizer = inner.children!.any((c) => c is TextSpan && c.recognizer != null);
+      final hasRecognizer = outer.children!.any(
+        (c) => c is TextSpan && (c as TextSpan).recognizer != null,
+      );
       expect(hasRecognizer, isTrue);
     });
 

--- a/test/widgets/rich_link_text_test.dart
+++ b/test/widgets/rich_link_text_test.dart
@@ -35,38 +35,54 @@ void main() {
       expect(url.url, 'http://www.example.com');
     });
 
-    test('www URL with defaultToHttps adds https', () {
-      final result = linkify(
-        'visit www.example.com now',
-        options: const LinkifyOptions(defaultToHttps: true),
-      );
-      final url = result.firstWhere((e) => e is UrlElement) as UrlElement;
-      expect(url.url, 'https://www.example.com');
-    });
-
     test('humanizes URL display text', () {
-      final result = linkify(
-        'visit https://example.com/path now',
-        options: const LinkifyOptions(humanize: true),
-      );
+      final result = linkify('visit https://example.com/path now');
       final url = result.firstWhere((e) => e is UrlElement) as UrlElement;
       expect(url.text, isNot(contains('https://')));
       expect(url.url, contains('https://'));
     });
 
-    test('does not humanize when humanize is false', () {
-      final result = linkify(
-        'visit https://example.com now',
-        options: const LinkifyOptions(humanize: false),
-      );
-      final url = result.firstWhere((e) => e is UrlElement) as UrlElement;
-      expect(url.text, equals(url.url));
-    });
-
-    test('excludeLastPeriod removes trailing dot from URL', () {
+    test('removes trailing period from URL', () {
       final result = linkify('visit https://example.com. now');
       final url = result.firstWhere((e) => e is UrlElement) as UrlElement;
       expect(url.url, isNot(endsWith('.')));
+    });
+
+    test('linkifies multiple URLs that end with a period', () {
+      final result = linkify('https://a.com. more text https://b.com. end');
+      final urls = result.whereType<UrlElement>().toList();
+      expect(urls, hasLength(2));
+      expect(urls[0].url, 'https://a.com');
+      expect(urls[1].url, 'https://b.com');
+      final texts = result.whereType<TextElement>().map((e) => e.text).join();
+      expect(texts, contains('more text'));
+      expect(texts, contains('end'));
+    });
+
+    test('preserves balanced parentheses in URLs (e.g. Wikipedia)', () {
+      final result = linkify('http://en.wikipedia.org/wiki/Saw_(film)');
+      final url = result.firstWhere((e) => e is UrlElement) as UrlElement;
+      expect(url.url, 'http://en.wikipedia.org/wiki/Saw_(film)');
+    });
+
+    test('strips unbalanced trailing ) from URL in parentheses', () {
+      final result = linkify('see (https://example.com/path)');
+      final url = result.firstWhere((e) => e is UrlElement) as UrlElement;
+      expect(url.url, 'https://example.com/path');
+      final texts = result.whereType<TextElement>().map((e) => e.text).join();
+      expect(texts, contains(')'));
+    });
+
+    test('strips only unbalanced ) from Wikipedia URL in parentheses', () {
+      final result = linkify('(https://en.wikipedia.org/wiki/Dart_(programming_language))');
+      final url = result.firstWhere((e) => e is UrlElement) as UrlElement;
+      expect(url.url, 'https://en.wikipedia.org/wiki/Dart_(programming_language)');
+    });
+
+    test('strips multiple unbalanced trailing parentheses', () {
+      final result = linkify('(see https://example.com))');
+      final url = result.firstWhere((e) => e is UrlElement) as UrlElement;
+      expect(url.url, 'https://example.com');
     });
 
     test('detects email address', () {
@@ -204,14 +220,16 @@ void main() {
     });
   });
 
-  group('Linkify widget', () {
+  group('RichLinkText widget', () {
     testWidgets('renders plain text', (WidgetTester tester) async {
-      await tester.pumpWidget(const MaterialApp(home: Linkify(text: 'hello world')));
+      await tester.pumpWidget(const MaterialApp(home: RichLinkText(text: 'hello world')));
       expect(find.text('hello world'), findsOneWidget);
     });
 
     testWidgets('renders multiple elements', (WidgetTester tester) async {
-      await tester.pumpWidget(const MaterialApp(home: Linkify(text: 'before https://a.com after')));
+      await tester.pumpWidget(
+        const MaterialApp(home: RichLinkText(text: 'before https://a.com after')),
+      );
       expect(find.byType(RichText), findsOneWidget);
       final richText = tester.widget<RichText>(find.byType(RichText));
       final plainText = richText.text.toPlainText();
@@ -222,7 +240,7 @@ void main() {
     testWidgets('onOpen callback is wired into TextSpan recognizer', (WidgetTester tester) async {
       await tester.pumpWidget(
         MaterialApp(
-          home: Linkify(text: 'tap https://example.com', onOpen: (_) {}),
+          home: RichLinkText(text: 'tap https://example.com', onOpen: (_) {}),
         ),
       );
 
@@ -233,12 +251,29 @@ void main() {
       expect(hasRecognizer, isTrue);
     });
 
+    testWidgets('onOpen is called when a link is tapped', (WidgetTester tester) async {
+      LinkableElement? tappedLink;
+      await tester.pumpWidget(
+        MaterialApp(
+          home: Center(
+            child: IntrinsicWidth(
+              child: RichLinkText(text: 'https://example.com', onOpen: (link) => tappedLink = link),
+            ),
+          ),
+        ),
+      );
+
+      await tester.tap(find.text('example.com'));
+      expect(tappedLink, isNotNull);
+      expect(tappedLink!.url, 'https://example.com');
+    });
+
     testWidgets('passes maxLines and overflow', (WidgetTester tester) async {
       await tester.pumpWidget(
         const MaterialApp(
           home: SizedBox(
             width: 100,
-            child: Linkify(
+            child: RichLinkText(
               text: 'very long text that should definitely overflow the given width',
               maxLines: 1,
               overflow: TextOverflow.ellipsis,
@@ -257,7 +292,7 @@ void main() {
 
       await tester.pumpWidget(
         const MaterialApp(
-          home: Linkify(text: 'plain text no links', style: customStyle),
+          home: RichLinkText(text: 'plain text no links', style: customStyle),
         ),
       );
 


### PR DESCRIPTION
Resolves #2092 

I wrote a custom `rich_link_text.dart` since, I couldn't find any other trust worthy and maintained packages.

Drop in replacement.
Removes external dependency over `flutter_linkify` and `linkify` packages

I did see a relavent PR #3282 for this issue, but it seemed stale.

Closes #3282 