### PR TITLE
fix: remove extra top spacing when profile has no name or bio

### DIFF
--- a/lib/src/view/user/user_profile.dart
+++ b/lib/src/view/user/user_profile.dart
@@ -71,7 +71,7 @@ class UserProfileWidget extends ConsumerWidget {
                 overflow: TextOverflow.ellipsis,
                 linkStyle: Styles.linkStyle,
               ),
-            const SizedBox(height: 10),
+            if (userFullName != null || user.profile?.bio != null) const SizedBox(height: 10),
             if (user.profile?.fideRating != null)
               Padding(
                 padding: const EdgeInsets.only(bottom: 5),


### PR DESCRIPTION
## Problem
When a user's profile card has neither a real name (`realName == null`) nor a bio (`bio == null`), an extra top spacing appears at the top of the profile section.

This was caused by `const SizedBox(height: 10)` being rendered after the name/bio section, creating a 10px empty space above the user's ratings and details.

## Solution
Wrapped the spacer in a condition (`if (userFullName != null || user.profile?.bio != null)`), ensuring that the 10px spacing is only rendered when a user has a name or bio.

Fixes #3528