### PR TITLE
Fix broadcast error when analysis summary has no accuracy

### DIFF
--- a/lib/src/model/analysis/analysis_summary.dart
+++ b/lib/src/model/analysis/analysis_summary.dart
@@ -31,8 +31,8 @@ PlayerAnalysis _playerAnalysisSummaryFromPick(RequiredPick pick) {
     inaccuracies: pick('inaccuracy').asIntOrThrow(),
     mistakes: pick('mistake').asIntOrThrow(),
     blunders: pick('blunder').asIntOrThrow(),
-    acpl: pick('acpl').asIntOrThrow(),
-    accuracy: pick('accuracy').asIntOrThrow(),
+    acpl: pick('acpl').asIntOrNull(),
+    accuracy: pick('accuracy').asIntOrNull(),
   );
 }
 


### PR DESCRIPTION
Loading a broadcast game without accuracy / acpl crashes with a `PickException`. This can happen when a game only has one ply, like this one: https://lichess.org/broadcast/kanizsa-open-2026-group-a-top-boards/round-1/PohT1PTB/kBZCI9JC

<img width="367" height="639" alt="Screenshot 2026-08-16 at 12 58 58" src="https://github.com/user-attachments/assets/9c705ea1-1bca-40ed-9803-627d68b69527" />

This video shows the crash: https://github.com/user-attachments/assets/4542eab2-a336-4914-a0e1-1b47ab3f5875

Verified and tested the fix in the iOS simulator.
