### PR TITLE
add pinned comment to broadcast boards tab

### DIFF
--- a/lib/src/model/broadcast/broadcast.dart
+++ b/lib/src/model/broadcast/broadcast.dart
@@ -165,6 +165,7 @@ sealed class BroadcastRound with _$BroadcastRound {
     required DateTime? finishedAt,
     required bool startsAfterPrevious,
     required BroadcastCustomScoring? customScoring,
+    String? pinnedComment,
   }) = _BroadcastRound;
 }
 

--- a/lib/src/model/broadcast/broadcast_repository.dart
+++ b/lib/src/model/broadcast/broadcast_repository.dart
@@ -240,14 +240,15 @@ BroadcastRoundResponse _makeRoundWithGamesFromJson(Map<String, dynamic> json) {
   final groupName = pick(json, 'group', 'name').asStringOrNull();
   final group = pick(json, 'group', 'tours').asListOrNull(_tournamentGroupFromPick)?.toIList();
   final tournament = pick(json, 'tour').required();
-  final round = pick(json, 'round').required();
+  final roundPick = pick(json, 'round').required();
   final games = pick(json, 'games').required();
+  final pinnedComment = pick(json, 'study', 'pinnedComment').asStringOrNull();
 
   return (
     groupName: groupName,
     group: group,
     tournament: _tournamentDataFromPick(tournament),
-    round: _roundFromPick(round),
+    round: _roundFromPick(roundPick).copyWith(pinnedComment: pinnedComment),
     games: _gamesFromPick(games),
     photos: _photosFromJson(json),
     isSubscribed: pick(json, 'isSubscribed').asBoolOrNull(),

--- a/lib/src/view/broadcast/broadcast_boards_tab.dart
+++ b/lib/src/view/broadcast/broadcast_boards_tab.dart
@@ -6,6 +6,7 @@ import 'package:lichess_mobile/src/model/broadcast/broadcast_preferences.dart';
 import 'package:lichess_mobile/src/model/broadcast/broadcast_round_controller.dart';
 import 'package:lichess_mobile/src/model/common/eval.dart';
 import 'package:lichess_mobile/src/model/common/id.dart';
+import 'package:lichess_mobile/src/styles/lichess_icons.dart';
 import 'package:lichess_mobile/src/styles/styles.dart';
 import 'package:lichess_mobile/src/utils/duration.dart';
 import 'package:lichess_mobile/src/utils/l10n_context.dart';
@@ -67,6 +68,7 @@ class BroadcastBoardsTab extends ConsumerWidget {
                 tournamentSlug: tournamentSlug,
                 roundSlug: value.round.slug,
                 customScoring: value.round.customScoring,
+                pinnedComment: value.round.pinnedComment,
               ),
       AsyncError(:final error) => Center(child: Text('Could not load broadcast: $error')),
       _ => const Center(child: CircularProgressIndicator.adaptive()),
@@ -83,6 +85,7 @@ class BroadcastPreview extends ConsumerStatefulWidget {
     required this.tournamentSlug,
     required this.roundSlug,
     required this.customScoring,
+    required this.pinnedComment,
   });
 
   // A circular progress indicator is used instead of shimmers currently
@@ -93,7 +96,8 @@ class BroadcastPreview extends ConsumerStatefulWidget {
       title = '',
       tournamentSlug = '',
       roundSlug = '',
-      customScoring = null;
+      customScoring = null,
+      pinnedComment = null;
 
   final BroadcastTournamentId tournamentId;
   final BroadcastRoundId roundId;
@@ -102,6 +106,7 @@ class BroadcastPreview extends ConsumerStatefulWidget {
   final String tournamentSlug;
   final String roundSlug;
   final BroadcastCustomScoring? customScoring;
+  final String? pinnedComment;
   @override
   ConsumerState<BroadcastPreview> createState() => _BroadcastPreviewState();
 }
@@ -147,12 +152,23 @@ class _BroadcastPreviewState extends ConsumerState<BroadcastPreview> {
         ? widget.games
         : widget.games!.where((game) => _containsPlayer(game, _searchQuery)).toIList();
     final showSearchBar = widget.games != null && widget.games!.length > 6;
+    final hasComment = widget.pinnedComment != null && widget.pinnedComment!.isNotEmpty;
     final mediaQueryPadding = MediaQuery.paddingOf(context);
 
     return CustomScrollView(
       slivers: [
+        if (hasComment)
+          SliverSafeArea(
+            bottom: false,
+            sliver: SliverPadding(
+              padding: Styles.bodyPadding.copyWith(bottom: 0.0),
+              sliver: SliverToBoxAdapter(child: _PinnedCommentCard(text: widget.pinnedComment!)),
+            ),
+          ),
+
         if (showSearchBar)
           SliverSafeArea(
+            top: !hasComment,
             bottom: false,
             sliver: SliverPadding(
               padding: Styles.bodyPadding.copyWith(bottom: 0.0),
@@ -416,4 +432,21 @@ class _PlayerWidget extends StatelessWidget {
 bool _containsPlayer(BroadcastGame game, String query) {
   final q = query.toLowerCase();
   return game.players.values.any((pwc) => pwc.player.name?.toLowerCase().contains(q) ?? false);
+}
+
+class _PinnedCommentCard extends StatelessWidget {
+  const _PinnedCommentCard({required this.text});
+
+  final String text;
+
+  @override
+  Widget build(BuildContext context) {
+    return Card(
+      margin: EdgeInsets.zero,
+      child: ListTile(
+        leading: const Icon(LichessIcons.radio_tower_lichess, size: 28),
+        title: Text(text, style: TextStyle(fontSize: _kPlayerWidgetTextStyle.fontSize)),
+      ),
+    );
+  }
 }


### PR DESCRIPTION
closes #3130 as https://github.com/lichess-org/lila/commit/cf0c9f3e45415135f3e2261b4ef8c9b2cf5631c1 was deployed now.

Preview:

<img width="602" height="1341" alt="image" src="https://github.com/user-attachments/assets/8f24f100-ee92-4bcf-aaf5-948231b145bc" />

<img width="2038" height="1246" alt="image" src="https://github.com/user-attachments/assets/0d7d6061-7708-4d30-85cd-7b58b8584cce" />


Remarks:
- I tried to make sure the safe area works on iOS too, but I cannot test it.
- It takes vertical space in the boards tab, which I do not like that much, but I think in the overview tab it would not be seen. I think pinned comments are mostly used for tiebreaks regulations or if there are lichess server problems so it might be useful to show prominently in the boards tab.


