### PR TITLE
Added a report button directly in the game menu

### DIFF
--- a/lib/src/view/game/game_screen.dart
+++ b/lib/src/view/game/game_screen.dart
@@ -344,7 +344,7 @@ class _GameMenu extends ConsumerWidget {
             label: context.l10n.reportXToModerators(opponentUsername),
             onPressed: () => launchUrl(
               lichessUri('/report', {
-                'username': opponentUsername,
+                'username': gameState.value?.game.opponent?.user?.id,
                 'login': gameState.value?.game.me?.user?.id,
               }),
             ),

--- a/lib/src/view/game/game_screen.dart
+++ b/lib/src/view/game/game_screen.dart
@@ -34,6 +34,7 @@ import 'package:lichess_mobile/src/widgets/feedback.dart';
 import 'package:lichess_mobile/src/widgets/misc.dart';
 import 'package:lichess_mobile/src/widgets/platform_context_menu_button.dart';
 import 'package:lichess_mobile/src/widgets/shimmer.dart';
+import 'package:url_launcher/url_launcher.dart';
 
 /// Screen to play a game, or to show a challenge or to show current user's past games.
 ///
@@ -310,6 +311,8 @@ class _GameMenu extends ConsumerWidget {
   @override
   Widget build(BuildContext context, WidgetRef ref) {
     final isBookmarkedAsync = ref.watch(isGameBookmarkedProvider(gameId));
+    final gameState = ref.watch(gameControllerProvider(gameId));
+    final opponentUsername = gameState.value?.game.opponent?.user?.name;
 
     return ContextMenuIconButton(
       icon: const Icon(Icons.more_horiz),
@@ -335,6 +338,17 @@ class _GameMenu extends ConsumerWidget {
           onToggleBookmark: () =>
               ref.read(gameControllerProvider(gameId).notifier).toggleBookmark(),
         ),
+        if (opponentUsername != null)
+          ContextMenuAction(
+            icon: Icons.flag_outlined,
+            label: context.l10n.reportXToModerators(opponentUsername),
+            onPressed: () => launchUrl(
+              lichessUri('/report', {
+                'username': opponentUsername,
+                'login': gameState.value?.game.me?.user?.id,
+              }),
+            ),
+          ),
         ...(switch (ref.watch(gameShareDataProvider(gameId))) {
           AsyncData(:final value) =>
             value.finished


### PR DESCRIPTION
I added the report button directly to the game menu and used the same logic as in `user_screen` when reporting from the profile page (referencing issue #3482 ).

I also thought about automatically adding the game URL to the report, but I couldn't find any references explaining how the `/report` endpoint works, specifically what parameters it takes besides the username.

However, I couldn't fully test it because lichess.dev is asking me to verify my account, and the server isn't sending the verification email.

It's my first time contributing, so any feedback would be greatly appreciated.
