### PR TITLE
Fix username overflows across the app

### DIFF
--- a/lib/src/view/game/game_loading_board.dart
+++ b/lib/src/view/game/game_loading_board.dart
@@ -620,7 +620,10 @@ class ChallengeDeclinedBoard extends StatelessWidget {
                           mainAxisSize: MainAxisSize.min,
                           children: [
                             const Text(' — '),
-                            UserFullNameWidget(user: challenge.destUser?.user),
+                            Flexible(
+                              fit: FlexFit.loose,
+                              child: UserFullNameWidget(user: challenge.destUser?.user),
+                            ),
                             if (challenge.destUser?.lagRating != null) ...[
                               const SizedBox(width: 6.0),
                               LagIndicator(lagRating: challenge.destUser!.lagRating!, size: 13.0),

--- a/lib/src/view/home/blog_carousel.dart
+++ b/lib/src/view/home/blog_carousel.dart
@@ -300,12 +300,15 @@ class _BlogCardContent extends StatelessWidget {
                 crossAxisAlignment: CrossAxisAlignment.baseline,
                 textBaseline: TextBaseline.alphabetic,
                 children: [
-                  UserFullNameWidget(
-                    user: post.author,
-                    showPatron: false,
-                    showFlair: false,
-                    style: TextStyle(color: subTitleColor, letterSpacing: -0.2),
+                  Expanded(
+                    child: UserFullNameWidget(
+                      user: post.author,
+                      showPatron: false,
+                      showFlair: false,
+                      style: TextStyle(color: subTitleColor, letterSpacing: -0.2),
+                    ),
                   ),
+                  const SizedBox(width: 4.0),
                   Text(
                     _dateFormat.format(post.createdAt),
                     style: TextStyle(color: subTitleColor, letterSpacing: -0.2, fontSize: 12.0),

--- a/lib/src/view/play/create_challenge_bottom_sheet.dart
+++ b/lib/src/view/play/create_challenge_bottom_sheet.dart
@@ -376,7 +376,10 @@ class _CreateChallengeBottomSheetState extends ConsumerState<CreateChallengeBott
                                             mainAxisSize: MainAxisSize.min,
                                             children: [
                                               const Text(' — '),
-                                              UserFullNameWidget(user: widget.user),
+                                              Flexible(
+                                                fit: FlexFit.loose,
+                                                child: UserFullNameWidget(user: widget.user),
+                                              ),
                                             ],
                                           ),
                                         ),

--- a/lib/src/view/watch/tv_screen.dart
+++ b/lib/src/view/watch/tv_screen.dart
@@ -93,7 +93,7 @@ class _TvScreenState extends ConsumerState<TvScreen> {
                 : Row(
                     mainAxisSize: MainAxisSize.min,
                     children: [
-                      UserFullNameWidget(user: widget.user),
+                      Expanded(child: UserFullNameWidget(user: widget.user)),
                       const SizedBox(width: 4.0),
                       const Icon(Icons.live_tv),
                     ],


### PR DESCRIPTION
Fixes #3512

This pr fixes overflow caused by long usernames in some components. It happens when UserFullNameWidget is wrapped in a Row without using a suitable flex widget (Expanded, Flexible etc).

### Changes made:
- view/watch/tv_screen.dart => Wrapped the username widget with an Expanded
- view/play/create_challenge_bottom_sheet.dart => Wrapped the username widget with a Flexible
- view/home/blog_carousel.dart => Wrapped the username widget with an Expanded
- view/game/game_loading.dart => Wrapped the username widget with a Flexible

### Screenshots
#### 1. view/watch/tv_screen.dart
#### Before and After

<img width="286" height="250.5" alt="TV Screen - Before" src="https://github.com/user-attachments/assets/58e2c110-b3e4-4513-b756-66a4a3dfd64d"/>
<img width="272" height="250.5" alt="TV Screen - After" src="https://github.com/user-attachments/assets/c3e69b32-2868-4711-ba90-e181c2a9cdeb" />

#### 2. view/game/game_loading.dart (also applies to view/play/create_challenge_bottom_sheet.dart)
#### Before and After

<img width="271" height="292" alt="Game Loading - Before" src="https://github.com/user-attachments/assets/25541dec-6de3-4d0a-b30e-e8689a98abdd" />
<img width="273" height="292" alt="Game Loading - After1" src="https://github.com/user-attachments/assets/6db4c658-9cc9-467d-aca9-6a6a48cd62a2" />
<img width="271" height="292" alt="Game Loading - After2" src="https://github.com/user-attachments/assets/f12d1e5b-90a5-4519-88a1-924b022bc8ac" />

#### 3. view/home/blog_carousel.dart
#### Before and After

<img width="270" height="321.5" alt="Blog Carousel - Before" src="https://github.com/user-attachments/assets/3360e1a5-46b7-4555-b528-ddb213951d0c" />
<img width="270.5" height="321.5" alt="Blog Carousel - After" src="https://github.com/user-attachments/assets/d1f47395-6c70-4bbe-b018-f96bdd0060c0" />

### Tests run:
- flutter analyze
- flutter test

