### PR TITLE
fix game layout on foldables

### DIFF
--- a/lib/src/widgets/game_layout.dart
+++ b/lib/src/widgets/game_layout.dart
@@ -496,6 +496,7 @@ class _GameLayoutState extends ConsumerState<GameLayout> {
           );
         } else {
           final defaultBoardSize = constraints.biggest.shortestSide;
+          final maxHeight = constraints.maxHeight;
 
           final isShortScreen = isShortVerticalScreen(context);
 
@@ -506,6 +507,12 @@ class _GameLayoutState extends ConsumerState<GameLayout> {
           double effectiveBoardSize =
               (isTablet ? defaultBoardSize - kTabletBoardTableSidePadding * 2 : defaultBoardSize) -
               pocketsPadding;
+
+          //Reserve vertical space for the top and bottom tables and the user actions bar if present.
+          final maxAllowedBoardSize = maxHeight - 180.0;
+          if (effectiveBoardSize > maxAllowedBoardSize) {
+            effectiveBoardSize = maxAllowedBoardSize;
+          }
 
           if (isShortScreen) {
             effectiveBoardSize -= 16;

--- a/test/widgets/game_layout_test.dart
+++ b/test/widgets/game_layout_test.dart
@@ -155,8 +155,18 @@ void main() {
         final isShortScreen =
             surface.height - surface.width - kToolbarHeight - kBottomBarHeight <
             kSmallHeightMinusBoard;
-        final baseBoardSize = isTablet ? surface.width - 32.0 : surface.width;
-        final expectedBoardSize = isShortScreen ? baseBoardSize - 16.0 : baseBoardSize;
+
+        double expectedBoardSize = isTablet ? surface.width - 32.0 : surface.width;
+
+        final maxAllowedBoardSize = surface.height - 180.0;
+        if (expectedBoardSize > maxAllowedBoardSize) {
+          expectedBoardSize = maxAllowedBoardSize;
+        }
+
+        if (isShortScreen) {
+          expectedBoardSize -= 16.0;
+        }
+
         expect(
           boardSize,
           Size(expectedBoardSize, expectedBoardSize),


### PR DESCRIPTION
Fixes the overflow for z-fold devices, as simple as possible.
Fixes #3145 

after:
<img width="1271" height="1533" alt="image" src="https://github.com/user-attachments/assets/34dba29d-0d04-4130-8e9e-5ecb35e6b65b" />

before:
<img width="1278" height="1480" alt="image" src="https://github.com/user-attachments/assets/6a9f830f-8e63-416d-bdc8-775f71ea8d3e" />
