### PR TITLE
Play move sound instantly in bullet

### DIFF
--- a/lib/src/model/game/game_controller.dart
+++ b/lib/src/model/game/game_controller.dart
@@ -610,14 +610,10 @@ class GameController extends AsyncNotifier<GameState> with ChatMixin<GameState> 
 
   /// Move feedback while playing
   void _playMoveFeedback(SanMove sanMove, {bool skipAnimationDelay = false}) {
-    final speed = state.value?.game.meta.speed;
-    final isBullet = speed == Speed.bullet || speed == Speed.ultraBullet;
-
-    final animationDuration = isBullet
-        ? Duration.zero
-        : ref.read(boardPreferencesProvider).pieceAnimationDuration;
-
-    final delay = animationDuration ~/ 2;
+    final pieceAnimationDuration = state.value?.hasPieceAnimation == true
+        ? ref.read(boardPreferencesProvider).pieceAnimationDuration
+        : Duration.zero;
+    final delay = pieceAnimationDuration ~/ 2;
 
     if (skipAnimationDelay || delay <= Duration.zero) {
       _moveFeedback(sanMove);
@@ -1215,6 +1211,9 @@ sealed class GameState with _$GameState, ChatMixinState {
       Zen.gameAuto => true,
     };
   }
+
+  /// Whether piece animations are enabled for this game. Animations are disabled for bullet and ultrabullet games.
+  bool get hasPieceAnimation => game.meta.speed != .bullet && game.meta.speed != .ultraBullet;
 
   bool get canPremove => game.meta.speed != Speed.correspondence;
   bool get canAutoQueen => autoQueenSettingOverride ?? (game.prefs?.autoQueen == AutoQueen.always);

--- a/lib/src/model/game/game_controller.dart
+++ b/lib/src/model/game/game_controller.dart
@@ -610,7 +610,12 @@ class GameController extends AsyncNotifier<GameState> with ChatMixin<GameState> 
 
   /// Move feedback while playing
   void _playMoveFeedback(SanMove sanMove, {bool skipAnimationDelay = false}) {
-    final animationDuration = ref.read(boardPreferencesProvider).pieceAnimationDuration;
+    final speed = state.value?.game.meta.speed;
+    final isBullet = speed == Speed.bullet || speed == Speed.ultraBullet;
+
+    final animationDuration = isBullet
+        ? Duration.zero
+        : ref.read(boardPreferencesProvider).pieceAnimationDuration;
 
     final delay = animationDuration ~/ 2;
 

--- a/lib/src/view/game/game_body.dart
+++ b/lib/src/view/game/game_body.dart
@@ -415,9 +415,9 @@ class _PlayableGameBoardState extends ConsumerState<_PlayableGameBoard> {
     final topSide = topPlayerIsBlack ? Side.black : Side.white;
     final bottomSide = topPlayerIsBlack ? Side.white : Side.black;
 
-    final animationDuration = shell.speed == Speed.ultraBullet || shell.speed == Speed.bullet
-        ? Duration.zero
-        : boardPrefs.pieceAnimationDuration;
+    final animationDuration = shell.hasPieceAnimation
+        ? boardPrefs.pieceAnimationDuration
+        : Duration.zero;
 
     return FocusDetector(
       onFocusRegained: () {
@@ -480,7 +480,7 @@ class _PlayableGameBoardState extends ConsumerState<_PlayableGameBoard> {
 typedef _ShellData = ({
   Variant variant,
   Side youAre,
-  Speed speed,
+  bool hasPieceAnimation,
   bool zen,
   bool playable,
   bool canPremove,
@@ -498,7 +498,7 @@ _ShellData? _shellOf(AsyncValue<GameState> state) {
   return (
     variant: s.game.meta.variant,
     youAre: s.game.youAre ?? Side.white,
-    speed: s.game.meta.speed,
+    hasPieceAnimation: s.hasPieceAnimation,
     zen: s.isZenModeActive,
     playable: s.game.playable,
     canPremove: s.canPremove,


### PR DESCRIPTION
Before the sounds in bullet where not played instantly if played with tap to move or for opponents move.
