### PR TITLE
Fix GIF export failure by increasing timeouts and adding progressive feedback

### DIFF
--- a/lib/src/model/game/game_share_service.dart
+++ b/lib/src/model/game/game_share_service.dart
@@ -2,7 +2,6 @@ import 'dart:convert';
 
 import 'package:dartchess/dartchess.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
-import 'package:http/http.dart' show Response;
 import 'package:lichess_mobile/src/constants.dart';
 import 'package:lichess_mobile/src/model/common/id.dart';
 import 'package:lichess_mobile/src/model/game/exported_game.dart';
@@ -58,9 +57,9 @@ class GameShareService {
             '$kLichessCDNHost/export/fen.gif?fen=${Uri.encodeComponent(fen)}&color=${orientation.name}${lastMove != null ? '&lastMove=${lastMove.uci}' : ''}&theme=${boardTheme.gifApiName}&piece=${pieceTheme.name}',
           ),
         )
-        .timeout(const Duration(seconds: 1));
+        .timeout(const Duration(seconds: 5));
     if (resp.statusCode != 200) {
-      throw Exception('Failed to get GIF');
+      throw Exception('Failed to get GIF: status ${resp.statusCode}');
     }
     return XFile.fromData(resp.bodyBytes, mimeType: 'image/gif');
   }
@@ -79,22 +78,22 @@ class GameShareService {
         ? BoardTheme.brown
         : boardPreferences.boardTheme;
     final pieceTheme = boardPreferences.pieceSet;
-    final resp = await Future.wait([
-      _ref
-          .read(defaultClientProvider)
-          .get(
-            Uri.parse(
-              '$kLichessCDNHost/game/export/gif/${orientation.name}/$id.gif?theme=${boardTheme.gifApiName}&piece=${pieceTheme.name}&players=$playerNames&ratings=$showPlayerRatings&glyphs=$moveAnnotations&clocks=$chessClock',
-            ),
-          ),
-      _ref.read(gameRepositoryProvider).getGame(id),
-    ]).timeout(const Duration(seconds: 1));
 
-    final gifResp = resp[0] as Response;
-    final game = resp[1] as ExportedGame;
+    // Fetch metadata first
+    final game = await _ref.read(gameRepositoryProvider).getGame(id);
+
+    // Fetch the actual GIF animation (heavy synchronous task)
+    final gifResp = await _ref
+        .read(defaultClientProvider)
+        .get(
+          Uri.parse(
+            '$kLichessCDNHost/game/export/gif/${orientation.name}/$id.gif?theme=${boardTheme.gifApiName}&piece=${pieceTheme.name}&players=$playerNames&ratings=$showPlayerRatings&glyphs=$moveAnnotations&clocks=$chessClock',
+          ),
+        )
+        .timeout(const Duration(minutes: 2));
 
     if (gifResp.statusCode != 200) {
-      throw Exception('Failed to get GIF');
+      throw Exception('Failed to get GIF: status ${gifResp.statusCode}');
     }
     return (XFile.fromData(gifResp.bodyBytes, mimeType: 'image/gif'), game);
   }
@@ -115,9 +114,9 @@ class GameShareService {
             'piece': pieceTheme.name,
           }),
         )
-        .timeout(const Duration(seconds: 1));
+        .timeout(const Duration(seconds: 5));
     if (resp.statusCode != 200) {
-      throw Exception('Failed to get GIF');
+      throw Exception('Failed to get GIF: status ${resp.statusCode}');
     }
     return XFile.fromData(resp.bodyBytes, mimeType: 'image/gif');
   }

--- a/lib/src/view/game/gif_export_dialog.dart
+++ b/lib/src/view/game/gif_export_dialog.dart
@@ -1,3 +1,5 @@
+import 'dart:async';
+
 import 'package:dartchess/dartchess.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
@@ -30,12 +32,35 @@ class _GifExportState extends ConsumerState<GifExport> {
   bool showPlayerRatings = true;
   bool moveAnnotations = false;
   bool chessClock = false;
-  bool loading = false;
+  String? loadingMessage;
+  final List<Timer> _timers = [];
+
+  void _addMessageTimer(Duration delay, String message) {
+    _timers.add(
+      Timer(delay, () {
+        if (mounted) {
+          setState(() {
+            loadingMessage = message;
+          });
+        }
+      }),
+    );
+  }
+
+  void _clearTimers() {
+    for (final timer in _timers) {
+      timer.cancel();
+    }
+    _timers.clear();
+  }
 
   Future<void> _export() async {
     setState(() {
-      loading = true;
+      loadingMessage = 'Generating GIF...';
     });
+    _addMessageTimer(const Duration(seconds: 10), 'Long games take a bit more time...');
+    _addMessageTimer(const Duration(seconds: 30), 'Almost there! Finalizing the GIF...');
+
     try {
       await shareGameGif(
         context,
@@ -56,15 +81,22 @@ class _GifExportState extends ConsumerState<GifExport> {
         ).showSnackBar(SnackBar(content: Text('Failed to export GIF: $e')));
       }
     } finally {
+      _clearTimers();
       if (mounted) {
         setState(() {
-          loading = false;
+          loadingMessage = null;
         });
       }
     }
     if (mounted) {
       Navigator.pop(context);
     }
+  }
+
+  @override
+  void dispose() {
+    _clearTimers();
+    super.dispose();
   }
 
   @override
@@ -116,15 +148,29 @@ class _GifExportState extends ConsumerState<GifExport> {
         ),
         Padding(
           padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 8),
-          child: FilledButton(
-            onPressed: loading ? null : _export,
-            child: loading
-                ? const SizedBox(
-                    height: 20,
-                    width: 20,
-                    child: CircularProgressIndicator.adaptive(strokeWidth: 3),
-                  )
-                : Text(context.l10n.next, textAlign: TextAlign.center),
+          child: Column(
+            crossAxisAlignment: CrossAxisAlignment.stretch,
+            children: [
+              FilledButton(
+                onPressed: loadingMessage != null ? null : _export,
+                child: loadingMessage != null
+                    ? const SizedBox(
+                        height: 20,
+                        width: 20,
+                        child: CircularProgressIndicator.adaptive(strokeWidth: 3),
+                      )
+                    : Text(context.l10n.next, textAlign: TextAlign.center),
+              ),
+              if (loadingMessage != null)
+                Padding(
+                  padding: const EdgeInsets.only(top: 8),
+                  child: Text(
+                    loadingMessage!,
+                    textAlign: TextAlign.center,
+                    style: Theme.of(context).textTheme.bodySmall,
+                  ),
+                ),
+            ],
           ),
         ),
       ],


### PR DESCRIPTION
closes #3391 

The bug occurs because the network request to fetch the GIF has a very aggressive 1-second timeout in the GameShareService.
https://github.com/dev-shady/lichess-mobile/blob/main/lib/src/model/game/game_share_service.dart#L91

Generating a GIF for a full chess game (which involves rendering many frames and stitching them together) often takes more than one second on the server side if the game is long (5–10min time control or many moves in short games) & GIF isn't already cached. Once the gif is cached at the backend, the client will receive it almost instantly.

For the majority of games with all options (name, rating, clock, move annotation) gif creation could take up to 1 minute but in some cases for long classic games, it could go beyond 1min as I observed in some cases. The backend changes ([adopted recently](https://github.com/lichess-org/mobile/pull/2566) in client) https://github.com/lichess-org/lila/pull/19154 introduced 2 more options to support in gif which means higher server response time for new combinations.

### Changes:

game_share_service.dart:
- Increased game GIF generation timeouts to 2 minutes to accommodate long games (100+ moves) plus all export options combination.
- Decoupled game metadata fetching from the GIF byte request to ensure database latency doesn't compete with the api response.
- Updated error messages to include HTTP status codes for better production troubleshooting.
- Updated both chapterGif and screenshotPosition timeout of study usecase to 5 sec to give more time as export options have increased. Since study games will not have too many moves so it shouldn't require a long 2min timeout.

gif_export_dialog.dart:
- Replaced the simple spinner with progressive loading messages to improve perceived performance during long exports.
- Added milestones at 10s and 30s to show message updates for Classical/longer games so user doesn't think that it is stuck.
- Implemented a timer management system to ensure all background messages are correctly cancelled when the export finishes or the dialog is closed.

### Video:

**[Blitz Game < 2sec](https://drive.google.com/file/d/1-cs3J5XvN1RJr9myLuM6N5bl1acXwcaK/view?usp=sharing)** 

**[Simulated 15sec time](https://drive.google.com/file/d/1PTC8ZAp56XmiXzYYlcQbF5tXq_ea5Km3/view?usp=sharing)**

**[Simulated 35sec time](https://drive.google.com/file/d/1lcY9K3onNQTFey1lPhwD6LnjZEbGS473/view?usp=sharing)**
