### PR TITLE
Fix blank checkbox in home widgets settings

### DIFF
--- a/lib/src/view/home/home_tab_screen.dart
+++ b/lib/src/view/home/home_tab_screen.dart
@@ -183,6 +183,17 @@ class _HomeScreenState extends ConsumerState<HomeTabScreen> {
                 ? ref.watch(followingCarouselProvider)
                 : const AsyncValue.data(IListConst<FollowingUser>([]));
 
+            // Widgets whose content can be empty should not show a checkbox in
+            // edit mode when there is nothing to display next to it.
+            final hasFeaturedTournaments = featuredTournaments.maybeWhen(
+              data: (tournaments) => tournaments.any((t) => t.isSupportedInApp),
+              orElse: () => true,
+            );
+            final hasFollowing = followingAsync.maybeWhen(
+              data: (following) => following.isNotEmpty,
+              orElse: () => true,
+            );
+
             final isKidMode = ref.watch(kidModeProvider).value ?? false;
 
             // Show the welcome screen if not logged in and there are no recent games and no stored games
@@ -264,7 +275,7 @@ class _HomeScreenState extends ConsumerState<HomeTabScreen> {
                     ),
                   _EditableWidget(
                     widget: HomeEditableWidget.featuredTournaments,
-                    shouldShow: hasServerContent,
+                    shouldShow: hasServerContent && hasFeaturedTournaments,
                     child: FeaturedTournamentsWidget(featured: featuredTournaments),
                   ),
                   if (_worker != null && !isKidMode)
@@ -295,7 +306,7 @@ class _HomeScreenState extends ConsumerState<HomeTabScreen> {
                   ),
                 _EditableWidget(
                   widget: HomeEditableWidget.friends,
-                  shouldShow: authUser != null && hasServerContent,
+                  shouldShow: authUser != null && hasServerContent && hasFollowing,
                   child: FollowingCarousel(followingAsync),
                 ),
                 Row(
@@ -369,7 +380,7 @@ class _HomeScreenState extends ConsumerState<HomeTabScreen> {
                 ),
                 _EditableWidget(
                   widget: HomeEditableWidget.friends,
-                  shouldShow: authUser != null && hasServerContent,
+                  shouldShow: authUser != null && hasServerContent && hasFollowing,
                   child: FollowingCarousel(followingAsync),
                 ),
                 _EditableWidget(
@@ -389,7 +400,7 @@ class _HomeScreenState extends ConsumerState<HomeTabScreen> {
                 ),
                 _EditableWidget(
                   widget: HomeEditableWidget.featuredTournaments,
-                  shouldShow: hasServerContent,
+                  shouldShow: hasServerContent && hasFeaturedTournaments,
                   child: FeaturedTournamentsWidget(featured: featuredTournaments),
                 ),
                 if (_worker != null && !isKidMode)

--- a/test/mock_server_responses.dart
+++ b/test/mock_server_responses.dart
@@ -77,3 +77,25 @@ String mockAccountOngoingGamesResponse() => '''
   ]
 }
 ''';
+
+/// Mock server response for /tournament/featured endpoint.
+const mockFeaturedTournamentsResponse = '''
+{
+  "featured": [
+    {
+      "id": "AbCdEfGh",
+      "fullName": "Hourly Blitz Arena",
+      "clock": {"limit": 300, "increment": 0},
+      "rated": true,
+      "createdBy": "lichess",
+      "minutes": 57,
+      "perf": {"key": "blitz", "name": "Blitz", "position": 1},
+      "schedule": {"freq": "hourly", "speed": "blitz"},
+      "variant": "standard",
+      "startsAt": 1700000000000,
+      "finishesAt": 1700003420000,
+      "nbPlayers": 100
+    }
+  ]
+}
+''';

--- a/test/view/home/home_tab_screen_test.dart
+++ b/test/view/home/home_tab_screen_test.dart
@@ -17,6 +17,7 @@ import 'package:lichess_mobile/src/view/game/game_list_tile.dart';
 import 'package:lichess_mobile/src/view/home/games_carousel.dart';
 import 'package:lichess_mobile/src/view/home/home_tab_screen.dart';
 import 'package:lichess_mobile/src/view/play/quick_game_matrix.dart';
+import 'package:lichess_mobile/src/view/tournament/tournament_list_screen.dart';
 import 'package:lichess_mobile/src/widgets/buttons.dart';
 import 'package:lichess_mobile/src/widgets/feedback.dart';
 import 'package:lichess_mobile/src/widgets/platform.dart';
@@ -238,6 +239,73 @@ void main() {
       expect(find.text('Recent games'), findsNothing);
       expect(find.text('1 game in play'), findsOneWidget);
       expect(find.byType(OngoingGameCarouselItem), findsOneWidget);
+    });
+
+    group('home widgets edit mode', () {
+      testWidgets('featured tournaments checkbox is hidden when there are none to show', (
+        tester,
+      ) async {
+        final mockClient = MockClient((request) {
+          if (request.url.path == '/tournament/featured') {
+            return mockResponse('{"featured":[]}', 200);
+          }
+          return mockResponse('', 200);
+        });
+        final app = await makeTestProviderScope(
+          tester,
+          child: const Application(),
+          defaultPreferences: {kWelcomeMessageShownKey: true},
+          overrides: {
+            httpClientFactoryProvider: httpClientFactoryProvider.overrideWith(
+              (ref) => FakeHttpClientFactory(() => mockClient),
+            ),
+          },
+        );
+        await tester.pumpWidget(app);
+
+        // wait for connectivity
+        expect(find.byType(CircularProgressIndicator), findsOneWidget);
+        await tester.pumpAndSettle();
+
+        await tester.tap(find.text('Customize'));
+        await tester.pumpAndSettle(); // wait for settings screen to open
+
+        expect(find.widgetWithText(PlatformAppBar, 'Home widgets'), findsOneWidget);
+        expect(find.byType(FeaturedTournamentsWidget), findsNothing);
+      });
+
+      testWidgets('featured tournaments checkbox is shown when there are some to show', (
+        tester,
+      ) async {
+        final mockClient = MockClient((request) {
+          if (request.url.path == '/tournament/featured') {
+            return mockResponse(mockFeaturedTournamentsResponse, 200);
+          }
+          return mockResponse('', 200);
+        });
+        final app = await makeTestProviderScope(
+          tester,
+          child: const Application(),
+          defaultPreferences: {kWelcomeMessageShownKey: true},
+          overrides: {
+            httpClientFactoryProvider: httpClientFactoryProvider.overrideWith(
+              (ref) => FakeHttpClientFactory(() => mockClient),
+            ),
+          },
+        );
+        await tester.pumpWidget(app);
+
+        // wait for connectivity
+        expect(find.byType(CircularProgressIndicator), findsOneWidget);
+        await tester.pumpAndSettle();
+
+        await tester.tap(find.text('Customize'));
+        await tester.pumpAndSettle(); // wait for settings screen to open
+
+        expect(find.widgetWithText(PlatformAppBar, 'Home widgets'), findsOneWidget);
+        expect(find.byType(FeaturedTournamentsWidget), findsOneWidget);
+        expect(find.text('Open tournaments'), findsOneWidget);
+      });
     });
   });
 


### PR DESCRIPTION
The "Home widgets" settings screen can show a checkbox with nothing next to it — here between Quick pairing and Blog:

<img src="https://raw.githubusercontent.com/philyawj/mobile/pr-assets/lichess-empty-chess.png" width="320" alt="Home widgets settings screen showing a checkbox with no content next to it" />

**Cause:** in edit mode, `_EditableWidget` always renders a checkbox beside the widget's own content — the content is the row's only label. When that content renders as `SizedBox.shrink()`, the checkbox is left floating. In the screenshot that's the featured tournaments widget: `FeaturedTournamentsWidget` shrinks when no featured tournament is supported by the app, but its `shouldShow` is only `hasServerContent`. The friends carousel has the same problem when the user follows no one.

**Fix:** gate `shouldShow` for those two widgets on actually having content. Loading and error states are unchanged (shimmer / error text still show). Added widget tests covering both states of the tournaments case.

I couldn't find an existing issue or open PR about this. Feel free to push changes to this branch if you'd like it done differently.

AI disclosure: this fix was made with Claude Code (Claude Fable 5), targeting this isolated problem; I reviewed the change.