### PR TITLE
improve app startup time

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -1,3 +1,5 @@
+import 'dart:async';
+
 import 'package:flutter/foundation.dart';
 import 'package:flutter_native_splash/flutter_native_splash.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
@@ -18,9 +20,10 @@ Future<void> main() async {
   // See src/app.dart for splash screen removal
   FlutterNativeSplash.preserve(widgetsBinding: widgetsBinding);
 
-  await lichessBinding.preloadSharedPreferences();
-
-  await preloadPieceImages();
+  await Future.wait([
+    lichessBinding.preloadSharedPreferences(),
+    if (defaultTargetPlatform != TargetPlatform.linux) lichessBinding.initializeFirebase(),
+  ]);
 
   // Must run before [initializeApp], which uses the system colors to pick the default board theme
   // on first run.
@@ -28,17 +31,13 @@ Future<void> main() async {
     await androidDisplayInitialization(widgetsBinding);
   }
 
-  await initializeApp();
+  final locale = setupIntl(widgetsBinding);
 
-  await SoundService.initialize();
-
-  final locale = await setupIntl(widgetsBinding);
-
-  await initializeLocalNotifications(locale);
-
-  if (defaultTargetPlatform != TargetPlatform.linux) {
-    await lichessBinding.initializeFirebase();
-  }
+  // Background initialization tasks (non-blocking for first frame)
+  unawaited(preloadPieceImages());
+  unawaited(initializeApp());
+  unawaited(SoundService.initialize());
+  unawaited(initializeLocalNotifications(locale));
 
   runApp(
     ProviderScope(

--- a/lib/src/init.dart
+++ b/lib/src/init.dart
@@ -1,3 +1,4 @@
+import 'dart:async';
 import 'dart:convert';
 
 import 'package:flutter/services.dart';
@@ -128,6 +129,10 @@ Future<void> androidDisplayInitialization(WidgetsBinding widgetsBinding) async {
   );
 
   /// Enables high refresh rate for devices where it was previously disabled
+  unawaited(_setHighRefreshRate());
+}
+
+Future<void> _setHighRefreshRate() async {
   final List<DisplayMode> supported = await FlutterDisplayMode.supported;
   final DisplayMode active = await FlutterDisplayMode.active;
 

--- a/lib/src/intl.dart
+++ b/lib/src/intl.dart
@@ -14,7 +14,7 @@ Locale getSystemLocale(WidgetsBinding widgetsBinding) {
 }
 
 /// Setup [Intl.defaultLocale] and timeago locale and messages.
-Future<Locale> setupIntl(WidgetsBinding widgetsBinding) async {
+Locale setupIntl(WidgetsBinding widgetsBinding) {
   final systemLocale = getSystemLocale(widgetsBinding);
 
   // Get locale from shared preferences, if any

--- a/lib/src/model/common/preloaded_data.dart
+++ b/lib/src/model/common/preloaded_data.dart
@@ -1,3 +1,4 @@
+import 'dart:async';
 import 'dart:io' show Directory;
 
 import 'package:device_info_plus/device_info_plus.dart';
@@ -28,29 +29,25 @@ typedef PreloadedData = ({
 final preloadedDataProvider = FutureProvider<PreloadedData>((Ref ref) async {
   final authStorage = ref.read(authStorageProvider);
 
-  final pInfo = await PackageInfo.fromPlatform();
-  final deviceInfo = await DeviceInfoPlugin().deviceInfo;
+  final (
+    pInfo,
+    deviceInfo,
+    sri,
+    authUser,
+    physicalMemory,
+    appDocumentsDirectory,
+    appSupportDirectory,
+  ) = await (
+    PackageInfo.fromPlatform(),
+    DeviceInfoPlugin().deviceInfo,
+    _readOrCreateSri(),
+    authStorage.read(),
+    System.instance.getTotalRam(),
+    _getDirectoryOrNull(getApplicationDocumentsDirectory),
+    _getDirectoryOrNull(getApplicationSupportDirectory),
+  ).wait;
 
-  // Generate a socket random identifier and store it for the app lifetime
-  String? storedSri;
-  try {
-    storedSri = await SecureStorage.instance.read(key: kSRIStorageKey);
-    if (storedSri == null) {
-      final sri = genRandomString(12);
-      await SecureStorage.instance.write(key: kSRIStorageKey, value: sri);
-      storedSri = sri;
-    }
-  } on PlatformException catch (_) {
-    // Clear all secure storage if an error occurs because it probably means the key has
-    // been lost
-    await SecureStorage.instance.deleteAll();
-  }
-
-  final sri = storedSri ?? genRandomString(12);
-
-  AuthUser? authUser = await authStorage.read();
   final token = authUser?.token;
-
   if (token != null) {
     final userAgent = makeUserAgent(pInfo, deviceInfo, sri, null);
     final client = DefaultClient(ref.read(httpClientFactoryProvider)(), userAgent: userAgent);
@@ -61,7 +58,6 @@ final preloadedDataProvider = FutureProvider<PreloadedData>((Ref ref) async {
           final isValid = data[token] != null;
           if (!isValid) {
             authStorage.delete();
-            authUser = null;
           }
         })
         .catchError((_) {
@@ -72,18 +68,7 @@ final preloadedDataProvider = FutureProvider<PreloadedData>((Ref ref) async {
         });
   }
 
-  final physicalMemory = await System.instance.getTotalRam() ?? 256.0;
-  final engineMaxMemory = (physicalMemory / 10).ceil();
-
-  Directory? appDocumentsDirectory;
-  try {
-    appDocumentsDirectory = await getApplicationDocumentsDirectory();
-  } catch (_) {}
-
-  Directory? appSupportDirectory;
-  try {
-    appSupportDirectory = await getApplicationSupportDirectory();
-  } catch (_) {}
+  final engineMaxMemory = ((physicalMemory ?? 256.0) / 10).ceil();
 
   return (
     packageInfo: pInfo,
@@ -95,3 +80,30 @@ final preloadedDataProvider = FutureProvider<PreloadedData>((Ref ref) async {
     appSupportDirectory: appSupportDirectory,
   );
 }, name: 'PreloadedDataProvider');
+
+/// Reads the stored socket random identifier, generating and persisting a
+/// new one if none exists yet or if secure storage turns out to be
+/// unreadable.
+Future<String> _readOrCreateSri() async {
+  try {
+    final storedSri = await SecureStorage.instance.read(key: kSRIStorageKey);
+    if (storedSri != null) return storedSri;
+    final newSri = genRandomString(12);
+    await SecureStorage.instance.write(key: kSRIStorageKey, value: newSri);
+    return newSri;
+  } on PlatformException catch (_) {
+    // Clear all secure storage if an error occurs because it probably means
+    // the key has been lost.
+    await SecureStorage.instance.deleteAll();
+    return genRandomString(12);
+  }
+}
+
+/// Runs [getDirectory], returning `null` instead of throwing if it fails.
+Future<Directory?> _getDirectoryOrNull(Future<Directory> Function() getDirectory) async {
+  try {
+    return await getDirectory();
+  } catch (_) {
+    return null;
+  }
+}

--- a/lib/src/utils/chessboard.dart
+++ b/lib/src/utils/chessboard.dart
@@ -23,10 +23,10 @@ Future<void> precachePieceImages(PieceSet pieceSet) async {
 
     ChessgroundImages.instance.clear();
 
-    for (final asset in pieceSet.assets.values) {
-      await ChessgroundImages.instance.load(asset, devicePixelRatio: devicePixelRatio);
-      debugPrint('Preloaded piece image: ${asset.assetName}');
-    }
+    await Future.wait([
+      for (final asset in pieceSet.assets.values)
+        ChessgroundImages.instance.load(asset, devicePixelRatio: devicePixelRatio),
+    ]);
   } catch (e) {
     debugPrint('Failed to preload piece images: $e');
   }


### PR DESCRIPTION
Improves the dart initialization, mostly by switching to .wait when waiting for multiple futures instead of a sequence of await statements. https://dart.dev/libraries/dart-async#waiting-for-multiple-futures
Made tasks that are not blocking the initial homepage frame (`SoundService.initialize()`,` initializeLocalNotifications()`, `initializeApp()`) asynchronous without awaiting to reach `runApp` faster.
Made  `setupIntl` synchronous as nothing in the function has a future.

Tested on 2 physical devices with 10 cold starts each (`adb shell am start-activity -W`) in` --profile` mode:

```
Old code on Pixel6a
----------------------------------------
Results across 10 runs:
  Average: 1180 ms
  Min:     1154 ms
  Max:     1212 ms
----------------------------------------

New code on Pixel6a
----------------------------------------
Results across 10 runs:
  Average: 949 ms
  Min:     914 ms
  Max:     969 ms
----------------------------------------

Old Code on Nothing Phone 3a Pro
----------------------------------------
Results across 10 runs:
  Average: 1891 ms
  Min:     1784 ms
  Max:     2079 ms
----------------------------------------

New Code on Nothing Phone 3a Pro:
----------------------------------------
Results across 10 runs:
  Average: 1468 ms
  Min:     1406 ms
  Max:     1526 ms
----------------------------------------
```
Changes made working closely with AI (copilot and Gemini chat), all changes pushed here are reviewed and verified by myself.
Definitely needs to be tested on iOS too.
