### PR TITLE
analysis: copy the main line or variation PGN from the move menu

### DIFF
--- a/lib/src/model/analysis/analysis_controller.dart
+++ b/lib/src/model/analysis/analysis_controller.dart
@@ -551,6 +551,13 @@ class AnalysisController extends AsyncNotifier<AnalysisState>
     _setPath(path.penultimate, shouldRecomputeRootView: true);
   }
 
+  @override
+  String makeLinePgn(UciPath path, {required bool includeVariations}) => _root.makeLinePgn(
+    path,
+    variant: state.requireValue.variant,
+    includeVariations: includeVariations,
+  );
+
   void addCurrentPathAsPremove() {
     state = AsyncData(
       state.requireValue.copyWith(

--- a/lib/src/model/broadcast/broadcast_analysis_controller.dart
+++ b/lib/src/model/broadcast/broadcast_analysis_controller.dart
@@ -420,6 +420,13 @@ class BroadcastAnalysisController extends AsyncNotifier<BroadcastAnalysisState>
     _setPath(path.penultimate, shouldRecomputeRootView: true);
   }
 
+  @override
+  String makeLinePgn(UciPath path, {required bool includeVariations}) => _root.makeLinePgn(
+    path,
+    variant: state.requireValue.variant,
+    includeVariations: includeVariations,
+  );
+
   void _setPath(
     UciPath path, {
     bool shouldForceShowVariation = false,

--- a/lib/src/model/common/node.dart
+++ b/lib/src/model/common/node.dart
@@ -353,6 +353,54 @@ abstract class Node {
 
     return pgnGame.makePgn();
   }
+
+  /// Exports the line going through [path] as a PGN string.
+  ///
+  /// Mirrors the website's "Copy main line PGN" and "Copy variation PGN": the moves up to [path]
+  /// are exported as a single line, dropping the sidelines branching off them, then the line
+  /// follows the first child of each node to the end. Sidelines after [path] are kept only when
+  /// [includeVariations] is true.
+  ///
+  /// Comments and annotations are dropped. A `Variant` or `FEN` tag is added when the line does not
+  /// start from the standard initial position. Returns an empty string when the line has no move.
+  String makeLinePgn(UciPath path, {required Variant variant, required bool includeVariations}) {
+    final pgnRoot = PgnNode<PgnNodeData>();
+
+    PgnNode<PgnNodeData> pgnNode = pgnRoot;
+    Node node = this;
+    for (final branch in branchesOn(path)) {
+      final pgnChild = PgnChildNode(PgnNodeData(san: branch.sanMove.san));
+      pgnNode.children.add(pgnChild);
+      pgnNode = pgnChild;
+      node = branch;
+    }
+
+    final List<({Node from, PgnNode<PgnNodeData> to})> stack = [(from: node, to: pgnNode)];
+    while (stack.isNotEmpty) {
+      final frame = stack.removeLast();
+      final children = includeVariations ? frame.from.children : frame.from.children.take(1);
+      for (final childFrom in children) {
+        final childTo = PgnChildNode(PgnNodeData(san: childFrom.sanMove.san));
+        frame.to.children.add(childTo);
+        stack.add((from: childFrom, to: childTo));
+      }
+    }
+
+    // A line without any move has nothing to export: don't return bare headers.
+    if (pgnRoot.children.isEmpty) return '';
+
+    // Compare against the variant's own initial position: the initial FEN of crazyhouse and
+    // three-check carries extra fields and never equals the standard one.
+    final fen = position.fen;
+    return PgnGame(
+      headers: {
+        if (variant != Variant.standard) 'Variant': variant.pgnName,
+        if (fen != Position.initialPosition(variant.rule).fen) 'FEN': fen,
+      },
+      moves: pgnRoot,
+      comments: [],
+    ).makePgn();
+  }
 }
 
 /// A branch node of a game tree

--- a/lib/src/model/study/study_controller.dart
+++ b/lib/src/model/study/study_controller.dart
@@ -468,6 +468,13 @@ class StudyController extends AsyncNotifier<StudyState>
     _setPath(path.penultimate, shouldRecomputeRootView: true);
   }
 
+  @override
+  String makeLinePgn(UciPath path, {required bool includeVariations}) => _root.makeLinePgn(
+    path,
+    variant: state.requireValue.variant,
+    includeVariations: includeVariations,
+  );
+
   void _sendMoveToSocket(Move move) {
     if (state.requireValue.isWriteable == false) return;
 

--- a/lib/src/widgets/pgn.dart
+++ b/lib/src/widgets/pgn.dart
@@ -3,6 +3,7 @@ import 'package:collection/collection.dart';
 import 'package:dartchess/dartchess.dart';
 import 'package:dynamic_system_colors/dynamic_system_colors.dart';
 import 'package:fast_immutable_collections/fast_immutable_collections.dart';
+import 'package:flutter/services.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:lichess_mobile/src/model/account/account_preferences.dart';
 import 'package:lichess_mobile/src/model/common/node.dart';
@@ -119,6 +120,9 @@ abstract class PgnTreeNotifier {
   void promoteVariation(UciPath path, bool toMainLine);
   void deleteFromHere(UciPath path);
   void userJump(UciPath path);
+
+  /// Exports the line going through [path] as a PGN string, see [Node.makeLinePgn].
+  String makeLinePgn(UciPath path, {required bool includeVariations});
 }
 
 enum PgnTreeDisplayMode {
@@ -1453,6 +1457,28 @@ class _MoveContextMenu extends ConsumerWidget {
             onPressed: () => notifier?.promoteVariation(path, true),
           ),
         ],
+        BottomSheetContextMenuAction(
+          icon: Icons.copy,
+          child: Text(
+            lineInfo.type == _LineType.mainline
+                ? context.l10n.copyMainLinePgn
+                : context.l10n.copyVariationPgn,
+          ),
+          onPressed: () async {
+            final pgn = notifier?.makeLinePgn(
+              path,
+              includeVariations: lineInfo.type != _LineType.mainline,
+            );
+            if (pgn == null) return;
+            // The result token and trailing newline belong in a PGN file, not on the clipboard.
+            final line = pgn.trimRight().replaceFirst(RegExp(r'\s*\*$'), '');
+            // The bottom sheet can be disposed before the clipboard write completes.
+            final messenger = ScaffoldMessenger.of(context);
+            await Clipboard.setData(ClipboardData(text: line));
+            if (!messenger.mounted) return;
+            messenger.showSnackBar(const SnackBar(content: Text('PGN copied.'))); // TODO l10n
+          },
+        ),
         BottomSheetContextMenuAction(
           icon: Icons.delete,
           child: Text(context.l10n.deleteFromHere),

--- a/test/model/common/node_test.dart
+++ b/test/model/common/node_test.dart
@@ -536,6 +536,119 @@ void main() {
         expect(root.mainline.last.sanMove.move, move);
       });
     });
+
+    group('makeLinePgn', () {
+      const pgn = '1. e4 e5 (1... c5 2. Nf3 (2. c3)) 2. Nf3 Nc6 (2... d6) 3. Bb5';
+      final root = Root.fromPgnGame(PgnGame.parsePgn(pgn));
+
+      test('main line, without the sidelines branching off it', () {
+        expect(
+          root.makeLinePgn(
+            UciPath.fromUciMoves(['e2e4', 'e7e5']),
+            variant: Variant.standard,
+            includeVariations: false,
+          ),
+          '1. e4 e5 2. Nf3 Nc6 3. Bb5 *\n',
+        );
+      });
+
+      test('variation, with the sidelines after the end of the path', () {
+        expect(
+          root.makeLinePgn(
+            UciPath.fromUciMoves(['e2e4', 'c7c5']),
+            variant: Variant.standard,
+            includeVariations: true,
+          ),
+          '1. e4 c5 2. Nf3 ( 2. c3 ) *\n',
+        );
+      });
+
+      test('nested variation drops earlier siblings and annotations', () {
+        final root = Root.fromPgnGame(
+          PgnGame.parsePgn(
+            r'{root} 1. e4 $1 {comment} e5 (1... c5 2. Nf3 (2. c3 d5 (2... Nf6) 3. exd5)) 2. Nf3',
+          ),
+        );
+        expect(
+          root.makeLinePgn(
+            UciPath.fromUciMoves(['e2e4', 'c7c5', 'c2c3']),
+            variant: .standard,
+            includeVariations: true,
+          ),
+          '1. e4 c5 2. c3 d5 ( 2... Nf6 ) 3. exd5 *\n',
+        );
+      });
+
+      test('from the root', () {
+        expect(
+          root.makeLinePgn(UciPath.empty, variant: Variant.standard, includeVariations: false),
+          '1. e4 e5 2. Nf3 Nc6 3. Bb5 *\n',
+        );
+      });
+
+      test('adds the tags needed to replay a non standard game', () {
+        const fen = 'r1bqkbnr/pppp1ppp/2n5/4p3/4P3/5N2/PPPP1PPP/RNBQKB1R w KQkq - 2 3';
+        final root = Root.fromPgnGame(PgnGame.parsePgn('[FEN "$fen"]\n\n3. Bb5 a6'));
+        expect(
+          root.makeLinePgn(
+            root.mainlinePath,
+            variant: Variant.fromPosition,
+            includeVariations: false,
+          ),
+          '[Variant "From Position"]\n[FEN "$fen"]\n\n3. Bb5 a6 *\n',
+        );
+      });
+
+      test('preserves move numbering and position when black moves first', () {
+        const fen = 'r1bqkbnr/pppp1ppp/2n5/4p3/4P3/5N2/PPPP1PPP/RNBQKB1R b KQkq - 2 3';
+        final root = Root.fromPgnGame(PgnGame.parsePgn('[FEN "$fen"]\n\n3... a6 4. Bc4'));
+        final pgn = root.makeLinePgn(
+          root.mainlinePath,
+          variant: .standard,
+          includeVariations: false,
+        );
+        expect(pgn, '[FEN "$fen"]\n\n3... a6 4. Bc4 *\n');
+        final replay = Root.fromPgnGame(PgnGame.parsePgn(pgn));
+        expect(replay.mainline.last.position.fen, root.mainline.last.position.fen);
+      });
+
+      test('preserves the starting position and variant for Chess960', () {
+        const fen = 'rkrbbnnq/pppppppp/8/8/8/8/PPPPPPPP/RKRBBNNQ w CAca - 0 1';
+        final root = Root.fromPgnGame(
+          PgnGame.parsePgn('[Variant "Chess960"]\n[FEN "$fen"]\n\n1. d4 d5 2. c4'),
+        );
+        final pgn = root.makeLinePgn(
+          root.mainlinePath,
+          variant: .chess960,
+          includeVariations: false,
+        );
+        final game = PgnGame.parsePgn(pgn);
+        expect(game.headers['Variant'], 'Chess960');
+        expect(game.headers['FEN'], root.position.fen);
+        final replay = Root.fromPgnGame(game);
+        expect(replay.mainline.length, 3);
+        expect(replay.mainline.last.position.fen, root.mainline.last.position.fen);
+      });
+
+      test('adds no FEN tag for a variant starting from its own initial position', () {
+        final root = Root.fromPgnGame(
+          PgnGame.parsePgn('[Variant "Crazyhouse"]\n\n1. e4 e5 2. Nf3 Nc6'),
+        );
+        expect(
+          root.makeLinePgn(root.mainlinePath, variant: .crazyhouse, includeVariations: false),
+          '[Variant "Crazyhouse"]\n\n1. e4 e5 2. Nf3 Nc6 *\n',
+        );
+      });
+
+      test('is empty when there is no move to copy', () {
+        const fen = 'r1bqkbnr/pppp1ppp/2n5/4p3/4P3/5N2/PPPP1PPP/RNBQKB1R w KQkq - 2 3';
+        final root = Root.fromPgnGame(PgnGame.parsePgn('[FEN "$fen"]\n\n*'));
+        expect(
+          root.makeLinePgn(UciPath.empty, variant: .fromPosition, includeVariations: false),
+          '',
+        );
+      });
+    });
   });
 
   group('addMoveAt isUserAdded', () {

--- a/test/view/analysis/analysis_screen_test.dart
+++ b/test/view/analysis/analysis_screen_test.dart
@@ -1,3 +1,4 @@
+import 'dart:async';
 import 'dart:convert';
 
 import 'package:chessground/chessground.dart';
@@ -5,6 +6,7 @@ import 'package:collection/collection.dart';
 import 'package:cupertino_ui/cupertino_ui.dart';
 import 'package:dartchess/dartchess.dart';
 import 'package:fast_immutable_collections/fast_immutable_collections.dart';
+import 'package:flutter/services.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:http/testing.dart';
 import 'package:lichess_mobile/src/model/analysis/analysis_controller.dart';
@@ -688,6 +690,89 @@ void main() {
           expect(e4NodeBeforeTap, isNot(e4NodeAfterTap));
         },
       );
+    });
+
+    group('Copy line PGN', () {
+      /// Records every text the app writes to the clipboard.
+      List<String> captureClipboard({Future<void>? response}) {
+        final copied = <String>[];
+        final messenger = TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger;
+        messenger.setMockMethodCallHandler(SystemChannels.platform, (methodCall) async {
+          if (methodCall.method == 'Clipboard.setData') {
+            final arguments = methodCall.arguments as Map<Object?, Object?>;
+            copied.add(arguments['text']! as String);
+            if (response != null) await response;
+          }
+          return null;
+        });
+        addTearDown(() => messenger.setMockMethodCallHandler(SystemChannels.platform, null));
+        return copied;
+      }
+
+      const pgn = '1. e4 e5 (1... c5 2. Nf3 (2. c3)) 2. Nf3 Nc6 (2... d6) 3. Bb5';
+
+      for (final displayMode in PgnTreeDisplayMode.values) {
+        group(displayMode.name, () {
+          testWidgets('copies the main line without the sidelines branching off it', (
+            tester,
+          ) async {
+            final copied = captureClipboard();
+            await buildTree(tester, pgn, displayMode);
+
+            await tester.longPress(find.text('e5'));
+            await tester.pumpAndSettle();
+
+            expect(find.text('Copy variation PGN'), findsNothing);
+            await tester.tap(find.text('Copy main line PGN'));
+            await tester.pumpAndSettle();
+
+            expect(copied, ['1. e4 e5 2. Nf3 Nc6 3. Bb5']);
+            expect(
+              find.descendant(of: find.byType(SnackBar), matching: find.text('PGN copied.')),
+              findsOneWidget,
+            );
+          });
+
+          testWidgets('copies a variation with the sidelines after the pressed move', (
+            tester,
+          ) async {
+            final copied = captureClipboard();
+            await buildTree(tester, pgn, displayMode);
+
+            await tester.longPress(find.text('1… c5'));
+            await tester.pumpAndSettle();
+
+            expect(find.text('Copy main line PGN'), findsNothing);
+            await tester.tap(find.text('Copy variation PGN'));
+            await tester.pumpAndSettle();
+
+            expect(copied, ['1. e4 c5 2. Nf3 ( 2. c3 )']);
+          });
+
+          testWidgets('confirms copying after the move menu has closed', (tester) async {
+            final response = Completer<void>();
+            final copied = captureClipboard(response: response.future);
+            await buildTree(tester, pgn, displayMode);
+
+            await tester.longPress(find.text('e5'));
+            await tester.pumpAndSettle();
+            await tester.tap(find.text('Copy main line PGN'));
+            await tester.pumpAndSettle();
+
+            expect(find.byType(BottomSheet), findsNothing);
+            expect(copied, ['1. e4 e5 2. Nf3 Nc6 3. Bb5']);
+            expect(find.text('PGN copied.'), findsNothing);
+
+            response.complete();
+            await tester.pumpAndSettle();
+
+            expect(
+              find.descendant(of: find.byType(SnackBar), matching: find.text('PGN copied.')),
+              findsOneWidget,
+            );
+          });
+        });
+      }
     });
 
     group('PgnTreeDisplayMode.twoColumn', () {


### PR DESCRIPTION
This feature was in my closed PR https://github.com/lichess-org/mobile/pull/3617, where the study functionality had overlap with another PR. But the "Copy Mainline" part is still unique.

---
Why this PR:
There was no way to get the moves out of the app's analysis feature. The website has the ability to copy a mainline/variation PGN, but the app does not. I really wanted this feature, behavior should be the same as on the website

---

Long-pressing a move now offers "Copy main line PGN" on a main line move and "Copy variation PGN" on a variation, matching the website's wording and its semantics:

  - the moves leading to the pressed move are exported as a single line, ignoring the sidelines that branch off them;
  - the line then continues with the first child of each node until it ends;
  - sidelines branching off after that point are kept only when copying a variation.

A Variant or FEN header is added when the line does not start from the standard initial position, so the result can always be replayed.

The tree walk lives in Node.makeLinePgn and is unit tested; the three screens with a move tree (analysis, broadcast and study) reach it through a new PgnTreeNotifier.makeLinePgn.

[Screen_recording_20260901_113707_small.webm](https://github.com/user-attachments/assets/58476652-9ea9-4d26-ba63-a109c2730eed)

I used Claude Opus & Fable 5