### PR TITLE
amoled background

### DIFF
--- a/lib/src/model/settings/brightness.dart
+++ b/lib/src/model/settings/brightness.dart
@@ -20,13 +20,10 @@ class CurrentBrightness extends Notifier<Brightness> {
       }
     };
 
-    switch (themeMode) {
-      case BackgroundThemeMode.dark:
-        return Brightness.dark;
-      case BackgroundThemeMode.light:
-        return Brightness.light;
-      case BackgroundThemeMode.system:
-        return WidgetsBinding.instance.platformDispatcher.platformBrightness;
-    }
+    return switch (themeMode) {
+      BackgroundThemeMode.dark || BackgroundThemeMode.amoled => Brightness.dark,
+      BackgroundThemeMode.light => Brightness.light,
+      BackgroundThemeMode.system => WidgetsBinding.instance.platformDispatcher.platformBrightness,
+    };
   }
 }

--- a/lib/src/model/settings/general_preferences.dart
+++ b/lib/src/model/settings/general_preferences.dart
@@ -141,7 +141,10 @@ enum BackgroundThemeMode {
   light,
 
   /// Always use the dark mode (if available) regardless of system preference.
-  dark;
+  dark,
+
+  /// Pure black for amoled screens.
+  amoled;
 
   String title(AppLocalizations l10n) {
     switch (this) {
@@ -151,6 +154,8 @@ enum BackgroundThemeMode {
         return l10n.dark;
       case BackgroundThemeMode.light:
         return l10n.light;
+      case BackgroundThemeMode.amoled:
+        return 'Amoled black';
     }
   }
 }

--- a/lib/src/theme.dart
+++ b/lib/src/theme.dart
@@ -17,7 +17,7 @@ ThemeData makeAppTheme(BuildContext context, GeneralPrefs generalPrefs, BoardPre
       ? Brightness.dark
       : switch (generalPrefs.themeMode) {
           BackgroundThemeMode.light => Brightness.light,
-          BackgroundThemeMode.dark => Brightness.dark,
+          BackgroundThemeMode.dark || BackgroundThemeMode.amoled => Brightness.dark,
           BackgroundThemeMode.system => MediaQuery.platformBrightnessOf(context),
         };
 
@@ -123,7 +123,9 @@ ThemeData _makeDefaultTheme(
       ? ThemeData.from(colorScheme: systemScheme, textTheme: textTheme)
       : ThemeData.from(colorScheme: boardScheme, textTheme: textTheme);
 
-  return theme.copyWith(
+  final isAmoled = generalPrefs.themeMode == BackgroundThemeMode.amoled;
+
+  final finalTheme = theme.copyWith(
     cupertinoOverrideTheme: _makeCupertinoThemeData(theme.colorScheme, brightness),
     splashFactory: isIOS ? NoSplash.splashFactory : null,
     appBarTheme: _appBarTheme.copyWith(
@@ -166,6 +168,24 @@ ThemeData _makeDefaultTheme(
     bottomSheetTheme: isIOS ? _kCupertinoBottomSheetTheme : null,
     sliderTheme: kSliderTheme,
     extensions: [lichessCustomColors.harmonized(theme.colorScheme)],
+  );
+
+  if (!isAmoled) return finalTheme;
+
+  return finalTheme.copyWith(
+    scaffoldBackgroundColor: const Color(0xFF000000),
+    appBarTheme: finalTheme.appBarTheme.copyWith(
+      backgroundColor: const Color(0xFF000000),
+      surfaceTintColor: Colors.transparent,
+    ),
+    bottomAppBarTheme: finalTheme.bottomAppBarTheme.copyWith(color: const Color(0xFF000000)),
+    colorScheme: finalTheme.colorScheme.copyWith(
+      surface: const Color(0xFF000000),
+      surfaceContainerLowest: const Color(0xFF000000),
+      surfaceContainerLow: const Color(0xFF000000),
+      surfaceContainer: const Color(0xFF000000),
+      surfaceTint: Colors.transparent,
+    ),
   );
 }
 


### PR DESCRIPTION
adds a 4th background option, Amoled black. It turns a lot of surfaces to pitch black (RGB 0,0,0)
Video:

[Screencast_20260811_102647.webm](https://github.com/user-attachments/assets/de07ea5f-1d37-48e7-a770-fb8e77a30c8b)

The advantage is that amoled screens physically turn off pixels to display true black (RGB 0,0,0), which reduces battery consumption. Also I personally like the look of a pure black background.

Note that I did not make all surfaces pitch black, so that for example the search bar is still highlighted in a different color.

Inspired by #3541 