### PR TITLE
Ignore own chat messages in unread counts

### DIFF
--- a/lib/src/model/chat/chat_mixin.dart
+++ b/lib/src/model/chat/chat_mixin.dart
@@ -1,6 +1,7 @@
 import 'dart:async';
 import 'dart:math' as math;
 
+import 'package:dartchess/dartchess.dart';
 import 'package:fast_immutable_collections/fast_immutable_collections.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:freezed_annotation/freezed_annotation.dart';
@@ -67,6 +68,10 @@ mixin ChatMixin<T extends ChatMixinState> on AnyNotifier<AsyncValue<T>, T> {
   /// do not.
   @protected
   bool get chatIsPublic;
+
+  /// The side the current user is playing
+  @protected
+  Side? get chatPlayerSide => null;
 
   LightUser? get _me => ref.read(authControllerProvider)?.user;
 
@@ -138,6 +143,31 @@ mixin ChatMixin<T extends ChatMixinState> on AnyNotifier<AsyncValue<T>, T> {
     updateChatState(chatState.copyWith(unreadMessages: 0));
   }
 
+  /// Returns `true` when [message] was sent by the current user and should
+  /// therefore not increment the unread badge counter.
+  bool _isOwnMessage(ChatMessage message) {
+    final username = message.username;
+    if (username == null) return false;
+
+    // Regular user message sent by the current user.
+    final me = _me;
+    if (me != null && username.toLowerCase() == me.id.value) return true;
+
+    // Lichess system messages about draw offers/declines by the current user's side.
+    if (username == 'lichess') {
+      final side = chatPlayerSide;
+      if (side != null) {
+        final text = message.message;
+        if (side == .white && text == 'White offers draw') return true;
+        if (side == .black && text == 'Black offers draw') return true;
+        if (side == .white && text == 'White declines draw') return true;
+        if (side == .black && text == 'Black declines draw') return true;
+      }
+    }
+
+    return false;
+  }
+
   IList<ChatMessage> _selectMessages(IList<ChatMessage> all) {
     return all
         .where(
@@ -185,7 +215,9 @@ mixin ChatMixin<T extends ChatMixinState> on AnyNotifier<AsyncValue<T>, T> {
 
       final oldMessages = chatState.messages;
       final newMessages = _selectMessages(oldMessages.add(message));
-      final newUnread = newMessages.length - oldMessages.length;
+      final addedCount = newMessages.length - oldMessages.length;
+      final isOwn = addedCount > 0 && _isOwnMessage(message);
+      final newUnread = isOwn ? 0 : addedCount;
       if (chatIsPublic == false && newUnread > 0) {
         ref.read(soundServiceProvider).play(Sound.confirmation, volume: 0.5);
       }

--- a/lib/src/model/game/game_controller.dart
+++ b/lib/src/model/game/game_controller.dart
@@ -126,6 +126,10 @@ class GameController extends AsyncNotifier<GameState> with ChatMixin<GameState> 
   @override
   bool get chatIsPublic => false;
 
+  @protected
+  @override
+  Side? get chatPlayerSide => state.value?.game.youAre;
+
   @override
   Future<GameState> build() async {
     _socketClient = _openSocket();

--- a/test/model/chat/chat_mixin_test.dart
+++ b/test/model/chat/chat_mixin_test.dart
@@ -1,3 +1,4 @@
+import 'package:dartchess/dartchess.dart';
 import 'package:fast_immutable_collections/fast_immutable_collections.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
@@ -38,11 +39,17 @@ class _FakeChatState with ChatMixinState {
 // A minimal notifier that mixes in [ChatMixin] so its logic can be exercised in
 // isolation. Test helpers expose the protected members.
 class _TestChatNotifier extends AsyncNotifier<_FakeChatState> with ChatMixin<_FakeChatState> {
-  _TestChatNotifier({required this.initialData, required this.isPublic, required this.enabled});
+  _TestChatNotifier({
+    required this.initialData,
+    required this.isPublic,
+    required this.enabled,
+    this.playerSide,
+  });
 
   final ChatData? initialData;
   final bool isPublic;
   final bool enabled;
+  final Side? playerSide;
 
   @override
   StringId get chatId => const StringId('test-chat-id');
@@ -52,6 +59,9 @@ class _TestChatNotifier extends AsyncNotifier<_FakeChatState> with ChatMixin<_Fa
 
   @override
   bool get chatIsPublic => isPublic;
+
+  @override
+  Side? get chatPlayerSide => playerSide;
 
   @override
   Future<_FakeChatState> build() async {
@@ -91,9 +101,15 @@ AsyncNotifierProvider<_TestChatNotifier, _FakeChatState> _makeProvider({
   ChatData? initialData,
   bool isPublic = false,
   bool enabled = true,
+  Side? playerSide,
 }) {
   return AsyncNotifierProvider<_TestChatNotifier, _FakeChatState>(
-    () => _TestChatNotifier(initialData: initialData, isPublic: isPublic, enabled: enabled),
+    () => _TestChatNotifier(
+      initialData: initialData,
+      isPublic: isPublic,
+      enabled: enabled,
+      playerSide: playerSide,
+    ),
   );
 }
 
@@ -301,6 +317,113 @@ void main() {
       );
 
       expect(container.read(provider).requireValue.chatState!.messages, isEmpty);
+    });
+
+    test('does not increment unread for own message', () async {
+      final container = await makeContainer(
+        authUser: const AuthUser(
+          token: 'token',
+          user: LightUser(id: UserId('myname'), name: 'MyName'),
+        ),
+        overrides: {kidModeProvider: kidModeProvider.overrideWith((ref) => false)},
+      );
+      await _warmKidMode(container);
+      final provider = _makeProvider(initialData: _chatData([]));
+      final notifier = container.read(provider.notifier);
+      await container.read(provider.future);
+
+      notifier.dispatch(
+        SocketEvent(
+          topic: 'message',
+          data: _msgData('Good game, well played', username: 'MyName'),
+        ),
+      );
+
+      final state = container.read(provider).requireValue;
+      expect(state.chatState!.messages.length, 1);
+      expect(state.chatState!.unreadMessages, 0);
+    });
+
+    test('does not increment unread for own draw offer', () async {
+      final container = await makeContainer(
+        authUser: const AuthUser(
+          token: 'token',
+          user: LightUser(id: UserId('myname'), name: 'MyName'),
+        ),
+        overrides: {kidModeProvider: kidModeProvider.overrideWith((ref) => false)},
+      );
+      await _warmKidMode(container);
+      final provider = _makeProvider(initialData: _chatData([]), playerSide: Side.black);
+      final notifier = container.read(provider.notifier);
+      await container.read(provider.future);
+
+      notifier.dispatch(
+        SocketEvent(
+          topic: 'message',
+          data: _msgData('Black offers draw', username: 'lichess'),
+        ),
+      );
+
+      final state = container.read(provider).requireValue;
+      expect(state.chatState!.messages.length, 1);
+      expect(state.chatState!.unreadMessages, 0);
+    });
+
+    test('increments unread when the opponent offers a draw', () async {
+      final container = await makeContainer(
+        authUser: const AuthUser(
+          token: 'token',
+          user: LightUser(id: UserId('myname'), name: 'MyName'),
+        ),
+        overrides: {kidModeProvider: kidModeProvider.overrideWith((ref) => false)},
+      );
+      await _warmKidMode(container);
+      // We are Black, so a White draw offer is from the opponent.
+      final provider = _makeProvider(initialData: _chatData([]), playerSide: Side.black);
+      final notifier = container.read(provider.notifier);
+      await container.read(provider.future);
+
+      notifier.dispatch(
+        SocketEvent(
+          topic: 'message',
+          data: _msgData('White offers draw', username: 'lichess'),
+        ),
+      );
+
+      final state = container.read(provider).requireValue;
+      expect(state.chatState!.messages.length, 1);
+      expect(state.chatState!.unreadMessages, 1);
+    });
+
+    test('does not reset existing unread count when own draw offer arrives', () async {
+      final container = await makeContainer(
+        authUser: const AuthUser(
+          token: 'token',
+          user: LightUser(id: UserId('myname'), name: 'MyName'),
+        ),
+        overrides: {kidModeProvider: kidModeProvider.overrideWith((ref) => false)},
+      );
+      await _warmKidMode(container);
+      // Start with one unread message from the opponent.
+      final provider = _makeProvider(
+        initialData: _chatData([_msg('hello', username: 'opponent')]),
+        playerSide: Side.white,
+      );
+      final notifier = container.read(provider.notifier);
+      await container.read(provider.future);
+      expect(container.read(provider).requireValue.chatState!.unreadMessages, 1);
+
+      notifier.dispatch(
+        SocketEvent(
+          topic: 'message',
+          data: _msgData('White offers draw', username: 'lichess'),
+        ),
+      );
+
+      final state = container.read(provider).requireValue;
+      expect(state.chatState!.messages.length, 2);
+      // The existing unread from the opponent must not be cleared.
+      expect(state.chatState!.unreadMessages, 1);
     });
 
     test('ignores non-message topics', () async {


### PR DESCRIPTION
fix #3418 

Don't increase the badge if the message was sent by the own account (f.ex. with the gg wp setting) or if it is the own draw offer or draw decline message by us.

I am not sure if we should also filter out `rematch sent ` messages, as this is a bit disturbing too, the problem is that it is the same message no matter which color sent the request.

Tested manually, video:

[Screencast_20260815_170847.webm](https://github.com/user-attachments/assets/30e48e70-2480-4503-8ad0-d69751c6940c)


 - AI tools used:
 Copilot to help generate the tests and autocomplete