### PR TITLE
Auto-paste FEN in board editor while allowing edit on error

### DIFF
--- a/lib/src/view/board_editor/board_editor_screen.dart
+++ b/lib/src/view/board_editor/board_editor_screen.dart
@@ -58,6 +58,7 @@ class BoardEditorScreen extends ConsumerWidget {
             onPressed: () => showDialog<void>(
               context: context,
               builder: (_) => _FenDialog(
+                initialFen: boardEditorState.fen,
                 onFenLoaded: (fen) =>
                     ref.read(boardEditorControllerProvider(params).notifier).loadFen(fen),
               ),
@@ -460,8 +461,9 @@ class _BottomBar extends ConsumerWidget {
 }
 
 class _FenDialog extends StatefulWidget {
-  const _FenDialog({required this.onFenLoaded});
+  const _FenDialog({required this.initialFen, required this.onFenLoaded});
 
+  final String initialFen;
   final void Function(String fen) onFenLoaded;
 
   @override
@@ -469,7 +471,20 @@ class _FenDialog extends StatefulWidget {
 }
 
 class _FenDialogState extends State<_FenDialog> {
-  final _controller = TextEditingController();
+  late final TextEditingController _controller;
+  bool _hasError = false;
+
+  @override
+  void initState() {
+    super.initState();
+    _controller = TextEditingController(text: widget.initialFen);
+    // Auto-check the clipboard on open for 1-touch convenience: if the clipboard
+    // contains a valid FEN, _submit() will load it and close the dialog immediately.
+    // If invalid, the dialog remains open so the user can edit the text.
+    WidgetsBinding.instance.addPostFrameCallback((_) {
+      _pasteFromClipboard();
+    });
+  }
 
   @override
   void dispose() {
@@ -478,39 +493,69 @@ class _FenDialogState extends State<_FenDialog> {
   }
 
   Future<void> _pasteFromClipboard() async {
-    final ClipboardData? data = await Clipboard.getData(Clipboard.kTextPlain);
-    if (data?.text == null || !mounted) return;
+    final data = await Clipboard.getData(Clipboard.kTextPlain);
+    final text = data?.text?.trim();
+    if (text == null || text.isEmpty || !mounted) return;
 
-    final text = data!.text!.trim();
-    if (text.isEmpty) return;
+    _controller.value = TextEditingValue(
+      text: text,
+      selection: TextSelection.collapsed(offset: text.length),
+    );
+    _submit();
+  }
 
-    _controller.text = text;
+  void _submit() {
+    final text = _controller.text.trim();
     try {
       final pos = Chess.fromSetup(Setup.parseFen(text));
       widget.onFenLoaded(pos.fen);
+      if (mounted) {
+        Navigator.of(context, rootNavigator: true).pop();
+      }
     } catch (_) {
-      showSnackBar(context, context.l10n.invalidFen, type: SnackBarType.error);
-    } finally {
-      Navigator.of(context, rootNavigator: true).pop();
+      // Keep the dialog open on invalid FEN so the user can edit and correct
+      // the input field rather than discarding their edits.
+      if (mounted) {
+        setState(() {
+          _hasError = true;
+        });
+        showSnackBar(context, context.l10n.invalidFen, type: SnackBarType.error);
+      }
     }
   }
 
   @override
   Widget build(BuildContext context) {
     return AlertDialog(
+      title: const Text('FEN'),
       content: TextField(
         controller: _controller,
-        readOnly: true,
-        onTap: _pasteFromClipboard,
+        autofocus: true,
+        onChanged: (_) {
+          if (_hasError) {
+            setState(() {
+              _hasError = false;
+            });
+          }
+        },
         decoration: InputDecoration(
           hintText: context.l10n.pasteTheFenStringHere,
+          errorText: _hasError ? context.l10n.invalidFen : null,
           suffixIcon: IconButton(
             icon: const Icon(Icons.paste),
             onPressed: _pasteFromClipboard,
             tooltip: 'Paste from clipboard',
           ),
         ),
+        onSubmitted: (_) => _submit(),
       ),
+      actions: [
+        TextButton(
+          onPressed: () => Navigator.of(context, rootNavigator: true).pop(),
+          child: Text(context.l10n.cancel),
+        ),
+        TextButton(onPressed: _submit, child: Text(context.l10n.ok)),
+      ],
     );
   }
 }

--- a/test/view/board_editor/board_editor_screen_test.dart
+++ b/test/view/board_editor/board_editor_screen_test.dart
@@ -392,12 +392,7 @@ void main() {
         await tester.tap(find.byIcon(Icons.edit));
         await tester.pumpAndSettle();
 
-        expect(find.byType(AlertDialog), findsOneWidget);
-
-        await tester.tap(find.byIcon(Icons.paste));
-        await tester.pumpAndSettle();
-
-        // Dialog is gone, board editor is still on screen
+        // Dialog is automatically processed and closed, board editor is still on screen
         expect(find.byType(AlertDialog), findsNothing);
         expect(find.byType(BoardEditorScreen), findsOneWidget);
 
@@ -417,9 +412,6 @@ void main() {
         await tester.tap(find.byIcon(Icons.edit));
         await tester.pumpAndSettle();
 
-        await tester.tap(find.byIcon(Icons.paste));
-        await tester.pumpAndSettle();
-
         final container = ProviderScope.containerOf(tester.element(find.byType(BoardEditorScreen)));
         final state = container.read(boardEditorControllerProvider(null));
         expect(state.sideToPlay, Side.black);
@@ -437,9 +429,6 @@ void main() {
         await tester.tap(find.byIcon(Icons.edit));
         await tester.pumpAndSettle();
 
-        await tester.tap(find.byIcon(Icons.paste));
-        await tester.pumpAndSettle();
-
         final container = ProviderScope.containerOf(tester.element(find.byType(BoardEditorScreen)));
         final state = container.read(boardEditorControllerProvider(null));
 
@@ -449,7 +438,7 @@ void main() {
         expect(state.castlingRights[CastlingRight.blackQueen], isTrue);
       });
 
-      testWidgets('Pasting invalid FEN closes dialog and shows snackbar', (tester) async {
+      testWidgets('Pasting invalid FEN keeps dialog open and displays error', (tester) async {
         _mockClipboard('not a valid fen');
 
         final app = await makeTestProviderScopeApp(tester, home: const BoardEditorScreen());
@@ -458,11 +447,8 @@ void main() {
         await tester.tap(find.byIcon(Icons.edit));
         await tester.pumpAndSettle();
 
-        await tester.tap(find.byIcon(Icons.paste));
-        await tester.pumpAndSettle();
-
-        expect(find.byType(AlertDialog), findsNothing);
-        expect(find.text('Invalid FEN'), findsOneWidget);
+        expect(find.byType(AlertDialog), findsOneWidget);
+        expect(find.text('Invalid FEN'), findsWidgets);
       });
     });
 


### PR DESCRIPTION
Previously, tapping the FEN edit button opened a read-only dialog that automatically pasted from the clipboard and immediately closed the dialog regardless of whether the FEN was valid or invalid. If the pasted FEN had a typo or was invalid, the user was shown an error snackbar without any opportunity to edit or correct the string.

Make the text field interactive and prepopulate it with the current position's FEN. On open, auto-read the clipboard: if it contains a valid FEN, automatically load the position and close the dialog to preserve 1-touch convenience. If the FEN is invalid or unparseable, keep the dialog open with the string focused for editing and display inline error feedback.