### PR TITLE
Blink the next mistake button

### DIFF
--- a/lib/src/view/analysis/retro_screen.dart
+++ b/lib/src/view/analysis/retro_screen.dart
@@ -287,6 +287,7 @@ class _BottomBar extends ConsumerWidget {
               // TODO: translate
               label: 'Next mistake',
               showLabel: true,
+              blink: true,
               onTap: ref.read(retroControllerProvider(options).notifier).nextMistake,
             ),
         ],

--- a/test/view/analysis/retro_screen_test.dart
+++ b/test/view/analysis/retro_screen_test.dart
@@ -17,6 +17,7 @@ import 'package:lichess_mobile/src/model/explorer/opening_explorer.dart';
 import 'package:lichess_mobile/src/model/game/game_socket_events.dart';
 import 'package:lichess_mobile/src/network/http.dart';
 import 'package:lichess_mobile/src/view/analysis/retro_screen.dart';
+import 'package:lichess_mobile/src/widgets/bottom_bar.dart';
 import 'package:mocktail/mocktail.dart';
 
 import '../../network/fake_http_client_factory.dart';
@@ -229,6 +230,10 @@ void main() {
 
       expect(find.text('Good move'), findsOneWidget);
       expect(find.text('Next'), findsOneWidget);
+      expect(
+        tester.widget<BottomBarButton>(find.widgetWithText(BottomBarButton, 'Next mistake')).blink,
+        isTrue,
+      );
 
       await tester.tap(find.text('Next mistake'));
       await tester.pump();
@@ -251,6 +256,10 @@ void main() {
       expect(boardHasPiece(tester, Square.c5, Piece.blackPawn), isTrue);
 
       expect(find.text('Next mistake'), findsOneWidget);
+      expect(
+        tester.widget<BottomBarButton>(find.widgetWithText(BottomBarButton, 'Next mistake')).blink,
+        isTrue,
+      );
       await tester.tap(find.text('Next mistake'));
       await tester.pump();
 


### PR DESCRIPTION
Fixes #2953

## What changed

- Reuse the existing `BottomBarButton` blink animation for the retro-analysis `Next mistake` action.
- Cover both states where that action is reachable: after a correct move and after viewing the solution.

This makes the next step visually discoverable without introducing a new animation or changing the surrounding retro flow.

## Validation

- RED-first focused regression: `One mistake by both sides` failed before the production change with `Expected: true` / `Actual: <false>`, then passed after the change.
- `dart format --output=none --set-exit-if-changed ...` — 2 files, 0 changes
- `flutter analyze` — no issues
- `flutter test --concurrency=4` — 1,310 tests passed
- Final focused regression rerun — passed
- `git diff --check` — passed

## Manual UI proof

Tested in the supported Linux desktop release build pointed at `lichess.org`, using the public server-analyzed game `RPInH9lN`. I opened **Review white's mistakes**, selected **View the solution**, and confirmed that **Next mistake** repeatedly transitions through the existing blink animation.

![Next mistake blink](https://raw.githubusercontent.com/henriquejsza/mobile/7bc60abded66725351c7c79d4a7e7d678afdbef1/next-mistake-blink.gif)

The GIF contains 28 genuine Spectacle compositor captures over 14 seconds from the running release app; it does not use widget-test screenshots or synthesized UI frames.
