### PR TITLE
add game phases when server data is arriving via websockets

### DIFF
--- a/lib/src/model/game/game_socket_events.dart
+++ b/lib/src/model/game/game_socket_events.dart
@@ -215,6 +215,13 @@ ServerEvalEvent _serverEvalEventFromPick(RequiredPick pick) {
             blunders: pa('blunder').asIntOrThrow(),
             acpl: pa('acpl').asIntOrNull(),
             accuracy: pa('accuracy').asIntOrNull(),
+            phases: pa('phases').letOrNull(
+              (p) => (
+                opening: p('opening').asIntOrNull(),
+                middlegame: p('middlegame').asIntOrNull(),
+                endgame: p('endgame').asIntOrNull(),
+              ),
+            ),
           ),
         ),
         black: it('black').letOrThrow(
@@ -224,6 +231,13 @@ ServerEvalEvent _serverEvalEventFromPick(RequiredPick pick) {
             blunders: pa('blunder').asIntOrThrow(),
             acpl: pa('acpl').asIntOrNull(),
             accuracy: pa('accuracy').asIntOrNull(),
+            phases: pa('phases').letOrNull(
+              (p) => (
+                opening: p('opening').asIntOrNull(),
+                middlegame: p('middlegame').asIntOrNull(),
+                endgame: p('endgame').asIntOrNull(),
+              ),
+            ),
           ),
         ),
       ),


### PR DESCRIPTION
fix #3595
Parses the game phase accuracy when they come in via websocket
Tested with the lichess server.

In theory we could easily add the game phase data to broadcasts too, but the website does not do it...