### PR TITLE
add showThreat +Boardeditor and continue from here to Broadcasts and studies

### DIFF
--- a/lib/src/view/analysis/analysis_actions.dart
+++ b/lib/src/view/analysis/analysis_actions.dart
@@ -1,0 +1,38 @@
+import 'package:dartchess/dartchess.dart';
+import 'package:flutter/widgets.dart';
+import 'package:lichess_mobile/src/model/common/chess.dart';
+import 'package:lichess_mobile/src/utils/l10n_context.dart';
+import 'package:lichess_mobile/src/view/board_editor/board_editor_screen.dart';
+import 'package:lichess_mobile/src/view/offline_computer/offline_computer_game_screen.dart';
+import 'package:lichess_mobile/src/view/over_the_board/over_the_board_screen.dart';
+import 'package:lichess_mobile/src/widgets/adaptive_action_sheet.dart';
+
+void openBoardEditor(BuildContext context, Variant variant, String fen, Side orientation) {
+  Navigator.of(context).push(
+    BoardEditorScreen.buildRoute((
+      initialVariant: variant,
+      initialFen: fen,
+      initialOrientation: orientation,
+    )),
+  );
+}
+
+Future<void> showContinueFromHereMenu(BuildContext context, Variant variant, String fen) {
+  return showAdaptiveActionSheet(
+    context: context,
+    actions: [
+      BottomSheetAction(
+        makeLabel: (context) => Text(context.l10n.playAgainstComputer),
+        onPressed: () => Navigator.of(
+          context,
+        ).push(OfflineComputerGameScreen.buildRoute(initialVariant: variant, initialFen: fen)),
+      ),
+      BottomSheetAction(
+        makeLabel: (context) => Text(context.l10n.mobileOverTheBoard),
+        onPressed: () => Navigator.of(
+          context,
+        ).push(OverTheBoardScreen.buildRoute(initialVariant: variant, initialFen: fen)),
+      ),
+    ],
+  );
+}

--- a/lib/src/view/analysis/analysis_screen.dart
+++ b/lib/src/view/analysis/analysis_screen.dart
@@ -15,6 +15,7 @@ import 'package:lichess_mobile/src/utils/immersive_mode.dart';
 import 'package:lichess_mobile/src/utils/l10n_context.dart';
 import 'package:lichess_mobile/src/utils/navigation.dart';
 import 'package:lichess_mobile/src/utils/share.dart';
+import 'package:lichess_mobile/src/view/analysis/analysis_actions.dart';
 import 'package:lichess_mobile/src/view/analysis/analysis_layout.dart';
 import 'package:lichess_mobile/src/view/analysis/analysis_settings_screen.dart';
 import 'package:lichess_mobile/src/view/analysis/analysis_share_screen.dart';
@@ -23,15 +24,12 @@ import 'package:lichess_mobile/src/view/analysis/game_analysis_board.dart';
 import 'package:lichess_mobile/src/view/analysis/retro_screen.dart';
 import 'package:lichess_mobile/src/view/analysis/server_analysis.dart';
 import 'package:lichess_mobile/src/view/analysis/tree_view.dart';
-import 'package:lichess_mobile/src/view/board_editor/board_editor_screen.dart';
 import 'package:lichess_mobile/src/view/engine/engine_button.dart';
 import 'package:lichess_mobile/src/view/engine/engine_gauge.dart';
 import 'package:lichess_mobile/src/view/engine/engine_lines.dart';
 import 'package:lichess_mobile/src/view/explorer/explorer_view.dart';
 import 'package:lichess_mobile/src/view/game/exported_game_title.dart';
 import 'package:lichess_mobile/src/view/game/game_common_widgets.dart';
-import 'package:lichess_mobile/src/view/offline_computer/offline_computer_game_screen.dart';
-import 'package:lichess_mobile/src/view/over_the_board/over_the_board_screen.dart';
 import 'package:lichess_mobile/src/view/tournament/tournament_screen.dart';
 import 'package:lichess_mobile/src/view/user/user_or_profile_screen.dart';
 import 'package:lichess_mobile/src/widgets/adaptive_action_sheet.dart';
@@ -591,50 +589,22 @@ class _BottomBar extends ConsumerWidget {
         if (analysisState.isComputerAnalysisAllowed)
           BottomSheetAction(
             makeLabel: (context) => Text(context.l10n.boardEditor),
-            onPressed: () {
-              final boardFen = analysisState.currentPosition.fen;
-              Navigator.of(context).push(
-                BoardEditorScreen.buildRoute((
-                  initialVariant: analysisState.variant,
-                  initialFen: boardFen,
-                  initialOrientation: null,
-                )),
-              );
-            },
+            onPressed: () => openBoardEditor(
+              context,
+              analysisState.variant,
+              analysisState.currentPosition.fen,
+              analysisState.pov,
+            ),
           ),
         if (analysisState.isComputerAnalysisAllowed)
           BottomSheetAction(
             makeLabel: (context) => Text(context.l10n.continueFromHere),
-            onPressed: () => _showContinueFromHereMenu(context, ref),
-          ),
-      ],
-    );
-  }
-
-  Future<void> _showContinueFromHereMenu(BuildContext context, WidgetRef ref) {
-    final analysisState = ref.read(analysisControllerProvider(options)).requireValue;
-    final boardFen = analysisState.currentPosition.fen;
-    return showAdaptiveActionSheet(
-      context: context,
-      actions: [
-        BottomSheetAction(
-          makeLabel: (context) => Text(context.l10n.playAgainstComputer),
-          onPressed: () => Navigator.of(context).push(
-            OfflineComputerGameScreen.buildRoute(
-              initialVariant: analysisState.variant,
-              initialFen: boardFen,
+            onPressed: () => showContinueFromHereMenu(
+              context,
+              analysisState.variant,
+              analysisState.currentPosition.fen,
             ),
           ),
-        ),
-        BottomSheetAction(
-          makeLabel: (context) => Text(context.l10n.mobileOverTheBoard),
-          onPressed: () => Navigator.of(context).push(
-            OverTheBoardScreen.buildRoute(
-              initialVariant: analysisState.variant,
-              initialFen: boardFen,
-            ),
-          ),
-        ),
       ],
     );
   }

--- a/lib/src/view/broadcast/broadcast_game_screen.dart
+++ b/lib/src/view/broadcast/broadcast_game_screen.dart
@@ -18,6 +18,7 @@ import 'package:lichess_mobile/src/utils/immersive_mode.dart';
 import 'package:lichess_mobile/src/utils/l10n_context.dart';
 import 'package:lichess_mobile/src/utils/navigation.dart';
 import 'package:lichess_mobile/src/utils/share.dart';
+import 'package:lichess_mobile/src/view/analysis/analysis_actions.dart';
 import 'package:lichess_mobile/src/view/analysis/analysis_board.dart';
 import 'package:lichess_mobile/src/view/analysis/analysis_layout.dart';
 import 'package:lichess_mobile/src/view/broadcast/broadcast_game_screen_providers.dart';
@@ -29,6 +30,7 @@ import 'package:lichess_mobile/src/view/engine/engine_button.dart';
 import 'package:lichess_mobile/src/view/engine/engine_gauge.dart';
 import 'package:lichess_mobile/src/view/engine/engine_lines.dart';
 import 'package:lichess_mobile/src/view/explorer/explorer_view.dart';
+
 import 'package:lichess_mobile/src/widgets/adaptive_action_sheet.dart';
 import 'package:lichess_mobile/src/widgets/bottom_bar.dart';
 import 'package:lichess_mobile/src/widgets/buttons.dart';
@@ -795,6 +797,8 @@ class _BroadcastGameBottomBar extends ConsumerWidget {
 
   Future<void> _showMenu(BuildContext context, WidgetRef ref) {
     final ctrlProvider = broadcastAnalysisControllerProvider((roundId: roundId, gameId: gameId));
+    final state = ref.read(ctrlProvider).requireValue;
+    final evalPrefs = ref.read(engineEvaluationPreferencesProvider);
 
     return showAdaptiveActionSheet(
       context: context,
@@ -808,6 +812,25 @@ class _BroadcastGameBottomBar extends ConsumerWidget {
         BottomSheetAction(
           makeLabel: (context) => Text(context.l10n.flipBoard),
           onPressed: () => ref.read(ctrlProvider.notifier).toggleBoard(),
+        ),
+        if (state.isEngineAvailable(evalPrefs) && state.canShowThreat)
+          BottomSheetAction(
+            makeLabel: (context) => Text(
+              state.engineInThreatMode
+                  ? context.l10n.mobileStopShowingThreat
+                  : context.l10n.showThreat,
+            ),
+            onPressed: () => ref.read(ctrlProvider.notifier).toggleEngineThreatMode(),
+          ),
+        BottomSheetAction(
+          makeLabel: (context) => Text(context.l10n.boardEditor),
+          onPressed: () =>
+              openBoardEditor(context, state.variant, state.currentPosition.fen, state.pov),
+        ),
+        BottomSheetAction(
+          makeLabel: (context) => Text(context.l10n.continueFromHere),
+          onPressed: () =>
+              showContinueFromHereMenu(context, state.variant, state.currentPosition.fen),
         ),
       ],
     );

--- a/lib/src/view/study/study_bottom_bar.dart
+++ b/lib/src/view/study/study_bottom_bar.dart
@@ -4,8 +4,10 @@ import 'package:lichess_mobile/src/model/account/account_repository.dart';
 import 'package:lichess_mobile/src/model/analysis/analysis_controller.dart';
 import 'package:lichess_mobile/src/model/chat/chat.dart';
 import 'package:lichess_mobile/src/model/common/id.dart';
+import 'package:lichess_mobile/src/model/engine/evaluation_preferences.dart';
 import 'package:lichess_mobile/src/model/study/study_controller.dart';
 import 'package:lichess_mobile/src/utils/l10n_context.dart';
+import 'package:lichess_mobile/src/view/analysis/analysis_actions.dart';
 import 'package:lichess_mobile/src/view/analysis/analysis_screen.dart';
 import 'package:lichess_mobile/src/view/chat/chat_screen.dart';
 import 'package:lichess_mobile/src/view/engine/engine_button.dart';
@@ -299,6 +301,7 @@ class _StudyMenuButton extends ConsumerWidget {
 
   Future<void> _showStudyMenu(BuildContext context, WidgetRef ref) {
     final state = ref.read(studyControllerProvider(options)).requireValue;
+    final evalPrefs = ref.read(engineEvaluationPreferencesProvider);
     final isKidMode = ref.read(kidModeProvider).value == true;
 
     final chatOptions = state.study.chat != null
@@ -330,6 +333,28 @@ class _StudyMenuButton extends ConsumerWidget {
             onPressed: () =>
                 Navigator.of(context).push(ChatScreen.buildRoute(options: chatOptions)),
           ),
+        if (state.isEngineAvailable(evalPrefs) && state.canShowThreat)
+          BottomSheetAction(
+            makeLabel: (context) => Text(
+              state.engineInThreatMode
+                  ? context.l10n.mobileStopShowingThreat
+                  : context.l10n.showThreat,
+            ),
+            onPressed: () =>
+                ref.read(studyControllerProvider(options).notifier).toggleEngineThreatMode(),
+          ),
+        if (state.isComputerAnalysisAllowed && state.currentPosition != null) ...[
+          BottomSheetAction(
+            makeLabel: (context) => Text(context.l10n.boardEditor),
+            onPressed: () =>
+                openBoardEditor(context, state.variant, state.currentPosition!.fen, state.pov),
+          ),
+          BottomSheetAction(
+            makeLabel: (context) => Text(context.l10n.continueFromHere),
+            onPressed: () =>
+                showContinueFromHereMenu(context, state.variant, state.currentPosition!.fen),
+          ),
+        ],
       ],
     );
   }


### PR DESCRIPTION
closes #2942

Adds  showThreat, Boardeditor and continue from here to broadcasts and studies (if Computer Analysis is allowed), I extracted it in a separate file as it is reused in 3 places now:

Screenshots:
<img width="523" height="1152" alt="image" src="https://github.com/user-attachments/assets/163681de-748e-4783-9b8b-0fee32a67174" />
<img width="530" height="1153" alt="image" src="https://github.com/user-attachments/assets/000fd2dc-3dc7-4a18-9f4f-d98cabb33a33" />


AI-Tools used:
Copilot to refactor into a shared file and autocomplete.

