### PR TITLE
study: add player names and clocks from PGN dataa

### DIFF
--- a/lib/src/model/analysis/analysis_controller.dart
+++ b/lib/src/model/analysis/analysis_controller.dart
@@ -8,7 +8,6 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:freezed_annotation/freezed_annotation.dart';
 import 'package:intl/intl.dart';
 import 'package:lichess_mobile/src/model/account/account_service.dart';
-import 'package:lichess_mobile/src/model/analysis/analysis_player.dart';
 import 'package:lichess_mobile/src/model/analysis/analysis_preferences.dart';
 import 'package:lichess_mobile/src/model/analysis/common_analysis_state.dart';
 import 'package:lichess_mobile/src/model/analysis/forecast.dart';
@@ -941,14 +940,6 @@ sealed class AnalysisState
     serverEval: currentNode.serverEval,
     filters: (id: evaluationContext.id, path: currentPath),
   );
-
-  /// Creates an AnalysisPlayer from PGN headers for the given side.
-  ///
-  /// Used for pgn analysis to display player names and ratings if provided in the PGN.
-  AnalysisPlayer? playerFromPgnHeaders(Side side) {
-    if (archivedGame != null) return null;
-    return AnalysisPlayer.fromPgnHeaders(pgnHeaders, side);
-  }
 }
 
 @freezed

--- a/lib/src/model/analysis/analysis_player.dart
+++ b/lib/src/model/analysis/analysis_player.dart
@@ -12,8 +12,12 @@ part 'analysis_player.freezed.dart';
 sealed class AnalysisPlayer with _$AnalysisPlayer {
   const AnalysisPlayer._();
 
-  const factory AnalysisPlayer({required String name, String? title, int? rating}) =
-      _AnalysisPlayer;
+  const factory AnalysisPlayer({
+    required String name,
+    required Side side,
+    String? title,
+    int? rating,
+  }) = _AnalysisPlayer;
 
   /// Creates an AnalysisPlayer from PGN headers for the given side.
   ///
@@ -30,6 +34,6 @@ sealed class AnalysisPlayer with _$AnalysisPlayer {
     final eloStr = pgnHeaders.get(eloKey);
     final rating = eloStr != null ? int.tryParse(eloStr) : null;
 
-    return AnalysisPlayer(name: name, title: title, rating: rating);
+    return AnalysisPlayer(name: name, side: side, title: title, rating: rating);
   }
 }

--- a/lib/src/model/study/study_controller.dart
+++ b/lib/src/model/study/study_controller.dart
@@ -191,6 +191,7 @@ class StudyController extends AsyncNotifier<StudyState>
         variant: variant,
         study: study,
         currentPath: UciPath.empty,
+        clocks: null,
         isOnMainline: true,
         root: null,
         currentNode: StudyCurrentNode.illegalPosition(),
@@ -233,6 +234,7 @@ class StudyController extends AsyncNotifier<StudyState>
       variant: variant,
       study: study,
       currentPath: currentPath,
+      clocks: _getClocks(currentPath),
       isOnMainline: true,
       root: _root.view,
       currentNode: StudyCurrentNode.fromNode(_root),
@@ -559,6 +561,7 @@ class StudyController extends AsyncNotifier<StudyState>
       this.state = AsyncValue.data(
         state.copyWith(
           currentPath: path,
+          clocks: _getClocks(path),
           isOnMainline: _root.isOnMainline(path),
           currentNode: StudyCurrentNode.fromNode(currentNode),
           currentBranchOpening: branchOpening,
@@ -570,6 +573,7 @@ class StudyController extends AsyncNotifier<StudyState>
       this.state = AsyncValue.data(
         state.copyWith(
           currentPath: path,
+          clocks: _getClocks(path),
           isOnMainline: _root.isOnMainline(path),
           currentNode: StudyCurrentNode.fromNode(currentNode),
           currentBranchOpening: branchOpening,
@@ -601,6 +605,16 @@ class StudyController extends AsyncNotifier<StudyState>
             : null,
         root: _root.view,
       ),
+    );
+  }
+
+  ({Duration? parentClock, Duration? clock}) _getClocks(UciPath path) {
+    final node = _root.nodeAt(path);
+    final parent = _root.parentAt(path);
+
+    return (
+      parentClock: (parent is Branch) ? parent.clock : null,
+      clock: (node is Branch) ? node.clock : null,
     );
   }
 }
@@ -659,6 +673,9 @@ sealed class StudyState
 
     /// Whether local evaluation is allowed for this study.
     required bool isComputerAnalysisAllowed,
+
+    /// Clocks if available.
+    required ({Duration? parentClock, Duration? clock})? clocks,
 
     /// Whether we're currently in gamebook mode, where the user has to find the right moves.
     required bool gamebookActive,

--- a/lib/src/view/analysis/analysis_player_widget.dart
+++ b/lib/src/view/analysis/analysis_player_widget.dart
@@ -1,0 +1,177 @@
+import 'package:dartchess/dartchess.dart';
+import 'package:fast_immutable_collections/fast_immutable_collections.dart';
+import 'package:lichess_mobile/src/model/analysis/analysis_controller.dart';
+import 'package:lichess_mobile/src/model/analysis/analysis_player.dart';
+import 'package:lichess_mobile/src/styles/styles.dart';
+import 'package:lichess_mobile/src/utils/duration.dart';
+import 'package:lichess_mobile/src/view/analysis/analysis_layout.dart';
+import 'package:material_ui/material_ui.dart';
+
+({PgnPlayerWidget? white, PgnPlayerWidget? black}) playerWidgetsFromPgnHeaders({
+  required IMap<String, String> pgnHeaders,
+  required Side sideToMove,
+  required Duration? whiteClock,
+  required Duration? blackClock,
+}) {
+  final whitePlayer = AnalysisPlayer.fromPgnHeaders(pgnHeaders, Side.white);
+  final blackPlayer = AnalysisPlayer.fromPgnHeaders(pgnHeaders, Side.black);
+
+  if (whitePlayer != null || blackPlayer != null) {
+    final resultString = pgnHeaders.get('Result');
+    final result = resultString != null
+        ? AnalysisGameResult.resultFromPgnResult(resultString)
+        : null;
+
+    return (
+      white: whitePlayer != null
+          ? PgnPlayerWidget(
+              player: whitePlayer,
+              result: result,
+              isSideToMove: sideToMove == Side.white,
+              clock: whiteClock,
+            )
+          : null,
+      black: blackPlayer != null
+          ? PgnPlayerWidget(
+              player: blackPlayer,
+              result: result,
+              isSideToMove: sideToMove == Side.black,
+              clock: blackClock,
+            )
+          : null,
+    );
+  }
+
+  return (white: null, black: null);
+}
+
+/// Player widget for PGN imports, displaying analysis player info
+class PgnPlayerWidget extends StatelessWidget {
+  const PgnPlayerWidget({
+    required this.player,
+    required this.isSideToMove,
+    required this.result,
+    this.clock,
+  });
+
+  final AnalysisPlayer player;
+  final Duration? clock;
+  final bool isSideToMove;
+  final AnalysisGameResult? result;
+
+  @override
+  Widget build(BuildContext context) {
+    return AnalysisPlayerWidget(
+      side: player.side,
+      result: result,
+      clock: clock,
+      isSideToMove: isSideToMove,
+      playerNameWidget: Row(
+        children: [
+          if (player.title != null) ...[
+            Text(
+              player.title!,
+              style: TextStyle(
+                color: (player.title == 'BOT')
+                    ? context.lichessColors.fancy
+                    : context.lichessColors.brag,
+                fontWeight: .bold,
+              ),
+            ),
+            const SizedBox(width: 5),
+          ],
+          Row(
+            mainAxisSize: MainAxisSize.min,
+            children: [
+              Text(
+                player.name,
+                style: const TextStyle(fontWeight: .bold),
+                overflow: .ellipsis,
+              ),
+              if (player.rating != null) ...[
+                const SizedBox(width: 5),
+                Text(
+                  player.rating.toString(),
+                  overflow: .ellipsis,
+                  style: TextStyle(fontWeight: FontWeight.w400, color: textShade(context, 0.8)),
+                ),
+              ],
+            ],
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+class AnalysisPlayerWidget extends StatelessWidget {
+  const AnalysisPlayerWidget({
+    required this.playerNameWidget,
+    required this.result,
+    required this.side,
+    required this.isSideToMove,
+    required this.clock,
+  });
+
+  final Widget playerNameWidget;
+  final AnalysisGameResult? result;
+  final Side side;
+  final Duration? clock;
+  final bool isSideToMove;
+
+  @override
+  Widget build(BuildContext context) {
+    final resultString = result?.resultToString(side);
+    final colorScheme = ColorScheme.of(context);
+    return Container(
+      height: kAnalysisBoardHeaderOrFooterHeight,
+      padding: const EdgeInsets.only(left: 8.0),
+      child: Row(
+        children: [
+          Expanded(
+            child: Row(
+              children: [
+                if (resultString != null) ...[
+                  Text(
+                    resultString,
+                    style: TextStyle(
+                      fontWeight: .bold,
+                      color: switch (result!) {
+                        AnalysisGameResult.whiteWins =>
+                          side == Side.white
+                              ? context.lichessColors.good
+                              : context.lichessColors.error,
+                        AnalysisGameResult.blackWins =>
+                          side == Side.white
+                              ? context.lichessColors.error
+                              : context.lichessColors.good,
+                        _ => null,
+                      },
+                    ),
+                  ),
+                  const SizedBox(width: 16.0),
+                ],
+                playerNameWidget,
+              ],
+            ),
+          ),
+          if (clock != null)
+            Container(
+              height: kAnalysisBoardHeaderOrFooterHeight,
+              padding: const EdgeInsets.symmetric(horizontal: 8.0),
+              color: isSideToMove ? colorScheme.secondaryContainer : null,
+              child: Center(
+                child: Text(
+                  clock!.toHoursMinutesSeconds(showTenths: clock! < const Duration(minutes: 1)),
+                  style: TextStyle(
+                    color: isSideToMove ? colorScheme.onSecondaryContainer : null,
+                    fontFeatures: const [FontFeature.tabularFigures()],
+                  ),
+                ),
+              ),
+            ),
+        ],
+      ),
+    );
+  }
+}

--- a/lib/src/view/analysis/analysis_screen.dart
+++ b/lib/src/view/analysis/analysis_screen.dart
@@ -3,14 +3,11 @@ import 'package:dartchess/dartchess.dart';
 import 'package:fast_immutable_collections/fast_immutable_collections.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:lichess_mobile/src/model/analysis/analysis_controller.dart';
-import 'package:lichess_mobile/src/model/analysis/analysis_player.dart';
 import 'package:lichess_mobile/src/model/analysis/analysis_preferences.dart';
 import 'package:lichess_mobile/src/model/auth/auth_controller.dart';
 import 'package:lichess_mobile/src/model/common/chess.dart';
 import 'package:lichess_mobile/src/model/engine/evaluation_preferences.dart';
 import 'package:lichess_mobile/src/model/game/player.dart';
-import 'package:lichess_mobile/src/styles/styles.dart';
-import 'package:lichess_mobile/src/utils/duration.dart';
 import 'package:lichess_mobile/src/utils/focus_detector.dart';
 import 'package:lichess_mobile/src/utils/immersive_mode.dart';
 import 'package:lichess_mobile/src/utils/l10n_context.dart';
@@ -18,6 +15,7 @@ import 'package:lichess_mobile/src/utils/navigation.dart';
 import 'package:lichess_mobile/src/utils/share.dart';
 import 'package:lichess_mobile/src/view/analysis/analysis_actions.dart';
 import 'package:lichess_mobile/src/view/analysis/analysis_layout.dart';
+import 'package:lichess_mobile/src/view/analysis/analysis_player_widget.dart';
 import 'package:lichess_mobile/src/view/analysis/analysis_settings_screen.dart';
 import 'package:lichess_mobile/src/view/analysis/analysis_share_screen.dart';
 import 'package:lichess_mobile/src/view/analysis/conditional_premoves.dart';
@@ -45,16 +43,6 @@ import 'package:lichess_mobile/src/widgets/variant_app_bar_title.dart';
 import 'package:logging/logging.dart';
 import 'package:material_ui/material_ui.dart';
 import 'package:share_plus/share_plus.dart';
-
-extension _AnalysisGameResultColor on AnalysisGameResult {
-  Color? colorFor(Side side, BuildContext context) => switch (this) {
-    AnalysisGameResult.whiteWins =>
-      side == Side.white ? context.lichessColors.good : context.lichessColors.error,
-    AnalysisGameResult.blackWins =>
-      side == Side.white ? context.lichessColors.error : context.lichessColors.good,
-    _ => null,
-  };
-}
 
 final _logger = Logger('AnalysisScreen');
 
@@ -219,46 +207,31 @@ class _Body extends ConsumerWidget {
       final result = resultString != null
           ? AnalysisGameResult.resultFromPgnResult(resultString)
           : null;
-      boardFooter = _PlayerWidget(
-        player: footerPlayer,
+      boardFooter = AnalysisPlayerWidget(
+        playerNameWidget: _PlayerName(player: footerPlayer),
         clock: footerClock,
         isSideToMove: analysisState.currentPosition.turn == pov,
-        result: result?.resultToString(pov),
-        resultColor: result?.colorFor(pov, context),
+        result: result,
+        side: pov,
       );
-      boardHeader = _PlayerWidget(
-        player: headerPlayer,
+      boardHeader = AnalysisPlayerWidget(
+        playerNameWidget: _PlayerName(player: headerPlayer),
         clock: headerClock,
         isSideToMove: analysisState.currentPosition.turn == pov.opposite,
-        result: result?.resultToString(pov.opposite),
-        resultColor: result?.colorFor(pov.opposite, context),
+        result: result,
+        side: pov.opposite,
       );
     } else if (options case Pgn()) {
-      // PGN analysis - try to get player info from PGN headers
-      final footerPlayer = analysisState.playerFromPgnHeaders(pov);
-      final headerPlayer = analysisState.playerFromPgnHeaders(pov.opposite);
+      final playerWidgets = playerWidgetsFromPgnHeaders(
+        pgnHeaders: analysisState.pgnHeaders,
+        sideToMove: analysisState.currentPosition.turn,
+        whiteClock: null,
+        blackClock: null,
+      );
 
-      if (footerPlayer != null || headerPlayer != null) {
-        final resultString = analysisState.pgnHeaders.get('Result');
-        final result = resultString != null
-            ? AnalysisGameResult.resultFromPgnResult(resultString)
-            : null;
-
-        boardFooter = footerPlayer != null
-            ? _AnalysisPlayerWidget(
-                player: footerPlayer,
-                result: result?.resultToString(pov),
-                resultColor: result?.colorFor(pov, context),
-              )
-            : null;
-        boardHeader = headerPlayer != null
-            ? _AnalysisPlayerWidget(
-                player: headerPlayer,
-                result: result?.resultToString(pov.opposite),
-                resultColor: result?.colorFor(pov.opposite, context),
-              )
-            : null;
-      }
+      (boardFooter, boardHeader) = pov == Side.white
+          ? (playerWidgets.white, playerWidgets.black)
+          : (playerWidgets.black, playerWidgets.white);
     }
 
     return FocusDetector(
@@ -354,81 +327,25 @@ class _Body extends ConsumerWidget {
   }
 }
 
-class _PlayerWidget extends StatelessWidget {
-  const _PlayerWidget({
-    required this.player,
-    required this.clock,
-    required this.isSideToMove,
-    this.result,
-    this.resultColor,
-  });
+class _PlayerName extends StatelessWidget {
+  const _PlayerName({required this.player});
 
   final Player player;
-  final Duration? clock;
-  final String? result;
-  final Color? resultColor;
-  final bool isSideToMove;
 
   @override
   Widget build(BuildContext context) {
-    return Container(
-      height: kAnalysisBoardHeaderOrFooterHeight,
-      padding: const EdgeInsets.only(left: 8.0),
-      child: Row(
-        children: [
-          if (result != null) ...[
-            Text(
-              result!,
-              style: TextStyle(fontWeight: FontWeight.bold, color: resultColor),
-            ),
-            const SizedBox(width: 16.0),
-          ],
-          if (player.user != null)
-            Expanded(
-              child: UserFullNameWidget.player(
-                user: player.user,
-                name: player.name,
-                rating: player.rating,
-                ratingDiff: player.ratingDiff,
-                provisional: player.provisional,
-                aiLevel: player.aiLevel,
-                style: const TextStyle(fontWeight: FontWeight.bold),
-                onTap: () =>
-                    Navigator.of(context).push(UserOrProfileScreen.buildRoute(player.user!)),
-              ),
-            )
-          else
-            Expanded(child: Text(player.fullName(context.l10n))),
-          if (clock != null) _Clock(timeLeft: clock!, isSideToMove: isSideToMove),
-        ],
-      ),
-    );
-  }
-}
-
-class _Clock extends StatelessWidget {
-  const _Clock({required this.timeLeft, required this.isSideToMove});
-
-  final Duration timeLeft;
-  final bool isSideToMove;
-
-  @override
-  Widget build(BuildContext context) {
-    final colorScheme = ColorScheme.of(context);
-    return Container(
-      height: kAnalysisBoardHeaderOrFooterHeight,
-      padding: const EdgeInsets.symmetric(horizontal: 8.0),
-      color: isSideToMove ? colorScheme.secondaryContainer : null,
-      child: Center(
-        child: Text(
-          timeLeft.toHoursMinutesSeconds(showTenths: timeLeft < const Duration(minutes: 1)),
-          style: TextStyle(
-            color: isSideToMove ? colorScheme.onSecondaryContainer : null,
-            fontFeatures: const [FontFeature.tabularFigures()],
-          ),
-        ),
-      ),
-    );
+    return player.user != null
+        ? UserFullNameWidget.player(
+            user: player.user,
+            name: player.name,
+            rating: player.rating,
+            ratingDiff: player.ratingDiff,
+            provisional: player.provisional,
+            aiLevel: player.aiLevel,
+            style: const TextStyle(fontWeight: FontWeight.bold),
+            onTap: () => Navigator.of(context).push(UserOrProfileScreen.buildRoute(player.user!)),
+          )
+        : Text(player.fullName(context.l10n));
   }
 }
 
@@ -733,61 +650,6 @@ class _AnalysisMenu extends ConsumerWidget {
             },
           ),
       ],
-    );
-  }
-}
-
-/// Player widget for PGN imports, displaying analysis player info
-class _AnalysisPlayerWidget extends StatelessWidget {
-  const _AnalysisPlayerWidget({required this.player, this.result, this.resultColor});
-
-  final AnalysisPlayer player;
-  final String? result;
-  final Color? resultColor;
-
-  @override
-  Widget build(BuildContext context) {
-    return Container(
-      height: kAnalysisBoardHeaderOrFooterHeight,
-      padding: const EdgeInsets.only(left: 8.0),
-      child: Row(
-        children: [
-          if (result != null) ...[
-            Text(
-              result!,
-              style: TextStyle(fontWeight: .bold, color: resultColor),
-            ),
-            const SizedBox(width: 16.0),
-          ],
-          if (player.title != null) ...[
-            Text(
-              player.title!,
-              style: TextStyle(
-                color: (player.title == 'BOT')
-                    ? context.lichessColors.fancy
-                    : context.lichessColors.brag,
-                fontWeight: .bold,
-              ),
-            ),
-            const SizedBox(width: 5),
-          ],
-          Flexible(
-            child: Text(
-              player.name,
-              style: const TextStyle(fontWeight: .bold),
-              overflow: .ellipsis,
-            ),
-          ),
-          if (player.rating != null) ...[
-            const SizedBox(width: 5),
-            Text(
-              player.rating.toString(),
-              overflow: .ellipsis,
-              style: TextStyle(fontWeight: FontWeight.w400, color: textShade(context, 0.8)),
-            ),
-          ],
-        ],
-      ),
     );
   }
 }

--- a/lib/src/view/study/study_screen.dart
+++ b/lib/src/view/study/study_screen.dart
@@ -20,6 +20,7 @@ import 'package:lichess_mobile/src/utils/navigation.dart';
 import 'package:lichess_mobile/src/utils/share.dart';
 import 'package:lichess_mobile/src/view/analysis/analysis_board.dart';
 import 'package:lichess_mobile/src/view/analysis/analysis_layout.dart';
+import 'package:lichess_mobile/src/view/analysis/analysis_player_widget.dart';
 import 'package:lichess_mobile/src/view/analysis/server_analysis.dart';
 import 'package:lichess_mobile/src/view/engine/engine_gauge.dart';
 import 'package:lichess_mobile/src/view/engine/engine_lines.dart';
@@ -407,6 +408,17 @@ class _Body extends ConsumerWidget {
         ? StudyGamebook(options)
         : StudyTreeView(options, showTopDivider: tabs.length == 1);
 
+    final playerWidgets = playerWidgetsFromPgnHeaders(
+      pgnHeaders: studyState.pgnHeaders,
+      sideToMove: studyState.currentPosition?.turn ?? Side.white,
+      whiteClock: studyState.currentPosition?.turn == Side.white
+          ? studyState.clocks?.parentClock
+          : studyState.clocks?.clock,
+      blackClock: studyState.currentPosition?.turn == Side.black
+          ? studyState.clocks?.parentClock
+          : studyState.clocks?.clock,
+    );
+
     return AnalysisLayout(
       tabController: tabController,
       pov: pov,
@@ -414,6 +426,8 @@ class _Body extends ConsumerWidget {
       boardBuilder: (context, boardSize, borderRadius) =>
           StudyAnalysisBoard(options: options, boardSize: boardSize, boardRadius: borderRadius),
       smallBoard: studyPrefs.smallBoard,
+      boardHeader: pov == Side.white ? playerWidgets.black : playerWidgets.white,
+      boardFooter: pov == Side.white ? playerWidgets.white : playerWidgets.black,
       engineGaugeBuilder:
           isComputerAnalysisAllowed && showEvaluationGauge && engineGaugeParams != null
           ? (context) {

--- a/test/view/study/study_screen_test.dart
+++ b/test/view/study/study_screen_test.dart
@@ -796,6 +796,52 @@ void main() {
     ]);
   });
 
+  testWidgets('Displays PGN player names and clocks', (WidgetTester tester) async {
+    final mockRepository = MockStudyRepository();
+    when(() => mockRepository.getStudy(id: testId)).thenAnswer(
+      (_) async => (
+        makeStudy(
+          chapter: makeChapter(
+            id: const StudyChapterId('1'),
+            orientation: Side.white,
+            gamebook: false,
+          ),
+        ),
+        null,
+        '''
+[White "Magnus"]
+[Black "Hikaru"]
+[Result "1-0"]
+
+1. e4 { [%clk 0:10:00] } e5 { [%clk 0:10:00] } 2. Nf3 { [%clk 0:09:50] } 1-0
+''',
+      ),
+    );
+
+    final app = await makeTestProviderScopeApp(
+      tester,
+      home: const StudyScreen(options: (id: testId, initialChapter: null)),
+      overrides: {
+        studyRepositoryProvider: studyRepositoryProvider.overrideWith((ref) => mockRepository),
+      },
+    );
+    await tester.pumpWidget(app);
+    // Wait for study to load
+    await tester.pumpAndSettle();
+
+    await playMove(tester, 'e2', 'e4');
+    await playMove(tester, 'e7', 'e5');
+    await playMove(tester, 'g1', 'f3');
+
+    final whiteFooter = find.byKey(const ValueKey(Side.white));
+    expect(find.descendant(of: whiteFooter, matching: find.text('Magnus')), findsOneWidget);
+    expect(find.descendant(of: whiteFooter, matching: find.text('09:50')), findsOneWidget);
+
+    final blackHeader = find.byKey(const ValueKey(Side.black));
+    expect(find.descendant(of: blackHeader, matching: find.text('Hikaru')), findsOneWidget);
+    expect(find.descendant(of: blackHeader, matching: find.text('10:00')), findsOneWidget);
+  });
+
   testWidgets('Displays correct annotation for castling on correct square', (
     WidgetTester tester,
   ) async {


### PR DESCRIPTION
Like analysis of imported PGNs already does, this adds player names and their clocks to the header/footer of the board in studies.

I also did some refactoring to share most of the code between AnalysisScreen and StudyScreen for this.

<img width="540" height="1212" alt="Screenshot_1787861815" src="https://github.com/user-attachments/assets/d326530e-8e02-46eb-bf3f-4704af17e98a" />
