### PR TITLE
improve 960 support in editor

### DIFF
--- a/lib/src/model/board_editor/board_editor_controller.dart
+++ b/lib/src/model/board_editor/board_editor_controller.dart
@@ -252,50 +252,64 @@ sealed class BoardEditorState with _$BoardEditorState {
     },
   };
 
-  /// Returns the castling rights part of the FEN string.
-  ///
-  /// If the rook is missing on one side of the king, or the king is missing on the
-  /// backrank, the castling right is removed.
-  String get _castlingRightsPart {
-    final parts = <String>[];
-    final Map<CastlingRight, bool> hasRook = {};
-    final Board board = Board.parseFen(writeFen(pieces.unlock));
-    for (final side in Side.values) {
+  /// Checks if the pieces are in the correct positions so that castling is possible.
+  bool isCastlingPossible(Side side, CastlingSide castlingSide) {
+    if (variant == .chess960) {
+      final board = Board.parseFen(writeFen(pieces.unlock));
       final backrankKing = SquareSet.backrankOf(side) & board.kings;
       final rooksAndKings =
           (board.bySide(side) & SquareSet.backrankOf(side)) & (board.rooks | board.kings);
-      for (final castlingSide in CastlingSide.values) {
-        final candidate = castlingSide == CastlingSide.king
-            ? rooksAndKings.squares.lastOrNull
-            : rooksAndKings.squares.firstOrNull;
-        final isCastlingPossible =
-            candidate != null && board.rooks.has(candidate) && backrankKing.singleSquare != null;
-        switch ((side, castlingSide)) {
-          case (Side.white, CastlingSide.king):
-            hasRook[CastlingRight.whiteKing] = isCastlingPossible;
-          case (Side.white, CastlingSide.queen):
-            hasRook[CastlingRight.whiteQueen] = isCastlingPossible;
-          case (Side.black, CastlingSide.king):
-            hasRook[CastlingRight.blackKing] = isCastlingPossible;
-          case (Side.black, CastlingSide.queen):
-            hasRook[CastlingRight.blackQueen] = isCastlingPossible;
-        }
-      }
+
+      final candidate = castlingSide == .king
+          ? rooksAndKings.squares.lastOrNull
+          : rooksAndKings.squares.firstOrNull;
+
+      return candidate != null && board.rooks.has(candidate) && backrankKing.singleSquare != null;
+    } else {
+      final Square kingSquare = side == .white ? .e1 : .e8;
+      final Square rookSquare = castlingSide == .king
+          ? (side == .white ? .h1 : .h8)
+          : (side == .white ? .a1 : .a8);
+
+      return pieces[kingSquare]?.role == .king &&
+          pieces[kingSquare]?.color == side &&
+          pieces[rookSquare]?.role == .rook &&
+          pieces[rookSquare]?.color == side;
     }
-    for (final right in CastlingRight.values) {
-      if (hasRook[right]! && castlingRights[right]!) {
-        switch (right) {
-          case CastlingRight.whiteKing:
-            parts.add('K');
-          case CastlingRight.whiteQueen:
-            parts.add('Q');
-          case CastlingRight.blackKing:
-            parts.add('k');
-          case CastlingRight.blackQueen:
-            parts.add('q');
-        }
-      }
+  }
+
+  /// Returns the castling rights part of the FEN string.
+  ///
+  /// For standard variants, checks if the kings and rooks are on their normal starting squares.
+  /// For Chess960, dynamically checks the backrank for rooks relative to the king.
+  /// Returns the castling rights part of the FEN string.
+  ///
+  /// For standard variants, checks if the kings and rooks are on their normal starting squares.
+  /// For Chess960, dynamically checks the backrank for rooks relative to the king.
+  String get _castlingRightsPart {
+    final parts = <String>[];
+
+    if (variant.sideCanCastle(.white) &&
+        castlingRights[.whiteKing]! &&
+        isCastlingPossible(.white, .king)) {
+      parts.add('K');
     }
+    if (variant.sideCanCastle(.white) &&
+        castlingRights[.whiteQueen]! &&
+        isCastlingPossible(.white, .queen)) {
+      parts.add('Q');
+    }
+    if (variant.sideCanCastle(.black) &&
+        castlingRights[.blackKing]! &&
+        isCastlingPossible(.black, .king)) {
+      parts.add('k');
+    }
+    if (variant.sideCanCastle(.black) &&
+        castlingRights[.blackQueen]! &&
+        isCastlingPossible(.black, .queen)) {
+      parts.add('q');
+    }
+
     return parts.isEmpty ? '-' : parts.join('');
   }
 

--- a/lib/src/view/board_editor/board_editor_filters.dart
+++ b/lib/src/view/board_editor/board_editor_filters.dart
@@ -61,14 +61,17 @@ class BoardEditorFilters extends ConsumerWidget {
                     ),
                   ),
                   ...[CastlingSide.king, CastlingSide.queen].map((castlingSide) {
+                    final isPossible = editorState.isCastlingPossible(side, castlingSide);
                     return ChoiceChip(
                       label: Text(castlingSide == CastlingSide.king ? 'O-O' : 'O-O-O'),
-                      selected: editorState.isCastlingAllowed(side, castlingSide),
-                      onSelected: (selected) {
-                        ref
-                            .read(editorController.notifier)
-                            .setCastling(side, castlingSide, selected);
-                      },
+                      selected: isPossible && editorState.isCastlingAllowed(side, castlingSide),
+                      onSelected: isPossible
+                          ? (selected) {
+                              ref
+                                  .read(editorController.notifier)
+                                  .setCastling(side, castlingSide, selected);
+                            }
+                          : null,
                     );
                   }),
                 ],

--- a/lib/src/view/board_editor/board_editor_screen.dart
+++ b/lib/src/view/board_editor/board_editor_screen.dart
@@ -1,3 +1,4 @@
+import 'dart:math' as math;
 import 'package:chessground/chessground.dart';
 import 'package:cupertino_ui/cupertino_ui.dart';
 import 'package:dartchess/dartchess.dart';
@@ -8,8 +9,10 @@ import 'package:lichess_mobile/src/model/analysis/analysis_controller.dart';
 import 'package:lichess_mobile/src/model/auth/auth_controller.dart';
 import 'package:lichess_mobile/src/model/board_editor/board_editor_controller.dart';
 import 'package:lichess_mobile/src/model/common/chess.dart';
+import 'package:lichess_mobile/src/model/common/chess960.dart';
 import 'package:lichess_mobile/src/model/common/id.dart';
 import 'package:lichess_mobile/src/model/settings/board_preferences.dart';
+import 'package:lichess_mobile/src/styles/lichess_icons.dart';
 import 'package:lichess_mobile/src/styles/styles.dart';
 import 'package:lichess_mobile/src/utils/l10n_context.dart';
 import 'package:lichess_mobile/src/utils/navigation.dart';
@@ -303,20 +306,35 @@ class _BottomBar extends ConsumerWidget {
                         .loadFen(editorState.variant.initialPosition.fen);
                   },
                 ),
-              BottomSheetAction(
-                makeLabel: (context) => Text(context.l10n.loadPosition),
-                onPressed: () {
-                  final notifier = ref.read(editorController.notifier);
-                  Navigator.of(context).push(
-                    BoardEditorPositionsScreen.buildRoute(
-                      onPositionSelected: (position) => {
-                        notifier.loadFen(position.fen),
-                        Navigator.of(context).pop(),
-                      },
-                    ),
-                  );
-                },
-              ),
+              if (editorState.variant == .chess960)
+                BottomSheetAction(
+                  makeLabel: (context) => const Text('Chess960 Position'),
+                  onPressed: () {
+                    showDialog<void>(
+                      context: context,
+                      builder: (_) => _Chess960PositionDialog(
+                        onFenLoaded: (fen) {
+                          ref.read(editorController.notifier).loadFen(fen);
+                        },
+                      ),
+                    );
+                  },
+                ),
+              if (editorState.variant == .standard)
+                BottomSheetAction(
+                  makeLabel: (context) => Text(context.l10n.loadPosition),
+                  onPressed: () {
+                    final notifier = ref.read(editorController.notifier);
+                    Navigator.of(context).push(
+                      BoardEditorPositionsScreen.buildRoute(
+                        onPositionSelected: (position) => {
+                          notifier.loadFen(position.fen),
+                          Navigator.of(context).pop(),
+                        },
+                      ),
+                    );
+                  },
+                ),
               if (editorState.variant == Variant.standard)
                 BottomSheetAction(
                   // TODO: l10n
@@ -364,10 +382,7 @@ class _BottomBar extends ConsumerWidget {
                 onPressed: () => showChoicePicker<Variant>(
                   context,
                   choices: readSupportedVariants
-                      .where(
-                        // TODO, for chess960 to be meaningful here, we'd need to display a dialog to load one of the starting positions
-                        (variant) => variant != Variant.fromPosition && variant != Variant.chess960,
-                      )
+                      .where((variant) => variant != .fromPosition)
                       .toList(),
                   selectedItem: editorState.variant,
                   labelBuilder: (variant) => VariantLabel(variant),
@@ -414,9 +429,7 @@ class _BottomBar extends ConsumerWidget {
                         orientation: editorState.orientation,
                         pgn: editorState.pgn!,
                         isComputerAnalysisAllowed: true,
-                        variant: editorState.variant.rule == Rule.chess
-                            ? Variant.fromPosition
-                            : editorState.variant,
+                        variant: editorState.variant,
                       ),
                     ),
                   );
@@ -511,6 +524,75 @@ class _FenDialogState extends State<_FenDialog> {
           ),
         ),
       ),
+    );
+  }
+}
+
+class _Chess960PositionDialog extends StatefulWidget {
+  const _Chess960PositionDialog({required this.onFenLoaded});
+
+  final void Function(String fen) onFenLoaded;
+
+  @override
+  State<_Chess960PositionDialog> createState() => _Chess960PositionDialogState();
+}
+
+class _Chess960PositionDialogState extends State<_Chess960PositionDialog> {
+  final _controller = TextEditingController();
+
+  @override
+  void dispose() {
+    _controller.dispose();
+    super.dispose();
+  }
+
+  void _generateRandom() {
+    // Chess960 IDs range from 0 to 959.
+    final randomId = math.Random().nextInt(960);
+    _controller.text = randomId.toString();
+  }
+
+  void _loadPosition() {
+    final id = int.tryParse(_controller.text);
+    if (id == null || id < 0 || id > 959) {
+      showSnackBar(context, 'Please enter a number between 0 and 959', type: .error);
+      return;
+    }
+    final fen = chess960Position(id).fen;
+    widget.onFenLoaded(fen);
+    Navigator.of(context, rootNavigator: true).pop();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return AlertDialog(
+      title: const Text('Chess960 Position'),
+      content: Column(
+        mainAxisSize: MainAxisSize.min,
+        children: [
+          TextField(
+            controller: _controller,
+            keyboardType: .number,
+            decoration: InputDecoration(
+              hintText: 'Position ID (0-959)',
+              suffixIcon: IconButton(
+                icon: const Icon(LichessIcons.die_six),
+                onPressed: _generateRandom,
+                tooltip: context.l10n.randomChess960Position,
+              ),
+            ),
+            inputFormatters: [FilteringTextInputFormatter.digitsOnly],
+            onSubmitted: (_) => _loadPosition(),
+          ),
+        ],
+      ),
+      actions: [
+        TextButton(
+          onPressed: () => Navigator.of(context, rootNavigator: true).pop(),
+          child: Text(context.l10n.cancel),
+        ),
+        TextButton(onPressed: _loadPosition, child: Text(context.l10n.loadPosition)),
+      ],
     );
   }
 }

--- a/lib/src/view/board_editor/board_editor_screen.dart
+++ b/lib/src/view/board_editor/board_editor_screen.dart
@@ -539,6 +539,7 @@ class _Chess960PositionDialog extends StatefulWidget {
 
 class _Chess960PositionDialogState extends State<_Chess960PositionDialog> {
   final _controller = TextEditingController();
+  String? _errorText;
 
   @override
   void dispose() {
@@ -547,17 +548,28 @@ class _Chess960PositionDialogState extends State<_Chess960PositionDialog> {
   }
 
   void _generateRandom() {
-    // Chess960 IDs range from 0 to 959.
     final randomId = math.Random().nextInt(960);
-    _controller.text = randomId.toString();
+    setState(() {
+      _controller.text = randomId.toString();
+      _errorText = null;
+    });
+  }
+
+  void _validateInput(String value) {
+    final id = int.tryParse(value);
+    setState(() {
+      if (id != null && id > 959) {
+        _errorText = 'Max ID is 959';
+      } else {
+        _errorText = null;
+      }
+    });
   }
 
   void _loadPosition() {
     final id = int.tryParse(_controller.text);
-    if (id == null || id < 0 || id > 959) {
-      showSnackBar(context, 'Please enter a number between 0 and 959', type: .error);
-      return;
-    }
+    if (id == null) return;
+
     final fen = chess960Position(id).fen;
     widget.onFenLoaded(fen);
     Navigator.of(context, rootNavigator: true).pop();
@@ -568,13 +580,15 @@ class _Chess960PositionDialogState extends State<_Chess960PositionDialog> {
     return AlertDialog(
       title: const Text('Chess960 Position'),
       content: Column(
-        mainAxisSize: MainAxisSize.min,
+        mainAxisSize: .min,
         children: [
           TextField(
             controller: _controller,
             keyboardType: .number,
+            onChanged: _validateInput,
             decoration: InputDecoration(
               hintText: 'Position ID (0-959)',
+              errorText: _errorText,
               suffixIcon: IconButton(
                 icon: const Icon(LichessIcons.die_six),
                 onPressed: _generateRandom,
@@ -591,7 +605,10 @@ class _Chess960PositionDialogState extends State<_Chess960PositionDialog> {
           onPressed: () => Navigator.of(context, rootNavigator: true).pop(),
           child: Text(context.l10n.cancel),
         ),
-        TextButton(onPressed: _loadPosition, child: Text(context.l10n.loadPosition)),
+        TextButton(
+          onPressed: _errorText == null && _controller.text.isNotEmpty ? _loadPosition : null,
+          child: Text(context.l10n.loadPosition),
+        ),
       ],
     );
   }

--- a/test/view/board_editor/board_editor_screen_test.dart
+++ b/test/view/board_editor/board_editor_screen_test.dart
@@ -658,16 +658,14 @@ void main() {
 
     // Enter an out-of-bounds ID
     await tester.enterText(find.byType(TextField), '999');
-
-    // Tap the Load button (which is the last TextButton in the dialog actions)
-    await tester.tap(find.text('Load position'));
     await tester.pump();
+
+    // Verify the 'Load position' button is actually disabled
+    final loadButton = tester.widget<TextButton>(find.widgetWithText(TextButton, 'Load position'));
+    expect(loadButton.onPressed, isNull);
 
     // The dialog should remain open because validation failed
     expect(find.byType(AlertDialog), findsOneWidget);
-
-    // The error SnackBar should appear
-    expect(find.textContaining('0 and 959'), findsOneWidget);
   });
 }
 

--- a/test/view/board_editor/board_editor_screen_test.dart
+++ b/test/view/board_editor/board_editor_screen_test.dart
@@ -5,6 +5,7 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:lichess_mobile/src/model/board_editor/board_editor_controller.dart';
 import 'package:lichess_mobile/src/model/common/chess.dart';
+import 'package:lichess_mobile/src/model/common/chess960.dart';
 import 'package:lichess_mobile/src/view/board_editor/board_editor_screen.dart';
 import 'package:lichess_mobile/src/widgets/bottom_bar.dart';
 import 'package:material_ui/material_ui.dart';
@@ -184,7 +185,13 @@ void main() {
       container
           .read(controllerProvider.notifier)
           .loadFen('rnbqkbnr/pppppppp/8/8/8/8/PPPPPPPP/4RK1R');
-
+      // in standard chess with the King on f1, white cannot castle
+      expect(
+        container.read(controllerProvider).fen,
+        'rnbqkbnr/pppppppp/8/8/8/8/PPPPPPPP/4RK1R w kq - 0 1',
+      );
+      container.read(controllerProvider.notifier).setVariant(.chess960);
+      // in chess960, the King on f1 can castle
       expect(
         container.read(controllerProvider).fen,
         'rnbqkbnr/pppppppp/8/8/8/8/PPPPPPPP/4RK1R w KQkq - 0 1',
@@ -206,6 +213,59 @@ void main() {
         container.read(controllerProvider).fen,
         'rnbqkbnr/pppppppp/8/8/8/5K2/PPPPPPPP/4R2R w kq - 0 1',
       );
+    });
+
+    testWidgets('Standard castling is strictly revoked if king or rook leaves starting square', (
+      tester,
+    ) async {
+      final app = await makeTestProviderScopeApp(tester, home: const BoardEditorScreen());
+      await tester.pumpWidget(app);
+
+      final container = ProviderScope.containerOf(tester.element(find.byType(ChessboardEditor)));
+      final controllerProvider = boardEditorControllerProvider(null);
+
+      // In editor mode, dragging a piece just moves it without changing the turn
+      await dragFromTo(tester, 'e1', 'd1');
+
+      // White king moved, so White's castling rights should be removed from the FEN
+      expect(
+        container.read(controllerProvider).fen,
+        'rnbqkbnr/pppppppp/8/8/8/8/PPPPPPPP/RNBK1BNR w kq - 0 1',
+      );
+
+      // Move it back to e1
+      await dragFromTo(tester, 'd1', 'e1');
+
+      // Since the castling right is still enabled in the underlying state,
+      // putting the king back restores the FEN output.
+      expect(
+        container.read(controllerProvider).fen,
+        'rnbqkbnr/pppppppp/8/8/8/8/PPPPPPPP/RNB1KBNR w KQkq - 0 1',
+      );
+    });
+
+    testWidgets('isCastlingPossible accurately reflects board validity for the UI', (tester) async {
+      final app = await makeTestProviderScopeApp(tester, home: const BoardEditorScreen());
+      await tester.pumpWidget(app);
+
+      final container = ProviderScope.containerOf(tester.element(find.byType(ChessboardEditor)));
+      final controllerProvider = boardEditorControllerProvider(null);
+
+      // Start with standard position
+      var state = container.read(controllerProvider);
+      expect(state.isCastlingPossible(.white, .king), isTrue);
+
+      // Remove the white h1 rook
+      await tester.tap(find.byKey(const Key('delete-button-white')));
+      await tester.pump();
+      await tapSquare(tester, 'h1');
+
+      state = container.read(controllerProvider);
+
+      // Kingside castling should now report as physically impossible for the UI chips
+      expect(state.isCastlingPossible(.white, .king), isFalse);
+      // Queenside should remain possible
+      expect(state.isCastlingPossible(.white, .queen), isTrue);
     });
 
     testWidgets('Possible en passant squares are calculated correctly', (tester) async {
@@ -538,6 +598,76 @@ void main() {
       // Variant we set previously should be preselected
       expect(find.textContaining('Atomic'), findsOneWidget);
     });
+  });
+  testWidgets('Chess960 position dialog loads valid ID', (tester) async {
+    // Boot up the editor directly in Chess960 mode
+    final app = await makeTestProviderScopeApp(
+      tester,
+      home: const BoardEditorScreen(
+        params: (initialVariant: Variant.chess960, initialFen: null, initialOrientation: null),
+      ),
+    );
+    await tester.pumpWidget(app);
+
+    // Open the bottom sheet menu
+    await tester.tap(find.bySemanticsLabel('Menu'));
+    await tester.pump();
+
+    // Tap the action to open the dialog
+    await tester.tap(find.text('Chess960 Position'));
+    await tester.pump();
+
+    expect(find.byType(AlertDialog), findsOneWidget);
+
+    // Enter a valid FRC ID
+    await tester.enterText(find.byType(TextField), '0');
+    await tester.pump();
+
+    // load position
+    await tester.tap(find.text('Load position'));
+    await tester.pump();
+
+    // Verify the dialog closes successfully
+    expect(find.byType(AlertDialog), findsNothing);
+
+    // Verify the board state has updated to match the FEN for ID 0
+    final container = ProviderScope.containerOf(tester.element(find.byType(ChessboardEditor)));
+    final controllerProvider = boardEditorControllerProvider((
+      initialVariant: Variant.chess960,
+      initialFen: null,
+      initialOrientation: null,
+    ));
+
+    expect(container.read(controllerProvider).fen, chess960Position(0).fen);
+  });
+
+  testWidgets('Chess960 position dialog rejects invalid ID', (tester) async {
+    final app = await makeTestProviderScopeApp(
+      tester,
+      home: const BoardEditorScreen(
+        params: (initialVariant: Variant.chess960, initialFen: null, initialOrientation: null),
+      ),
+    );
+    await tester.pumpWidget(app);
+
+    await tester.tap(find.bySemanticsLabel('Menu'));
+    await tester.pump();
+
+    await tester.tap(find.text('Chess960 Position'));
+    await tester.pump();
+
+    // Enter an out-of-bounds ID
+    await tester.enterText(find.byType(TextField), '999');
+
+    // Tap the Load button (which is the last TextButton in the dialog actions)
+    await tester.tap(find.text('Load position'));
+    await tester.pump();
+
+    // The dialog should remain open because validation failed
+    expect(find.byType(AlertDialog), findsOneWidget);
+
+    // The error SnackBar should appear
+    expect(find.textContaining('0 and 959'), findsOneWidget);
   });
 }
 


### PR DESCRIPTION
closes #1179 

Makes 960 its own variant in the editor, this helps makes the editor less confusing for people entering a standard chess position, where the rooks/kings are on the backrank but not on their initial square. Currently when entering a position with the Rook, lets say on g1, the default was that kingside was still possible which can mess with the analysis later.

Things implemented/fixed:

- In all chess Variants except 960: if Kings + Rooks not on initial square the choice chips for castling are not interactable
- In chess960: if Kings + Rooks not on backrank the choice chips for castling are not interactable
- In variants where castling is not possible, do not add castling rights to the fen, leave them empty instead
- Only enable load position in standard chess as for other chess variants the opening and endgame positions are not relevant
- Open a 960Analysisboard if the variant is 960 (just a visual change to add the 960 icon in the analysis header)
- Adds a 960 randomizer and position loader to the board editor
- Added a bunch of tests

Video:

[960 Editor](https://github.com/user-attachments/assets/70c83996-29aa-44ea-bb9b-451c8ff53984)


AI tools:
Copilot, mostly for test generation and autocomplete

