### PR TITLE
change RichText to Text.rich() to scale with system font size

### DIFF
--- a/lib/src/view/broadcast/broadcast_game_screen.dart
+++ b/lib/src/view/broadcast/broadcast_game_screen.dart
@@ -437,8 +437,8 @@ class _PgnTagsView extends ConsumerWidget {
                         final value = pgnHeaders[tag.tagName]!;
                         final url = tag.isLink ? tag.buildUrl(value) : null;
                         if (url != null) {
-                          return RichText(
-                            text: TextSpan(
+                          return Text.rich(
+                            TextSpan(
                               text: value,
                               style: Styles.linkStyle,
                               recognizer: TapGestureRecognizer()

--- a/lib/src/view/game/correspondence_clock_widget.dart
+++ b/lib/src/view/game/correspondence_clock_widget.dart
@@ -120,10 +120,8 @@ class _CorrespondenceClockState extends State<CorrespondenceClock> {
           padding: const EdgeInsets.symmetric(vertical: 3.0, horizontal: 5.0),
           child: MediaQuery.withClampedTextScaling(
             maxScaleFactor: kMaxClockTextScaleFactor,
-            child: RichText(
-              textAlign: TextAlign.center,
-              maxLines: 2,
-              text: TextSpan(
+            child: Text.rich(
+              TextSpan(
                 text: '$daysStr$hoursStr',
                 style: TextStyle(
                   color: widget.active ? clockStyle.activeTextColor : clockStyle.textColor,
@@ -147,6 +145,8 @@ class _CorrespondenceClockState extends State<CorrespondenceClock> {
                   ],
                 ],
               ),
+              textAlign: TextAlign.center,
+              maxLines: 2,
             ),
           ),
         ),

--- a/lib/src/view/message/conversation_screen.dart
+++ b/lib/src/view/message/conversation_screen.dart
@@ -454,7 +454,7 @@ class _MessageContent extends StatelessWidget {
 
     return Stack(
       children: [
-        RichText(text: TextSpan(children: [linkSpan, spacer])),
+        Text.rich(TextSpan(children: [linkSpan, spacer])),
         Positioned(right: 0, bottom: 0, child: Text(time, style: timeStyle)),
       ],
     );

--- a/lib/src/widgets/clock.dart
+++ b/lib/src/widgets/clock.dart
@@ -88,8 +88,8 @@ class Clock extends StatelessWidget {
             padding: padding,
             child: MediaQuery.withClampedTextScaling(
               maxScaleFactor: kMaxClockTextScaleFactor,
-              child: RichText(
-                text: TextSpan(
+              child: Text.rich(
+                TextSpan(
                   text: hours > 0
                       ? '$hoursDisplay:${mins.toString().padLeft(2, '0')}:$secs'
                       : '$minsDisplay:$secs',


### PR DESCRIPTION
I changed all the RichText to Text.rich() to scale  with the system font size, it is suggested here:
https://api.flutter.dev/flutter/widgets/RichText-class.html . The problem was reported in the google play reviews.

> Consider using the [Text](https://api.flutter.dev/flutter/widgets/Text-class.html) widget to integrate with the [DefaultTextStyle](https://api.flutter.dev/flutter/widgets/DefaultTextStyle-class.html) automatically. When all the text uses the same style, the default constructor is less verbose. The [Text.rich](https://api.flutter.dev/flutter/widgets/Text/Text.rich.html) constructor allows you to style multiple spans with the default text style while still allowing specified styles per span.

Pictures of all the occurrences changed with the maximum android font size for dramatic effect:

| RichText | Text.rich() |
| ----| ---|
|<img width="643" height="1408" alt="image" src="https://github.com/user-attachments/assets/cd369d23-8728-4b19-a152-a621015b354d" />|<img width="645" height="1401" alt="image" src="https://github.com/user-attachments/assets/97d8bbba-9431-4f82-b57e-94b61245a2d4" /> |
|<img width="650" height="1401" alt="image" src="https://github.com/user-attachments/assets/87af3bf8-02e6-4c58-8d33-8966c1c34a1d" /> | <img width="648" height="1396" alt="image" src="https://github.com/user-attachments/assets/d50fc841-3aac-46ba-a5a1-ab413dc76c17" />|
| <img width="645" height="1394" alt="image" src="https://github.com/user-attachments/assets/6d3cd116-7a43-4cb3-b1f6-cbfca3d7365a" />| <img width="649" height="1439" alt="image" src="https://github.com/user-attachments/assets/948b7716-5e28-44db-8dd7-b3957983e70d" />|
|<img width="646" height="1283" alt="image" src="https://github.com/user-attachments/assets/c99ed1f9-b176-45a5-8bc4-252fca321318" /> |<img width="645" height="1389" alt="image" src="https://github.com/user-attachments/assets/e19897ae-9c98-4bae-bb4c-56b54b9737de" />|



