### PR TITLE
Auto-detect draw by insufficient material in Over the Board mode

### DIFF
--- a/lib/src/model/over_the_board/over_the_board_game_controller.dart
+++ b/lib/src/model/over_the_board/over_the_board_game_controller.dart
@@ -110,6 +110,8 @@ class OverTheBoardGameController extends Notifier<OverTheBoardGameState> {
       }
     } else if (state.currentPosition.isStalemate) {
       state = state.copyWith(game: state.game.copyWith(status: GameStatus.stalemate));
+    } else if (state.currentPosition.isInsufficientMaterial) {
+      state = state.copyWith(game: state.game.copyWith(status: GameStatus.draw));
     }
 
     _moveFeedback(sanMove);


### PR DESCRIPTION
Summary
  - Fixes #3518
  - Over the Board mode now automatically detects draw by insufficient material (e.g. King vs King) after each move,
  ending the game immediately instead of requiring players to manually claim the draw
  - This adds the same `isInsufficientMaterial` check already present in the offline computer game controller
  (`offline_computer_game_controller.dart:200-201`)

  ## Changes
  - Added an `else if` branch in `OverTheBoardGameController.onMove()` that checks
  `state.currentPosition.isInsufficientMaterial` after each move, setting `GameStatus.draw` when detected