### PR TITLE
move analysisboard to the bottom of the menu

### DIFF
--- a/lib/src/view/game/game_body.dart
+++ b/lib/src/view/game/game_body.dart
@@ -898,14 +898,6 @@ class _GameBottomBar extends ConsumerWidget {
             ref.read(isBoardTurnedProvider.notifier).toggle();
           },
         ),
-        if (gameState.game.playable && gameState.game.meta.speed == Speed.correspondence ||
-            gameState.game.finished)
-          BottomSheetAction(
-            makeLabel: (context) => Text(context.l10n.analysis),
-            onPressed: () {
-              Navigator.of(context).push(AnalysisScreen.buildRoute(gameState.analysisOptions));
-            },
-          ),
         if (gameState.game.abortable)
           BottomSheetAction(
             makeLabel: (context) => Text(context.l10n.abortGame),
@@ -1049,6 +1041,14 @@ class _GameBottomBar extends ConsumerWidget {
             makeLabel: (context) => Text(context.l10n.backToTournament),
             onPressed: () {
               Navigator.of(context).push(TournamentScreen.buildRoute(gameState.tournament!.id));
+            },
+          ),
+        if (gameState.game.playable && gameState.game.meta.speed == Speed.correspondence ||
+            gameState.game.finished)
+          BottomSheetAction(
+            makeLabel: (context) => Text(context.l10n.analysis),
+            onPressed: () {
+              Navigator.of(context).push(AnalysisScreen.buildRoute(gameState.analysisOptions));
             },
           ),
       ],


### PR DESCRIPTION
closes #3573

<img width="652" height="1439" alt="image" src="https://github.com/user-attachments/assets/cb3a6a90-8f1f-45aa-9f5d-38d8a9c3f683" />

moves analysis board to the bottom of the menu
