### PR TITLE
add rating change to analysis board

### DIFF
--- a/lib/src/view/analysis/analysis_screen.dart
+++ b/lib/src/view/analysis/analysis_screen.dart
@@ -419,6 +419,7 @@ class _PlayerWidget extends StatelessWidget {
               child: UserFullNameWidget.player(
                 user: player.user,
                 rating: player.rating,
+                ratingDiff: player.ratingDiff,
                 provisional: player.provisional,
                 aiLevel: player.aiLevel,
                 style: const TextStyle(fontWeight: FontWeight.bold),

--- a/lib/src/widgets/user.dart
+++ b/lib/src/widgets/user.dart
@@ -129,6 +129,7 @@ class UserFullNameWidget extends ConsumerWidget {
     required this.user,
     this.aiLevel,
     this.rating,
+    this.ratingDiff,
     this.provisional,
     this.shouldShowOnline = false,
     this.showFlair = true,
@@ -142,6 +143,7 @@ class UserFullNameWidget extends ConsumerWidget {
     required this.user,
     required this.aiLevel,
     this.rating,
+    this.ratingDiff,
     this.provisional,
     this.shouldShowOnline = false,
     this.showFlair = true,
@@ -153,6 +155,8 @@ class UserFullNameWidget extends ConsumerWidget {
 
   final LightUser? user;
   final int? rating;
+
+  final int? ratingDiff;
 
   /// The AI level, if the user is lichess AI.
   final int? aiLevel;
@@ -236,6 +240,21 @@ class UserFullNameWidget extends ConsumerWidget {
               fontWeight: FontWeight.w400,
               fontSize: contextTextStyle.fontSize != null ? contextTextStyle.fontSize! - 3 : 13,
               color: textShade(context, 0.8),
+            ),
+          ),
+        ],
+        if (shouldShowRating && ratingDiff != null) ...[
+          const SizedBox(width: 5),
+          Text(
+            ratingDiff! > 0 ? '+$ratingDiff' : '$ratingDiff',
+            style: contextTextStyle.copyWith(
+              fontWeight: .w400,
+              fontSize: contextTextStyle.fontSize != null ? contextTextStyle.fontSize! - 3 : 13,
+              color: ratingDiff! > 0
+                  ? context.lichessColors.good
+                  : ratingDiff! == 0
+                  ? context.lichessColors.brag
+                  : context.lichessColors.error,
             ),
           ),
         ],


### PR DESCRIPTION
Adds the rating change to the analysis board, this information was currently not visible for users:

<img width="526" height="1154" alt="image" src="https://github.com/user-attachments/assets/b77e57fb-d206-4cc8-aab3-d03b72a35aba" />

closes #2039 
