### PR TITLE
Improve socket reliability and connectivity checks

### DIFF
--- a/lib/src/app.dart
+++ b/lib/src/app.dart
@@ -26,7 +26,6 @@ import 'package:lichess_mobile/src/model/settings/board_preferences.dart';
 import 'package:lichess_mobile/src/model/settings/general_preferences.dart';
 import 'package:lichess_mobile/src/model/study/study_preferences.dart';
 import 'package:lichess_mobile/src/network/connectivity.dart';
-import 'package:lichess_mobile/src/network/socket.dart';
 import 'package:lichess_mobile/src/quick_actions.dart';
 import 'package:lichess_mobile/src/shared_pgn_service.dart';
 import 'package:lichess_mobile/src/tab_navigation.dart';
@@ -178,7 +177,9 @@ class _AppState extends ConsumerState<Application> {
       }, fireImmediately: true);
     }
 
-    // Listen for connectivity changes and perform actions accordingly.
+    // Listening to the settled status rather than to [isDeviceOnlineProvider]: both actions are
+    // network calls, which must not be made on the optimistic assumption that a device whose
+    // status is not known yet is online.
     ref.listenManual(connectivityChangesProvider, (prev, current) async {
       final prevWasOffline = prev?.value?.isOnline == false;
       final currentIsOnline = current.value?.isOnline == true;
@@ -192,18 +193,9 @@ class _AppState extends ConsumerState<Application> {
       }
 
       // Perform actions once when the app comes online.
-      if (current.value?.isOnline == true && !_firstTimeOnlineCheck) {
+      if (currentIsOnline && !_firstTimeOnlineCheck) {
         _firstTimeOnlineCheck = true;
         ref.read(correspondenceServiceProvider).syncGames();
-      }
-
-      final socketClient = ref.read(socketPoolProvider).currentClient;
-      if (current.value?.isOnline == true &&
-          current.value?.appState == AppLifecycleState.resumed &&
-          !socketClient.isActive) {
-        socketClient.connect();
-      } else if (current.value?.isOnline == false) {
-        socketClient.close();
       }
     });
 

--- a/lib/src/app.dart
+++ b/lib/src/app.dart
@@ -181,7 +181,9 @@ class _AppState extends ConsumerState<Application> {
     // network calls, which must not be made on the optimistic assumption that a device whose
     // status is not known yet is online.
     ref.listenManual(connectivityChangesProvider, (prev, current) async {
-      final prevWasOffline = prev?.value?.isOnline == false;
+      // The previous state is read with [isDeviceOnlineIn], so that coming back from a check that
+      // failed — offline as far as the app is concerned — is an edge like any other.
+      final prevWasOffline = prev != null && !isDeviceOnlineIn(prev);
       final currentIsOnline = current.value?.isOnline == true;
 
       // Play registered moves whenever the app comes back online.

--- a/lib/src/model/lobby/create_game_service.dart
+++ b/lib/src/model/lobby/create_game_service.dart
@@ -163,7 +163,9 @@ class CreateGameService {
           _challengePingTimer?.cancel();
           _challengePingTimer = Timer.periodic(
             const Duration(seconds: 9),
-            (_) => socketClient.send('ping', null),
+            // Not queued while the socket is down: these say the user is still waiting *now*, and
+            // the listener above sends a fresh one as soon as it is back up.
+            (_) => socketClient.send('ping', null, noRetry: true),
           );
         }),
         socketClient.stream.listen((event) async {
@@ -238,7 +240,9 @@ class CreateGameService {
           _challengePingTimer?.cancel();
           _challengePingTimer = Timer.periodic(
             const Duration(seconds: 9),
-            (_) => socketClient.send('ping', null),
+            // Not queued while the socket is down: these say the user is still waiting *now*, and
+            // the listener above sends a fresh one as soon as it is back up.
+            (_) => socketClient.send('ping', null, noRetry: true),
           );
         }),
         socketClient.stream.listen((event) async {

--- a/lib/src/network/connectivity.dart
+++ b/lib/src/network/connectivity.dart
@@ -7,6 +7,7 @@ import 'package:http/http.dart';
 import 'package:lichess_mobile/src/constants.dart';
 import 'package:lichess_mobile/src/network/http.dart';
 import 'package:lichess_mobile/src/network/server_status.dart';
+import 'package:lichess_mobile/src/network/socket.dart';
 import 'package:lichess_mobile/src/utils/rate_limit.dart';
 import 'package:logging/logging.dart';
 
@@ -27,15 +28,18 @@ final connectivityPluginProvider = Provider<Connectivity>((Ref _) => Connectivit
 /// directly in the rare places that must not be optimistic, and [lichessConnectionStatusProvider]
 /// where a lichess outage has to be shown.
 final isDeviceOnlineProvider = Provider.autoDispose<bool>((ref) {
-  return switch (ref.watch(connectivityChangesProvider)) {
-    // A check that failed does mean we could not reach anything.
-    AsyncValue(hasError: true) => false,
-    // The last known answer, whether it comes from a settled check or from a re-run that has not
-    // completed yet.
-    AsyncValue(:final value?) => value.isOnline,
-    _ => true,
-  };
+  return ref.watch(connectivityChangesProvider.select(_isDeviceOnlineIn));
 }, name: 'IsDeviceOnlineProvider');
+
+/// [isDeviceOnlineProvider]'s view of a connectivity status.
+bool _isDeviceOnlineIn(AsyncValue<ConnectivityStatus> status) => switch (status) {
+  // A check that failed does mean we could not reach anything.
+  AsyncValue(hasError: true) => false,
+  // The last known answer, whether it comes from a settled check or from a re-run that has not
+  // completed yet.
+  AsyncValue(:final value?) => value.isOnline,
+  _ => true,
+};
 
 /// Represents the connection state of the app with respect to the lichess server.
 enum LichessConnectionStatus {
@@ -112,6 +116,28 @@ class ConnectivityChangesNotifier extends AsyncNotifier<ConnectivityStatus> {
       _connectivityChangesThrottler(() => _onConnectivityChange(result));
     });
 
+    // A socket answering the ping/pong protocol is proof that the device can reach the network, so
+    // it clears an offline status right away rather than leaving it up until the next check.
+    //
+    // Only that edge counts. A socket that is *not* connected proves nothing — it is also what
+    // returning from the background and switching routes look like — and it notices a dead link
+    // long after the check does, since that takes a ping going unanswered. The check therefore
+    // stays the authority on going offline.
+    final pool = ref.read(socketPoolProvider);
+    void onSocketChange() {
+      if (pool.averageLag.value == Duration.zero) return;
+      // Deferred: the pool updates this from inside [SocketPool.open], which controllers call
+      // while building, and Riverpod forbids a provider modifying another during a build.
+      scheduleMicrotask(() {
+        if (!ref.mounted || state.value?.isOnline != false) return;
+        _logger.info('Socket connected, the device is online.');
+        state = AsyncValue.data((isOnline: true, appState: state.requireValue.appState));
+      });
+    }
+
+    pool.averageLag.addListener(onSocketChange);
+    ref.onDispose(() => pool.averageLag.removeListener(onSocketChange));
+
     final AppLifecycleState? appState = WidgetsBinding.instance.lifecycleState;
 
     _appLifecycleListener = AppLifecycleListener(onStateChange: _onAppLifecycleChange);
@@ -171,7 +197,9 @@ class ConnectivityChangesNotifier extends AsyncNotifier<ConnectivityStatus> {
 
 typedef ConnectivityStatus = ({bool isOnline, AppLifecycleState? appState});
 
-final _internetCheckUris = [
+/// The URIs [isOnline] probes.
+@visibleForTesting
+final internetCheckUris = [
   Uri.parse('https://www.gstatic.com/generate_204'),
   Uri.parse('$kLichessCDNHost/assets/logo/lichess-favicon-32.png'),
 ];
@@ -191,8 +219,8 @@ final _internetCheckUris = [
 Future<bool> isOnline(Client client, {Duration timeout = const Duration(seconds: 5)}) {
   final completer = Completer<bool>();
   try {
-    int remaining = _internetCheckUris.length;
-    final futures = _internetCheckUris.map(
+    int remaining = internetCheckUris.length;
+    final futures = internetCheckUris.map(
       (uri) => client
           .head(uri, headers: const {kQuietRequestHeader: '1'})
           .timeout(timeout)
@@ -214,61 +242,4 @@ Future<bool> isOnline(Client client, {Duration timeout = const Duration(seconds:
     completer.complete(false);
   }
   return completer.future;
-}
-
-extension AsyncValueConnectivity on AsyncValue<ConnectivityStatus> {
-  /// Switches between device's connectivity status.
-  ///
-  /// Using this method assumes the the device is offline when the status is
-  /// not yet available (i.e. [AsyncValue.isLoading].
-  /// If you want to handle the loading state separately, use
-  /// [whenIsLoading] instead.
-  ///
-  /// This method is similar to [AsyncValueX.maybeWhen], but it takes two
-  /// functions, one for when the device is online and another for when it is
-  /// offline.
-  ///
-  /// Example:
-  /// ```dart
-  /// final status = ref.watch(connectivityChangesProvider);
-  /// final result = status.whenIs(
-  ///   online: () => 'Online',
-  ///   offline: () => 'Offline',
-  /// );
-  /// ```
-  R whenIs<R>({required R Function() online, required R Function() offline}) {
-    return maybeWhen(
-      skipLoadingOnReload: true,
-      data: (status) => status.isOnline ? online() : offline(),
-      orElse: offline,
-    );
-  }
-
-  /// Switches between device's connectivity status, but handling the loading state.
-  ///
-  /// This method is similar to [AsyncValueX.when], but it takes three
-  /// functions, one for when the device is online, another for when it is
-  /// offline, and the last for when the status is still loading.
-  ///
-  /// Example:
-  /// ```dart
-  /// final status = ref.watch(connectivityChangesProvider);
-  /// final result = status.whenIsLoading(
-  ///   online: () => 'Online',
-  ///   offline: () => 'Offline',
-  ///   loading: () => 'Loading',
-  /// );
-  /// ```
-  R whenIsLoading<R>({
-    required R Function() online,
-    required R Function() offline,
-    required R Function() loading,
-  }) {
-    return when(
-      skipLoadingOnReload: true,
-      data: (status) => status.isOnline ? online() : offline(),
-      loading: loading,
-      error: (error, stack) => offline(),
-    );
-  }
 }

--- a/lib/src/network/connectivity.dart
+++ b/lib/src/network/connectivity.dart
@@ -116,10 +116,21 @@ class ConnectivityChangesNotifier extends AsyncNotifier<ConnectivityStatus> {
   Client get _defaultClient => ref.read(defaultClientProvider);
   Connectivity get _connectivity => ref.read(connectivityPluginProvider);
 
+  /// The status the app is showing, or null while the first check has yet to settle anything.
+  ///
+  /// A check that failed settles the question too: [isDeviceOnlineProvider] reads an error as
+  /// offline — nothing could be reached — so it must be recoverable like any other offline status,
+  /// by a socket that connects or by a later check.
+  ConnectivityStatus? get _settledStatus => switch (state) {
+    AsyncValue(hasError: true) => (isOnline: false, appState: state.value?.appState),
+    AsyncValue(:final value?) => value,
+    _ => null,
+  };
+
   /// Writes a status, and marks every check that is already running as outdated.
   void _setOnlineStatus(bool isOnline) {
     _onlineStatusRevision++;
-    state = AsyncValue.data((isOnline: isOnline, appState: state.requireValue.appState));
+    state = AsyncValue.data((isOnline: isOnline, appState: state.value?.appState));
   }
 
   /// Whether a check that started at [revision] may still commit its result.
@@ -153,7 +164,7 @@ class ConnectivityChangesNotifier extends AsyncNotifier<ConnectivityStatus> {
       // Deferred: the pool updates this from inside [SocketPool.open], which controllers call
       // while building, and Riverpod forbids a provider modifying another during a build.
       scheduleMicrotask(() {
-        if (!ref.mounted || state.value?.isOnline != false) return;
+        if (!ref.mounted || _settledStatus?.isOnline != false) return;
         _setOnlineStatus(true);
       });
     }
@@ -171,11 +182,11 @@ class ConnectivityChangesNotifier extends AsyncNotifier<ConnectivityStatus> {
         // A device already known to be offline has nothing to learn from a socket that fails, and
         // must not take up the throttler's window: the connectivity event that brings the network
         // back is what has to run next, without waiting out a delay.
-        if (!ref.mounted || state.value?.isOnline != true) return;
+        if (!ref.mounted || _settledStatus?.isOnline != true) return;
         _connectivityChangesThrottler(() {
           // Checked again: the throttler may run this a delay later, by which time the status may
           // have settled offline on its own.
-          if (!ref.mounted || state.value?.isOnline != true) return;
+          if (!ref.mounted || _settledStatus?.isOnline != true) return;
           _refreshOnlineStatus('socket cannot connect');
         });
       });
@@ -217,13 +228,14 @@ class ConnectivityChangesNotifier extends AsyncNotifier<ConnectivityStatus> {
       ref.read(serverStatusProvider.notifier).onAppResumed();
     }
 
-    if (!state.hasValue) {
+    final settled = _settledStatus;
+    if (settled == null) {
       return;
     }
 
     // The lifecycle state is known right away, whatever the check that follows finds. It says
     // nothing about connectivity, so it does not outdate a check that is already running.
-    state = AsyncValue.data((isOnline: state.requireValue.isOnline, appState: appState));
+    state = AsyncValue.data((isOnline: settled.isOnline, appState: appState));
 
     if (appState != AppLifecycleState.resumed) {
       return;
@@ -248,12 +260,13 @@ class ConnectivityChangesNotifier extends AsyncNotifier<ConnectivityStatus> {
   ///
   /// [reason] is what prompted the check, for the logs.
   Future<void> _refreshOnlineStatus(String reason) async {
-    if (!state.hasValue) {
+    final settled = _settledStatus;
+    if (settled == null) {
       return;
     }
 
     final revision = _onlineStatusRevision;
-    final wasOnline = state.requireValue.isOnline;
+    final wasOnline = settled.isOnline;
     final newIsOnline = await isOnline(_defaultClient);
 
     if (!_isCurrent(revision)) return;

--- a/lib/src/network/connectivity.dart
+++ b/lib/src/network/connectivity.dart
@@ -143,7 +143,7 @@ class ConnectivityChangesNotifier extends AsyncNotifier<ConnectivityStatus> {
   }
 
   @override
-  Future<ConnectivityStatus> build() {
+  Future<ConnectivityStatus> build() async {
     ref.onDispose(() {
       _connectivitySubscription?.cancel();
       _appLifecycleListener?.dispose();
@@ -160,7 +160,9 @@ class ConnectivityChangesNotifier extends AsyncNotifier<ConnectivityStatus> {
     // A socket answering the ping/pong protocol is proof that the device can reach the network, so
     // it clears an offline status right away rather than leaving it up until the next check.
     void onSocketConnected() {
-      if (pool.averageLag.value == Duration.zero) return;
+      // The pool's own lag is the last one any route reported, and it deliberately outlives the
+      // client that measured it: only the current client says whether a socket is up right now.
+      if (!pool.currentClient.isConnected) return;
       // Deferred: the pool updates this from inside [SocketPool.open], which controllers call
       // while building, and Riverpod forbids a provider modifying another during a build.
       scheduleMicrotask(() {
@@ -203,19 +205,10 @@ class ConnectivityChangesNotifier extends AsyncNotifier<ConnectivityStatus> {
 
     _appLifecycleListener = AppLifecycleListener(onStateChange: _onAppLifecycleChange);
 
-    return _initialStatus(appState, pool);
-  }
-
-  /// Runs the first check, and reconciles its result with the socket pool.
-  ///
-  /// [onSocketConnected] has no status to correct while this check is still running, so a pong
-  /// that lands in that window would otherwise be dropped, leaving the device reported offline
-  /// until the next lag change. A socket that is connected by the time the check answers is proof
-  /// of a working network, and outranks a check that came back offline.
-  Future<ConnectivityStatus> _initialStatus(AppLifecycleState? appState, SocketPool pool) async {
-    final result = await _connectivity.checkConnectivity();
-    final status = await _getConnectivityStatus(result, appState);
-    if (!status.isOnline && pool.averageLag.value != Duration.zero) {
+    final status = await _getConnectivityStatus(await _connectivity.checkConnectivity(), appState);
+    // A socket that is connected by the time the check answers is proof of a working network, and
+    // outranks a check that came back offline.
+    if (!status.isOnline && pool.currentClient.isConnected) {
       return (isOnline: true, appState: status.appState);
     }
     return status;

--- a/lib/src/network/connectivity.dart
+++ b/lib/src/network/connectivity.dart
@@ -28,11 +28,14 @@ final connectivityPluginProvider = Provider<Connectivity>((Ref _) => Connectivit
 /// directly in the rare places that must not be optimistic, and [lichessConnectionStatusProvider]
 /// where a lichess outage has to be shown.
 final isDeviceOnlineProvider = Provider.autoDispose<bool>((ref) {
-  return ref.watch(connectivityChangesProvider.select(_isDeviceOnlineIn));
+  return ref.watch(connectivityChangesProvider.select(isDeviceOnlineIn));
 }, name: 'IsDeviceOnlineProvider');
 
 /// [isDeviceOnlineProvider]'s view of a connectivity status.
-bool _isDeviceOnlineIn(AsyncValue<ConnectivityStatus> status) => switch (status) {
+///
+/// Exposed so that the few places reading [connectivityChangesProvider] directly can tell online
+/// from offline the same way, error states included.
+bool isDeviceOnlineIn(AsyncValue<ConnectivityStatus> status) => switch (status) {
   // A check that failed does mean we could not reach anything.
   AsyncValue(hasError: true) => false,
   // The last known answer, whether it comes from a settled check or from a re-run that has not

--- a/lib/src/network/connectivity.dart
+++ b/lib/src/network/connectivity.dart
@@ -7,7 +7,6 @@ import 'package:http/http.dart';
 import 'package:lichess_mobile/src/constants.dart';
 import 'package:lichess_mobile/src/network/http.dart';
 import 'package:lichess_mobile/src/network/server_status.dart';
-import 'package:lichess_mobile/src/network/socket.dart';
 import 'package:lichess_mobile/src/utils/rate_limit.dart';
 import 'package:logging/logging.dart';
 
@@ -91,8 +90,6 @@ final lichessConnectionStatusProvider = Provider.autoDispose<LichessConnectionSt
 ///
 /// - Uses the [Connectivity] plugin to listen to connectivity changes
 /// - Uses [AppLifecycleListener] to check connectivity on app resume
-/// - Uses [SocketPool] to check if the device is online when the current status is offline and a
-/// socket connects or fails to connect.
 final connectivityChangesProvider =
     AsyncNotifierProvider<ConnectivityChangesNotifier, ConnectivityStatus>(
       ConnectivityChangesNotifier.new,
@@ -117,8 +114,8 @@ class ConnectivityChangesNotifier extends AsyncNotifier<ConnectivityStatus> {
   /// The status the app is showing, or null while the first check has yet to settle anything.
   ///
   /// A check that failed settles the question too: [isDeviceOnlineProvider] reads an error as
-  /// offline — nothing could be reached — so it must be recoverable like any other offline status,
-  /// by a socket that connects or by a later check.
+  /// offline — nothing could be reached — so a later check has an offline status to compare with,
+  /// like any other.
   ConnectivityStatus? get _settledStatus => switch (state) {
     AsyncValue(hasError: true) => (isOnline: false, appState: state.value?.appState),
     AsyncValue(:final value?) => value,
@@ -156,71 +153,11 @@ class ConnectivityChangesNotifier extends AsyncNotifier<ConnectivityStatus> {
       _connectivityChangesThrottler(() => _onConnectivityChange(result));
     });
 
-    final pool = ref.read(socketPoolProvider);
-
-    // A socket answering the ping/pong protocol is proof that the device can reach the network, so
-    // it clears an offline status right away rather than leaving it up until the next check.
-    void onSocketConnected() {
-      if (!pool.isConnected.value) return;
-      // Deferred: the pool updates this from inside [SocketPool.open], which controllers call
-      // while building, and Riverpod forbids a provider modifying another during a build.
-      scheduleMicrotask(() {
-        if (!ref.mounted) return;
-        final settled = _settledStatus;
-        if (settled == null) return;
-        if (settled.isOnline) {
-          _claimRevision();
-        } else {
-          _setOnlineStatus(true);
-        }
-      });
-    }
-
-    // The other way around, a socket that cannot connect is only a suspicion: it may be lichess
-    // that is down, and the socket goes on failing long after the network is back. So it does not
-    // set the status offline, it merely asks the check to run — the check remains the authority.
-    //
-    // This is also what keeps the two providers from egging each other on: [SocketPool] reconnects
-    // on the offline -> online edge only, and [SocketPool.isFailing] only turns true once per run
-    // of failures, so each failing run costs at most one check.
-    void onSocketFailing() {
-      if (!pool.isFailing.value) return;
-      scheduleMicrotask(() {
-        if (!ref.mounted || _settledStatus?.isOnline != true) return;
-        _refreshOnlineStatus('socket cannot connect');
-      });
-    }
-
-    pool.isConnected.addListener(onSocketConnected);
-    pool.isFailing.addListener(onSocketFailing);
-    ref.onDispose(() {
-      pool.isConnected.removeListener(onSocketConnected);
-      pool.isFailing.removeListener(onSocketFailing);
-    });
-
     final AppLifecycleState? appState = WidgetsBinding.instance.lifecycleState;
 
     _appLifecycleListener = AppLifecycleListener(onStateChange: _onAppLifecycleChange);
 
-    final ConnectivityStatus status;
-    try {
-      status = await _getConnectivityStatus(await _connectivity.checkConnectivity(), appState);
-    } catch (_) {
-      // A check that could not even run is read as offline, and the socket has no way back in: the
-      // report it made while this one was running found nothing settled to correct, and was
-      // dropped. So the socket has the same say here as it does below.
-      if (pool.isConnected.value) {
-        return (isOnline: true, appState: appState);
-      }
-      rethrow;
-    }
-
-    // A socket that is connected by the time the check answers is proof of a working network, and
-    // outranks a check that came back offline.
-    if (!status.isOnline && pool.isConnected.value) {
-      return (isOnline: true, appState: status.appState);
-    }
-    return status;
+    return await _getConnectivityStatus(await _connectivity.checkConnectivity(), appState);
   }
 
   Future<void> _onAppLifecycleChange(AppLifecycleState appState) async {
@@ -262,14 +199,8 @@ class ConnectivityChangesNotifier extends AsyncNotifier<ConnectivityStatus> {
     _setOnlineStatus(newConn.isOnline);
   }
 
-  Future<void> _onConnectivityChange(List<ConnectivityResult> result) {
-    return _refreshOnlineStatus('connectivity changed: $result');
-  }
-
-  /// Runs the online check and updates the status if it disagrees with it.
-  ///
-  /// [reason] is what prompted the check, for the logs.
-  Future<void> _refreshOnlineStatus(String reason) async {
+  /// Runs the online check on a connectivity change, and updates the status if it disagrees.
+  Future<void> _onConnectivityChange(List<ConnectivityResult> result) async {
     final settled = _settledStatus;
     if (settled == null) {
       return;
@@ -284,7 +215,7 @@ class ConnectivityChangesNotifier extends AsyncNotifier<ConnectivityStatus> {
     // A check that confirms the status has nothing to write: the checks it overtook were already
     // outdated by the revision it claimed on its way in.
     if (newIsOnline != wasOnline) {
-      _logger.info('Connectivity status: $reason, isOnline: $newIsOnline');
+      _logger.info('Connectivity status: connectivity changed: $result, isOnline: $newIsOnline');
       _setOnlineStatus(newIsOnline);
     }
   }

--- a/lib/src/network/connectivity.dart
+++ b/lib/src/network/connectivity.dart
@@ -204,7 +204,19 @@ class ConnectivityChangesNotifier extends AsyncNotifier<ConnectivityStatus> {
 
     _appLifecycleListener = AppLifecycleListener(onStateChange: _onAppLifecycleChange);
 
-    final status = await _getConnectivityStatus(await _connectivity.checkConnectivity(), appState);
+    final ConnectivityStatus status;
+    try {
+      status = await _getConnectivityStatus(await _connectivity.checkConnectivity(), appState);
+    } catch (_) {
+      // A check that could not even run is read as offline, and the socket has no way back in: the
+      // report it made while this one was running found nothing settled to correct, and was
+      // dropped. So the socket has the same say here as it does below.
+      if (pool.currentClient.isConnected) {
+        return (isOnline: true, appState: appState);
+      }
+      rethrow;
+    }
+
     // A socket that is connected by the time the check answers is proof of a working network, and
     // outranks a check that came back offline.
     if (!status.isOnline && pool.currentClient.isConnected) {

--- a/lib/src/network/connectivity.dart
+++ b/lib/src/network/connectivity.dart
@@ -180,10 +180,9 @@ class ConnectivityChangesNotifier extends AsyncNotifier<ConnectivityStatus> {
       return;
     }
 
-    final revision = _claimRevision();
-    final ConnectivityStatus newConn;
+    final List<ConnectivityResult> result;
     try {
-      newConn = await _getConnectivityStatus(await _connectivity.checkConnectivity(), appState);
+      result = await _connectivity.checkConnectivity();
     } catch (e, s) {
       // A check that could not run says nothing about the network, and here — unlike in [build] —
       // there is already a settled status to fall back on: it is left as it is, rather than turned
@@ -191,6 +190,12 @@ class ConnectivityChangesNotifier extends AsyncNotifier<ConnectivityStatus> {
       _logger.warning('Connectivity check on app resume failed', e, s);
       return;
     }
+
+    // Claimed only now that there is a check to run: one that never got off the ground would
+    // otherwise outdate a probe already in flight, whose answer would then be dropped with nothing
+    // written in its place.
+    final revision = _claimRevision();
+    final newConn = await _getConnectivityStatus(result, appState);
 
     if (!_isCurrent(revision)) return;
 

--- a/lib/src/network/connectivity.dart
+++ b/lib/src/network/connectivity.dart
@@ -239,10 +239,10 @@ typedef ConnectivityStatus = ({bool isOnline, AppLifecycleState? appState});
 
 /// The URIs [isOnline] probes.
 @visibleForTesting
-final internetCheckUris = [
+final internetCheckUris = List<Uri>.unmodifiable([
   Uri.parse('https://www.gstatic.com/generate_204'),
   Uri.parse('$kLichessCDNHost/assets/logo/lichess-favicon-32.png'),
-];
+]);
 
 /// Checks if the device is online by making a HEAD request to a list of URIs.
 ///

--- a/lib/src/network/connectivity.dart
+++ b/lib/src/network/connectivity.dart
@@ -88,7 +88,8 @@ final lichessConnectionStatusProvider = Provider.autoDispose<LichessConnectionSt
 ///
 /// - Uses the [Connectivity] plugin to listen to connectivity changes
 /// - Uses [AppLifecycleListener] to check connectivity on app resume
-/// - Uses [SocketPool] to check if the device is online when the current status is offline and a socket connects
+/// - Uses [SocketPool] to check if the device is online when the current status is offline and a
+/// socket connects or fails to connect.
 final connectivityChangesProvider =
     AsyncNotifierProvider<ConnectivityChangesNotifier, ConnectivityStatus>(
       ConnectivityChangesNotifier.new,
@@ -117,10 +118,11 @@ class ConnectivityChangesNotifier extends AsyncNotifier<ConnectivityStatus> {
       _connectivityChangesThrottler(() => _onConnectivityChange(result));
     });
 
+    final pool = ref.read(socketPoolProvider);
+
     // A socket answering the ping/pong protocol is proof that the device can reach the network, so
     // it clears an offline status right away rather than leaving it up until the next check.
-    final pool = ref.read(socketPoolProvider);
-    void onSocketChange() {
+    void onSocketConnected() {
       if (pool.averageLag.value == Duration.zero) return;
       // Deferred: the pool updates this from inside [SocketPool.open], which controllers call
       // while building, and Riverpod forbids a provider modifying another during a build.
@@ -131,8 +133,27 @@ class ConnectivityChangesNotifier extends AsyncNotifier<ConnectivityStatus> {
       });
     }
 
-    pool.averageLag.addListener(onSocketChange);
-    ref.onDispose(() => pool.averageLag.removeListener(onSocketChange));
+    // The other way around, a socket that cannot connect is only a suspicion: it may be lichess
+    // that is down, and the socket goes on failing long after the network is back. So it does not
+    // set the status offline, it merely asks the check to run — the check remains the authority.
+    //
+    // This is also what keeps the two providers from egging each other on: [SocketPool] reconnects
+    // on the offline -> online edge only, and a socket only reports a *run* of failures once, so
+    // each failing run costs at most one check.
+    void onSocketFailing() {
+      if (!pool.isFailing.value) return;
+      scheduleMicrotask(() {
+        if (!ref.mounted || state.value?.isOnline != true) return;
+        _connectivityChangesThrottler(() => _refreshOnlineStatus('socket cannot connect'));
+      });
+    }
+
+    pool.averageLag.addListener(onSocketConnected);
+    pool.isFailing.addListener(onSocketFailing);
+    ref.onDispose(() {
+      pool.averageLag.removeListener(onSocketConnected);
+      pool.isFailing.removeListener(onSocketFailing);
+    });
 
     final AppLifecycleState? appState = WidgetsBinding.instance.lifecycleState;
 
@@ -164,19 +185,27 @@ class ConnectivityChangesNotifier extends AsyncNotifier<ConnectivityStatus> {
     }
   }
 
-  Future<void> _onConnectivityChange(List<ConnectivityResult> result) async {
+  Future<void> _onConnectivityChange(List<ConnectivityResult> result) {
+    _logger.fine('Connectivity changed: $result');
+    return _refreshOnlineStatus('connectivity changed: $result');
+  }
+
+  /// Runs the online check and updates the status if it disagrees with it.
+  ///
+  /// [reason] is what prompted the check, for the logs.
+  Future<void> _refreshOnlineStatus(String reason) async {
     if (!state.hasValue) {
       return;
     }
 
     final wasOnline = state.requireValue.isOnline;
-
-    _logger.fine('Connectivity changed: $result');
     final newIsOnline = await isOnline(_defaultClient);
     _logger.fine('Online check result: $newIsOnline');
 
+    if (!ref.mounted) return;
+
     if (newIsOnline != wasOnline) {
-      _logger.info('Connectivity status: $result, isOnline: $newIsOnline');
+      _logger.info('Connectivity status: $reason, isOnline: $newIsOnline');
       state = AsyncValue.data((isOnline: newIsOnline, appState: state.value?.appState));
     }
   }

--- a/lib/src/network/connectivity.dart
+++ b/lib/src/network/connectivity.dart
@@ -100,7 +100,10 @@ class ConnectivityChangesNotifier extends AsyncNotifier<ConnectivityStatus> {
   StreamSubscription<List<ConnectivityResult>>? _connectivitySubscription;
   AppLifecycleListener? _appLifecycleListener;
 
-  final _connectivityChangesThrottler = Throttler(kConnectivityThrottleDelay);
+  // Trailing: [onSocketFailing] reports a run of failures once, so a call dropped here is a signal
+  // lost for good — no later notification would ask for the check again, and the status would stay
+  // online while the socket keeps failing.
+  final _connectivityChangesThrottler = Throttler(kConnectivityThrottleDelay, trailing: true);
 
   Client get _defaultClient => ref.read(defaultClientProvider);
   Connectivity get _connectivity => ref.read(connectivityPluginProvider);
@@ -143,8 +146,16 @@ class ConnectivityChangesNotifier extends AsyncNotifier<ConnectivityStatus> {
     void onSocketFailing() {
       if (!pool.isFailing.value) return;
       scheduleMicrotask(() {
+        // A device already known to be offline has nothing to learn from a socket that fails, and
+        // must not take up the throttler's window: the connectivity event that brings the network
+        // back is what has to run next, without waiting out a delay.
         if (!ref.mounted || state.value?.isOnline != true) return;
-        _connectivityChangesThrottler(() => _refreshOnlineStatus('socket cannot connect'));
+        _connectivityChangesThrottler(() {
+          // Checked again: the throttler may run this a delay later, by which time the status may
+          // have settled offline on its own.
+          if (!ref.mounted || state.value?.isOnline != true) return;
+          _refreshOnlineStatus('socket cannot connect');
+        });
       });
     }
 
@@ -159,7 +170,23 @@ class ConnectivityChangesNotifier extends AsyncNotifier<ConnectivityStatus> {
 
     _appLifecycleListener = AppLifecycleListener(onStateChange: _onAppLifecycleChange);
 
-    return _connectivity.checkConnectivity().then((r) => _getConnectivityStatus(r, appState));
+    return _initialStatus(appState, pool);
+  }
+
+  /// Runs the first check, and reconciles its result with the socket pool.
+  ///
+  /// [onSocketConnected] has no status to correct while this check is still running, so a pong
+  /// that lands in that window would otherwise be dropped, leaving the device reported offline
+  /// until the next lag change. A socket that is connected by the time the check answers is proof
+  /// of a working network, and outranks a check that came back offline.
+  Future<ConnectivityStatus> _initialStatus(AppLifecycleState? appState, SocketPool pool) async {
+    final result = await _connectivity.checkConnectivity();
+    final status = await _getConnectivityStatus(result, appState);
+    if (!status.isOnline && pool.averageLag.value != Duration.zero) {
+      _logger.info('Initial check says offline but a socket is connected: the device is online.');
+      return (isOnline: true, appState: status.appState);
+    }
+    return status;
   }
 
   Future<void> _onAppLifecycleChange(AppLifecycleState appState) async {

--- a/lib/src/network/connectivity.dart
+++ b/lib/src/network/connectivity.dart
@@ -131,7 +131,7 @@ class ConnectivityChangesNotifier extends AsyncNotifier<ConnectivityStatus> {
       // while building, and Riverpod forbids a provider modifying another during a build.
       scheduleMicrotask(() {
         if (!ref.mounted || state.value?.isOnline != false) return;
-        _logger.info('Socket connected, the device is online.');
+        _logger.fine('Socket connected, the device is online.');
         state = AsyncValue.data((isOnline: true, appState: state.requireValue.appState));
       });
     }
@@ -183,7 +183,7 @@ class ConnectivityChangesNotifier extends AsyncNotifier<ConnectivityStatus> {
     final result = await _connectivity.checkConnectivity();
     final status = await _getConnectivityStatus(result, appState);
     if (!status.isOnline && pool.averageLag.value != Duration.zero) {
-      _logger.info('Initial check says offline but a socket is connected: the device is online.');
+      _logger.fine('Initial check says offline but a socket is connected: the device is online.');
       return (isOnline: true, appState: status.appState);
     }
     return status;
@@ -213,7 +213,6 @@ class ConnectivityChangesNotifier extends AsyncNotifier<ConnectivityStatus> {
   }
 
   Future<void> _onConnectivityChange(List<ConnectivityResult> result) {
-    _logger.fine('Connectivity changed: $result');
     return _refreshOnlineStatus('connectivity changed: $result');
   }
 
@@ -227,7 +226,6 @@ class ConnectivityChangesNotifier extends AsyncNotifier<ConnectivityStatus> {
 
     final wasOnline = state.requireValue.isOnline;
     final newIsOnline = await isOnline(_defaultClient);
-    _logger.fine('Online check result: $newIsOnline');
 
     if (!ref.mounted) return;
 

--- a/lib/src/network/connectivity.dart
+++ b/lib/src/network/connectivity.dart
@@ -117,13 +117,13 @@ class ConnectivityChangesNotifier extends AsyncNotifier<ConnectivityStatus> {
   Connectivity get _connectivity => ref.read(connectivityPluginProvider);
 
   /// Writes a status, and marks every check that is already running as outdated.
-  void _setStatus(ConnectivityStatus status) {
+  void _setOnlineStatus(bool isOnline) {
     _onlineStatusRevision++;
-    state = AsyncValue.data(status);
+    state = AsyncValue.data((isOnline: isOnline, appState: state.requireValue.appState));
   }
 
   /// Whether a check that started at [revision] may still commit its result.
-  bool _isCurrent(int revision, String reason) {
+  bool _isCurrent(int revision) {
     if (!ref.mounted) return false;
     if (revision != _onlineStatusRevision) {
       return false;
@@ -154,7 +154,7 @@ class ConnectivityChangesNotifier extends AsyncNotifier<ConnectivityStatus> {
       // while building, and Riverpod forbids a provider modifying another during a build.
       scheduleMicrotask(() {
         if (!ref.mounted || state.value?.isOnline != false) return;
-        _setStatus((isOnline: true, appState: state.requireValue.appState));
+        _setOnlineStatus(true);
       });
     }
 
@@ -233,11 +233,11 @@ class ConnectivityChangesNotifier extends AsyncNotifier<ConnectivityStatus> {
     final result = await _connectivity.checkConnectivity();
     final newConn = await _getConnectivityStatus(result, appState);
 
-    if (!_isCurrent(revision, 'app resumed')) return;
+    if (!_isCurrent(revision)) return;
 
     // The app may have been backgrounded again while the check ran, so the lifecycle state is read
     // again rather than taken from the check.
-    _setStatus((isOnline: newConn.isOnline, appState: state.requireValue.appState));
+    _setOnlineStatus(newConn.isOnline);
   }
 
   Future<void> _onConnectivityChange(List<ConnectivityResult> result) {
@@ -256,11 +256,15 @@ class ConnectivityChangesNotifier extends AsyncNotifier<ConnectivityStatus> {
     final wasOnline = state.requireValue.isOnline;
     final newIsOnline = await isOnline(_defaultClient);
 
-    if (!_isCurrent(revision, reason)) return;
+    if (!_isCurrent(revision)) return;
 
     if (newIsOnline != wasOnline) {
       _logger.info('Connectivity status: $reason, isOnline: $newIsOnline');
-      _setStatus((isOnline: newIsOnline, appState: state.requireValue.appState));
+      _setOnlineStatus(newIsOnline);
+    } else {
+      // A check that confirms the status is evidence just as fresh as one that changes it: it has
+      // nothing to notify about, but it still outdates the slower checks it has overtaken.
+      _onlineStatusRevision++;
     }
   }
 

--- a/lib/src/network/connectivity.dart
+++ b/lib/src/network/connectivity.dart
@@ -118,11 +118,6 @@ class ConnectivityChangesNotifier extends AsyncNotifier<ConnectivityStatus> {
 
     // A socket answering the ping/pong protocol is proof that the device can reach the network, so
     // it clears an offline status right away rather than leaving it up until the next check.
-    //
-    // Only that edge counts. A socket that is *not* connected proves nothing — it is also what
-    // returning from the background and switching routes look like — and it notices a dead link
-    // long after the check does, since that takes a ping going unanswered. The check therefore
-    // stays the authority on going offline.
     final pool = ref.read(socketPoolProvider);
     void onSocketChange() {
       if (pool.averageLag.value == Duration.zero) return;

--- a/lib/src/network/connectivity.dart
+++ b/lib/src/network/connectivity.dart
@@ -88,6 +88,7 @@ final lichessConnectionStatusProvider = Provider.autoDispose<LichessConnectionSt
 ///
 /// - Uses the [Connectivity] plugin to listen to connectivity changes
 /// - Uses [AppLifecycleListener] to check connectivity on app resume
+/// - Uses [SocketPool] to check if the device is online when the current status is offline and a socket connects
 final connectivityChangesProvider =
     AsyncNotifierProvider<ConnectivityChangesNotifier, ConnectivityStatus>(
       ConnectivityChangesNotifier.new,

--- a/lib/src/network/connectivity.dart
+++ b/lib/src/network/connectivity.dart
@@ -105,8 +105,31 @@ class ConnectivityChangesNotifier extends AsyncNotifier<ConnectivityStatus> {
   // online while the socket keeps failing.
   final _connectivityChangesThrottler = Throttler(kConnectivityThrottleDelay, trailing: true);
 
+  /// Bumped by every write that decides whether the device is online.
+  ///
+  /// A check reads the network over hundreds of milliseconds, and a resume, a socket pong or
+  /// another check can settle the question with fresher evidence while it runs. Each check
+  /// captures this revision before it starts and drops its result if it has moved since, so that a
+  /// slow answer never overwrites what happened while it was on its way.
+  int _onlineStatusRevision = 0;
+
   Client get _defaultClient => ref.read(defaultClientProvider);
   Connectivity get _connectivity => ref.read(connectivityPluginProvider);
+
+  /// Writes a status, and marks every check that is already running as outdated.
+  void _setStatus(ConnectivityStatus status) {
+    _onlineStatusRevision++;
+    state = AsyncValue.data(status);
+  }
+
+  /// Whether a check that started at [revision] may still commit its result.
+  bool _isCurrent(int revision, String reason) {
+    if (!ref.mounted) return false;
+    if (revision != _onlineStatusRevision) {
+      return false;
+    }
+    return true;
+  }
 
   @override
   Future<ConnectivityStatus> build() {
@@ -131,8 +154,7 @@ class ConnectivityChangesNotifier extends AsyncNotifier<ConnectivityStatus> {
       // while building, and Riverpod forbids a provider modifying another during a build.
       scheduleMicrotask(() {
         if (!ref.mounted || state.value?.isOnline != false) return;
-        _logger.fine('Socket connected, the device is online.');
-        state = AsyncValue.data((isOnline: true, appState: state.requireValue.appState));
+        _setStatus((isOnline: true, appState: state.requireValue.appState));
       });
     }
 
@@ -183,7 +205,6 @@ class ConnectivityChangesNotifier extends AsyncNotifier<ConnectivityStatus> {
     final result = await _connectivity.checkConnectivity();
     final status = await _getConnectivityStatus(result, appState);
     if (!status.isOnline && pool.averageLag.value != Duration.zero) {
-      _logger.fine('Initial check says offline but a socket is connected: the device is online.');
       return (isOnline: true, appState: status.appState);
     }
     return status;
@@ -200,16 +221,23 @@ class ConnectivityChangesNotifier extends AsyncNotifier<ConnectivityStatus> {
       return;
     }
 
-    if (appState == AppLifecycleState.resumed) {
-      final newConn = await _connectivity.checkConnectivity().then(
-        (r) => _getConnectivityStatus(r, appState),
-      );
+    // The lifecycle state is known right away, whatever the check that follows finds. It says
+    // nothing about connectivity, so it does not outdate a check that is already running.
+    state = AsyncValue.data((isOnline: state.requireValue.isOnline, appState: appState));
 
-      state = AsyncValue.data(newConn);
-    } else {
-      final (:isOnline, appState: _) = state.requireValue;
-      state = AsyncValue.data((isOnline: isOnline, appState: appState));
+    if (appState != AppLifecycleState.resumed) {
+      return;
     }
+
+    final revision = _onlineStatusRevision;
+    final result = await _connectivity.checkConnectivity();
+    final newConn = await _getConnectivityStatus(result, appState);
+
+    if (!_isCurrent(revision, 'app resumed')) return;
+
+    // The app may have been backgrounded again while the check ran, so the lifecycle state is read
+    // again rather than taken from the check.
+    _setStatus((isOnline: newConn.isOnline, appState: state.requireValue.appState));
   }
 
   Future<void> _onConnectivityChange(List<ConnectivityResult> result) {
@@ -224,14 +252,15 @@ class ConnectivityChangesNotifier extends AsyncNotifier<ConnectivityStatus> {
       return;
     }
 
+    final revision = _onlineStatusRevision;
     final wasOnline = state.requireValue.isOnline;
     final newIsOnline = await isOnline(_defaultClient);
 
-    if (!ref.mounted) return;
+    if (!_isCurrent(revision, reason)) return;
 
     if (newIsOnline != wasOnline) {
       _logger.info('Connectivity status: $reason, isOnline: $newIsOnline');
-      state = AsyncValue.data((isOnline: newIsOnline, appState: state.value?.appState));
+      _setStatus((isOnline: newIsOnline, appState: state.requireValue.appState));
     }
   }
 

--- a/lib/src/network/connectivity.dart
+++ b/lib/src/network/connectivity.dart
@@ -108,12 +108,13 @@ class ConnectivityChangesNotifier extends AsyncNotifier<ConnectivityStatus> {
   // online while the socket keeps failing.
   final _connectivityChangesThrottler = Throttler(kConnectivityThrottleDelay, trailing: true);
 
-  /// Bumped by every write that decides whether the device is online.
+  /// Claimed by every check that starts and every write that decides whether the device is online.
   ///
   /// A check reads the network over hundreds of milliseconds, and a resume, a socket pong or
-  /// another check can settle the question with fresher evidence while it runs. Each check
-  /// captures this revision before it starts and drops its result if it has moved since, so that a
-  /// slow answer never overwrites what happened while it was on its way.
+  /// another check can settle the question with fresher evidence while it runs. Claiming the
+  /// revision on the way in makes the last thing to start the one that gets to speak: a check
+  /// commits only if nothing has claimed it since, so neither a slow answer nor an older one that
+  /// happens to arrive first can overwrite what came after it.
   int _onlineStatusRevision = 0;
 
   Client get _defaultClient => ref.read(defaultClientProvider);
@@ -130,9 +131,12 @@ class ConnectivityChangesNotifier extends AsyncNotifier<ConnectivityStatus> {
     _ => null,
   };
 
+  /// Claims the newest revision, outdating everything that is already running.
+  int _claimRevision() => ++_onlineStatusRevision;
+
   /// Writes a status, and marks every check that is already running as outdated.
   void _setOnlineStatus(bool isOnline) {
-    _onlineStatusRevision++;
+    _claimRevision();
     state = AsyncValue.data((isOnline: isOnline, appState: state.value?.appState));
   }
 
@@ -237,7 +241,7 @@ class ConnectivityChangesNotifier extends AsyncNotifier<ConnectivityStatus> {
       return;
     }
 
-    final revision = _onlineStatusRevision;
+    final revision = _claimRevision();
     final result = await _connectivity.checkConnectivity();
     final newConn = await _getConnectivityStatus(result, appState);
 
@@ -261,19 +265,17 @@ class ConnectivityChangesNotifier extends AsyncNotifier<ConnectivityStatus> {
       return;
     }
 
-    final revision = _onlineStatusRevision;
+    final revision = _claimRevision();
     final wasOnline = settled.isOnline;
     final newIsOnline = await isOnline(_defaultClient);
 
     if (!_isCurrent(revision)) return;
 
+    // A check that confirms the status has nothing to write: the checks it overtook were already
+    // outdated by the revision it claimed on its way in.
     if (newIsOnline != wasOnline) {
       _logger.info('Connectivity status: $reason, isOnline: $newIsOnline');
       _setOnlineStatus(newIsOnline);
-    } else {
-      // A check that confirms the status is evidence just as fresh as one that changes it: it has
-      // nothing to notify about, but it still outdates the slower checks it has overtaken.
-      _onlineStatusRevision++;
     }
   }
 

--- a/lib/src/network/connectivity.dart
+++ b/lib/src/network/connectivity.dart
@@ -244,8 +244,16 @@ class ConnectivityChangesNotifier extends AsyncNotifier<ConnectivityStatus> {
     }
 
     final revision = _claimRevision();
-    final result = await _connectivity.checkConnectivity();
-    final newConn = await _getConnectivityStatus(result, appState);
+    final ConnectivityStatus newConn;
+    try {
+      newConn = await _getConnectivityStatus(await _connectivity.checkConnectivity(), appState);
+    } catch (e, s) {
+      // A check that could not run says nothing about the network, and here — unlike in [build] —
+      // there is already a settled status to fall back on: it is left as it is, rather than turned
+      // into an error something else would have to undo.
+      _logger.warning('Connectivity check on app resume failed', e, s);
+      return;
+    }
 
     if (!_isCurrent(revision)) return;
 

--- a/lib/src/network/connectivity.dart
+++ b/lib/src/network/connectivity.dart
@@ -161,9 +161,7 @@ class ConnectivityChangesNotifier extends AsyncNotifier<ConnectivityStatus> {
     // A socket answering the ping/pong protocol is proof that the device can reach the network, so
     // it clears an offline status right away rather than leaving it up until the next check.
     void onSocketConnected() {
-      // The pool's own lag is the last one any route reported, and it deliberately outlives the
-      // client that measured it: only the current client says whether a socket is up right now.
-      if (!pool.currentClient.isConnected) return;
+      if (!pool.isConnected.value) return;
       // Deferred: the pool updates this from inside [SocketPool.open], which controllers call
       // while building, and Riverpod forbids a provider modifying another during a build.
       scheduleMicrotask(() {
@@ -193,10 +191,10 @@ class ConnectivityChangesNotifier extends AsyncNotifier<ConnectivityStatus> {
       });
     }
 
-    pool.averageLag.addListener(onSocketConnected);
+    pool.isConnected.addListener(onSocketConnected);
     pool.isFailing.addListener(onSocketFailing);
     ref.onDispose(() {
-      pool.averageLag.removeListener(onSocketConnected);
+      pool.isConnected.removeListener(onSocketConnected);
       pool.isFailing.removeListener(onSocketFailing);
     });
 
@@ -211,7 +209,7 @@ class ConnectivityChangesNotifier extends AsyncNotifier<ConnectivityStatus> {
       // A check that could not even run is read as offline, and the socket has no way back in: the
       // report it made while this one was running found nothing settled to correct, and was
       // dropped. So the socket has the same say here as it does below.
-      if (pool.currentClient.isConnected) {
+      if (pool.isConnected.value) {
         return (isOnline: true, appState: appState);
       }
       rethrow;
@@ -219,7 +217,7 @@ class ConnectivityChangesNotifier extends AsyncNotifier<ConnectivityStatus> {
 
     // A socket that is connected by the time the check answers is proof of a working network, and
     // outranks a check that came back offline.
-    if (!status.isOnline && pool.currentClient.isConnected) {
+    if (!status.isOnline && pool.isConnected.value) {
       return (isOnline: true, appState: status.appState);
     }
     return status;

--- a/lib/src/network/connectivity.dart
+++ b/lib/src/network/connectivity.dart
@@ -173,8 +173,14 @@ class ConnectivityChangesNotifier extends AsyncNotifier<ConnectivityStatus> {
       // Deferred: the pool updates this from inside [SocketPool.open], which controllers call
       // while building, and Riverpod forbids a provider modifying another during a build.
       scheduleMicrotask(() {
-        if (!ref.mounted || _settledStatus?.isOnline != false) return;
-        _setOnlineStatus(true);
+        if (!ref.mounted) return;
+        final settled = _settledStatus;
+        if (settled == null) return;
+        if (settled.isOnline) {
+          _claimRevision();
+        } else {
+          _setOnlineStatus(true);
+        }
       });
     }
 
@@ -188,13 +194,8 @@ class ConnectivityChangesNotifier extends AsyncNotifier<ConnectivityStatus> {
     void onSocketFailing() {
       if (!pool.isFailing) return;
       scheduleMicrotask(() {
-        // A device already known to be offline has nothing to learn from a socket that fails, and
-        // must not take up the throttler's window: the connectivity event that brings the network
-        // back is what has to run next, without waiting out a delay.
         if (!ref.mounted || _settledStatus?.isOnline != true) return;
         _connectivityChangesThrottler(() {
-          // Checked again: the throttler may run this a delay later, by which time the status may
-          // have settled offline on its own.
           if (!ref.mounted || _settledStatus?.isOnline != true) return;
           _refreshOnlineStatus('socket cannot connect');
         });

--- a/lib/src/network/connectivity.dart
+++ b/lib/src/network/connectivity.dart
@@ -103,18 +103,12 @@ class ConnectivityChangesNotifier extends AsyncNotifier<ConnectivityStatus> {
   StreamSubscription<List<ConnectivityResult>>? _connectivitySubscription;
   AppLifecycleListener? _appLifecycleListener;
 
-  // Trailing: [onSocketFailing] reports a run of failures once, so a call dropped here is a signal
-  // lost for good — no later notification would ask for the check again, and the status would stay
-  // online while the socket keeps failing.
+  // Trailing: the plugin reports each change once, so a call dropped here is a signal lost for
+  // good — nothing would ask for the check again, and the status would stay as it was until the
+  // next change.
   final _connectivityChangesThrottler = Throttler(kConnectivityThrottleDelay, trailing: true);
 
   /// Claimed by every check that starts and every write that decides whether the device is online.
-  ///
-  /// A check reads the network over hundreds of milliseconds, and a resume, a socket pong or
-  /// another check can settle the question with fresher evidence while it runs. Claiming the
-  /// revision on the way in makes the last thing to start the one that gets to speak: a check
-  /// commits only if nothing has claimed it since, so neither a slow answer nor an older one that
-  /// happens to arrive first can overwrite what came after it.
   int _onlineStatusRevision = 0;
 
   Client get _defaultClient => ref.read(defaultClientProvider);
@@ -189,24 +183,21 @@ class ConnectivityChangesNotifier extends AsyncNotifier<ConnectivityStatus> {
     // set the status offline, it merely asks the check to run — the check remains the authority.
     //
     // This is also what keeps the two providers from egging each other on: [SocketPool] reconnects
-    // on the offline -> online edge only, and a socket only reports a *run* of failures once, so
-    // each failing run costs at most one check.
+    // on the offline -> online edge only, and [SocketPool.isFailing] only turns true once per run
+    // of failures, so each failing run costs at most one check.
     void onSocketFailing() {
-      if (!pool.isFailing) return;
+      if (!pool.isFailing.value) return;
       scheduleMicrotask(() {
         if (!ref.mounted || _settledStatus?.isOnline != true) return;
-        _connectivityChangesThrottler(() {
-          if (!ref.mounted || _settledStatus?.isOnline != true) return;
-          _refreshOnlineStatus('socket cannot connect');
-        });
+        _refreshOnlineStatus('socket cannot connect');
       });
     }
 
     pool.averageLag.addListener(onSocketConnected);
-    pool.failingSince.addListener(onSocketFailing);
+    pool.isFailing.addListener(onSocketFailing);
     ref.onDispose(() {
       pool.averageLag.removeListener(onSocketConnected);
-      pool.failingSince.removeListener(onSocketFailing);
+      pool.isFailing.removeListener(onSocketFailing);
     });
 
     final AppLifecycleState? appState = WidgetsBinding.instance.lifecycleState;

--- a/lib/src/network/connectivity.dart
+++ b/lib/src/network/connectivity.dart
@@ -182,7 +182,7 @@ class ConnectivityChangesNotifier extends AsyncNotifier<ConnectivityStatus> {
     // on the offline -> online edge only, and a socket only reports a *run* of failures once, so
     // each failing run costs at most one check.
     void onSocketFailing() {
-      if (!pool.isFailing.value) return;
+      if (!pool.isFailing) return;
       scheduleMicrotask(() {
         // A device already known to be offline has nothing to learn from a socket that fails, and
         // must not take up the throttler's window: the connectivity event that brings the network
@@ -198,10 +198,10 @@ class ConnectivityChangesNotifier extends AsyncNotifier<ConnectivityStatus> {
     }
 
     pool.averageLag.addListener(onSocketConnected);
-    pool.isFailing.addListener(onSocketFailing);
+    pool.failingSince.addListener(onSocketFailing);
     ref.onDispose(() {
       pool.averageLag.removeListener(onSocketConnected);
-      pool.isFailing.removeListener(onSocketFailing);
+      pool.failingSince.removeListener(onSocketFailing);
     });
 
     final AppLifecycleState? appState = WidgetsBinding.instance.lifecycleState;

--- a/lib/src/network/socket.dart
+++ b/lib/src/network/socket.dart
@@ -26,6 +26,13 @@ const _kDefaultConnectTimeout = Duration(seconds: 10);
 const _kPingDelay = Duration(milliseconds: 2500);
 const _kPingMaxLag = Duration(seconds: 9);
 const _kAutoReconnectDelay = Duration(milliseconds: 3500);
+
+/// The ceiling of the exponential backoff between failed connection attempts.
+const _kMaxAutoReconnectDelay = Duration(seconds: 60);
+
+/// How long the socket keeps retrying at full speed before the backoff sets in.
+const _kReconnectGracePeriod = Duration(seconds: 30);
+
 const _kResendAckDelay = Duration(milliseconds: 1500);
 const _kVersionGapRetryDelay = Duration(milliseconds: 200);
 const _kIdleTimeout = Duration(seconds: 2);
@@ -94,11 +101,16 @@ class SocketClient {
     this.pingDelay = _kPingDelay,
     this.pingMaxLag = _kPingMaxLag,
     this.autoReconnectDelay = _kAutoReconnectDelay,
+    this.reconnectGracePeriod = _kReconnectGracePeriod,
     this.resendAckDelay = _kResendAckDelay,
   }) : assert(route.path.isNotEmpty, 'Route path must not be empty'),
        assert(pingDelay > Duration.zero, 'Ping delay must be greater than 0'),
        assert(pingMaxLag > Duration.zero, 'Ping max lag must be greater than 0'),
        assert(autoReconnectDelay > Duration.zero, 'Auto reconnect delay must be greater than 0'),
+       assert(
+         reconnectGracePeriod > Duration.zero,
+         'Reconnect grace period must be greater than 0',
+       ),
        assert(resendAckDelay > Duration.zero, 'Resend ack delay must be greater than 0');
 
   final WebSocketChannelFactory channelFactory;
@@ -126,6 +138,10 @@ class SocketClient {
 
   /// The delay before reconnecting after a connection failure.
   final Duration autoReconnectDelay;
+
+  /// How long connection failures keep being retried at [autoReconnectDelay], before the delay
+  /// starts doubling.
+  final Duration reconnectGracePeriod;
 
   /// The delay before resending an ack.
   final Duration resendAckDelay;
@@ -175,6 +191,9 @@ class SocketClient {
   /// The current number of successful connections.
   int nbConnectionSuccess = 0;
 
+  /// When the current run of failed connection attempts started, null while the socket is healthy.
+  DateTime? _failingSince;
+
   /// The current ack id. Incremented for each ack.
   int _ackId = 1;
 
@@ -223,6 +242,7 @@ class SocketClient {
     }
 
     _disconnect();
+
     final epoch = _connectionEpoch;
     _pongCount = 0;
     _reconnectTimer?.cancel();
@@ -279,6 +299,7 @@ class SocketClient {
       _logger.fine('WebSocket connection to $route established.');
 
       nbConnectionSuccess++;
+      _failingSince = null;
 
       if (nbConnectionSuccess == 1) {
         _firstConnection.complete();
@@ -312,16 +333,25 @@ class SocketClient {
       }
 
       _resendAcks();
-    } catch (e, st) {
+    } catch (e) {
       // Don't revive a client that was closed or reconnected while the failed attempt was in
       // flight, otherwise it would keep reconnecting in the background forever.
       if (isDisposed || epoch != _connectionEpoch) {
         _logger.fine('Stale WebSocket connection to $route failed:', e);
         return;
       }
-      _logger.severe('WebSocket connection failed:', e, st);
       _averageLag.value = Duration.zero;
-      _scheduleReconnect(autoReconnectDelay);
+      _failingSince ??= clock_package.clock.now();
+
+      // A failed attempt says nothing on its own: it is what a device with no network looks like,
+      // and that is not an error the logs should shout about. The backoff is what keeps a socket
+      // that cannot connect from retrying in a tight loop.
+      final delay = _reconnectDelay;
+      _logger.fine(
+        'WebSocket connection to $route failed (for ${_failingFor.inSeconds}s now), retrying in '
+        '${delay.inMilliseconds}ms: $e',
+      );
+      _scheduleReconnect(delay);
     }
   }
 
@@ -388,6 +418,7 @@ class SocketClient {
   Future<void> close() {
     nbConnectionAttempts = 0;
     nbConnectionSuccess = 0;
+    _failingSince = null;
     _firstConnection = Completer<void>();
     return _disconnect();
   }
@@ -513,6 +544,27 @@ class SocketClient {
     _averageLag.value += (currentLag - _averageLag.value) * mix;
   }
 
+  /// How long this run of failures has been going on.
+  Duration get _failingFor {
+    final since = _failingSince;
+    return since == null ? Duration.zero : clock_package.clock.now().difference(since);
+  }
+
+  /// How long to wait before the next attempt.
+  ///
+  /// Stays at [autoReconnectDelay] for the first [reconnectGracePeriod], so that a transient
+  /// failure is retried at full speed, then doubles for every further grace period spent failing,
+  /// up to [_kMaxAutoReconnectDelay]. A device left with no network thus settles into a slow poll
+  /// instead of a tight loop, without ever making a blip cost more than a few seconds.
+  Duration get _reconnectDelay {
+    final failingFor = _failingFor;
+    if (failingFor <= reconnectGracePeriod) return autoReconnectDelay;
+
+    final doublings = failingFor.inMicroseconds ~/ reconnectGracePeriod.inMicroseconds;
+    final delay = autoReconnectDelay * (1 << math.min(doublings, 8));
+    return delay < _kMaxAutoReconnectDelay ? delay : _kMaxAutoReconnectDelay;
+  }
+
   void _scheduleReconnect(Duration delay) {
     _reconnectTimer?.cancel();
     _reconnectTimer = Timer(delay, () {
@@ -584,7 +636,6 @@ class SocketPool {
         _averageLag.value = client.averageLag.value;
       }
     });
-
     _pool[_currentRoute] = client;
   }
 
@@ -594,6 +645,8 @@ class SocketPool {
   final Duration idleTimeout;
 
   final _averageLag = ValueNotifier(Duration.zero);
+
+  Timer? _closeInBackgroundTimer;
 
   /// The average lag computed from ping/pong protocol of the current active route.
   ///
@@ -614,6 +667,28 @@ class SocketPool {
   /// The socket clients pool.
   final Map<Uri, SocketClient> _pool = {};
   final Map<Uri, Timer?> _disposeTimers = {};
+
+  /// Call when the app goes to the background.
+  ///
+  /// The socket is kept for a while, as the user may well come right back, then closed to spare
+  /// the battery.
+  void onAppHidden() {
+    _closeInBackgroundTimer?.cancel();
+    _closeInBackgroundTimer = Timer(_kDisconnectOnBackgroundTimeout, () {
+      _logger.info(
+        'App is in background for ${_kDisconnectOnBackgroundTimeout.inMinutes}m, closing socket.',
+      );
+      currentClient.close();
+    });
+  }
+
+  /// Call when the app comes back to the foreground.
+  void onAppShown() {
+    _closeInBackgroundTimer?.cancel();
+    if (!currentClient.isActive) {
+      currentClient.connect();
+    }
+  }
 
   /// Opens a socket connection to the given [route].
   ///
@@ -696,6 +771,7 @@ class SocketPool {
     }
     _isDisposed = true;
     _averageLag.dispose();
+    _closeInBackgroundTimer?.cancel();
     _disposeTimers.forEach((_, t) => t?.cancel());
     _pool.forEach((_, c) => c.dispose());
   }
@@ -704,7 +780,6 @@ class SocketPool {
 /// The global socket pool provider.
 final socketPoolProvider = Provider<SocketPool>((Ref ref) {
   final pool = SocketPool(ref);
-  Timer? closeInBackgroundTimer;
 
   pool.currentClient.connect();
 
@@ -713,29 +788,18 @@ final socketPoolProvider = Provider<SocketPool>((Ref ref) {
     pool.currentClient.connect();
   });
 
+  // Observing the app lifecycle here rather than in [SocketPool], because an
+  // [AppLifecycleListener] needs a [WidgetsBinding], which the pool must not require of the tests
+  // that build one.
   final appLifecycleListener = AppLifecycleListener(
-    onHide: () {
-      closeInBackgroundTimer?.cancel();
-      closeInBackgroundTimer = Timer(_kDisconnectOnBackgroundTimeout, () {
-        _logger.info(
-          'App is in background for ${_kDisconnectOnBackgroundTimeout.inMinutes}m, closing socket.',
-        );
-        pool.currentClient.close();
-      });
-    },
-    onShow: () {
-      closeInBackgroundTimer?.cancel();
-      if (!pool.currentClient.isActive) {
-        pool.currentClient.connect();
-      }
-    },
+    onHide: pool.onAppHidden,
+    onShow: pool.onAppShown,
   );
 
   ref.onDispose(() {
     subscription.cancel();
-    pool.dispose();
-    closeInBackgroundTimer?.cancel();
     appLifecycleListener.dispose();
+    pool.dispose();
   });
 
   return pool;

--- a/lib/src/network/socket.dart
+++ b/lib/src/network/socket.dart
@@ -171,7 +171,14 @@ class SocketClient {
   DateTime _lastPing = clock_package.clock.now();
 
   final _averageLag = ValueNotifier(Duration.zero);
-  final _isFailing = ValueNotifier(false);
+
+  /// When the current run of failures started, null while the socket is healthy.
+  ///
+  /// A run starts at the first attempt that goes wrong — a connection that could not be made, or a
+  /// ping that went unanswered — and ends only once a pong proves the socket usable again. The
+  /// handshake alone does not end it: a channel that opens and then answers nothing would reset
+  /// the backoff on every attempt, and never look failing to anyone watching.
+  final _failingSince = ValueNotifier<DateTime?>(null);
 
   StreamSubscription<SocketEvent>? _socketStreamSubscription;
 
@@ -192,9 +199,6 @@ class SocketClient {
 
   /// The current number of successful connections.
   int nbConnectionSuccess = 0;
-
-  /// When the current run of failed connection attempts started, null while the socket is healthy.
-  DateTime? _failingSince;
 
   /// The current ack id. Incremented for each ack.
   int _ackId = 1;
@@ -230,11 +234,14 @@ class SocketClient {
   /// Whether the socket is connected.
   bool get isConnected => averageLag.value != Duration.zero;
 
-  /// Whether the socket is failing to connect, and waiting out its backoff before trying again.
+  /// When the current run of failures started, null while the socket is healthy.
   ///
-  /// Set once when a run of failures starts, and cleared when the socket connects or is closed, so
+  /// Set once when a run starts, and cleared when the socket answers a ping again or is closed, so
   /// that a listener hears about a socket that cannot connect, not about each of its attempts.
-  ValueListenable<bool> get isFailing => _isFailing;
+  ValueListenable<DateTime?> get failingSince => _failingSince;
+
+  /// Whether the socket is failing, and waiting out its backoff before trying again.
+  bool get isFailing => _failingSince.value != null;
 
   /// Whether the client is disposed. If true the client cannot be reconnected, or
   /// be listened to.
@@ -307,8 +314,6 @@ class SocketClient {
       _logger.fine('WebSocket connection to $route established.');
 
       nbConnectionSuccess++;
-      _failingSince = null;
-      _isFailing.value = false;
 
       if (nbConnectionSuccess == 1) {
         _firstConnection.complete();
@@ -350,8 +355,7 @@ class SocketClient {
         return;
       }
       _averageLag.value = Duration.zero;
-      _failingSince ??= clock_package.clock.now();
-      _isFailing.value = true;
+      _failingSince.value ??= clock_package.clock.now();
 
       final delay = _reconnectDelay;
       final message =
@@ -428,7 +432,7 @@ class SocketClient {
     _versionGapRetryTimer?.cancel();
     _streamController.close();
     _averageLag.dispose();
-    _isFailing.dispose();
+    _failingSince.dispose();
     isDisposed = true;
     _disconnect();
   }
@@ -441,8 +445,7 @@ class SocketClient {
   Future<void> close() {
     nbConnectionAttempts = 0;
     nbConnectionSuccess = 0;
-    _failingSince = null;
-    _isFailing.value = false;
+    _failingSince.value = null;
     _firstConnection = Completer<void>();
     return _disconnect();
   }
@@ -556,6 +559,8 @@ class SocketClient {
     _reconnectTimer?.cancel();
     if (_pongCount == 0) {
       _logger.fine('Ping/pong protocol for $route established.');
+      // The socket is not merely open, it answers: this is what ends a run of failures.
+      _failingSince.value = null;
     }
     _schedulePing(pingDelay);
     _pongCount++;
@@ -570,7 +575,7 @@ class SocketClient {
 
   /// How long this run of failures has been going on.
   Duration get _failingFor {
-    final since = _failingSince;
+    final since = _failingSince.value;
     return since == null ? Duration.zero : clock_package.clock.now().difference(since);
   }
 
@@ -593,6 +598,10 @@ class SocketClient {
     _reconnectTimer?.cancel();
     _reconnectTimer = Timer(delay, () {
       if (!isDisposed) {
+        // Whatever scheduled it, a reconnect only ever follows a failure: an attempt that could
+        // not connect, or a ping left unanswered for [pingMaxLag]. Both start a run, so that the
+        // backoff grows and the connectivity check is asked for.
+        _failingSince.value ??= clock_package.clock.now();
         _logger.fine('Reconnecting WebSocket.');
         _averageLag.value = Duration.zero;
         connect();
@@ -678,7 +687,7 @@ class SocketPool {
   final Duration idleTimeout;
 
   final _averageLag = ValueNotifier(Duration.zero);
-  final _isFailing = ValueNotifier(false);
+  final _failingSince = ValueNotifier<DateTime?>(null);
 
   Timer? _closeInBackgroundTimer;
 
@@ -689,8 +698,11 @@ class SocketPool {
   /// A duration of zero means the socket is not connected.
   ValueListenable<Duration> get averageLag => _averageLag;
 
-  /// Whether the current socket is failing to connect, and waiting out its backoff.
-  ValueListenable<bool> get isFailing => _isFailing;
+  /// When the current socket's run of failures started, null while it is healthy.
+  ValueListenable<DateTime?> get failingSince => _failingSince;
+
+  /// Whether the current socket is failing, and waiting out its backoff.
+  bool get isFailing => _failingSince.value != null;
 
   /// Whether the pool is disposed.
   ///
@@ -763,7 +775,7 @@ class SocketPool {
   /// to [currentClient]'s.
   void _syncCurrentClientFailingState(SocketClient client) {
     if (client.isDisposed) return;
-    _isFailing.value = client.isFailing.value;
+    _failingSince.value = client.failingSince.value;
   }
 
   /// Reflects [client]'s connection state in the pool's own, for as long as it is the current one.
@@ -773,9 +785,9 @@ class SocketPool {
         _averageLag.value = client.averageLag.value;
       }
     });
-    client.isFailing.addListener(() {
+    client.failingSince.addListener(() {
       if (_currentRoute == client.route) {
-        _isFailing.value = client.isFailing.value;
+        _failingSince.value = client.failingSince.value;
       }
     });
   }
@@ -786,7 +798,7 @@ class SocketPool {
   /// device that cannot connect at all, and is only ever cut short by something — the app coming
   /// back to the foreground, the network coming back — saying that this time it might work.
   void _connectIfNeeded() {
-    if (!currentClient.isActive || currentClient.isFailing.value) {
+    if (!currentClient.isActive || currentClient.isFailing) {
       currentClient.connect();
     }
   }
@@ -877,7 +889,7 @@ class SocketPool {
     }
     _isDisposed = true;
     _averageLag.dispose();
-    _isFailing.dispose();
+    _failingSince.dispose();
     _closeInBackgroundTimer?.cancel();
     _disposeTimers.forEach((_, t) => t?.cancel());
     _pool.forEach((_, c) => c.dispose());

--- a/lib/src/network/socket.dart
+++ b/lib/src/network/socket.dart
@@ -736,6 +736,22 @@ class SocketPool {
     }
   }
 
+  /// Takes [client]'s failing state as the pool's own, when it becomes the current one.
+  ///
+  /// The mirror below only forwards what a client emits from now on, so the pool has to read the
+  /// state of the client it switches to: the one it switches away from clears its failing state as
+  /// it is closed, but by then it is no longer the current route and that update is dropped — the
+  /// pool would stay failing, and swallow the next real failure as a value it already holds.
+  ///
+  /// The average lag is deliberately left as it is: a client that has yet to answer its first ping
+  /// has no lag to speak of, and blanking the pool's on every route change would have every screen
+  /// switch flash as a disconnection. Consumers that care about a single route already compare it
+  /// to [currentClient]'s.
+  void _syncCurrentClientFailingState(SocketClient client) {
+    if (client.isDisposed) return;
+    _isFailing.value = client.isFailing.value;
+  }
+
   /// Reflects [client]'s connection state in the pool's own, for as long as it is the current one.
   void _mirrorCurrentClientState(SocketClient client) {
     client.averageLag.addListener(() {
@@ -810,6 +826,7 @@ class SocketPool {
             // battery, and nothing is watching what the default one would bring in anyway.
             if (route == _currentRoute) {
               _currentRoute = Uri(path: kDefaultSocketRoute);
+              _syncCurrentClientFailingState(currentClient);
               if (!_isAppInBackground && !currentClient.isActive) {
                 currentClient.connect();
               }
@@ -830,6 +847,8 @@ class SocketPool {
     });
 
     final client = _pool[route]!;
+    _syncCurrentClientFailingState(client);
+
     if (forceReconnect == true || !client.isActive) {
       client.connect();
     }

--- a/lib/src/network/socket.dart
+++ b/lib/src/network/socket.dart
@@ -179,7 +179,11 @@ class SocketClient {
   /// ping that went unanswered — and ends only once a pong proves the socket usable again. The
   /// handshake alone does not end it: a channel that opens and then answers nothing would reset
   /// the backoff on every attempt, and never look failing to anyone watching.
-  final _failingSince = ValueNotifier<DateTime?>(null);
+  ///
+  /// Only the backoff needs the instant it started; [_isFailing] is what the outside sees.
+  DateTime? _failingSince;
+
+  final _isFailing = ValueNotifier(false);
 
   StreamSubscription<SocketEvent>? _socketStreamSubscription;
 
@@ -235,14 +239,12 @@ class SocketClient {
   /// Whether the socket is connected.
   bool get isConnected => averageLag.value != Duration.zero;
 
-  /// When the current run of failures started, null while the socket is healthy.
-  ///
-  /// Set once when a run starts, and cleared when the socket answers a ping again or is closed, so
-  /// that a listener hears about a socket that cannot connect, not about each of its attempts.
-  ValueListenable<DateTime?> get failingSince => _failingSince;
-
   /// Whether the socket is failing, and waiting out its backoff before trying again.
-  bool get isFailing => _failingSince.value != null;
+  ///
+  /// Turns true when a run of failures starts, and false again when the socket answers a ping or
+  /// is closed, so that a listener hears about a socket that cannot connect, not about each of its
+  /// attempts.
+  ValueListenable<bool> get isFailing => _isFailing;
 
   /// Whether the client is disposed. If true the client cannot be reconnected, or
   /// be listened to.
@@ -356,7 +358,7 @@ class SocketClient {
         return;
       }
       _averageLag.value = Duration.zero;
-      _failingSince.value ??= clock_package.clock.now();
+      _startFailing();
 
       final delay = _reconnectDelay;
       final message =
@@ -434,7 +436,7 @@ class SocketClient {
     _versionGapRetryTimer?.cancel();
     _streamController.close();
     _averageLag.dispose();
-    _failingSince.dispose();
+    _isFailing.dispose();
     isDisposed = true;
     _disconnect();
   }
@@ -447,7 +449,7 @@ class SocketClient {
   Future<void> close() {
     nbConnectionAttempts = 0;
     nbConnectionSuccess = 0;
-    _failingSince.value = null;
+    _stopFailing();
     _firstConnection = Completer<void>();
     return _disconnect();
   }
@@ -573,7 +575,7 @@ class SocketClient {
 
     // The socket is not answering: it is no longer proof of anything to whoever watches the lag.
     _averageLag.value = Duration.zero;
-    _failingSince.value ??= clock_package.clock.now();
+    _startFailing();
 
     final delay = _reconnectDelay;
     _logger.fine(
@@ -590,7 +592,7 @@ class SocketClient {
     // The socket is not merely open, it answers: this, and not the handshake before it, is what
     // ends a run of failures — and it makes any reconnect waiting out the backoff moot.
     _reconnectTimer?.cancel();
-    _failingSince.value = null;
+    _stopFailing();
     if (_pongCount == 0) {
       _logger.fine('Ping/pong protocol for $route established.');
     }
@@ -605,9 +607,21 @@ class SocketClient {
     _averageLag.value += (currentLag - _averageLag.value) * mix;
   }
 
+  /// Starts a run of failures, if one is not already going on.
+  void _startFailing() {
+    _failingSince ??= clock_package.clock.now();
+    _isFailing.value = true;
+  }
+
+  /// Ends the current run of failures.
+  void _stopFailing() {
+    _failingSince = null;
+    _isFailing.value = false;
+  }
+
   /// How long this run of failures has been going on.
   Duration get _failingFor {
-    final since = _failingSince.value;
+    final since = _failingSince;
     return since == null ? Duration.zero : clock_package.clock.now().difference(since);
   }
 
@@ -715,7 +729,7 @@ class SocketPool {
   final Duration idleTimeout;
 
   final _averageLag = ValueNotifier(Duration.zero);
-  final _failingSince = ValueNotifier<DateTime?>(null);
+  final _isFailing = ValueNotifier(false);
 
   Timer? _closeInBackgroundTimer;
 
@@ -726,11 +740,8 @@ class SocketPool {
   /// A duration of zero means the socket is not connected.
   ValueListenable<Duration> get averageLag => _averageLag;
 
-  /// When the current socket's run of failures started, null while it is healthy.
-  ValueListenable<DateTime?> get failingSince => _failingSince;
-
   /// Whether the current socket is failing, and waiting out its backoff.
-  bool get isFailing => _failingSince.value != null;
+  ValueListenable<bool> get isFailing => _isFailing;
 
   /// Whether the pool is disposed.
   ///
@@ -803,7 +814,7 @@ class SocketPool {
   /// to [currentClient]'s.
   void _syncCurrentClientFailingState(SocketClient client) {
     if (client.isDisposed) return;
-    _failingSince.value = client.failingSince.value;
+    _isFailing.value = client.isFailing.value;
   }
 
   /// Reflects [client]'s connection state in the pool's own, for as long as it is the current one.
@@ -813,9 +824,9 @@ class SocketPool {
         _averageLag.value = client.averageLag.value;
       }
     });
-    client.failingSince.addListener(() {
+    client.isFailing.addListener(() {
       if (_currentRoute == client.route) {
-        _failingSince.value = client.failingSince.value;
+        _isFailing.value = client.isFailing.value;
       }
     });
   }
@@ -826,7 +837,7 @@ class SocketPool {
   /// device that cannot connect at all, and is only ever cut short by something — the app coming
   /// back to the foreground, the network coming back — saying that this time it might work.
   void _connectIfNeeded() {
-    if (!currentClient.isActive || currentClient.isFailing) {
+    if (!currentClient.isActive || currentClient.isFailing.value) {
       currentClient.connect();
     }
   }
@@ -917,7 +928,7 @@ class SocketPool {
     }
     _isDisposed = true;
     _averageLag.dispose();
-    _failingSince.dispose();
+    _isFailing.dispose();
     _closeInBackgroundTimer?.cancel();
     _disposeTimers.forEach((_, t) => t?.cancel());
     _pool.forEach((_, c) => c.dispose());

--- a/lib/src/network/socket.dart
+++ b/lib/src/network/socket.dart
@@ -772,11 +772,14 @@ class SocketPool {
 
   final _averageLag = ValueNotifier(Duration.zero);
 
-  /// Whether the current socket has answered a ping since the device was last found offline.
+  /// Whether a socket has answered a ping since the device was last found offline.
   ///
-  /// A socket that did has already made the connection the online edge would ask for: its own
-  /// retry got to the network before the check noticed it was back. One that did not says nothing:
-  /// it may well be holding a connection to a network that is gone.
+  /// One that did has already made the connection the online edge would ask for: its own retry got
+  /// to the network before the check noticed it was back. One that did not says nothing: it may
+  /// well be holding a connection to a network that is gone.
+  ///
+  /// It says nothing about *which* socket answered, so it is only ever read together with the
+  /// current client's own state — the pool may have switched route since.
   bool _socketAnsweredSinceOffline = false;
 
   Timer? _closeInBackgroundTimer;
@@ -836,10 +839,14 @@ class SocketPool {
   void onDeviceBackOnline() {
     if (_isAppInBackground) return;
 
-    // The socket answered a ping while the device was held offline, so it is already on the
-    // network this edge is announcing: reconnecting it here would cost an event gap and a
+    // The current socket answered a ping while the device was held offline, so it is already on
+    // the network this edge is announcing: reconnecting it here would cost an event gap and a
     // handshake to end up exactly where it is.
-    if (_socketAnsweredSinceOffline) {
+    //
+    // The flag alone would not do: it is not reset when the pool switches route, so it may well be
+    // the socket of the route before this one that answered, while the current one is failing and
+    // has everything to gain from an attempt now.
+    if (_socketAnsweredSinceOffline && currentClient.isConnected) {
       return;
     }
 

--- a/lib/src/network/socket.dart
+++ b/lib/src/network/socket.dart
@@ -398,7 +398,11 @@ class SocketClient {
   }
 
   /// Sends a message to the websocket.
-  void send(String topic, Object? data, {bool? ackable, bool? withLag}) {
+  ///
+  /// [noRetry] drops the message when there is no connection to write it to, instead of queueing
+  /// it for the next one. It says nothing about [ackable] messages, which are retried until acked
+  /// whatever happens.
+  void send(String topic, Object? data, {bool? ackable, bool? withLag, bool noRetry = false}) {
     Map<String, Object> message;
     int? ackId;
 
@@ -427,7 +431,7 @@ class SocketClient {
     final sink = _sink;
     if (sink != null) {
       sink.add(encoded);
-    } else {
+    } else if (!noRetry) {
       // Not connected: queue the message so it is sent once the connection
       // (re)opens, instead of being silently dropped.
       _resendWhenOpen.add((ackId, encoded));

--- a/lib/src/network/socket.dart
+++ b/lib/src/network/socket.dart
@@ -14,6 +14,7 @@ import 'package:lichess_mobile/src/model/auth/auth_controller.dart';
 import 'package:lichess_mobile/src/model/auth/bearer.dart';
 import 'package:lichess_mobile/src/model/common/preloaded_data.dart';
 import 'package:lichess_mobile/src/model/common/socket.dart';
+import 'package:lichess_mobile/src/network/connectivity.dart';
 import 'package:lichess_mobile/src/network/http.dart';
 import 'package:logging/logging.dart';
 import 'package:package_info_plus/package_info_plus.dart';
@@ -227,6 +228,9 @@ class SocketClient {
 
   /// Whether the socket is connected.
   bool get isConnected => averageLag.value != Duration.zero;
+
+  /// Whether the socket is failing to connect, and waiting out its backoff before trying again.
+  bool get isFailing => _failingSince != null;
 
   /// Whether the client is disposed. If true the client cannot be reconnected, or
   /// be listened to.
@@ -637,6 +641,17 @@ class SocketPool {
       }
     });
     _pool[_currentRoute] = client;
+
+    // Deferred: [ConnectivityChangesNotifier] reads this pool while building, so listening to it
+    // right here would have the two providers build each other, which Riverpod forbids.
+    scheduleMicrotask(() {
+      if (_isDisposed) return;
+      _ref.listen(connectivityChangesProvider, (prev, next) {
+        if (prev?.value?.isOnline == false && next.value?.isOnline == true) {
+          onDeviceOnline();
+        }
+      });
+    });
   }
 
   final Ref _ref;
@@ -647,6 +662,8 @@ class SocketPool {
   final _averageLag = ValueNotifier(Duration.zero);
 
   Timer? _closeInBackgroundTimer;
+
+  bool _isAppInBackground = false;
 
   /// The average lag computed from ping/pong protocol of the current active route.
   ///
@@ -673,6 +690,7 @@ class SocketPool {
   /// The socket is kept for a while, as the user may well come right back, then closed to spare
   /// the battery.
   void onAppHidden() {
+    _isAppInBackground = true;
     _closeInBackgroundTimer?.cancel();
     _closeInBackgroundTimer = Timer(_kDisconnectOnBackgroundTimeout, () {
       _logger.info(
@@ -684,8 +702,29 @@ class SocketPool {
 
   /// Call when the app comes back to the foreground.
   void onAppShown() {
+    _isAppInBackground = false;
     _closeInBackgroundTimer?.cancel();
-    if (!currentClient.isActive) {
+    _connectIfNeeded();
+  }
+
+  /// Call when the device comes back online, after having been offline.
+  ///
+  /// A socket that went down with the network keeps retrying on an exponential backoff, so it may
+  /// be up to a minute before it notices on its own that the network is back. Connectivity knows
+  /// first, so it is worth an attempt right away.
+  void onDeviceOnline() {
+    if (_isAppInBackground) return;
+    _logger.info('Device is back online, reconnecting the socket.');
+    _connectIfNeeded();
+  }
+
+  /// Connects the current client, unless it is already connected or on its way to being.
+  ///
+  /// A client waiting out its reconnect backoff does need connecting: the wait is there to spare a
+  /// device that cannot connect at all, and is only ever cut short by something — the app coming
+  /// back to the foreground, the network coming back — saying that this time it might work.
+  void _connectIfNeeded() {
+    if (!currentClient.isActive || currentClient.isFailing) {
       currentClient.connect();
     }
   }

--- a/lib/src/network/socket.dart
+++ b/lib/src/network/socket.dart
@@ -655,8 +655,10 @@ class SocketPool {
     // right here would have the two providers build each other, which Riverpod forbids.
     scheduleMicrotask(() {
       if (_isDisposed) return;
+      // [isDeviceOnlineIn] rather than the raw value: a check that failed reads as offline there,
+      // and coming back from one is an edge the socket has to hear about like any other.
       _ref.listen(connectivityChangesProvider, (prev, next) {
-        if (prev?.value?.isOnline == false && next.value?.isOnline == true) {
+        if (prev != null && !isDeviceOnlineIn(prev) && isDeviceOnlineIn(next)) {
           onDeviceOnline();
         }
       });

--- a/lib/src/network/socket.dart
+++ b/lib/src/network/socket.dart
@@ -259,7 +259,7 @@ class SocketClient {
       throw StateError('SocketClient is disposed, cannot connect.');
     }
 
-    _disconnect();
+    unawaited(_disconnect());
 
     final epoch = _connectionEpoch;
     _pongCount = 0;
@@ -558,8 +558,10 @@ class SocketClient {
   void _onChannelGone(int epoch, [Object? error, StackTrace? stackTrace]) {
     if (isDisposed || epoch != _connectionEpoch) return;
 
-    _pingTimer?.cancel();
-    _pongTimeoutTimer?.cancel();
+    // The peer is gone, but the channel is still there to be closed, and its timers to be
+    // cancelled — as for a pong timeout, [send] must queue rather than write to a dead sink.
+    unawaited(_disconnect());
+
     _averageLag.value = Duration.zero;
     _startFailing();
 
@@ -609,6 +611,11 @@ class SocketClient {
   /// forever.
   void _onPongTimeout() {
     if (isDisposed) return;
+
+    // Drop the channel now rather than at the end of the backoff, which can be a minute long: a
+    // sink nothing answers on is not somewhere to write, and [send] queues for the next connection
+    // as soon as there is none. This cancels the ping and ack timers along with it.
+    unawaited(_disconnect());
 
     // The socket is not answering: it is no longer proof of anything to whoever watches the lag.
     _averageLag.value = Duration.zero;

--- a/lib/src/network/socket.dart
+++ b/lib/src/network/socket.dart
@@ -832,7 +832,12 @@ class SocketPool {
   void onDeviceOnline() {
     if (_isAppInBackground) return;
     _logger.info('Device is back online, reconnecting the socket.');
-    _connectIfNeeded();
+    // Unconditionally, unlike [_connectIfNeeded]: a socket that lost its network without noticing
+    // yet — no ping due, nothing that tore the channel down — still looks perfectly healthy, and
+    // the connection it holds belongs to a network that is gone. Waiting for it to find out on its
+    // own costs up to [SocketClient.pingMaxLag], and the handshake it costs to be sure is cheap
+    // next to a socket that is up but deaf.
+    currentClient.connect();
   }
 
   /// Call when the session changes: the socket carries the token, so it has to be reopened.

--- a/lib/src/network/socket.dart
+++ b/lib/src/network/socket.dart
@@ -171,6 +171,7 @@ class SocketClient {
   DateTime _lastPing = clock_package.clock.now();
 
   final _averageLag = ValueNotifier(Duration.zero);
+  final _isFailing = ValueNotifier(false);
 
   StreamSubscription<SocketEvent>? _socketStreamSubscription;
 
@@ -230,7 +231,10 @@ class SocketClient {
   bool get isConnected => averageLag.value != Duration.zero;
 
   /// Whether the socket is failing to connect, and waiting out its backoff before trying again.
-  bool get isFailing => _failingSince != null;
+  ///
+  /// Set once when a run of failures starts, and cleared when the socket connects or is closed, so
+  /// that a listener hears about a socket that cannot connect, not about each of its attempts.
+  ValueListenable<bool> get isFailing => _isFailing;
 
   /// Whether the client is disposed. If true the client cannot be reconnected, or
   /// be listened to.
@@ -304,6 +308,7 @@ class SocketClient {
 
       nbConnectionSuccess++;
       _failingSince = null;
+      _isFailing.value = false;
 
       if (nbConnectionSuccess == 1) {
         _firstConnection.complete();
@@ -346,6 +351,7 @@ class SocketClient {
       }
       _averageLag.value = Duration.zero;
       _failingSince ??= clock_package.clock.now();
+      _isFailing.value = true;
 
       // A failed attempt says nothing on its own: it is what a device with no network looks like,
       // and that is not an error the logs should shout about. The backoff is what keeps a socket
@@ -410,6 +416,7 @@ class SocketClient {
     _versionGapRetryTimer?.cancel();
     _streamController.close();
     _averageLag.dispose();
+    _isFailing.dispose();
     isDisposed = true;
     _disconnect();
   }
@@ -423,6 +430,7 @@ class SocketClient {
     nbConnectionAttempts = 0;
     nbConnectionSuccess = 0;
     _failingSince = null;
+    _isFailing.value = false;
     _firstConnection = Completer<void>();
     return _disconnect();
   }
@@ -635,11 +643,7 @@ class SocketPool {
       pingDelay: const Duration(seconds: 25),
     );
 
-    client.averageLag.addListener(() {
-      if (_currentRoute == client.route) {
-        _averageLag.value = client.averageLag.value;
-      }
-    });
+    _mirrorCurrentClientState(client);
     _pool[_currentRoute] = client;
 
     // Deferred: [ConnectivityChangesNotifier] reads this pool while building, so listening to it
@@ -660,6 +664,7 @@ class SocketPool {
   final Duration idleTimeout;
 
   final _averageLag = ValueNotifier(Duration.zero);
+  final _isFailing = ValueNotifier(false);
 
   Timer? _closeInBackgroundTimer;
 
@@ -669,6 +674,9 @@ class SocketPool {
   ///
   /// A duration of zero means the socket is not connected.
   ValueListenable<Duration> get averageLag => _averageLag;
+
+  /// Whether the current socket is failing to connect, and waiting out its backoff.
+  ValueListenable<bool> get isFailing => _isFailing;
 
   /// Whether the pool is disposed.
   ///
@@ -728,13 +736,27 @@ class SocketPool {
     }
   }
 
+  /// Reflects [client]'s connection state in the pool's own, for as long as it is the current one.
+  void _mirrorCurrentClientState(SocketClient client) {
+    client.averageLag.addListener(() {
+      if (_currentRoute == client.route) {
+        _averageLag.value = client.averageLag.value;
+      }
+    });
+    client.isFailing.addListener(() {
+      if (_currentRoute == client.route) {
+        _isFailing.value = client.isFailing.value;
+      }
+    });
+  }
+
   /// Connects the current client, unless it is already connected or on its way to being.
   ///
   /// A client waiting out its reconnect backoff does need connecting: the wait is there to spare a
   /// device that cannot connect at all, and is only ever cut short by something — the app coming
   /// back to the foreground, the network coming back — saying that this time it might work.
   void _connectIfNeeded() {
-    if (!currentClient.isActive || currentClient.isFailing) {
+    if (!currentClient.isActive || currentClient.isFailing.value) {
       currentClient.connect();
     }
   }
@@ -796,11 +818,7 @@ class SocketPool {
         },
         onEventGapFailure: onEventGapFailure,
       );
-      newClient.averageLag.addListener(() {
-        if (_currentRoute == newClient.route) {
-          _averageLag.value = newClient.averageLag.value;
-        }
-      });
+      _mirrorCurrentClientState(newClient);
       _pool[route] = newClient;
     }
 
@@ -826,6 +844,7 @@ class SocketPool {
     }
     _isDisposed = true;
     _averageLag.dispose();
+    _isFailing.dispose();
     _closeInBackgroundTimer?.cancel();
     _disposeTimers.forEach((_, t) => t?.cancel());
     _pool.forEach((_, c) => c.dispose());

--- a/lib/src/network/socket.dart
+++ b/lib/src/network/socket.dart
@@ -472,27 +472,25 @@ class SocketClient {
     _reconnectTimer?.cancel();
     _ackResendTimer?.cancel();
 
-    final future =
-        _sink
-            ?.close()
-            .then((_) {
-              _logger.fine('WebSocket connection to $route was properly closed.');
-              if (isDisposed) {
-                return;
-              }
-              _averageLag.value = Duration.zero;
-            })
-            .catchError((Object? error) {
-              _logger.warning('WebSocket connection to $route could not be closed:', error);
-              if (isDisposed) {
-                return;
-              }
-              _averageLag.value = Duration.zero;
-            }) ??
-        Future.value();
-    _channel = null;
+    // Now, rather than when the close completes: closing a sink can take as long as it likes, and
+    // by the time it does the client may well be connected again — a lag blanked then would be the
+    // old channel marking the new connection as down, until the next pong put it right.
+    if (!isDisposed) {
+      _averageLag.value = Duration.zero;
+    }
 
-    return future;
+    final sink = _sink;
+    _channel = null;
+    if (sink == null) return Future.value();
+
+    return sink
+        .close()
+        .then((_) {
+          _logger.fine('WebSocket connection to $route was properly closed.');
+        })
+        .catchError((Object? error) {
+          _logger.warning('WebSocket connection to $route could not be closed:', error);
+        });
   }
 
   void _handleEvent(SocketEvent event, [int retries = 10]) {

--- a/lib/src/network/socket.dart
+++ b/lib/src/network/socket.dart
@@ -342,25 +342,30 @@ class SocketClient {
       }
 
       _resendAcks();
-    } catch (e) {
+    } catch (e, s) {
       // Don't revive a client that was closed or reconnected while the failed attempt was in
       // flight, otherwise it would keep reconnecting in the background forever.
       if (isDisposed || epoch != _connectionEpoch) {
-        _logger.fine('Stale WebSocket connection to $route failed:', e);
+        _logger.fine('Stale WebSocket connection to $route failed:', e, s);
         return;
       }
       _averageLag.value = Duration.zero;
       _failingSince ??= clock_package.clock.now();
       _isFailing.value = true;
 
-      // A failed attempt says nothing on its own: it is what a device with no network looks like,
-      // and that is not an error the logs should shout about. The backoff is what keeps a socket
-      // that cannot connect from retrying in a tight loop.
       final delay = _reconnectDelay;
-      _logger.fine(
-        'WebSocket connection to $route failed (for ${_failingFor.inSeconds}s now), retrying in '
-        '${delay.inMilliseconds}ms: $e',
-      );
+      final message =
+          'WebSocket connection to $route failed (for ${_failingFor.inSeconds}s now), retrying in '
+          '${delay.inMilliseconds}ms: $e';
+
+      // A connection that could not be made says nothing on its own: it is what a device with no
+      // network looks like, and that is not an error the logs should shout about.
+      if (_isConnectivityFailure(e)) {
+        _logger.fine(message);
+      } else {
+        _logger.severe(message, e, s);
+      }
+
       _scheduleReconnect(delay);
     }
   }
@@ -970,6 +975,13 @@ class SocketPingNotifier extends Notifier<SocketPingState> {
 final webSocketChannelFactoryProvider = Provider<WebSocketChannelFactory>((Ref ref) {
   return const WebSocketChannelFactory();
 });
+
+/// Whether [error] is one of the failures a socket runs into when the network is not there.
+bool _isConnectivityFailure(Object error) =>
+    error is SocketException ||
+    error is TimeoutException ||
+    error is WebSocketException ||
+    error is HandshakeException;
 
 /// A factory to create a [WebSocketChannel].
 ///

--- a/lib/src/network/socket.dart
+++ b/lib/src/network/socket.dart
@@ -766,7 +766,7 @@ class SocketPool {
         if (wasOnline && !isOnline) {
           _socketAnsweredSinceOffline = false;
         } else if (!wasOnline && isOnline) {
-          onDeviceOnline();
+          onDeviceBackOnline();
         }
       });
     });
@@ -827,6 +827,7 @@ class SocketPool {
   ///
   /// The socket is kept for a while, as the user may well come right back, then closed to spare
   /// the battery.
+  @visibleForTesting
   void onAppHidden() {
     _isAppInBackground = true;
     _closeInBackgroundTimer?.cancel();
@@ -839,6 +840,7 @@ class SocketPool {
   }
 
   /// Call when the app comes back to the foreground.
+  @visibleForTesting
   void onAppShown() {
     _isAppInBackground = false;
     _closeInBackgroundTimer?.cancel();
@@ -850,7 +852,8 @@ class SocketPool {
   /// A socket that went down with the network keeps retrying on an exponential backoff, so it may
   /// be up to a minute before it notices on its own that the network is back. Connectivity knows
   /// first, so it is worth an attempt right away.
-  void onDeviceOnline() {
+  @visibleForTesting
+  void onDeviceBackOnline() {
     if (_isAppInBackground) return;
 
     // The socket answered a ping while the device was held offline: it is what proved the network
@@ -872,6 +875,7 @@ class SocketPool {
   ///
   /// A socket closed in the background stays closed; it will carry the new session whenever it is
   /// opened again.
+  @visibleForTesting
   void onAuthChanged() {
     if (currentClient.isActive) {
       currentClient.connect();

--- a/lib/src/network/socket.dart
+++ b/lib/src/network/socket.dart
@@ -341,17 +341,19 @@ class SocketClient {
       // This runs *before* [_resendAcks] and bumps each flushed ackable
       // message's timestamp so that [_resendAcks] does not immediately send it a
       // second time (the periodic resend-until-acked behavior is preserved).
-      if (_resendWhenOpen.isNotEmpty) {
-        final pending = List<(int?, String)>.of(_resendWhenOpen);
-        _resendWhenOpen.clear();
-        final now = clock_package.clock.now();
-        for (final (ackId, message) in pending) {
-          _sink?.add(message);
-          if (ackId != null) {
-            final index = _acks.indexWhere((rec) => rec.$2 == ackId);
-            if (index != -1) {
-              _acks[index] = (now, _acks[index].$2, _acks[index].$3);
-            }
+      //
+      // Each message leaves the queue only once the sink has taken it, so that a write throwing
+      // partway through — a peer that hangs up mid-flush — leaves the rest of them queued for the
+      // connection that replaces this one, instead of dropping the lot.
+      final now = clock_package.clock.now();
+      while (_resendWhenOpen.isNotEmpty) {
+        final (ackId, message) = _resendWhenOpen.first;
+        channel.sink.add(message);
+        _resendWhenOpen.removeAt(0);
+        if (ackId != null) {
+          final index = _acks.indexWhere((rec) => rec.$2 == ackId);
+          if (index != -1) {
+            _acks[index] = (now, _acks[index].$2, _acks[index].$3);
           }
         }
       }

--- a/lib/src/network/socket.dart
+++ b/lib/src/network/socket.dart
@@ -364,7 +364,11 @@ class SocketClient {
         _logger.fine('Stale WebSocket connection to $route failed:', e, s);
         return;
       }
-      _averageLag.value = Duration.zero;
+      // The attempt may have got as far as a channel before it went wrong — a peer that hangs up
+      // between the handshake and the first ping, say. Drop it here as the pong timeout and the
+      // stream error do, so that [send] queues for the next connection rather than writing to a
+      // sink that is already gone. This cancels the timers of the failed attempt along with it.
+      unawaited(_disconnect());
       _startFailing();
 
       final delay = _reconnectDelay;

--- a/lib/src/network/socket.dart
+++ b/lib/src/network/socket.dart
@@ -312,7 +312,12 @@ class SocketClient {
             final event = SocketEvent.fromJson(jsonDecode(raw as String) as Map<String, dynamic>);
             return event;
           })
-          .listen(_handleEvent);
+          .listen(
+            _handleEvent,
+            onError: (Object error, StackTrace stackTrace) =>
+                _onChannelGone(epoch, error, stackTrace),
+            onDone: () => _onChannelGone(epoch),
+          );
 
       _logger.fine('WebSocket connection to $route established.');
 
@@ -540,6 +545,38 @@ class SocketClient {
           _globalStreamController.add(event);
         }
     }
+  }
+
+  /// Called when the channel is gone: the peer closed it, or the stream errored out.
+  ///
+  /// A device losing its network under an open socket ends here rather than at a ping going
+  /// unanswered, and that is worth acting on right away: waiting out [pingMaxLag] for a socket
+  /// already known to be dead only delays the reconnect, and everything watching the lag.
+  ///
+  /// [epoch] is the connection this subscription belonged to, so that a channel closing after the
+  /// client has moved on to another one is ignored.
+  void _onChannelGone(int epoch, [Object? error, StackTrace? stackTrace]) {
+    if (isDisposed || epoch != _connectionEpoch) return;
+
+    _pingTimer?.cancel();
+    _pongTimeoutTimer?.cancel();
+    _averageLag.value = Duration.zero;
+    _startFailing();
+
+    final delay = _reconnectDelay;
+    final message =
+        'WebSocket connection to $route was closed (failing for ${_failingFor.inSeconds}s now), '
+        'reconnecting in ${delay.inMilliseconds}ms.';
+
+    if (error == null || _isTransportUnavailable(error)) {
+      // A peer that hangs up, or a network that goes away under the socket: both are ordinary, and
+      // the reconnect below is the whole answer to them.
+      _logger.fine(message, error, stackTrace);
+    } else {
+      _logger.warning(message, error, stackTrace);
+    }
+
+    _scheduleReconnect(delay);
   }
 
   void _schedulePing(Duration delay) {
@@ -983,6 +1020,11 @@ class SocketPingNotifier extends Notifier<SocketPingState> {
   SocketPingState build({Uri? route}) {
     final pool = ref.watch(socketPoolProvider);
 
+    // A socket only notices a network that went away when a ping goes unanswered, up to
+    // [SocketClient.pingMaxLag] later. Connectivity knows first, so the indicator does not have to
+    // go on showing a lag measured over a network that is no longer there.
+    ref.watch(isDeviceOnlineProvider);
+
     pool.averageLag.addListener(_listener);
 
     ref.onDispose(() {
@@ -993,6 +1035,7 @@ class SocketPingNotifier extends Notifier<SocketPingState> {
   }
 
   Duration get _currentRouteLag {
+    if (!ref.read(isDeviceOnlineProvider)) return Duration.zero;
     final pool = ref.read(socketPoolProvider);
     return route != null
         ? route == pool.currentClient.route

--- a/lib/src/network/socket.dart
+++ b/lib/src/network/socket.dart
@@ -164,6 +164,7 @@ class SocketClient {
   Completer<void> _firstConnection = Completer<void>();
 
   Timer? _pingTimer;
+  Timer? _pongTimeoutTimer;
   Timer? _reconnectTimer;
   Timer? _ackResendTimer;
   Timer? _versionGapRetryTimer;
@@ -427,6 +428,7 @@ class SocketClient {
   void dispose() {
     _socketStreamSubscription?.cancel();
     _pingTimer?.cancel();
+    _pongTimeoutTimer?.cancel();
     _reconnectTimer?.cancel();
     _ackResendTimer?.cancel();
     _versionGapRetryTimer?.cancel();
@@ -457,6 +459,7 @@ class SocketClient {
     _connectionEpoch++;
     _socketStreamSubscription?.cancel();
     _pingTimer?.cancel();
+    _pongTimeoutTimer?.cancel();
     _reconnectTimer?.cancel();
     _ackResendTimer?.cancel();
 
@@ -550,17 +553,46 @@ class SocketClient {
           : 'p',
     );
     _lastPing = clock_package.clock.now();
-    _scheduleReconnect(pingMaxLag);
+    _schedulePongTimeout();
+  }
+
+  /// Gives the server [pingMaxLag] to answer the ping that was just sent.
+  void _schedulePongTimeout() {
+    _pongTimeoutTimer?.cancel();
+    _pongTimeoutTimer = Timer(pingMaxLag, _onPongTimeout);
+  }
+
+  /// Called when a ping has gone unanswered for [pingMaxLag]: the socket is of no use any more.
+  ///
+  /// This is a run of failures starting, exactly like a connection that could not be made, and the
+  /// reconnect that follows waits out the same backoff. A peer that accepts every handshake and
+  /// then answers nothing is thus retried more and more slowly, instead of every [pingMaxLag]
+  /// forever.
+  void _onPongTimeout() {
+    if (isDisposed) return;
+
+    // The socket is not answering: it is no longer proof of anything to whoever watches the lag.
+    _averageLag.value = Duration.zero;
+    _failingSince.value ??= clock_package.clock.now();
+
+    final delay = _reconnectDelay;
+    _logger.fine(
+      'No pong from $route in ${pingMaxLag.inMilliseconds}ms (failing for '
+      '${_failingFor.inSeconds}s now), reconnecting in ${delay.inMilliseconds}ms.',
+    );
+    _scheduleReconnect(delay);
   }
 
   void _handlePong(Duration pingDelay) {
     if (isDisposed) return;
 
+    _pongTimeoutTimer?.cancel();
+    // The socket is not merely open, it answers: this, and not the handshake before it, is what
+    // ends a run of failures — and it makes any reconnect waiting out the backoff moot.
     _reconnectTimer?.cancel();
+    _failingSince.value = null;
     if (_pongCount == 0) {
       _logger.fine('Ping/pong protocol for $route established.');
-      // The socket is not merely open, it answers: this is what ends a run of failures.
-      _failingSince.value = null;
     }
     _schedulePing(pingDelay);
     _pongCount++;
@@ -598,10 +630,6 @@ class SocketClient {
     _reconnectTimer?.cancel();
     _reconnectTimer = Timer(delay, () {
       if (!isDisposed) {
-        // Whatever scheduled it, a reconnect only ever follows a failure: an attempt that could
-        // not connect, or a ping left unanswered for [pingMaxLag]. Both start a run, so that the
-        // backoff grows and the connectivity check is asked for.
-        _failingSince.value ??= clock_package.clock.now();
         _logger.fine('Reconnecting WebSocket.');
         _averageLag.value = Duration.zero;
         connect();

--- a/lib/src/network/socket.dart
+++ b/lib/src/network/socket.dart
@@ -328,8 +328,10 @@ class SocketClient {
       }
 
       _averageLag.value = Duration.zero;
+      // The next ping is scheduled by the pong that answers this one: a second ping sent before
+      // then would push the pong timeout further out, and let a socket that answers nothing live
+      // [pingDelay] longer than it should.
       _sendPing();
-      _schedulePing(pingDelay);
 
       if (_socketOpenController.hasListener) {
         _socketOpenController.add(null);
@@ -604,11 +606,6 @@ class SocketClient {
   }
 
   /// Called when a ping has gone unanswered for [pingMaxLag]: the socket is of no use any more.
-  ///
-  /// This is a run of failures starting, exactly like a connection that could not be made, and the
-  /// reconnect that follows waits out the same backoff. A peer that accepts every handshake and
-  /// then answers nothing is thus retried more and more slowly, instead of every [pingMaxLag]
-  /// forever.
   void _onPongTimeout() {
     if (isDisposed) return;
 
@@ -619,9 +616,8 @@ class SocketClient {
 
     // The socket is not answering: it is no longer proof of anything to whoever watches the lag.
     _averageLag.value = Duration.zero;
-    _startFailing();
 
-    final delay = _reconnectDelay;
+    final delay = _startFailing() ? Duration.zero : _reconnectDelay;
     _logger.fine(
       'No pong from $route in ${pingMaxLag.inMilliseconds}ms (failing for '
       '${_failingFor.inSeconds}s now), reconnecting in ${delay.inMilliseconds}ms.',
@@ -652,9 +648,13 @@ class SocketClient {
   }
 
   /// Starts a run of failures, if one is not already going on.
-  void _startFailing() {
+  ///
+  /// Returns whether this is the failure that started it.
+  bool _startFailing() {
+    final startsRun = _failingSince == null;
     _failingSince ??= clock_package.clock.now();
     _isFailing.value = true;
+    return startsRun;
   }
 
   /// Ends the current run of failures.

--- a/lib/src/network/socket.dart
+++ b/lib/src/network/socket.dart
@@ -774,6 +774,7 @@ class SocketPool {
 
   final _averageLag = ValueNotifier(Duration.zero);
   final _isFailing = ValueNotifier(false);
+  final _isConnected = ValueNotifier(false);
 
   Timer? _closeInBackgroundTimer;
 
@@ -786,6 +787,13 @@ class SocketPool {
 
   /// Whether the current socket is failing, and waiting out its backoff.
   ValueListenable<bool> get isFailing => _isFailing;
+
+  /// Whether the current socket is connected, ie. it has answered a ping.
+  ///
+  /// This, and not [averageLag], is the signal that a socket is up: the lag deliberately outlives
+  /// the client that measured it, and two clients can well measure the same one — a value that
+  /// does not change notifies nobody.
+  ValueListenable<bool> get isConnected => _isConnected;
 
   /// Whether the pool is disposed.
   ///
@@ -850,7 +858,7 @@ class SocketPool {
     }
   }
 
-  /// Takes [client]'s failing state as the pool's own, when it becomes the current one.
+  /// Takes [client]'s connection state as the pool's own, when it becomes the current one.
   ///
   /// The mirror below only forwards what a client emits from now on, so the pool has to read the
   /// state of the client it switches to: the one it switches away from clears its failing state as
@@ -861,9 +869,10 @@ class SocketPool {
   /// has no lag to speak of, and blanking the pool's on every route change would have every screen
   /// switch flash as a disconnection. Consumers that care about a single route already compare it
   /// to [currentClient]'s.
-  void _syncCurrentClientFailingState(SocketClient client) {
+  void _syncCurrentClientState(SocketClient client) {
     if (client.isDisposed) return;
     _isFailing.value = client.isFailing.value;
+    _isConnected.value = client.isConnected;
   }
 
   /// Reflects [client]'s connection state in the pool's own, for as long as it is the current one.
@@ -871,6 +880,9 @@ class SocketPool {
     client.averageLag.addListener(() {
       if (_currentRoute == client.route) {
         _averageLag.value = client.averageLag.value;
+        // Set from the client's own change, not from the pool's lag: the assignment above can be a
+        // no-op — the same lag as the client before it — and still be a socket coming up.
+        _isConnected.value = client.isConnected;
       }
     });
     client.isFailing.addListener(() {
@@ -940,7 +952,7 @@ class SocketPool {
             // battery, and nothing is watching what the default one would bring in anyway.
             if (route == _currentRoute) {
               _currentRoute = Uri(path: kDefaultSocketRoute);
-              _syncCurrentClientFailingState(currentClient);
+              _syncCurrentClientState(currentClient);
               if (!_isAppInBackground && !currentClient.isActive) {
                 currentClient.connect();
               }
@@ -961,7 +973,7 @@ class SocketPool {
     });
 
     final client = _pool[route]!;
-    _syncCurrentClientFailingState(client);
+    _syncCurrentClientState(client);
 
     if (forceReconnect == true || !client.isActive) {
       client.connect();
@@ -978,6 +990,7 @@ class SocketPool {
     _isDisposed = true;
     _averageLag.dispose();
     _isFailing.dispose();
+    _isConnected.dispose();
     _closeInBackgroundTimer?.cancel();
     _disposeTimers.forEach((_, t) => t?.cancel());
     _pool.forEach((_, c) => c.dispose());

--- a/lib/src/network/socket.dart
+++ b/lib/src/network/socket.dart
@@ -760,7 +760,12 @@ class SocketPool {
       // [isDeviceOnlineIn] rather than the raw value: a check that failed reads as offline there,
       // and coming back from one is an edge the socket has to hear about like any other.
       _ref.listen(connectivityChangesProvider, (prev, next) {
-        if (prev != null && !isDeviceOnlineIn(prev) && isDeviceOnlineIn(next)) {
+        if (prev == null) return;
+        final wasOnline = isDeviceOnlineIn(prev);
+        final isOnline = isDeviceOnlineIn(next);
+        if (wasOnline && !isOnline) {
+          _socketAnsweredSinceOffline = false;
+        } else if (!wasOnline && isOnline) {
           onDeviceOnline();
         }
       });
@@ -775,6 +780,14 @@ class SocketPool {
   final _averageLag = ValueNotifier(Duration.zero);
   final _isFailing = ValueNotifier(false);
   final _isConnected = ValueNotifier(false);
+
+  /// Whether the current socket has answered a ping since the device was last found offline.
+  ///
+  /// A socket that did is the very thing that proves the network is back — connectivity clears an
+  /// offline status on its pong — and reconnecting it on the online edge that follows would tear
+  /// down the connection that produced it. One that did not says nothing: it may well be holding a
+  /// connection to a network that is gone.
+  bool _socketAnsweredSinceOffline = false;
 
   Timer? _closeInBackgroundTimer;
 
@@ -839,7 +852,14 @@ class SocketPool {
   /// first, so it is worth an attempt right away.
   void onDeviceOnline() {
     if (_isAppInBackground) return;
-    _logger.info('Device is back online, reconnecting the socket.');
+
+    // The socket answered a ping while the device was held offline: it is what proved the network
+    // is back, and reconnecting it here would tear down the very connection that did so — an event
+    // gap and a handshake on every socket-driven recovery.
+    if (_socketAnsweredSinceOffline) {
+      return;
+    }
+
     // Unconditionally, unlike [_connectIfNeeded]: a socket that lost its network without noticing
     // yet — no ping due, nothing that tore the channel down — still looks perfectly healthy, and
     // the connection it holds belongs to a network that is gone. Waiting for it to find out on its
@@ -880,9 +900,10 @@ class SocketPool {
     client.averageLag.addListener(() {
       if (_currentRoute == client.route) {
         _averageLag.value = client.averageLag.value;
-        // Set from the client's own change, not from the pool's lag: the assignment above can be a
-        // no-op — the same lag as the client before it — and still be a socket coming up.
         _isConnected.value = client.isConnected;
+        if (client.isConnected) {
+          _socketAnsweredSinceOffline = true;
+        }
       }
     });
     client.isFailing.addListener(() {

--- a/lib/src/network/socket.dart
+++ b/lib/src/network/socket.dart
@@ -32,7 +32,7 @@ const _kAutoReconnectDelay = Duration(milliseconds: 3500);
 const _kMaxAutoReconnectDelay = Duration(seconds: 60);
 
 /// How long the socket keeps retrying at full speed before the backoff sets in.
-const _kReconnectGracePeriod = Duration(seconds: 30);
+const _kReconnectGracePeriod = Duration(seconds: 60);
 
 const _kResendAckDelay = Duration(milliseconds: 1500);
 const _kVersionGapRetryDelay = Duration(milliseconds: 200);

--- a/lib/src/network/socket.dart
+++ b/lib/src/network/socket.dart
@@ -358,11 +358,18 @@ class SocketClient {
           'WebSocket connection to $route failed (for ${_failingFor.inSeconds}s now), retrying in '
           '${delay.inMilliseconds}ms: $e';
 
-      // A connection that could not be made says nothing on its own: it is what a device with no
-      // network looks like, and that is not an error the logs should shout about.
-      if (_isConnectivityFailure(e)) {
+      if (_isTransportUnavailable(e)) {
+        // A connection that could not even be attempted says nothing on its own: it is what a
+        // device with no network looks like, and that is not worth a line in the logs.
         _logger.fine(message);
+      } else if (e is Exception) {
+        // The server answered, but not with a websocket it accepted: a refused or malformed
+        // upgrade, a certificate that cannot be trusted. Retrying may well get past it, but this
+        // is the only sign a regression on the server or in the TLS chain gives from production.
+        _logger.warning(message, e, s);
       } else {
+        // An [Error] comes from the setup above rather than from the network, and retrying will
+        // not fix it.
         _logger.severe(message, e, s);
       }
 
@@ -978,12 +985,11 @@ final webSocketChannelFactoryProvider = Provider<WebSocketChannelFactory>((Ref r
   return const WebSocketChannelFactory();
 });
 
-/// Whether [error] is one of the failures a socket runs into when the network is not there.
-bool _isConnectivityFailure(Object error) =>
-    error is SocketException ||
-    error is TimeoutException ||
-    error is WebSocketException ||
-    error is HandshakeException;
+/// Whether [error] is the network simply not being there.
+///
+/// These are the two [WebSocketChannelFactory.create] documents, and the only two that say nothing
+/// beyond that. Anything else means the server answered.
+bool _isTransportUnavailable(Object error) => error is SocketException || error is TimeoutException;
 
 /// A factory to create a [WebSocketChannel].
 ///

--- a/lib/src/network/socket.dart
+++ b/lib/src/network/socket.dart
@@ -753,22 +753,17 @@ class SocketPool {
     _mirrorCurrentClientState(client);
     _pool[_currentRoute] = client;
 
-    // Deferred: [ConnectivityChangesNotifier] reads this pool while building, so listening to it
-    // right here would have the two providers build each other, which Riverpod forbids.
-    scheduleMicrotask(() {
-      if (_isDisposed) return;
-      // [isDeviceOnlineIn] rather than the raw value: a check that failed reads as offline there,
-      // and coming back from one is an edge the socket has to hear about like any other.
-      _ref.listen(connectivityChangesProvider, (prev, next) {
-        if (prev == null) return;
-        final wasOnline = isDeviceOnlineIn(prev);
-        final isOnline = isDeviceOnlineIn(next);
-        if (wasOnline && !isOnline) {
-          _socketAnsweredSinceOffline = false;
-        } else if (!wasOnline && isOnline) {
-          onDeviceBackOnline();
-        }
-      });
+    // [isDeviceOnlineIn] rather than the raw value: a check that failed reads as offline there,
+    // and coming back from one is an edge the socket has to hear about like any other.
+    _ref.listen(connectivityChangesProvider, (prev, next) {
+      if (prev == null) return;
+      final wasOnline = isDeviceOnlineIn(prev);
+      final isOnline = isDeviceOnlineIn(next);
+      if (wasOnline && !isOnline) {
+        _socketAnsweredSinceOffline = false;
+      } else if (!wasOnline && isOnline) {
+        onDeviceBackOnline();
+      }
     });
   }
 
@@ -778,15 +773,12 @@ class SocketPool {
   final Duration idleTimeout;
 
   final _averageLag = ValueNotifier(Duration.zero);
-  final _isFailing = ValueNotifier(false);
-  final _isConnected = ValueNotifier(false);
 
   /// Whether the current socket has answered a ping since the device was last found offline.
   ///
-  /// A socket that did is the very thing that proves the network is back — connectivity clears an
-  /// offline status on its pong — and reconnecting it on the online edge that follows would tear
-  /// down the connection that produced it. One that did not says nothing: it may well be holding a
-  /// connection to a network that is gone.
+  /// A socket that did has already made the connection the online edge would ask for: its own
+  /// retry got to the network before the check noticed it was back. One that did not says nothing:
+  /// it may well be holding a connection to a network that is gone.
   bool _socketAnsweredSinceOffline = false;
 
   Timer? _closeInBackgroundTimer;
@@ -797,16 +789,6 @@ class SocketPool {
   ///
   /// A duration of zero means the socket is not connected.
   ValueListenable<Duration> get averageLag => _averageLag;
-
-  /// Whether the current socket is failing, and waiting out its backoff.
-  ValueListenable<bool> get isFailing => _isFailing;
-
-  /// Whether the current socket is connected, ie. it has answered a ping.
-  ///
-  /// This, and not [averageLag], is the signal that a socket is up: the lag deliberately outlives
-  /// the client that measured it, and two clients can well measure the same one — a value that
-  /// does not change notifies nobody.
-  ValueListenable<bool> get isConnected => _isConnected;
 
   /// Whether the pool is disposed.
   ///
@@ -856,9 +838,9 @@ class SocketPool {
   void onDeviceBackOnline() {
     if (_isAppInBackground) return;
 
-    // The socket answered a ping while the device was held offline: it is what proved the network
-    // is back, and reconnecting it here would tear down the very connection that did so — an event
-    // gap and a handshake on every socket-driven recovery.
+    // The socket answered a ping while the device was held offline, so it is already on the
+    // network this edge is announcing: reconnecting it here would cost an event gap and a
+    // handshake to end up exactly where it is.
     if (_socketAnsweredSinceOffline) {
       return;
     }
@@ -882,37 +864,16 @@ class SocketPool {
     }
   }
 
-  /// Takes [client]'s connection state as the pool's own, when it becomes the current one.
-  ///
-  /// The mirror below only forwards what a client emits from now on, so the pool has to read the
-  /// state of the client it switches to: the one it switches away from clears its failing state as
-  /// it is closed, but by then it is no longer the current route and that update is dropped — the
-  /// pool would stay failing, and swallow the next real failure as a value it already holds.
-  ///
-  /// The average lag is deliberately left as it is: a client that has yet to answer its first ping
-  /// has no lag to speak of, and blanking the pool's on every route change would have every screen
-  /// switch flash as a disconnection. Consumers that care about a single route already compare it
-  /// to [currentClient]'s.
-  void _syncCurrentClientState(SocketClient client) {
-    if (client.isDisposed) return;
-    _isFailing.value = client.isFailing.value;
-    _isConnected.value = client.isConnected;
-  }
-
   /// Reflects [client]'s connection state in the pool's own, for as long as it is the current one.
   void _mirrorCurrentClientState(SocketClient client) {
     client.averageLag.addListener(() {
       if (_currentRoute == client.route) {
         _averageLag.value = client.averageLag.value;
-        _isConnected.value = client.isConnected;
+        // Read from the client, not from the pool's lag: the assignment above can be a no-op — the
+        // same lag as the client before it — and still be a socket answering.
         if (client.isConnected) {
           _socketAnsweredSinceOffline = true;
         }
-      }
-    });
-    client.isFailing.addListener(() {
-      if (_currentRoute == client.route) {
-        _isFailing.value = client.isFailing.value;
       }
     });
   }
@@ -977,7 +938,6 @@ class SocketPool {
             // battery, and nothing is watching what the default one would bring in anyway.
             if (route == _currentRoute) {
               _currentRoute = Uri(path: kDefaultSocketRoute);
-              _syncCurrentClientState(currentClient);
               if (!_isAppInBackground && !currentClient.isActive) {
                 currentClient.connect();
               }
@@ -998,7 +958,6 @@ class SocketPool {
     });
 
     final client = _pool[route]!;
-    _syncCurrentClientState(client);
 
     if (forceReconnect == true || !client.isActive) {
       client.connect();
@@ -1014,8 +973,6 @@ class SocketPool {
     }
     _isDisposed = true;
     _averageLag.dispose();
-    _isFailing.dispose();
-    _isConnected.dispose();
     _closeInBackgroundTimer?.cancel();
     _disposeTimers.forEach((_, t) => t?.cancel());
     _pool.forEach((_, c) => c.dispose());

--- a/lib/src/network/socket.dart
+++ b/lib/src/network/socket.dart
@@ -718,6 +718,16 @@ class SocketPool {
     _connectIfNeeded();
   }
 
+  /// Call when the session changes: the socket carries the token, so it has to be reopened.
+  ///
+  /// A socket closed in the background stays closed; it will carry the new session whenever it is
+  /// opened again.
+  void onAuthChanged() {
+    if (currentClient.isActive) {
+      currentClient.connect();
+    }
+  }
+
   /// Connects the current client, unless it is already connected or on its way to being.
   ///
   /// A client waiting out its reconnect backoff does need connecting: the wait is there to spare a
@@ -734,6 +744,10 @@ class SocketPool {
   /// It will use an existing connection if it is already active, unless [forceReconnect] is set to
   /// true.
   /// Any other active connection will be closed.
+  ///
+  /// This is the one way to a connection that the app being in the background does not stop:
+  /// a caller asking for a socket by route is asking for it now, and every one of them is a screen
+  /// or a controller the user is looking at.
   SocketClient open(
     Uri route, {
     int? version,
@@ -770,9 +784,11 @@ class SocketPool {
             _pool.remove(route);
             // if during the idle time no new socket is requested, we reconnect
             // the default socket
+            // Not while the app is in the background: the socket is closed there to spare the
+            // battery, and nothing is watching what the default one would bring in anyway.
             if (route == _currentRoute) {
               _currentRoute = Uri(path: kDefaultSocketRoute);
-              if (!currentClient.isActive) {
+              if (!_isAppInBackground && !currentClient.isActive) {
                 currentClient.connect();
               }
             }
@@ -823,9 +839,7 @@ final socketPoolProvider = Provider<SocketPool>((Ref ref) {
   pool.currentClient.connect();
 
   // force reconnect to the current socket with the new token
-  final subscription = authEventsStream.listen((_) {
-    pool.currentClient.connect();
-  });
+  final subscription = authEventsStream.listen((_) => pool.onAuthChanged());
 
   // Observing the app lifecycle here rather than in [SocketPool], because an
   // [AppLifecycleListener] needs a [WidgetsBinding], which the pool must not require of the tests

--- a/lib/src/utils/rate_limit.dart
+++ b/lib/src/utils/rate_limit.dart
@@ -18,19 +18,39 @@ class Debouncer {
 
 class Throttler {
   final Duration delay;
-  Timer? _timer;
 
-  Throttler(this.delay);
+  /// Whether a call made during the delay runs when it expires, instead of being dropped.
+  ///
+  /// Calls made in the same window are coalesced into a single trailing run, which uses the last
+  /// action given. Use this when dropping a call for good would lose a signal — a state change
+  /// that nothing will notify about again — rather than merely skip one of a repeating series.
+  final bool trailing;
+
+  Timer? _timer;
+  void Function()? _trailingAction;
+
+  Throttler(this.delay, {this.trailing = false});
 
   void call(void Function() action) {
-    if (_timer?.isActive ?? false) return;
+    if (_timer?.isActive ?? false) {
+      if (trailing) _trailingAction = action;
+      return;
+    }
 
     _timer?.cancel();
     action();
-    _timer = Timer(delay, () {});
+    _timer = Timer(delay, _onDelayExpired);
+  }
+
+  void _onDelayExpired() {
+    final trailingAction = _trailingAction;
+    if (trailingAction == null) return;
+    _trailingAction = null;
+    call(trailingAction);
   }
 
   void cancel() {
+    _trailingAction = null;
     _timer?.cancel();
   }
 }

--- a/lib/src/view/explorer/opening_explorer_view.dart
+++ b/lib/src/view/explorer/opening_explorer_view.dart
@@ -155,11 +155,9 @@ class _OpeningExplorerState extends ConsumerState<OpeningExplorerView> {
         return _buildListView(children: children);
       case AsyncError(:final error):
         debugPrint('SEVERE: [OpeningExplorerView] could not load opening explorer data; $error');
-        final connectivity = ref.watch(connectivityChangesProvider);
-        final message = connectivity.whenIs(
-          online: () => 'Could not load opening explorer data.',
-          offline: () => context.l10n.mobileOpeningExplorerNotAvailableOffline,
-        );
+        final message = ref.watch(isDeviceOnlineProvider)
+            ? 'Could not load opening explorer data.'
+            : context.l10n.mobileOpeningExplorerNotAvailableOffline;
         return _buildListView(children: [ExplorerMessage(message)]);
       case _:
         return _buildListView(isLoading: true, children: lastExplorerWidgets ?? _loadingChildren);

--- a/lib/src/view/explorer/tablebase_view.dart
+++ b/lib/src/view/explorer/tablebase_view.dart
@@ -25,11 +25,9 @@ class TablebaseView extends ConsumerWidget {
     switch (tablebaseAsync) {
       case AsyncData(:final value):
         if (value == null) {
-          final connectivity = ref.watch(connectivityChangesProvider);
-          final message = connectivity.whenIs(
-            online: () => 'Position not in tablebase.',
-            offline: () => 'Tablebase is not available offline.',
-          );
+          final message = ref.watch(isDeviceOnlineProvider)
+              ? 'Position not in tablebase.'
+              : 'Tablebase is not available offline.';
           return Center(
             child: Padding(padding: const EdgeInsets.all(16.0), child: Text(message)),
           );
@@ -138,11 +136,9 @@ class TablebaseView extends ConsumerWidget {
 
       case AsyncError(:final error):
         debugPrint('SEVERE: [TablebaseView] could not load tablebase data; $error');
-        final connectivity = ref.watch(connectivityChangesProvider);
-        final message = connectivity.whenIs(
-          online: () => 'Could not load tablebase data.',
-          offline: () => 'Tablebase is not available offline.',
-        );
+        final message = ref.watch(isDeviceOnlineProvider)
+            ? 'Could not load tablebase data.'
+            : 'Tablebase is not available offline.';
         return Center(
           child: Padding(padding: const EdgeInsets.all(16.0), child: Text(message)),
         );

--- a/test/binding.dart
+++ b/test/binding.dart
@@ -25,7 +25,12 @@ class TestLichessBinding extends LichessBinding {
   ///
   /// If there is an existing binding but it is not a [TestLichessBinding],
   /// this method throws an error.
+  ///
+  /// Also initializes the Flutter binding, which the app widely assumes to exist: an
+  /// [AppLifecycleListener] alone — the connectivity notifier and the socket pool both build one —
+  /// throws without it.
   factory TestLichessBinding.ensureInitialized() {
+    TestWidgetsFlutterBinding.ensureInitialized();
     if (_instance == null) {
       TestLichessBinding();
     }

--- a/test/network/connectivity_test.dart
+++ b/test/network/connectivity_test.dart
@@ -1,14 +1,17 @@
 import 'dart:io';
 
+import 'package:connectivity_plus/connectivity_plus.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:http/testing.dart';
 import 'package:lichess_mobile/src/network/connectivity.dart';
 import 'package:lichess_mobile/src/network/http.dart';
 import 'package:lichess_mobile/src/network/server_status.dart';
+import 'package:lichess_mobile/src/network/socket.dart';
 
 import '../test_container.dart';
 import '../utils/fake_connectivity.dart';
 import 'fake_http_client_factory.dart';
+import 'fake_websocket_channel.dart';
 import 'server_down_client.dart';
 
 /// A client that fails every request, as it would without any connectivity.
@@ -39,6 +42,62 @@ void main() {
 
       expect(container.read(isDeviceOnlineProvider), isFalse);
     });
+
+    test('a socket that connects clears an offline status', () async {
+      final container = await makeContainer(
+        overrides: {
+          httpClientFactoryProvider: httpClientFactoryProvider.overrideWith(
+            (ref) => FakeHttpClientFactory(() => _deviceOfflineClient),
+          ),
+        },
+      );
+
+      await container.read(connectivityChangesProvider.future);
+      expect(container.read(isDeviceOnlineProvider), isFalse);
+
+      // Nothing can reach the network in this container except the socket, whose connection is
+      // proof enough on its own: the status must not wait for the next check to be corrected.
+      final client = container.read(socketPoolProvider).currentClient;
+      client.connect();
+      await client.firstConnection;
+      await Future<void>.delayed(kFakeWebSocketConnectionLag * 4);
+      await pumpEventQueue();
+
+      expect(container.read(isDeviceOnlineProvider), isTrue);
+
+      client.close();
+    });
+
+    test(
+      'a connected socket does not keep the device online once a check says otherwise',
+      () async {
+        final container = await makeContainer(
+          overrides: {
+            httpClientFactoryProvider: httpClientFactoryProvider.overrideWith(
+              (ref) => FakeHttpClientFactory(() => _deviceOfflineClient),
+            ),
+          },
+        );
+        await container.read(connectivityChangesProvider.future);
+
+        final client = container.read(socketPoolProvider).currentClient;
+        client.connect();
+        await client.firstConnection;
+        await Future<void>.delayed(kFakeWebSocketConnectionLag * 4);
+        await pumpEventQueue();
+        expect(container.read(isDeviceOnlineProvider), isTrue);
+
+        // The network goes away. The socket only notices once a ping goes unanswered, tens of
+        // seconds later, so its stale state must not outweigh the check.
+        FakeConnectivity.controller.add([ConnectivityResult.none]);
+        await pumpEventQueue();
+
+        expect(client.isConnected, isTrue, reason: 'the socket has not noticed yet');
+        expect(container.read(isDeviceOnlineProvider), isFalse);
+
+        client.close();
+      },
+    );
 
     test('assumes online while the check is still running', () async {
       final container = await makeContainer(

--- a/test/network/connectivity_test.dart
+++ b/test/network/connectivity_test.dart
@@ -3,6 +3,7 @@ import 'dart:io';
 import 'package:connectivity_plus/connectivity_plus.dart';
 import 'package:fake_async/fake_async.dart';
 import 'package:flutter_test/flutter_test.dart';
+import 'package:http/http.dart' as http;
 import 'package:http/testing.dart';
 import 'package:lichess_mobile/src/network/connectivity.dart';
 import 'package:lichess_mobile/src/network/http.dart';
@@ -147,6 +148,77 @@ void main() {
         client.close();
       },
     );
+
+    test('a socket that cannot connect makes the check run again', () async {
+      // The network dies without the connectivity plugin ever saying so — a captive portal, or an
+      // interface that is up but leads nowhere.
+      var offline = false;
+      final container = await makeContainer(
+        overrides: {
+          httpClientFactoryProvider: httpClientFactoryProvider.overrideWith(
+            (ref) => FakeHttpClientFactory(
+              () => MockClient((request) async {
+                if (offline) throw const SocketException('No internet');
+                return http.Response('', 200);
+              }),
+            ),
+          ),
+          webSocketChannelFactoryProvider: webSocketChannelFactoryProvider.overrideWithValue(
+            FakeWebSocketChannelFactory((_) => throw const SocketException('No internet')),
+          ),
+        },
+      );
+
+      await container.read(connectivityChangesProvider.future);
+      expect(container.read(isDeviceOnlineProvider), isTrue);
+
+      offline = true;
+      container.read(socketPoolProvider).currentClient.connect();
+      await pumpEventQueue();
+
+      expect(container.read(isDeviceOnlineProvider), isFalse);
+    });
+
+    test('a failing socket alone does not take the device offline', () async {
+      // Only lichess is unreachable here: the device itself is online, and the app must go on
+      // saying so, however long the socket goes on failing.
+      var checks = 0;
+      final container = await makeContainer(
+        overrides: {
+          httpClientFactoryProvider: httpClientFactoryProvider.overrideWith(
+            (ref) => FakeHttpClientFactory(
+              () => MockClient((request) async {
+                if (request.url == internetCheckUris.first) checks++;
+                return http.Response('', 200);
+              }),
+            ),
+          ),
+          webSocketChannelFactoryProvider: webSocketChannelFactoryProvider.overrideWithValue(
+            FakeWebSocketChannelFactory((_) => throw const SocketException('No internet')),
+          ),
+        },
+      );
+
+      await container.read(connectivityChangesProvider.future);
+      checks = 0;
+
+      fakeAsync((async) {
+        container.read(socketPoolProvider).currentClient.connect();
+
+        // Minutes of failed attempts, each one backing off a little further.
+        async.elapse(const Duration(minutes: 5));
+
+        expect(container.read(isDeviceOnlineProvider), isTrue);
+        expect(
+          checks,
+          1,
+          reason: 'a run of failures is worth one check, however many attempts it is made of',
+        );
+
+        container.read(socketPoolProvider).currentClient.close();
+        async.flushTimers();
+      });
+    });
 
     test('assumes online while the check is still running', () async {
       final container = await makeContainer(

--- a/test/network/connectivity_test.dart
+++ b/test/network/connectivity_test.dart
@@ -351,6 +351,53 @@ void main() {
       binding.handleAppLifecycleStateChanged(AppLifecycleState.resumed);
     });
 
+    test('a check that confirms the status still outdates the slower ones', () async {
+      var offline = false;
+      var checkDelay = Duration.zero;
+      final container = await makeContainer(
+        overrides: {
+          httpClientFactoryProvider: httpClientFactoryProvider.overrideWith(
+            (ref) => FakeHttpClientFactory(
+              () => MockClient((request) async {
+                final (wasOffline, delay) = (offline, checkDelay);
+                await Future<void>.delayed(delay);
+                if (wasOffline) throw const SocketException('No internet');
+                return http.Response('', 200);
+              }),
+            ),
+          ),
+        },
+      );
+
+      final binding = TestWidgetsFlutterBinding.instance;
+
+      fakeAsync((async) {
+        container.read(connectivityChangesProvider);
+        async.elapse(const Duration(seconds: 1));
+        expect(container.read(isDeviceOnlineProvider), isTrue);
+
+        // Coming back to the app starts a check while the network is down, and it takes its time.
+        offline = true;
+        checkDelay = const Duration(seconds: 4);
+        binding.handleAppLifecycleStateChanged(AppLifecycleState.resumed);
+        async.elapse(const Duration(milliseconds: 100));
+
+        // The network is back, and a second check overtakes the first to say so. It confirms the
+        // status rather than changing it, so it writes nothing — but it is the fresher answer.
+        offline = false;
+        checkDelay = Duration.zero;
+        FakeConnectivity.controller.add([ConnectivityResult.wifi]);
+        async.elapse(const Duration(milliseconds: 100));
+        expect(container.read(isDeviceOnlineProvider), isTrue);
+
+        // The first check finally answers, with a network that is seconds out of date.
+        async.elapse(const Duration(seconds: 5));
+        expect(container.read(isDeviceOnlineProvider), isTrue);
+      });
+
+      binding.handleAppLifecycleStateChanged(AppLifecycleState.resumed);
+    });
+
     test('assumes online while the check is still running', () async {
       final container = await makeContainer(
         overrides: {

--- a/test/network/connectivity_test.dart
+++ b/test/network/connectivity_test.dart
@@ -133,6 +133,37 @@ void main() {
       client.close();
     });
 
+    test('a socket that connected while the check went wrong keeps the device online', () async {
+      final connectivity = PendingThenFailingConnectivity();
+      final container = await makeContainer(
+        overrides: {
+          connectivityPluginProvider: connectivityPluginProvider.overrideWith((_) => connectivity),
+          httpClientFactoryProvider: httpClientFactoryProvider.overrideWith(
+            (ref) => FakeHttpClientFactory(() => _deviceOfflineClient),
+          ),
+        },
+      );
+
+      final pendingCheck = container.read(connectivityChangesProvider.future);
+
+      // The socket answers its first ping while the check is still running, so its report finds
+      // nothing settled yet to correct and is dropped.
+      final client = container.read(socketPoolProvider).currentClient;
+      client.connect();
+      await client.firstConnection;
+      await Future<void>.delayed(kFakeWebSocketConnectionLag * 4);
+      await pumpEventQueue();
+
+      // Only then does the plugin go wrong. A failed check reads as offline, which the socket has
+      // already disproved — and nothing would come along to correct it.
+      connectivity.failNow();
+      await pendingCheck;
+
+      expect(container.read(isDeviceOnlineProvider), isTrue);
+
+      client.close();
+    });
+
     test('the lag left by a socket that has been closed is not proof of a connection', () async {
       // Only the second route fails to connect, so that the pool keeps the lag measured on the
       // first one — which it deliberately does not blank on a route change.

--- a/test/network/connectivity_test.dart
+++ b/test/network/connectivity_test.dart
@@ -407,6 +407,8 @@ void main() {
         // settles the question with a probe of its own.
         offline = false;
         checkDelay = Duration.zero;
+        // The binding may still be resumed from an earlier test, and only a change is notified.
+        binding.handleAppLifecycleStateChanged(AppLifecycleState.inactive);
         binding.handleAppLifecycleStateChanged(AppLifecycleState.resumed);
         async.elapse(const Duration(milliseconds: 100));
         expect(container.read(isDeviceOnlineProvider), isTrue);
@@ -418,8 +420,6 @@ void main() {
 
         async.flushTimers();
       });
-
-      binding.handleAppLifecycleStateChanged(AppLifecycleState.resumed);
     });
 
     test('a check that confirms the status still outdates the slower ones', () async {
@@ -450,6 +450,8 @@ void main() {
         // Coming back to the app starts a check while the network is down, and it takes its time.
         offline = true;
         checkDelay = const Duration(seconds: 4);
+        // The binding may still be resumed from an earlier test, and only a change is notified.
+        binding.handleAppLifecycleStateChanged(AppLifecycleState.inactive);
         binding.handleAppLifecycleStateChanged(AppLifecycleState.resumed);
         async.elapse(const Duration(milliseconds: 100));
 
@@ -465,8 +467,51 @@ void main() {
         async.elapse(const Duration(seconds: 5));
         expect(container.read(isDeviceOnlineProvider), isTrue);
       });
+    });
 
-      binding.handleAppLifecycleStateChanged(AppLifecycleState.resumed);
+    test('an older check finishing first does not outdate a newer one', () async {
+      var offline = false;
+      var checkDelay = Duration.zero;
+      final container = await makeContainer(
+        overrides: {
+          httpClientFactoryProvider: httpClientFactoryProvider.overrideWith(
+            (ref) => FakeHttpClientFactory(
+              () => MockClient((request) async {
+                final (wasOffline, delay) = (offline, checkDelay);
+                await Future<void>.delayed(delay);
+                if (wasOffline) throw const SocketException('No internet');
+                return http.Response('', 200);
+              }),
+            ),
+          ),
+        },
+      );
+
+      final binding = TestWidgetsFlutterBinding.instance;
+
+      fakeAsync((async) {
+        container.read(connectivityChangesProvider);
+        async.elapse(const Duration(seconds: 1));
+        expect(container.read(isDeviceOnlineProvider), isTrue);
+
+        // A check starts while the network is up, and will take a moment to confirm as much.
+        offline = false;
+        checkDelay = const Duration(milliseconds: 200);
+        FakeConnectivity.controller.add([ConnectivityResult.wifi]);
+        async.elapse(const Duration(milliseconds: 50));
+
+        // The network then dies, and the user coming back to the app starts a second check. It is
+        // the newer of the two, and its answer must win however long it takes to arrive — the
+        // older one finishing first must not disqualify it.
+        offline = true;
+        checkDelay = const Duration(seconds: 2);
+        // The binding may still be resumed from an earlier test, and only a change is notified.
+        binding.handleAppLifecycleStateChanged(AppLifecycleState.inactive);
+        binding.handleAppLifecycleStateChanged(AppLifecycleState.resumed);
+
+        async.elapse(const Duration(seconds: 5));
+        expect(container.read(isDeviceOnlineProvider), isFalse);
+      });
     });
 
     test('assumes online while the check is still running', () async {

--- a/test/network/connectivity_test.dart
+++ b/test/network/connectivity_test.dart
@@ -203,6 +203,54 @@ void main() {
       });
     });
 
+    test('a resume whose plugin call fails does not swallow a check already running', () async {
+      final connectivity = PluginFailingConnectivity()..shouldFail = false;
+      var offline = false;
+      var checkDelay = Duration.zero;
+      final container = await makeContainer(
+        overrides: {
+          connectivityPluginProvider: connectivityPluginProvider.overrideWith((_) => connectivity),
+          httpClientFactoryProvider: httpClientFactoryProvider.overrideWith(
+            (ref) => FakeHttpClientFactory(
+              () => MockClient((request) async {
+                final (wasOffline, delay) = (offline, checkDelay);
+                await Future<void>.delayed(delay);
+                if (wasOffline) throw const SocketException('No internet');
+                return http.Response('', 200);
+              }),
+            ),
+          ),
+        },
+      );
+      final binding = TestWidgetsFlutterBinding.instance;
+
+      fakeAsync((async) {
+        container.read(connectivityChangesProvider);
+        async.elapse(const Duration(seconds: 1));
+        expect(container.read(isDeviceOnlineProvider), isTrue);
+
+        // A connectivity event starts a check that takes seconds to report the network is gone.
+        offline = true;
+        checkDelay = const Duration(seconds: 3);
+        FakeConnectivity.controller.add([ConnectivityResult.none]);
+        async.elapse(const Duration(milliseconds: 100));
+
+        // The user comes back to the app meanwhile, and the plugin call that makes goes wrong. It
+        // has nothing to write, so it must not outdate the check that is still running either —
+        // that answer is all the app is going to get.
+        connectivity.shouldFail = true;
+        // The binding may still be resumed from an earlier test, and only a change is notified.
+        binding.handleAppLifecycleStateChanged(AppLifecycleState.inactive);
+        binding.handleAppLifecycleStateChanged(AppLifecycleState.resumed);
+        async.elapse(const Duration(milliseconds: 100));
+
+        async.elapse(const Duration(seconds: 5));
+        expect(container.read(isDeviceOnlineProvider), isFalse);
+
+        async.flushTimers();
+      });
+    });
+
     test('a slow check does not overwrite what happened while it ran', () async {
       // A network that comes and goes, and a check that takes as long as it is told to.
       var offline = false;

--- a/test/network/connectivity_test.dart
+++ b/test/network/connectivity_test.dart
@@ -118,6 +118,62 @@ void main() {
       });
     });
 
+    test('a plugin failure is retried, and the status recovers on a later attempt', () async {
+      // The real plugin fails with a [PlatformException], which riverpod retries — unlike the
+      // [Error] the other fakes throw, which it deliberately does not. So the provider goes
+      // through several builds here, and what the last one leaves behind is what the app uses.
+      final connectivity = PluginFailingConnectivity();
+      var probes = 0;
+      final container = await makeContainer(
+        overrides: {
+          connectivityPluginProvider: connectivityPluginProvider.overrideWith((_) => connectivity),
+          httpClientFactoryProvider: httpClientFactoryProvider.overrideWith(
+            (ref) => FakeHttpClientFactory(
+              () => MockClient((request) async {
+                if (request.url == internetCheckUris.first) probes++;
+                return http.Response('', 200);
+              }),
+            ),
+          ),
+        },
+      );
+
+      fakeAsync((async) {
+        // Listened to, not merely read: a provider nobody listens to is not retried.
+        container.listen(connectivityChangesProvider, (_, _) {});
+        async.elapse(const Duration(milliseconds: 100));
+        expect(connectivity.checks, 1);
+        expect(
+          container.read(isDeviceOnlineProvider),
+          isFalse,
+          reason: 'a check that could not run reached nothing',
+        );
+
+        // The first retry, half a second later.
+        async.elapse(const Duration(milliseconds: 500));
+        expect(connectivity.checks, 2);
+
+        // The plugin comes back before the six attempts are spent.
+        connectivity.shouldFail = false;
+        async.elapse(const Duration(seconds: 2));
+        expect(connectivity.checks, 3);
+        expect(container.read(isDeviceOnlineProvider), isTrue);
+
+        // The builds that failed left nothing behind: their subscriptions are gone, so a
+        // connectivity event runs one check, not one per attempt.
+        probes = 0;
+        FakeConnectivity.controller.add([ConnectivityResult.wifi]);
+        async.elapse(const Duration(milliseconds: 100));
+        expect(probes, 1);
+
+        // Not even once the throttle window a duplicate would have been coalesced into expires.
+        async.elapse(kConnectivityThrottleDelay * 2);
+        expect(probes, 1);
+
+        async.flushTimers();
+      });
+    });
+
     test('a check that goes wrong on resume leaves the status as it is', () async {
       final connectivity = SwitchableConnectivity();
       final container = await makeContainer(

--- a/test/network/connectivity_test.dart
+++ b/test/network/connectivity_test.dart
@@ -284,7 +284,7 @@ void main() {
       expect(container.read(isDeviceOnlineProvider), isFalse);
     });
 
-    test('a socket that starts failing during the throttle delay still gets a check', () async {
+    test('a socket that starts failing during the throttle delay is checked right away', () async {
       var offline = false;
       final container = await makeContainer(
         overrides: {
@@ -315,14 +315,12 @@ void main() {
         expect(container.read(isDeviceOnlineProvider), isTrue);
 
         // The network dies without the plugin ever saying so, and the socket is the only witness.
-        // It reports a run of failures once, and that report lands inside the window opened above:
-        // dropped, it would leave the device reported online with nothing left to correct it.
+        // It reports a run of failures once, so the check it asks for must not be held back by a
+        // window the connectivity plugin happens to have opened: the report would be lost, and
+        // nothing left to correct the device being reported online.
         offline = true;
         container.read(socketPoolProvider).currentClient.connect();
         async.elapse(const Duration(milliseconds: 100));
-        expect(container.read(isDeviceOnlineProvider), isTrue, reason: 'still throttled');
-
-        async.elapse(kConnectivityThrottleDelay);
         expect(container.read(isDeviceOnlineProvider), isFalse);
 
         container.read(socketPoolProvider).currentClient.close();

--- a/test/network/connectivity_test.dart
+++ b/test/network/connectivity_test.dart
@@ -70,6 +70,39 @@ void main() {
       client.close();
     });
 
+    test(
+      'a socket that connects while the first check is running keeps the device online',
+      () async {
+        // The check takes long enough for the socket to answer a pong before it comes back offline.
+        final container = await makeContainer(
+          overrides: {
+            httpClientFactoryProvider: httpClientFactoryProvider.overrideWith(
+              (ref) => FakeHttpClientFactory(
+                () => MockClient((request) async {
+                  await Future<void>.delayed(const Duration(milliseconds: 200));
+                  throw const SocketException('No internet');
+                }),
+              ),
+            ),
+          },
+        );
+
+        final pendingCheck = container.read(connectivityChangesProvider.future);
+
+        final client = container.read(socketPoolProvider).currentClient;
+        client.connect();
+        await client.firstConnection;
+        await Future<void>.delayed(kFakeWebSocketConnectionLag * 4);
+        await pumpEventQueue();
+
+        await pendingCheck;
+
+        expect(container.read(isDeviceOnlineProvider), isTrue);
+
+        client.close();
+      },
+    );
+
     test('the socket clears an offline status once, not on every lag change', () async {
       // A server whose answers get slower and slower, so that every pong moves the average lag.
       FakeWebSocketChannel? channel;
@@ -177,6 +210,52 @@ void main() {
       await pumpEventQueue();
 
       expect(container.read(isDeviceOnlineProvider), isFalse);
+    });
+
+    test('a socket that starts failing during the throttle delay still gets a check', () async {
+      var offline = false;
+      final container = await makeContainer(
+        overrides: {
+          httpClientFactoryProvider: httpClientFactoryProvider.overrideWith(
+            (ref) => FakeHttpClientFactory(
+              () => MockClient((request) async {
+                if (offline) throw const SocketException('No internet');
+                return http.Response('', 200);
+              }),
+            ),
+          ),
+          webSocketChannelFactoryProvider: webSocketChannelFactoryProvider.overrideWithValue(
+            FakeWebSocketChannelFactory((_) => throw const SocketException('No internet')),
+          ),
+        },
+      );
+
+      // The notifier is built inside [fakeAsync] so that the timers it starts from the connectivity
+      // subscription — the throttler's among them — belong to this zone and answer to [elapse].
+      fakeAsync((async) {
+        container.read(connectivityChangesProvider);
+        async.elapse(const Duration(seconds: 1));
+        expect(container.read(isDeviceOnlineProvider), isTrue);
+
+        // A connectivity event opens the throttle window while the network is still fine.
+        FakeConnectivity.controller.add([ConnectivityResult.wifi]);
+        async.elapse(const Duration(milliseconds: 100));
+        expect(container.read(isDeviceOnlineProvider), isTrue);
+
+        // The network dies without the plugin ever saying so, and the socket is the only witness.
+        // It reports a run of failures once, and that report lands inside the window opened above:
+        // dropped, it would leave the device reported online with nothing left to correct it.
+        offline = true;
+        container.read(socketPoolProvider).currentClient.connect();
+        async.elapse(const Duration(milliseconds: 100));
+        expect(container.read(isDeviceOnlineProvider), isTrue, reason: 'still throttled');
+
+        async.elapse(kConnectivityThrottleDelay);
+        expect(container.read(isDeviceOnlineProvider), isFalse);
+
+        container.read(socketPoolProvider).currentClient.close();
+        async.flushTimers();
+      });
     });
 
     test('a failing socket alone does not take the device offline', () async {

--- a/test/network/connectivity_test.dart
+++ b/test/network/connectivity_test.dart
@@ -1,6 +1,7 @@
 import 'dart:io';
 
 import 'package:connectivity_plus/connectivity_plus.dart';
+import 'package:fake_async/fake_async.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:http/testing.dart';
 import 'package:lichess_mobile/src/network/connectivity.dart';
@@ -66,6 +67,54 @@ void main() {
       expect(container.read(isDeviceOnlineProvider), isTrue);
 
       client.close();
+    });
+
+    test('the socket clears an offline status once, not on every lag change', () async {
+      // A server whose answers get slower and slower, so that every pong moves the average lag.
+      FakeWebSocketChannel? channel;
+      final container = await makeContainer(
+        overrides: {
+          httpClientFactoryProvider: httpClientFactoryProvider.overrideWith(
+            (ref) => FakeHttpClientFactory(() => _deviceOfflineClient),
+          ),
+          webSocketChannelFactoryProvider: webSocketChannelFactoryProvider.overrideWithValue(
+            FakeWebSocketChannelFactory((route) => channel = FakeWebSocketChannel(route)),
+          ),
+        },
+      );
+
+      await container.read(connectivityChangesProvider.future);
+      expect(container.read(isDeviceOnlineProvider), isFalse);
+
+      var statusChanges = 0;
+      container.listen(connectivityChangesProvider, (_, _) => statusChanges++);
+
+      final pool = container.read(socketPoolProvider);
+      var lagChanges = 0;
+      void countLagChange() => lagChanges++;
+      pool.averageLag.addListener(countLagChange);
+
+      fakeAsync((async) {
+        pool.currentClient.connect();
+        async.elapse(const Duration(seconds: 1));
+
+        expect(container.read(isDeviceOnlineProvider), isTrue);
+        expect(statusChanges, 1);
+
+        // The ping/pong protocol keeps moving the average lag for as long as the socket is up: an
+        // online status that is already settled must not be rewritten on every pong.
+        for (var i = 1; i <= 10; i++) {
+          channel!.connectionLag = Duration(milliseconds: 10 * i);
+          async.elapse(const Duration(seconds: 30));
+        }
+
+        expect(lagChanges, greaterThan(5), reason: 'the lag did keep changing');
+        expect(statusChanges, 1, reason: 'but the status was only ever settled once');
+
+        pool.averageLag.removeListener(countLagChange);
+        pool.currentClient.close();
+        async.flushTimers();
+      });
     });
 
     test(

--- a/test/network/connectivity_test.dart
+++ b/test/network/connectivity_test.dart
@@ -400,6 +400,35 @@ void main() {
       });
     });
 
+    test('a check that goes wrong on resume leaves the status as it is', () async {
+      final connectivity = SwitchableConnectivity();
+      final container = await makeContainer(
+        overrides: {
+          connectivityPluginProvider: connectivityPluginProvider.overrideWith((_) => connectivity),
+        },
+      );
+      final binding = TestWidgetsFlutterBinding.instance;
+
+      fakeAsync((async) {
+        container.read(connectivityChangesProvider);
+        async.elapse(const Duration(seconds: 1));
+        expect(container.read(isDeviceOnlineProvider), isTrue);
+
+        // The plugin goes wrong on the check the user coming back to the app asks for. That says
+        // nothing about the network, and there is a settled status here to leave alone — turning
+        // it into an error would take the app offline for no reason at all.
+        connectivity.shouldFail = true;
+        // The binding may still be resumed from an earlier test, and only a change is notified.
+        binding.handleAppLifecycleStateChanged(AppLifecycleState.inactive);
+        binding.handleAppLifecycleStateChanged(AppLifecycleState.resumed);
+        async.elapse(const Duration(milliseconds: 100));
+
+        expect(container.read(isDeviceOnlineProvider), isTrue);
+
+        async.flushTimers();
+      });
+    });
+
     test('a slow check does not overwrite what happened while it ran', () async {
       // A network that comes and goes, and a check that takes as long as it is told to.
       var offline = false;

--- a/test/network/connectivity_test.dart
+++ b/test/network/connectivity_test.dart
@@ -133,6 +133,48 @@ void main() {
       client.close();
     });
 
+    test('the lag left by a socket that has been closed is not proof of a connection', () async {
+      // Only the second route fails to connect, so that the pool keeps the lag measured on the
+      // first one — which it deliberately does not blank on a route change.
+      const failingRoute = '/failing/socket';
+      final container = await makeContainer(
+        overrides: {
+          httpClientFactoryProvider: httpClientFactoryProvider.overrideWith(
+            (ref) => FakeHttpClientFactory(
+              () => MockClient((request) async {
+                // Slow enough for the sockets below to come and go while the check runs.
+                await Future<void>.delayed(const Duration(milliseconds: 300));
+                throw const SocketException('No internet');
+              }),
+            ),
+          ),
+          webSocketChannelFactoryProvider: webSocketChannelFactoryProvider.overrideWithValue(
+            FakeWebSocketChannelFactory((route) {
+              if (route.path == failingRoute) throw const SocketException('No internet');
+              return FakeWebSocketChannel(route);
+            }),
+          ),
+        },
+      );
+
+      final pool = container.read(socketPoolProvider);
+      final connected = pool.open(Uri(path: kDefaultSocketRoute));
+      await connected.firstConnection;
+      await Future<void>.delayed(kFakeWebSocketConnectionLag * 4);
+      expect(pool.averageLag.value, isNot(Duration.zero));
+
+      pool.open(Uri(path: failingRoute));
+      await pumpEventQueue();
+      expect(pool.averageLag.value, isNot(Duration.zero), reason: 'the lag outlives its socket');
+      expect(pool.currentClient.isConnected, isFalse);
+
+      await container.read(connectivityChangesProvider.future);
+
+      expect(container.read(isDeviceOnlineProvider), isFalse);
+
+      pool.currentClient.close();
+    });
+
     test('the socket clears an offline status once, not on every lag change', () async {
       // A server whose answers get slower and slower, so that every pong moves the average lag.
       FakeWebSocketChannel? channel;

--- a/test/network/connectivity_test.dart
+++ b/test/network/connectivity_test.dart
@@ -104,6 +104,35 @@ void main() {
       },
     );
 
+    test('a socket that connects clears an offline status left by a failed check', () async {
+      final container = await makeContainer(
+        overrides: {
+          connectivityPluginProvider: connectivityPluginProvider.overrideWith(
+            (_) => FailingConnectivity(),
+          ),
+        },
+      );
+
+      await expectLater(container.read(connectivityChangesProvider.future), throwsStateError);
+      expect(
+        container.read(isDeviceOnlineProvider),
+        isFalse,
+        reason: 'a check that could not run reached nothing',
+      );
+
+      // The socket is proof of a working network whatever the failed check left behind, so the
+      // status must not stay offline until something else happens to probe it.
+      final client = container.read(socketPoolProvider).currentClient;
+      client.connect();
+      await client.firstConnection;
+      await Future<void>.delayed(kFakeWebSocketConnectionLag * 4);
+      await pumpEventQueue();
+
+      expect(container.read(isDeviceOnlineProvider), isTrue);
+
+      client.close();
+    });
+
     test('the socket clears an offline status once, not on every lag change', () async {
       // A server whose answers get slower and slower, so that every pong moves the average lag.
       FakeWebSocketChannel? channel;

--- a/test/network/connectivity_test.dart
+++ b/test/network/connectivity_test.dart
@@ -2,6 +2,7 @@ import 'dart:io';
 
 import 'package:connectivity_plus/connectivity_plus.dart';
 import 'package:fake_async/fake_async.dart';
+import 'package:flutter/widgets.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:http/http.dart' as http;
 import 'package:http/testing.dart';
@@ -297,6 +298,57 @@ void main() {
         container.read(socketPoolProvider).currentClient.close();
         async.flushTimers();
       });
+    });
+
+    test('a slow check does not overwrite what happened while it ran', () async {
+      // A network that comes and goes, and a check that takes as long as it is told to.
+      var offline = false;
+      var checkDelay = Duration.zero;
+      final container = await makeContainer(
+        overrides: {
+          httpClientFactoryProvider: httpClientFactoryProvider.overrideWith(
+            (ref) => FakeHttpClientFactory(
+              () => MockClient((request) async {
+                final (wasOffline, delay) = (offline, checkDelay);
+                await Future<void>.delayed(delay);
+                if (wasOffline) throw const SocketException('No internet');
+                return http.Response('', 200);
+              }),
+            ),
+          ),
+        },
+      );
+
+      final binding = TestWidgetsFlutterBinding.instance;
+
+      fakeAsync((async) {
+        container.read(connectivityChangesProvider);
+        async.elapse(const Duration(seconds: 1));
+        expect(container.read(isDeviceOnlineProvider), isTrue);
+
+        // A check starts while the network is down, and takes seconds to say so.
+        offline = true;
+        checkDelay = const Duration(seconds: 3);
+        FakeConnectivity.controller.add([ConnectivityResult.none]);
+        async.elapse(const Duration(milliseconds: 100));
+
+        // The network is back before that check answers, and the user coming back to the app
+        // settles the question with a probe of its own.
+        offline = false;
+        checkDelay = Duration.zero;
+        binding.handleAppLifecycleStateChanged(AppLifecycleState.resumed);
+        async.elapse(const Duration(milliseconds: 100));
+        expect(container.read(isDeviceOnlineProvider), isTrue);
+
+        // The slow check now answers with what the network looked like seconds ago: it must not
+        // overwrite the fresher answer.
+        async.elapse(const Duration(seconds: 5));
+        expect(container.read(isDeviceOnlineProvider), isTrue);
+
+        async.flushTimers();
+      });
+
+      binding.handleAppLifecycleStateChanged(AppLifecycleState.resumed);
     });
 
     test('assumes online while the check is still running', () async {

--- a/test/network/connectivity_test.dart
+++ b/test/network/connectivity_test.dart
@@ -46,7 +46,10 @@ void main() {
       expect(container.read(isDeviceOnlineProvider), isFalse);
     });
 
-    test('a socket that connects clears an offline status', () async {
+    test('a connected socket has no say in the status', () async {
+      // The socket is up and answering, and the check can reach nothing. That the socket works is
+      // only ever a suspicion — it may be holding a connection to a network that is already gone,
+      // which it would not notice for tens of seconds — so the check has the last word.
       final container = await makeContainer(
         overrides: {
           httpClientFactoryProvider: httpClientFactoryProvider.overrideWith(
@@ -55,313 +58,28 @@ void main() {
         },
       );
 
-      await container.read(connectivityChangesProvider.future);
-      expect(container.read(isDeviceOnlineProvider), isFalse);
-
-      // Nothing can reach the network in this container except the socket, whose connection is
-      // proof enough on its own: the status must not wait for the next check to be corrected.
       final client = container.read(socketPoolProvider).currentClient;
       client.connect();
       await client.firstConnection;
       await Future<void>.delayed(kFakeWebSocketConnectionLag * 4);
       await pumpEventQueue();
-
-      expect(container.read(isDeviceOnlineProvider), isTrue);
-
-      client.close();
-    });
-
-    test(
-      'a socket that connects while the first check is running keeps the device online',
-      () async {
-        // The check takes long enough for the socket to answer a pong before it comes back offline.
-        final container = await makeContainer(
-          overrides: {
-            httpClientFactoryProvider: httpClientFactoryProvider.overrideWith(
-              (ref) => FakeHttpClientFactory(
-                () => MockClient((request) async {
-                  await Future<void>.delayed(const Duration(milliseconds: 200));
-                  throw const SocketException('No internet');
-                }),
-              ),
-            ),
-          },
-        );
-
-        final pendingCheck = container.read(connectivityChangesProvider.future);
-
-        final client = container.read(socketPoolProvider).currentClient;
-        client.connect();
-        await client.firstConnection;
-        await Future<void>.delayed(kFakeWebSocketConnectionLag * 4);
-        await pumpEventQueue();
-
-        await pendingCheck;
-
-        expect(container.read(isDeviceOnlineProvider), isTrue);
-
-        client.close();
-      },
-    );
-
-    test('a socket that connects clears an offline status left by a failed check', () async {
-      final container = await makeContainer(
-        overrides: {
-          connectivityPluginProvider: connectivityPluginProvider.overrideWith(
-            (_) => FailingConnectivity(),
-          ),
-        },
-      );
-
-      await expectLater(container.read(connectivityChangesProvider.future), throwsStateError);
-      expect(
-        container.read(isDeviceOnlineProvider),
-        isFalse,
-        reason: 'a check that could not run reached nothing',
-      );
-
-      // The socket is proof of a working network whatever the failed check left behind, so the
-      // status must not stay offline until something else happens to probe it.
-      final client = container.read(socketPoolProvider).currentClient;
-      client.connect();
-      await client.firstConnection;
-      await Future<void>.delayed(kFakeWebSocketConnectionLag * 4);
-      await pumpEventQueue();
-
-      expect(container.read(isDeviceOnlineProvider), isTrue);
-
-      client.close();
-    });
-
-    test('a socket that connected while the check went wrong keeps the device online', () async {
-      final connectivity = PendingThenFailingConnectivity();
-      final container = await makeContainer(
-        overrides: {
-          connectivityPluginProvider: connectivityPluginProvider.overrideWith((_) => connectivity),
-          httpClientFactoryProvider: httpClientFactoryProvider.overrideWith(
-            (ref) => FakeHttpClientFactory(() => _deviceOfflineClient),
-          ),
-        },
-      );
-
-      final pendingCheck = container.read(connectivityChangesProvider.future);
-
-      // The socket answers its first ping while the check is still running, so its report finds
-      // nothing settled yet to correct and is dropped.
-      final client = container.read(socketPoolProvider).currentClient;
-      client.connect();
-      await client.firstConnection;
-      await Future<void>.delayed(kFakeWebSocketConnectionLag * 4);
-      await pumpEventQueue();
-
-      // Only then does the plugin go wrong. A failed check reads as offline, which the socket has
-      // already disproved — and nothing would come along to correct it.
-      connectivity.failNow();
-      await pendingCheck;
-
-      expect(container.read(isDeviceOnlineProvider), isTrue);
-
-      client.close();
-    });
-
-    test('the lag left by a socket that has been closed is not proof of a connection', () async {
-      // Only the second route fails to connect, so that the pool keeps the lag measured on the
-      // first one — which it deliberately does not blank on a route change.
-      const failingRoute = '/failing/socket';
-      final container = await makeContainer(
-        overrides: {
-          httpClientFactoryProvider: httpClientFactoryProvider.overrideWith(
-            (ref) => FakeHttpClientFactory(
-              () => MockClient((request) async {
-                // Slow enough for the sockets below to come and go while the check runs.
-                await Future<void>.delayed(const Duration(milliseconds: 300));
-                throw const SocketException('No internet');
-              }),
-            ),
-          ),
-          webSocketChannelFactoryProvider: webSocketChannelFactoryProvider.overrideWithValue(
-            FakeWebSocketChannelFactory((route) {
-              if (route.path == failingRoute) throw const SocketException('No internet');
-              return FakeWebSocketChannel(route);
-            }),
-          ),
-        },
-      );
-
-      final pool = container.read(socketPoolProvider);
-      final connected = pool.open(Uri(path: kDefaultSocketRoute));
-      await connected.firstConnection;
-      await Future<void>.delayed(kFakeWebSocketConnectionLag * 4);
-      expect(pool.averageLag.value, isNot(Duration.zero));
-
-      pool.open(Uri(path: failingRoute));
-      await pumpEventQueue();
-      expect(pool.averageLag.value, isNot(Duration.zero), reason: 'the lag outlives its socket');
-      expect(pool.currentClient.isConnected, isFalse);
-
-      await container.read(connectivityChangesProvider.future);
-
-      expect(container.read(isDeviceOnlineProvider), isFalse);
-
-      pool.currentClient.close();
-    });
-
-    test('the socket clears an offline status once, not on every lag change', () async {
-      // A server whose answers get slower and slower, so that every pong moves the average lag.
-      FakeWebSocketChannel? channel;
-      final container = await makeContainer(
-        overrides: {
-          httpClientFactoryProvider: httpClientFactoryProvider.overrideWith(
-            (ref) => FakeHttpClientFactory(() => _deviceOfflineClient),
-          ),
-          webSocketChannelFactoryProvider: webSocketChannelFactoryProvider.overrideWithValue(
-            FakeWebSocketChannelFactory((route) => channel = FakeWebSocketChannel(route)),
-          ),
-        },
-      );
+      expect(client.isConnected, isTrue);
 
       await container.read(connectivityChangesProvider.future);
       expect(container.read(isDeviceOnlineProvider), isFalse);
 
-      var statusChanges = 0;
-      container.listen(connectivityChangesProvider, (_, _) => statusChanges++);
-
-      final pool = container.read(socketPoolProvider);
-      var lagChanges = 0;
-      void countLagChange() => lagChanges++;
-      pool.averageLag.addListener(countLagChange);
-
-      fakeAsync((async) {
-        pool.currentClient.connect();
-        async.elapse(const Duration(seconds: 1));
-
-        expect(container.read(isDeviceOnlineProvider), isTrue);
-        expect(statusChanges, 1);
-
-        // The ping/pong protocol keeps moving the average lag for as long as the socket is up: an
-        // online status that is already settled must not be rewritten on every pong.
-        for (var i = 1; i <= 10; i++) {
-          channel!.connectionLag = Duration(milliseconds: 10 * i);
-          async.elapse(const Duration(seconds: 30));
-        }
-
-        expect(lagChanges, greaterThan(5), reason: 'the lag did keep changing');
-        expect(statusChanges, 1, reason: 'but the status was only ever settled once');
-
-        pool.averageLag.removeListener(countLagChange);
-        pool.currentClient.close();
-        async.flushTimers();
-      });
-    });
-
-    test(
-      'a connected socket does not keep the device online once a check says otherwise',
-      () async {
-        final container = await makeContainer(
-          overrides: {
-            httpClientFactoryProvider: httpClientFactoryProvider.overrideWith(
-              (ref) => FakeHttpClientFactory(() => _deviceOfflineClient),
-            ),
-          },
-        );
-        await container.read(connectivityChangesProvider.future);
-
-        final client = container.read(socketPoolProvider).currentClient;
-        client.connect();
-        await client.firstConnection;
-        await Future<void>.delayed(kFakeWebSocketConnectionLag * 4);
-        await pumpEventQueue();
-        expect(container.read(isDeviceOnlineProvider), isTrue);
-
-        // The network goes away. The socket only notices once a ping goes unanswered, tens of
-        // seconds later, so its stale state must not outweigh the check.
-        FakeConnectivity.controller.add([ConnectivityResult.none]);
-        await pumpEventQueue();
-
-        expect(client.isConnected, isTrue, reason: 'the socket has not noticed yet');
-        expect(container.read(isDeviceOnlineProvider), isFalse);
-
-        client.close();
-      },
-    );
-
-    test('a socket that cannot connect makes the check run again', () async {
-      // The network dies without the connectivity plugin ever saying so — a captive portal, or an
-      // interface that is up but leads nowhere.
-      var offline = false;
-      final container = await makeContainer(
-        overrides: {
-          httpClientFactoryProvider: httpClientFactoryProvider.overrideWith(
-            (ref) => FakeHttpClientFactory(
-              () => MockClient((request) async {
-                if (offline) throw const SocketException('No internet');
-                return http.Response('', 200);
-              }),
-            ),
-          ),
-          webSocketChannelFactoryProvider: webSocketChannelFactoryProvider.overrideWithValue(
-            FakeWebSocketChannelFactory((_) => throw const SocketException('No internet')),
-          ),
-        },
-      );
-
-      await container.read(connectivityChangesProvider.future);
-      expect(container.read(isDeviceOnlineProvider), isTrue);
-
-      offline = true;
-      container.read(socketPoolProvider).currentClient.connect();
+      // And it stays that way, however many pings the socket goes on answering.
+      await Future<void>.delayed(kFakeWebSocketConnectionLag * 10);
       await pumpEventQueue();
-
       expect(container.read(isDeviceOnlineProvider), isFalse);
+
+      client.close();
     });
 
-    test('a socket that starts failing during the throttle delay is checked right away', () async {
-      var offline = false;
-      final container = await makeContainer(
-        overrides: {
-          httpClientFactoryProvider: httpClientFactoryProvider.overrideWith(
-            (ref) => FakeHttpClientFactory(
-              () => MockClient((request) async {
-                if (offline) throw const SocketException('No internet');
-                return http.Response('', 200);
-              }),
-            ),
-          ),
-          webSocketChannelFactoryProvider: webSocketChannelFactoryProvider.overrideWithValue(
-            FakeWebSocketChannelFactory((_) => throw const SocketException('No internet')),
-          ),
-        },
-      );
-
-      // The notifier is built inside [fakeAsync] so that the timers it starts from the connectivity
-      // subscription — the throttler's among them — belong to this zone and answer to [elapse].
-      fakeAsync((async) {
-        container.read(connectivityChangesProvider);
-        async.elapse(const Duration(seconds: 1));
-        expect(container.read(isDeviceOnlineProvider), isTrue);
-
-        // A connectivity event opens the throttle window while the network is still fine.
-        FakeConnectivity.controller.add([ConnectivityResult.wifi]);
-        async.elapse(const Duration(milliseconds: 100));
-        expect(container.read(isDeviceOnlineProvider), isTrue);
-
-        // The network dies without the plugin ever saying so, and the socket is the only witness.
-        // It reports a run of failures once, so the check it asks for must not be held back by a
-        // window the connectivity plugin happens to have opened: the report would be lost, and
-        // nothing left to correct the device being reported online.
-        offline = true;
-        container.read(socketPoolProvider).currentClient.connect();
-        async.elapse(const Duration(milliseconds: 100));
-        expect(container.read(isDeviceOnlineProvider), isFalse);
-
-        container.read(socketPoolProvider).currentClient.close();
-        async.flushTimers();
-      });
-    });
-
-    test('a failing socket alone does not take the device offline', () async {
-      // Only lichess is unreachable here: the device itself is online, and the app must go on
-      // saying so, however long the socket goes on failing.
+    test('a failing socket has no say in the status', () async {
+      // A socket that cannot connect is only ever a suspicion: it may be lichess that is down, and
+      // a check asked for on its word would report offline wherever the probed hosts are blocked
+      // but the network is fine. So it neither takes the device offline nor asks anything.
       var checks = 0;
       final container = await makeContainer(
         overrides: {
@@ -391,8 +109,8 @@ void main() {
         expect(container.read(isDeviceOnlineProvider), isTrue);
         expect(
           checks,
-          1,
-          reason: 'a run of failures is worth one check, however many attempts it is made of',
+          0,
+          reason: 'the check runs on connectivity events and app resume, not on it',
         );
 
         container.read(socketPoolProvider).currentClient.close();
@@ -569,51 +287,6 @@ void main() {
 
         async.elapse(const Duration(seconds: 5));
         expect(container.read(isDeviceOnlineProvider), isFalse);
-      });
-    });
-
-    test('a pong keeps a check that started before it from taking the device offline', () async {
-      var offline = false;
-      var checkDelay = Duration.zero;
-      final container = await makeContainer(
-        overrides: {
-          httpClientFactoryProvider: httpClientFactoryProvider.overrideWith(
-            (ref) => FakeHttpClientFactory(
-              () => MockClient((request) async {
-                final (wasOffline, delay) = (offline, checkDelay);
-                await Future<void>.delayed(delay);
-                if (wasOffline) throw const SocketException('No internet');
-                return http.Response('', 200);
-              }),
-            ),
-          ),
-        },
-      );
-
-      fakeAsync((async) {
-        container.read(connectivityChangesProvider);
-        async.elapse(const Duration(seconds: 1));
-        expect(container.read(isDeviceOnlineProvider), isTrue);
-
-        // A check starts on a network that is momentarily down, and takes seconds to say so.
-        offline = true;
-        checkDelay = const Duration(seconds: 2);
-        FakeConnectivity.controller.add([ConnectivityResult.none]);
-        async.elapse(const Duration(milliseconds: 100));
-
-        // The socket then answers a ping, which is proof of a working network. It changes nothing
-        // to a status that already reads online, but it is newer than the check in flight.
-        final pool = container.read(socketPoolProvider);
-        pool.currentClient.connect();
-        async.elapse(const Duration(seconds: 1));
-        expect(pool.currentClient.isConnected, isTrue);
-
-        // The check now answers with a network that is seconds out of date.
-        async.elapse(const Duration(seconds: 5));
-        expect(container.read(isDeviceOnlineProvider), isTrue);
-
-        pool.currentClient.close();
-        async.flushTimers();
       });
     });
 

--- a/test/network/connectivity_test.dart
+++ b/test/network/connectivity_test.dart
@@ -514,6 +514,51 @@ void main() {
       });
     });
 
+    test('a pong keeps a check that started before it from taking the device offline', () async {
+      var offline = false;
+      var checkDelay = Duration.zero;
+      final container = await makeContainer(
+        overrides: {
+          httpClientFactoryProvider: httpClientFactoryProvider.overrideWith(
+            (ref) => FakeHttpClientFactory(
+              () => MockClient((request) async {
+                final (wasOffline, delay) = (offline, checkDelay);
+                await Future<void>.delayed(delay);
+                if (wasOffline) throw const SocketException('No internet');
+                return http.Response('', 200);
+              }),
+            ),
+          ),
+        },
+      );
+
+      fakeAsync((async) {
+        container.read(connectivityChangesProvider);
+        async.elapse(const Duration(seconds: 1));
+        expect(container.read(isDeviceOnlineProvider), isTrue);
+
+        // A check starts on a network that is momentarily down, and takes seconds to say so.
+        offline = true;
+        checkDelay = const Duration(seconds: 2);
+        FakeConnectivity.controller.add([ConnectivityResult.none]);
+        async.elapse(const Duration(milliseconds: 100));
+
+        // The socket then answers a ping, which is proof of a working network. It changes nothing
+        // to a status that already reads online, but it is newer than the check in flight.
+        final pool = container.read(socketPoolProvider);
+        pool.currentClient.connect();
+        async.elapse(const Duration(seconds: 1));
+        expect(pool.currentClient.isConnected, isTrue);
+
+        // The check now answers with a network that is seconds out of date.
+        async.elapse(const Duration(seconds: 5));
+        expect(container.read(isDeviceOnlineProvider), isTrue);
+
+        pool.currentClient.close();
+        async.flushTimers();
+      });
+    });
+
     test('assumes online while the check is still running', () async {
       final container = await makeContainer(
         overrides: {

--- a/test/network/fake_websocket_channel.dart
+++ b/test/network/fake_websocket_channel.dart
@@ -207,11 +207,12 @@ class FakeWebSocketChannel implements WebSocketChannel {
   /// Can be used to simulate a faulty connection.
   bool shouldSendPong = true;
 
-  /// Makes the next write to the sink throw, as one whose peer is already gone does.
+  /// Makes a write to the sink throw whenever this returns true, as one whose peer is already
+  /// gone does.
   ///
-  /// It is cleared by the write it fails, so that whatever the client does next is recorded as
-  /// usual — including a write it should not have made.
-  bool failNextWrite = false;
+  /// The data written is passed in, so that a test can break on one particular message and let
+  /// everything else through — including a write the client should not have made.
+  bool Function(dynamic data)? failWriteWhen;
 
   /// How long the channel takes to finish closing.
   ///
@@ -298,8 +299,7 @@ class _FakeWebSocketSink implements WebSocketSink {
 
   @override
   void add(dynamic data) {
-    if (_channel.failNextWrite) {
-      _channel.failNextWrite = false;
+    if (_channel.failWriteWhen?.call(data) == true) {
       throw StateError('Cannot add to a closed sink');
     }
     _channel._outcomingController.add(data);

--- a/test/network/fake_websocket_channel.dart
+++ b/test/network/fake_websocket_channel.dart
@@ -207,6 +207,12 @@ class FakeWebSocketChannel implements WebSocketChannel {
   /// Can be used to simulate a faulty connection.
   bool shouldSendPong = true;
 
+  /// Makes the next write to the sink throw, as one whose peer is already gone does.
+  ///
+  /// It is cleared by the write it fails, so that whatever the client does next is recorded as
+  /// usual — including a write it should not have made.
+  bool failNextWrite = false;
+
   /// How long the channel takes to finish closing.
   ///
   /// A real one is not closed the moment it is asked to be: the client can well be connected again
@@ -292,6 +298,10 @@ class _FakeWebSocketSink implements WebSocketSink {
 
   @override
   void add(dynamic data) {
+    if (_channel.failNextWrite) {
+      _channel.failNextWrite = false;
+      throw StateError('Cannot add to a closed sink');
+    }
     _channel._outcomingController.add(data);
 
     // Simulates pong response if connection is not closed

--- a/test/network/fake_websocket_channel.dart
+++ b/test/network/fake_websocket_channel.dart
@@ -207,6 +207,12 @@ class FakeWebSocketChannel implements WebSocketChannel {
   /// Can be used to simulate a faulty connection.
   bool shouldSendPong = true;
 
+  /// How long the channel takes to finish closing.
+  ///
+  /// A real one is not closed the moment it is asked to be: the client can well be connected again
+  /// by the time the old sink is done.
+  Duration closeDelay = Duration.zero;
+
   /// Number of pong response received
   int get pongCount => _pongCount;
 
@@ -338,7 +344,8 @@ class _FakeWebSocketSink implements WebSocketSink {
     _serverHandlersTimers.forEach((_, timer) {
       timer?.cancel();
     });
-    return _channel._close();
+    final delay = _channel.closeDelay;
+    return delay > Duration.zero ? Future<void>.delayed(delay, _channel._close) : _channel._close();
   }
 
   @override

--- a/test/network/fake_websocket_channel.dart
+++ b/test/network/fake_websocket_channel.dart
@@ -144,7 +144,40 @@ class FakeWebSocketChannel implements WebSocketChannel {
   late final _FakeWebSocketSink _sink;
 
   Future<void> _close() {
+    if (!_streamController.isClosed) {
+      _streamController.close();
+    }
     return _outcomingController.close();
+  }
+
+  /// The stream the client listens to, fed by the global incoming controller.
+  ///
+  /// It is per channel so that a single connection can be dropped, as [closeFromServer] does.
+  late final StreamController<dynamic> _streamController = StreamController<dynamic>.broadcast(
+    onListen: () {
+      _incomingSubscription = _incomingController.stream
+          .where((event) => event.$1 == route)
+          .map((event) => event.$2)
+          .listen(_streamController.add);
+    },
+    onCancel: () {
+      _incomingSubscription?.cancel();
+      _incomingSubscription = null;
+    },
+  );
+
+  StreamSubscription<dynamic>? _incomingSubscription;
+
+  /// Drops the connection the way a network going away under an open socket does.
+  ///
+  /// With [error], the stream errors out before it closes; without, it merely closes, as a peer
+  /// hanging up would.
+  void closeFromServer([Object? error]) {
+    if (_streamController.isClosed) return;
+    if (error != null) {
+      _streamController.addError(error);
+    }
+    _streamController.close();
   }
 
   int _pongCount = 0;
@@ -200,8 +233,7 @@ class FakeWebSocketChannel implements WebSocketChannel {
   WebSocketSink get sink => _sink;
 
   @override
-  Stream<dynamic> get stream =>
-      _incomingController.stream.where((event) => event.$1 == route).map((event) => event.$2);
+  Stream<dynamic> get stream => _streamController.stream;
 
   @override
   void pipe(StreamChannel<dynamic> other) {}

--- a/test/network/socket_test.dart
+++ b/test/network/socket_test.dart
@@ -9,6 +9,7 @@ import 'package:lichess_mobile/src/network/socket.dart';
 import 'package:package_info_plus/package_info_plus.dart';
 
 import '../binding.dart';
+import '../test_container.dart';
 import 'fake_websocket_channel.dart';
 
 final defaultSocketUri = Uri(path: kDefaultSocketRoute);
@@ -43,6 +44,7 @@ SocketClient makeTestSocketClient({
     pingDelay: const Duration(milliseconds: 50),
     pingMaxLag: const Duration(milliseconds: 200),
     autoReconnectDelay: const Duration(milliseconds: 100),
+    reconnectGracePeriod: const Duration(seconds: 1),
     resendAckDelay: const Duration(milliseconds: 100),
   );
 
@@ -50,6 +52,7 @@ SocketClient makeTestSocketClient({
 }
 
 void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
   TestLichessBinding.ensureInitialized();
 
   group('SocketClient', () {
@@ -158,6 +161,74 @@ void main() {
       expect(channels[1]!.closeCode, isNotNull);
       expect(socketClient.isConnected, false);
       expect(socketClient.nbConnectionSuccess, 0);
+    });
+
+    test('retries at full speed during the grace period, then backs off', () {
+      final attempts = <Duration>[];
+
+      fakeAsync((async) {
+        final start = async.elapsed;
+        final socketClient = makeTestSocketClient(
+          fakeChannelFactory: FakeWebSocketChannelFactory((_) {
+            attempts.add(async.elapsed - start);
+            throw const SocketException('Network is unreachable');
+          }),
+        );
+        socketClient.connect();
+
+        // The grace period is 1s in tests, the reconnect delay 100ms.
+        async.elapse(const Duration(seconds: 5));
+
+        final gaps = [for (var i = 1; i < attempts.length; i++) attempts[i] - attempts[i - 1]];
+
+        expect(
+          gaps.take(11),
+          everyElement(const Duration(milliseconds: 100)),
+          reason: 'a blip must not be made to wait',
+        );
+        expect(gaps[11], const Duration(milliseconds: 200), reason: 'then the delay doubles');
+        expect(gaps.last, greaterThan(const Duration(milliseconds: 200)));
+
+        socketClient.close();
+        async.flushTimers();
+      });
+    });
+
+    test('a successful connection resets the backoff', () {
+      fakeAsync((async) {
+        final attempts = <Duration>[];
+        final start = async.elapsed;
+        var failing = true;
+        final socketClient = makeTestSocketClient(
+          fakeChannelFactory: FakeWebSocketChannelFactory((route) {
+            attempts.add(async.elapsed - start);
+            if (failing) throw const SocketException('Network is unreachable');
+            return FakeWebSocketChannel(route);
+          }),
+        );
+        socketClient.connect();
+
+        // Fail well past the grace period, so the delay has grown.
+        async.elapse(const Duration(seconds: 5));
+        final grownGap = attempts.last - attempts[attempts.length - 2];
+        expect(grownGap, greaterThan(const Duration(milliseconds: 100)));
+
+        // The network comes back, then drops again: the next retry is at full speed, since this is
+        // a new failure and not the continuation of the old one.
+        failing = false;
+        async.elapse(const Duration(seconds: 5));
+        expect(socketClient.nbConnectionSuccess, greaterThan(0));
+
+        failing = true;
+        attempts.clear();
+        socketClient.connect();
+        async.elapse(const Duration(milliseconds: 250));
+
+        expect(attempts[1] - attempts[0], const Duration(milliseconds: 100));
+
+        socketClient.close();
+        async.flushTimers();
+      });
     });
 
     test('reconnects automatically if pong is not received', () async {
@@ -581,6 +652,39 @@ void main() {
       expect(onEventGapFailureCalled, 1);
 
       socketClient.close();
+    });
+  });
+
+  group('SocketPool', () {
+    test('closes the socket once the app has been in the background for a while', () async {
+      final container = await makeContainer();
+      final pool = container.read(socketPoolProvider);
+
+      // The pool made by the test container does not connect on its own.
+      pool.currentClient.connect();
+      await pool.currentClient.firstConnection;
+      expect(pool.currentClient.isActive, isTrue);
+
+      fakeAsync((async) {
+        pool.onAppHidden();
+
+        async.elapse(const Duration(seconds: 59));
+        expect(
+          pool.currentClient.isActive,
+          isTrue,
+          reason: 'the socket is kept for a while, as the user may well come right back',
+        );
+
+        async.elapse(const Duration(seconds: 2));
+        expect(pool.currentClient.isActive, isFalse);
+
+        // Coming back to the app brings it up again.
+        pool.onAppShown();
+        expect(pool.currentClient.isActive, isTrue);
+
+        pool.currentClient.close();
+        async.flushTimers();
+      });
     });
   });
 }

--- a/test/network/socket_test.dart
+++ b/test/network/socket_test.dart
@@ -977,6 +977,68 @@ void main() {
     });
 
     test(
+      'reconnects a socket that has yet to notice the network went away and came back',
+      () async {
+        var offline = false;
+        var channelsCreated = 0;
+        final container = await makeContainer(
+          overrides: {
+            httpClientFactoryProvider: httpClientFactoryProvider.overrideWith(
+              (ref) => FakeHttpClientFactory(
+                () => MockClient((request) async {
+                  if (offline) throw const SocketException('No internet');
+                  return http.Response('', 200);
+                }),
+              ),
+            ),
+            // The fake network has no idea it is gone: the channel stays open and goes on
+            // answering, which is just what a socket bound to a lost network looks like until its
+            // next ping — up to 25s away on the default route.
+            webSocketChannelFactoryProvider: webSocketChannelFactoryProvider.overrideWithValue(
+              FakeWebSocketChannelFactory((route) {
+                channelsCreated++;
+                return createDefaultFakeWebSocketChannel(route);
+              }),
+            ),
+          },
+        );
+
+        fakeAsync((async) {
+          // The notifier is built inside [fakeAsync] so that the timers it starts — the throttler's
+          // among them — belong to this zone and answer to [elapse].
+          container.read(connectivityChangesProvider);
+          final pool = container.read(socketPoolProvider);
+          pool.currentClient.connect();
+          async.elapse(const Duration(seconds: 1));
+
+          expect(channelsCreated, 1);
+          expect(pool.currentClient.isConnected, isTrue);
+          expect(container.read(isDeviceOnlineProvider), isTrue);
+
+          offline = true;
+          FakeConnectivity.controller.add([ConnectivityResult.none]);
+          async.elapse(const Duration(milliseconds: 100));
+          expect(container.read(isDeviceOnlineProvider), isFalse);
+          expect(pool.currentClient.isConnected, isTrue, reason: 'the socket has yet to find out');
+          expect(pool.currentClient.isFailing.value, isFalse);
+
+          // The network comes back before the socket has noticed anything at all. Its connection
+          // belongs to the network that went away, so it must be made again whatever it looks like.
+          offline = false;
+          async.elapse(kConnectivityThrottleDelay);
+          FakeConnectivity.controller.add([ConnectivityResult.wifi]);
+          async.elapse(const Duration(milliseconds: 100));
+
+          expect(container.read(isDeviceOnlineProvider), isTrue);
+          expect(channelsCreated, 2);
+
+          pool.currentClient.close();
+          async.flushTimers();
+        });
+      },
+    );
+
+    test(
       'reconnects the socket when a failed connectivity check is followed by an online one',
       () async {
         var offline = true;

--- a/test/network/socket_test.dart
+++ b/test/network/socket_test.dart
@@ -1,15 +1,23 @@
 import 'dart:io';
 
+import 'package:connectivity_plus/connectivity_plus.dart';
 import 'package:device_info_plus/device_info_plus.dart';
 import 'package:fake_async/fake_async.dart';
 import 'package:flutter/widgets.dart';
+import 'package:flutter_riverpod/misc.dart' show Override, ProviderOrFamily;
 import 'package:flutter_test/flutter_test.dart';
+import 'package:http/http.dart' as http;
+import 'package:http/testing.dart';
 import 'package:lichess_mobile/src/model/common/socket.dart';
+import 'package:lichess_mobile/src/network/connectivity.dart';
+import 'package:lichess_mobile/src/network/http.dart';
 import 'package:lichess_mobile/src/network/socket.dart';
 import 'package:package_info_plus/package_info_plus.dart';
 
 import '../binding.dart';
 import '../test_container.dart';
+import '../utils/fake_connectivity.dart';
+import 'fake_http_client_factory.dart';
 import 'fake_websocket_channel.dart';
 
 final defaultSocketUri = Uri(path: kDefaultSocketRoute);
@@ -686,8 +694,97 @@ void main() {
         async.flushTimers();
       });
     });
+
+    test('reconnects the socket as soon as the device is back online', () async {
+      var offline = true;
+      final container = await makeContainer(overrides: offlineNetworkOverrides(() => offline));
+
+      await container.read(connectivityChangesProvider.future);
+      expect(container.read(isDeviceOnlineProvider), isFalse);
+
+      final pool = container.read(socketPoolProvider);
+      pool.currentClient.connect();
+      await pumpEventQueue();
+      expect(pool.currentClient.isConnected, isFalse);
+
+      offline = false;
+      FakeConnectivity.controller.add([ConnectivityResult.wifi]);
+
+      // The socket, left to its own backoff, would not try again for seconds: connectivity knows
+      // the network is back first and brings it up at once.
+      await pool.currentClient.firstConnection.timeout(
+        const Duration(seconds: 1),
+        onTimeout: () => fail('the socket did not reconnect when the device came back online'),
+      );
+      await Future<void>.delayed(kFakeWebSocketConnectionLag * 4);
+      expect(pool.currentClient.isConnected, isTrue);
+
+      pool.currentClient.close();
+    });
+
+    test('does not reconnect the socket while the app is in the background', () async {
+      var offline = true;
+      var socketAttempts = 0;
+      final container = await makeContainer(
+        overrides: offlineNetworkOverrides(() => offline, onSocketAttempt: () => socketAttempts++),
+      );
+
+      await container.read(connectivityChangesProvider.future);
+
+      final pool = container.read(socketPoolProvider);
+      pool.currentClient.connect();
+      await pumpEventQueue();
+      expect(socketAttempts, 1);
+
+      pool.onAppHidden();
+
+      offline = false;
+      FakeConnectivity.controller.add([ConnectivityResult.wifi]);
+      await pumpEventQueue();
+      await Future<void>.delayed(kFakeWebSocketConnectionLag * 4);
+
+      expect(container.read(isDeviceOnlineProvider), isTrue);
+      expect(
+        socketAttempts,
+        1,
+        reason: 'nothing needs the socket while the app is in the background',
+      );
+      expect(pool.currentClient.isConnected, isFalse);
+
+      // Coming back to the app is what brings it up.
+      pool.onAppShown();
+      await pool.currentClient.firstConnection.timeout(
+        const Duration(seconds: 1),
+        onTimeout: () => fail('the socket did not reconnect when the app came back'),
+      );
+
+      pool.currentClient.close();
+    });
   });
 }
+
+/// Overrides for a container whose network is entirely down — the connectivity check and the
+/// socket alike — for as long as [isOffline] returns true.
+Map<ProviderOrFamily, Override> offlineNetworkOverrides(
+  bool Function() isOffline, {
+  VoidCallback? onSocketAttempt,
+}) => {
+  httpClientFactoryProvider: httpClientFactoryProvider.overrideWith(
+    (ref) => FakeHttpClientFactory(
+      () => MockClient((request) async {
+        if (isOffline()) throw const SocketException('No internet');
+        return http.Response('', 200);
+      }),
+    ),
+  ),
+  webSocketChannelFactoryProvider: webSocketChannelFactoryProvider.overrideWithValue(
+    FakeWebSocketChannelFactory((route) {
+      onSocketAttempt?.call();
+      if (isOffline()) throw const SocketException('No internet');
+      return createDefaultFakeWebSocketChannel(route);
+    }),
+  ),
+};
 
 Future<void> testEventEmitted(
   SocketClient socketClient,

--- a/test/network/socket_test.dart
+++ b/test/network/socket_test.dart
@@ -235,6 +235,39 @@ void main() {
       });
     });
 
+    test('a message sent with noRetry is dropped rather than queued', () {
+      var canConnect = false;
+      final sent = <dynamic>[];
+      final fakeChannelFactory = FakeWebSocketChannelFactory((route) {
+        if (!canConnect) throw const SocketException('No internet');
+        final channel = FakeWebSocketChannel(route);
+        channel.sentMessagesExceptPing.listen(sent.add);
+        return channel;
+      });
+
+      fakeAsync((async) {
+        final socketClient = makeTestSocketClient(fakeChannelFactory: fakeChannelFactory);
+        socketClient.connect();
+        async.elapse(const Duration(milliseconds: 20));
+        expect(socketClient.isConnected, isFalse);
+
+        // The keep-alive is only true of the moment it is sent; the other message is not.
+        socketClient.send('keepAlive', null, noRetry: true);
+        socketClient.send('talk', null);
+
+        canConnect = true;
+        async.elapse(const Duration(seconds: 1));
+
+        expect(socketClient.isConnected, isTrue);
+        expect(sent, [
+          jsonEncode({'t': 'talk'}),
+        ]);
+
+        socketClient.close();
+        async.flushTimers();
+      });
+    });
+
     test('a flush that breaks partway keeps the messages it did not send', () {
       var canConnect = false;
       var nextChannelBreaks = true;

--- a/test/network/socket_test.dart
+++ b/test/network/socket_test.dart
@@ -115,7 +115,7 @@ void main() {
       socketClient.close();
     });
 
-    test('an unexpected connection failure is logged in full, a network one is not', () async {
+    test('logs a connection failure at the level its cause deserves', () async {
       var attempts = 0;
       final fakeChannelFactory = FakeWebSocketChannelFactory((_) {
         attempts++;
@@ -123,9 +123,11 @@ void main() {
           // What a device with no network looks like: routine, and not worth a log the user's
           // crash reports would have to carry.
           1 => throw const SocketException('Connection failed'),
-          // A bug in the connection setup, which no amount of retrying will fix: the logs are the
-          // only place it can be seen from production.
-          2 => throw StateError('boom'),
+          // The server answered, but not with a websocket: a regression on its side, or a TLS
+          // chain the device will not trust.
+          2 => throw const WebSocketException('Connection was not upgraded to websocket'),
+          // A bug in the connection setup, which no amount of retrying will fix.
+          3 => throw StateError('boom'),
           _ => FakeWebSocketChannel(defaultSocketUri),
         };
       });
@@ -140,12 +142,18 @@ void main() {
       socketClient.connect();
 
       await socketClient.firstConnection;
-      expect(attempts, 3);
+      expect(attempts, 4);
 
-      expect(records, hasLength(1), reason: 'only the unexpected failure is reported');
-      expect(records.single.level, Level.SEVERE);
-      expect(records.single.error, isStateError);
-      expect(records.single.stackTrace, isNotNull, reason: 'the stack trace is what points at it');
+      expect(records, hasLength(2), reason: 'the missing network alone is not reported');
+      expect(records.first.level, Level.WARNING);
+      expect(records.first.error, isA<WebSocketException>());
+      expect(records.last.level, Level.SEVERE);
+      expect(records.last.error, isStateError);
+      expect(
+        records.every((record) => record.stackTrace != null),
+        isTrue,
+        reason: 'the stack trace is what points at the line that threw',
+      );
 
       socketClient.close();
     });

--- a/test/network/socket_test.dart
+++ b/test/network/socket_test.dart
@@ -758,6 +758,45 @@ void main() {
       pool.currentClient.close();
     });
 
+    test(
+      'reconnects the socket when a failed connectivity check is followed by an online one',
+      () async {
+        var offline = true;
+        final container = await makeContainer(
+          overrides: {
+            ...offlineNetworkOverrides(() => offline),
+            // The check itself cannot even run: what it leaves behind is an error, which the app
+            // reads as offline like any other check that reached nothing.
+            connectivityPluginProvider: connectivityPluginProvider.overrideWith(
+              (_) => FailingConnectivity(),
+            ),
+          },
+        );
+
+        await expectLater(container.read(connectivityChangesProvider.future), throwsStateError);
+        expect(container.read(isDeviceOnlineProvider), isFalse);
+
+        final pool = container.read(socketPoolProvider);
+        pool.currentClient.connect();
+        await pumpEventQueue();
+        expect(pool.currentClient.isConnected, isFalse);
+
+        // The socket is waiting out its backoff, and the only thing that can cut it short is the
+        // device coming back online — from an error just as much as from a settled offline status.
+        offline = false;
+        FakeConnectivity.controller.add([ConnectivityResult.wifi]);
+
+        await pool.currentClient.firstConnection.timeout(
+          const Duration(seconds: 1),
+          onTimeout: () => fail('the socket did not reconnect when the device came back online'),
+        );
+        await Future<void>.delayed(kFakeWebSocketConnectionLag * 4);
+        expect(pool.currentClient.isConnected, isTrue);
+
+        pool.currentClient.close();
+      },
+    );
+
     test('does not reconnect the socket while the app is in the background', () async {
       var offline = true;
       var socketAttempts = 0;

--- a/test/network/socket_test.dart
+++ b/test/network/socket_test.dart
@@ -168,29 +168,32 @@ void main() {
 
       fakeAsync((async) {
         final socketClient = makeTestSocketClient(fakeChannelFactory: fakeChannelFactory);
+        var failingChanges = 0;
+        socketClient.isFailing.addListener(() => failingChanges++);
         socketClient.connect();
 
         async.elapse(const Duration(milliseconds: 10));
-        expect(socketClient.isFailing, isFalse, reason: 'the first ping has yet to time out');
+        expect(socketClient.isFailing.value, isFalse, reason: 'the first ping has yet to time out');
 
         // The handshake keeps succeeding, so nothing here fails to connect: it is the ping going
         // unanswered that says this socket is no use.
         async.elapse(const Duration(seconds: 1));
-        expect(socketClient.isFailing, isTrue);
+        expect(socketClient.isFailing.value, isTrue);
+        expect(failingChanges, 1);
 
-        final failingSince = socketClient.failingSince.value;
         final attemptsSoFar = channelsCreated;
 
         // Every one of those handshakes used to end the run, which kept the backoff at its
         // shortest and told nobody the socket was failing.
         async.elapse(const Duration(seconds: 5));
         expect(channelsCreated, greaterThan(attemptsSoFar), reason: 'it does keep reconnecting');
-        expect(socketClient.failingSince.value, failingSince, reason: 'one run, not one per try');
+        expect(socketClient.isFailing.value, isTrue);
+        expect(failingChanges, 1, reason: 'one run, not one per try');
 
         // The server answers again: a pong, not a handshake, is what ends the run.
         serverAnswers = true;
         async.elapse(const Duration(seconds: 30));
-        expect(socketClient.isFailing, isFalse);
+        expect(socketClient.isFailing.value, isFalse);
         expect(socketClient.isConnected, isTrue);
 
         socketClient.close();
@@ -973,27 +976,27 @@ void main() {
       final pool = container.read(socketPoolProvider);
 
       var failingEdges = 0;
-      pool.failingSince.addListener(() {
-        if (pool.isFailing) failingEdges++;
+      pool.isFailing.addListener(() {
+        if (pool.isFailing.value) failingEdges++;
       });
 
       fakeAsync((async) {
         pool.open(Uri(path: flakyRoute));
         async.elapse(const Duration(seconds: 1));
-        expect(pool.isFailing, isTrue);
+        expect(pool.isFailing.value, isTrue);
         expect(failingEdges, 1);
 
         // Back to the default socket, which connects: the pool must not be left holding the
         // failing state of the client it just closed.
         pool.open(Uri(path: kDefaultSocketRoute));
         async.elapse(const Duration(seconds: 1));
-        expect(pool.isFailing, isFalse);
+        expect(pool.isFailing.value, isFalse);
 
         // A failure on the new current client is then heard as the change it is.
         defaultRouteFails = true;
         pool.currentClient.connect();
         async.elapse(const Duration(seconds: 1));
-        expect(pool.isFailing, isTrue);
+        expect(pool.isFailing.value, isTrue);
         expect(failingEdges, 2, reason: 'this failure must reach the listeners too');
 
         pool.currentClient.close();

--- a/test/network/socket_test.dart
+++ b/test/network/socket_test.dart
@@ -1,3 +1,4 @@
+import 'dart:convert';
 import 'dart:io';
 
 import 'package:connectivity_plus/connectivity_plus.dart';
@@ -156,6 +157,54 @@ void main() {
       );
 
       socketClient.close();
+    });
+
+    test('a message sent while the socket waits out its backoff is queued, not lost', () {
+      var serverAnswers = true;
+      // Every message this client sends, ping excepted, whichever channel it goes out on: one
+      // written to a channel that is already gone would show up here just the same.
+      final sent = <dynamic>[];
+      FakeWebSocketChannel? currentChannel;
+      final fakeChannelFactory = FakeWebSocketChannelFactory((route) {
+        final channel = FakeWebSocketChannel(route)..shouldSendPong = serverAnswers;
+        channel.sentMessagesExceptPing.listen(sent.add);
+        return currentChannel = channel;
+      });
+
+      fakeAsync((async) {
+        final socketClient = makeTestSocketClient(fakeChannelFactory: fakeChannelFactory);
+        socketClient.connect();
+
+        async.elapse(const Duration(milliseconds: 20));
+        expect(socketClient.isConnected, isTrue);
+
+        // The peer stops answering: the ping goes unanswered and the client falls back to its
+        // reconnect backoff, which is no place to be writing messages.
+        serverAnswers = false;
+        currentChannel!.shouldSendPong = false;
+        async.elapse(const Duration(milliseconds: 300));
+        expect(socketClient.isFailing.value, isTrue);
+        expect(socketClient.isConnected, isFalse);
+
+        socketClient.send('test', {'foo': 'bar'});
+        async.elapse(const Duration(milliseconds: 10));
+        expect(sent, isEmpty, reason: 'the channel it would have gone out on is closed');
+
+        // It goes out on the connection that replaces it instead.
+        serverAnswers = true;
+        async.elapse(const Duration(seconds: 1));
+
+        expect(socketClient.isConnected, isTrue);
+        expect(sent, [
+          jsonEncode({
+            't': 'test',
+            'd': {'foo': 'bar'},
+          }),
+        ]);
+
+        socketClient.close();
+        async.flushTimers();
+      });
     });
 
     test('a connection the peer drops is failing at once', () {

--- a/test/network/socket_test.dart
+++ b/test/network/socket_test.dart
@@ -1132,6 +1132,48 @@ void main() {
       },
     );
 
+    test('reconnects the socket when the plugin recovers on a retried build', () async {
+      // The real plugin fails with a [PlatformException], which riverpod retries: the status the
+      // socket listens to is settled by a later build than the one that first failed, and the edge
+      // it produces has to reach the pool like any other.
+      var socketDown = true;
+      final connectivity = PluginFailingConnectivity();
+      final container = await makeContainer(
+        overrides: {
+          connectivityPluginProvider: connectivityPluginProvider.overrideWith((_) => connectivity),
+          webSocketChannelFactoryProvider: webSocketChannelFactoryProvider.overrideWithValue(
+            FakeWebSocketChannelFactory((route) {
+              if (socketDown) throw const SocketException('No internet');
+              return createDefaultFakeWebSocketChannel(route);
+            }),
+          ),
+        },
+      );
+
+      fakeAsync((async) {
+        // Listened to, not merely read: a provider nobody listens to is not retried.
+        container.listen(connectivityChangesProvider, (_, _) {});
+        final pool = container.read(socketPoolProvider);
+        pool.currentClient.connect();
+        async.elapse(const Duration(milliseconds: 100));
+
+        expect(container.read(isDeviceOnlineProvider), isFalse);
+        expect(pool.currentClient.isFailing.value, isTrue);
+
+        // Everything comes back at once, and the retried build is what says so. The socket's own
+        // next attempt is [_kAutoReconnectDelay] away — seconds later than this.
+        socketDown = false;
+        connectivity.shouldFail = false;
+        async.elapse(const Duration(milliseconds: 600));
+
+        expect(container.read(isDeviceOnlineProvider), isTrue);
+        expect(pool.currentClient.isConnected, isTrue);
+
+        pool.currentClient.close();
+        async.flushTimers();
+      });
+    });
+
     test(
       'reconnects the socket when a failed connectivity check is followed by an online one',
       () async {

--- a/test/network/socket_test.dart
+++ b/test/network/socket_test.dart
@@ -198,6 +198,40 @@ void main() {
       });
     });
 
+    test('a socket that never answers a ping is retried on the backoff, not on every timeout', () {
+      var channelsCreated = 0;
+      final fakeChannelFactory = FakeWebSocketChannelFactory((route) {
+        channelsCreated++;
+        return FakeWebSocketChannel(route)..shouldSendPong = false;
+      });
+
+      fakeAsync((async) {
+        final socketClient = makeTestSocketClient(fakeChannelFactory: fakeChannelFactory);
+        socketClient.connect();
+
+        // Within the grace period the socket retries at full speed: a peer that has just stopped
+        // answering is worth a few quick attempts.
+        async.elapse(const Duration(seconds: 1));
+        final earlyAttempts = channelsCreated;
+        expect(earlyAttempts, greaterThan(2));
+
+        // Minutes of a peer that accepts every handshake and answers nothing: the delay between
+        // attempts has grown to its ceiling instead of staying at the pong timeout.
+        async.elapse(const Duration(minutes: 5));
+        final attemptsSoFar = channelsCreated;
+        async.elapse(const Duration(minutes: 1));
+
+        expect(
+          channelsCreated - attemptsSoFar,
+          lessThanOrEqualTo(2),
+          reason: 'a minute of a socket that never answers is worth about one attempt',
+        );
+
+        socketClient.close();
+        async.flushTimers();
+      });
+    });
+
     test('does not reconnect when closed while a connection attempt is in flight', () async {
       int numConnectionAttempts = 0;
 

--- a/test/network/socket_test.dart
+++ b/test/network/socket_test.dart
@@ -1153,6 +1153,41 @@ void main() {
       });
     });
 
+    test(
+      'a socket that comes up with the lag the pool already holds still reports connected',
+      () async {
+        final container = await makeContainer();
+
+        fakeAsync((async) {
+          final pool = container.read(socketPoolProvider);
+          pool.open(defaultSocketUri);
+          async.elapse(const Duration(seconds: 1));
+          expect(pool.isConnected.value, isTrue);
+          final lag = pool.averageLag.value;
+
+          var lagChanges = 0;
+          pool.averageLag.addListener(() => lagChanges++);
+          var connectedEdges = 0;
+          pool.isConnected.addListener(() {
+            if (pool.isConnected.value) connectedEdges++;
+          });
+
+          // Another route, whose socket answers in exactly the time the first one took, so the lag
+          // the pool holds is never written to a different value.
+          pool.open(Uri(path: '/other/socket/v5'));
+          async.elapse(const Duration(seconds: 1));
+
+          expect(pool.averageLag.value, lag);
+          expect(lagChanges, 0, reason: 'nothing about the lag has changed');
+          expect(pool.isConnected.value, isTrue);
+          expect(connectedEdges, 1, reason: 'a socket coming up is heard even so');
+
+          pool.currentClient.close();
+          async.flushTimers();
+        });
+      },
+    );
+
     test('takes on the connection state of the client it switches to', () async {
       const flakyRoute = '/flaky/socket/v5';
       var defaultRouteFails = false;

--- a/test/network/socket_test.dart
+++ b/test/network/socket_test.dart
@@ -726,7 +726,7 @@ void main() {
       var offline = true;
       var socketAttempts = 0;
       final container = await makeContainer(
-        overrides: offlineNetworkOverrides(() => offline, onSocketAttempt: () => socketAttempts++),
+        overrides: offlineNetworkOverrides(() => offline, onSocketAttempt: (_) => socketAttempts++),
       );
 
       await container.read(connectivityChangesProvider.future);
@@ -760,6 +760,72 @@ void main() {
 
       pool.currentClient.close();
     });
+
+    test('nothing reopens the socket once it has been closed in the background', () async {
+      final attempts = <Uri>[];
+      final container = await makeContainer(
+        overrides: offlineNetworkOverrides(() => false, onSocketAttempt: attempts.add),
+      );
+      final pool = container.read(socketPoolProvider);
+
+      fakeAsync((async) {
+        pool.currentClient.connect();
+        async.elapse(const Duration(seconds: 1));
+        expect(pool.currentClient.isConnected, isTrue);
+        expect(attempts.length, 1);
+
+        pool.onAppHidden();
+        async.elapse(const Duration(minutes: 2));
+        expect(pool.currentClient.isActive, isFalse, reason: 'the socket is closed in background');
+
+        // Everything that would bring the socket back in the foreground must leave it closed
+        // here, and no timer left over from the connected socket may bring it back either.
+        pool.onDeviceOnline();
+        pool.onAuthChanged();
+        async.elapse(const Duration(minutes: 10));
+
+        expect(attempts.length, 1, reason: 'the socket must stay closed while in the background');
+        expect(pool.currentClient.isActive, isFalse);
+
+        // The user coming back is the one thing that reopens it.
+        pool.onAppShown();
+        async.elapse(const Duration(seconds: 1));
+        expect(attempts.length, 2);
+        expect(pool.currentClient.isConnected, isTrue);
+
+        pool.currentClient.close();
+        async.flushTimers();
+      });
+    });
+
+    test('does not reopen the default socket in the background when a route goes idle', () async {
+      const route = '/lobby/socket/v5';
+      final attempts = <Uri>[];
+      final container = await makeContainer(
+        overrides: offlineNetworkOverrides(() => false, onSocketAttempt: attempts.add),
+      );
+      final pool = container.read(socketPoolProvider);
+
+      fakeAsync((async) {
+        final client = pool.open(Uri(path: route));
+        final subscription = client.stream.listen((_) {});
+        async.elapse(const Duration(seconds: 1));
+        expect(attempts.map((uri) => uri.path), [route]);
+
+        pool.onAppHidden();
+        async.elapse(const Duration(minutes: 2));
+
+        // The screen that was using this route is gone: the pool disposes its idle client, which
+        // in the foreground would have it fall back to the default socket.
+        subscription.cancel();
+        async.elapse(const Duration(minutes: 1));
+
+        expect(attempts.map((uri) => uri.path), [route]);
+        expect(pool.currentClient.isActive, isFalse);
+
+        async.flushTimers();
+      });
+    });
   });
 }
 
@@ -767,7 +833,7 @@ void main() {
 /// socket alike — for as long as [isOffline] returns true.
 Map<ProviderOrFamily, Override> offlineNetworkOverrides(
   bool Function() isOffline, {
-  VoidCallback? onSocketAttempt,
+  void Function(Uri route)? onSocketAttempt,
 }) => {
   httpClientFactoryProvider: httpClientFactoryProvider.overrideWith(
     (ref) => FakeHttpClientFactory(
@@ -779,7 +845,7 @@ Map<ProviderOrFamily, Override> offlineNetworkOverrides(
   ),
   webSocketChannelFactoryProvider: webSocketChannelFactoryProvider.overrideWithValue(
     FakeWebSocketChannelFactory((route) {
-      onSocketAttempt?.call();
+      onSocketAttempt?.call(route);
       if (isOffline()) throw const SocketException('No internet');
       return createDefaultFakeWebSocketChannel(route);
     }),

--- a/test/network/socket_test.dart
+++ b/test/network/socket_test.dart
@@ -241,6 +241,42 @@ void main() {
       });
     });
 
+    test('a channel that takes its time closing does not disconnect the one after it', () {
+      final channels = <FakeWebSocketChannel>[];
+      final fakeChannelFactory = FakeWebSocketChannelFactory((route) {
+        final channel = FakeWebSocketChannel(route)..closeDelay = const Duration(seconds: 5);
+        channels.add(channel);
+        return channel;
+      });
+
+      fakeAsync((async) {
+        final socketClient = makeTestSocketClient(fakeChannelFactory: fakeChannelFactory);
+        socketClient.connect();
+        async.elapse(const Duration(milliseconds: 20));
+        expect(socketClient.isConnected, isTrue);
+
+        // Reconnecting closes the first channel, which takes seconds to finish doing so — long
+        // after the socket that replaced it has answered a ping of its own.
+        socketClient.connect();
+        async.elapse(const Duration(milliseconds: 20));
+        expect(channels.length, 2);
+        expect(socketClient.isConnected, isTrue);
+
+        var disconnections = 0;
+        socketClient.averageLag.addListener(() {
+          if (socketClient.averageLag.value == Duration.zero) disconnections++;
+        });
+
+        async.elapse(const Duration(seconds: 6));
+
+        expect(socketClient.isConnected, isTrue);
+        expect(disconnections, 0, reason: 'the old channel closing says nothing about this one');
+
+        socketClient.close();
+        async.flushTimers();
+      });
+    });
+
     test('a connection the peer drops is failing at once', () {
       FakeWebSocketChannel? channel;
       final fakeChannelFactory = FakeWebSocketChannelFactory(

--- a/test/network/socket_test.dart
+++ b/test/network/socket_test.dart
@@ -198,8 +198,11 @@ void main() {
       final sent = <dynamic>[];
       var nextChannelFailsItsPing = true;
       final fakeChannelFactory = FakeWebSocketChannelFactory((route) {
-        final channel = FakeWebSocketChannel(route)..failNextWrite = nextChannelFailsItsPing;
-        nextChannelFailsItsPing = false;
+        final channel = FakeWebSocketChannel(route);
+        if (nextChannelFailsItsPing) {
+          nextChannelFailsItsPing = false;
+          channel.failWriteWhen = FakeWebSocketChannel.isPing;
+        }
         channel.sentMessagesExceptPing.listen(sent.add);
         return channel;
       });
@@ -225,6 +228,52 @@ void main() {
             't': 'test',
             'd': {'foo': 'bar'},
           }),
+        ]);
+
+        socketClient.close();
+        async.flushTimers();
+      });
+    });
+
+    test('a flush that breaks partway keeps the messages it did not send', () {
+      var canConnect = false;
+      var nextChannelBreaks = true;
+      final sent = <dynamic>[];
+      final fakeChannelFactory = FakeWebSocketChannelFactory((route) {
+        if (!canConnect) throw const SocketException('No internet');
+        final channel = FakeWebSocketChannel(route);
+        if (nextChannelBreaks) {
+          nextChannelBreaks = false;
+          // This peer takes the first message and hangs up on the second.
+          channel.failWriteWhen = (data) => data is String && data.contains('"t":"second"');
+        }
+        channel.sentMessagesExceptPing.listen(sent.add);
+        return channel;
+      });
+
+      fakeAsync((async) {
+        final socketClient = makeTestSocketClient(fakeChannelFactory: fakeChannelFactory);
+        socketClient.connect();
+        async.elapse(const Duration(milliseconds: 20));
+        expect(socketClient.isFailing.value, isTrue);
+
+        socketClient.send('first', null);
+        socketClient.send('second', null);
+
+        // The socket gets a channel again, and the flush breaks halfway through it.
+        canConnect = true;
+        async.elapse(const Duration(milliseconds: 150));
+        expect(sent, [
+          jsonEncode({'t': 'first'}),
+        ]);
+        expect(socketClient.isFailing.value, isTrue);
+
+        // The message that sink never took is still queued, and goes out on the next connection.
+        async.elapse(const Duration(seconds: 1));
+        expect(socketClient.isConnected, isTrue);
+        expect(sent, [
+          jsonEncode({'t': 'first'}),
+          jsonEncode({'t': 'second'}),
         ]);
 
         socketClient.close();

--- a/test/network/socket_test.dart
+++ b/test/network/socket_test.dart
@@ -976,6 +976,46 @@ void main() {
       pool.currentClient.close();
     });
 
+    test('does not reconnect the socket whose own pong brought the device back online', () async {
+      var channelsCreated = 0;
+      final container = await makeContainer(
+        overrides: {
+          // Nothing the check probes can be reached, so the device is held offline; the socket is
+          // the only thing that works, as it is on a network that blocks the probe hosts.
+          httpClientFactoryProvider: httpClientFactoryProvider.overrideWith(
+            (ref) => FakeHttpClientFactory(
+              () => MockClient((request) => throw const SocketException('No internet')),
+            ),
+          ),
+          webSocketChannelFactoryProvider: webSocketChannelFactoryProvider.overrideWithValue(
+            FakeWebSocketChannelFactory((route) {
+              channelsCreated++;
+              return createDefaultFakeWebSocketChannel(route);
+            }),
+          ),
+        },
+      );
+
+      fakeAsync((async) {
+        container.read(connectivityChangesProvider);
+        async.elapse(const Duration(seconds: 1));
+        expect(container.read(isDeviceOnlineProvider), isFalse);
+
+        final pool = container.read(socketPoolProvider);
+        pool.currentClient.connect();
+        async.elapse(const Duration(seconds: 1));
+
+        // The pong cleared the offline status, and that transition reaches the pool like any
+        // other. Reconnecting here would tear down the connection that proved the network.
+        expect(container.read(isDeviceOnlineProvider), isTrue);
+        expect(channelsCreated, 1);
+        expect(pool.currentClient.isConnected, isTrue);
+
+        pool.currentClient.close();
+        async.flushTimers();
+      });
+    });
+
     test(
       'reconnects a socket that has yet to notice the network went away and came back',
       () async {

--- a/test/network/socket_test.dart
+++ b/test/network/socket_test.dart
@@ -1012,6 +1012,75 @@ void main() {
       pool.currentClient.close();
     });
 
+    test(
+      'reconnects a failing socket even if the route before it answered while offline',
+      () async {
+        const otherRoute = '/other/socket/v5';
+        var networkDown = false;
+        final attempts = <Uri>[];
+        FakeWebSocketChannel? defaultChannel;
+        final container = await makeContainer(
+          overrides: {
+            httpClientFactoryProvider: httpClientFactoryProvider.overrideWith(
+              (ref) => FakeHttpClientFactory(
+                () => MockClient((request) async {
+                  if (networkDown) throw const SocketException('No internet');
+                  return http.Response('', 200);
+                }),
+              ),
+            ),
+            webSocketChannelFactoryProvider: webSocketChannelFactoryProvider.overrideWithValue(
+              FakeWebSocketChannelFactory((route) {
+                attempts.add(route);
+                if (networkDown) throw const SocketException('No internet');
+                final channel = createDefaultFakeWebSocketChannel(route);
+                if (route.path == kDefaultSocketRoute) defaultChannel = channel;
+                return channel;
+              }),
+            ),
+          },
+        );
+
+        fakeAsync((async) {
+          container.read(connectivityChangesProvider);
+          final pool = container.read(socketPoolProvider);
+          pool.open(defaultSocketUri);
+          async.elapse(const Duration(seconds: 1));
+          expect(pool.currentClient.isConnected, isTrue);
+
+          // The device is found offline, and the socket on the default route answers a ping all the
+          // same — the channel it holds is fine, whatever the probed hosts say.
+          networkDown = true;
+          FakeConnectivity.controller.add([ConnectivityResult.none]);
+          // A lag of its own, so that the pong to come is a change the pool hears about.
+          defaultChannel!.connectionLag = const Duration(milliseconds: 40);
+          async.elapse(const Duration(seconds: 30));
+          expect(container.read(isDeviceOnlineProvider), isFalse);
+          expect(pool.currentClient.isConnected, isTrue);
+
+          // A screen then opens another route, whose socket cannot connect and settles into its
+          // backoff. What the route before it answered says nothing about this one.
+          pool.open(Uri(path: otherRoute));
+          async.elapse(const Duration(milliseconds: 500));
+          expect(pool.currentClient.isConnected, isFalse);
+          final attemptsSoFar = attempts.length;
+
+          // The network comes back. This socket has everything to gain from an attempt now, rather
+          // than at the end of a backoff seconds away.
+          networkDown = false;
+          FakeConnectivity.controller.add([ConnectivityResult.wifi]);
+          async.elapse(const Duration(milliseconds: 200));
+
+          expect(container.read(isDeviceOnlineProvider), isTrue);
+          expect(attempts.length, attemptsSoFar + 1);
+          expect(pool.currentClient.isConnected, isTrue);
+
+          pool.currentClient.close();
+          async.flushTimers();
+        });
+      },
+    );
+
     test('does not reconnect a socket that came back up before the check noticed', () async {
       var offline = false;
       var channelsCreated = 0;

--- a/test/network/socket_test.dart
+++ b/test/network/socket_test.dart
@@ -158,6 +158,46 @@ void main() {
       socketClient.close();
     });
 
+    test('a socket that opens but never answers a ping is failing', () {
+      var serverAnswers = false;
+      var channelsCreated = 0;
+      final fakeChannelFactory = FakeWebSocketChannelFactory((route) {
+        channelsCreated++;
+        return FakeWebSocketChannel(route)..shouldSendPong = serverAnswers;
+      });
+
+      fakeAsync((async) {
+        final socketClient = makeTestSocketClient(fakeChannelFactory: fakeChannelFactory);
+        socketClient.connect();
+
+        async.elapse(const Duration(milliseconds: 10));
+        expect(socketClient.isFailing, isFalse, reason: 'the first ping has yet to time out');
+
+        // The handshake keeps succeeding, so nothing here fails to connect: it is the ping going
+        // unanswered that says this socket is no use.
+        async.elapse(const Duration(seconds: 1));
+        expect(socketClient.isFailing, isTrue);
+
+        final failingSince = socketClient.failingSince.value;
+        final attemptsSoFar = channelsCreated;
+
+        // Every one of those handshakes used to end the run, which kept the backoff at its
+        // shortest and told nobody the socket was failing.
+        async.elapse(const Duration(seconds: 5));
+        expect(channelsCreated, greaterThan(attemptsSoFar), reason: 'it does keep reconnecting');
+        expect(socketClient.failingSince.value, failingSince, reason: 'one run, not one per try');
+
+        // The server answers again: a pong, not a handshake, is what ends the run.
+        serverAnswers = true;
+        async.elapse(const Duration(seconds: 30));
+        expect(socketClient.isFailing, isFalse);
+        expect(socketClient.isConnected, isTrue);
+
+        socketClient.close();
+        async.flushTimers();
+      });
+    });
+
     test('does not reconnect when closed while a connection attempt is in flight', () async {
       int numConnectionAttempts = 0;
 
@@ -899,27 +939,27 @@ void main() {
       final pool = container.read(socketPoolProvider);
 
       var failingEdges = 0;
-      pool.isFailing.addListener(() {
-        if (pool.isFailing.value) failingEdges++;
+      pool.failingSince.addListener(() {
+        if (pool.isFailing) failingEdges++;
       });
 
       fakeAsync((async) {
         pool.open(Uri(path: flakyRoute));
         async.elapse(const Duration(seconds: 1));
-        expect(pool.isFailing.value, isTrue);
+        expect(pool.isFailing, isTrue);
         expect(failingEdges, 1);
 
         // Back to the default socket, which connects: the pool must not be left holding the
         // failing state of the client it just closed.
         pool.open(Uri(path: kDefaultSocketRoute));
         async.elapse(const Duration(seconds: 1));
-        expect(pool.isFailing.value, isFalse);
+        expect(pool.isFailing, isFalse);
 
         // A failure on the new current client is then heard as the change it is.
         defaultRouteFails = true;
         pool.currentClient.connect();
         async.elapse(const Duration(seconds: 1));
-        expect(pool.isFailing.value, isTrue);
+        expect(pool.isFailing, isTrue);
         expect(failingEdges, 2, reason: 'this failure must reach the listeners too');
 
         pool.currentClient.close();

--- a/test/network/socket_test.dart
+++ b/test/network/socket_test.dart
@@ -159,14 +159,48 @@ void main() {
       socketClient.close();
     });
 
+    test('the first pong timeout reconnects at once, the ones after it wait', () {
+      var channelsCreated = 0;
+      final fakeChannelFactory = FakeWebSocketChannelFactory((route) {
+        channelsCreated++;
+        return FakeWebSocketChannel(route)..shouldSendPong = false;
+      });
+
+      fakeAsync((async) {
+        // The ping goes out as the socket opens, so the first pong times out at [pingMaxLag].
+        final socketClient = makeTestSocketClient(fakeChannelFactory: fakeChannelFactory);
+        socketClient.connect();
+
+        async.elapse(const Duration(milliseconds: 199));
+        expect(channelsCreated, 1);
+
+        // 1ms past the timeout, and well short of the 100ms [autoReconnectDelay] this client is
+        // built with: the socket has already spent [pingMaxLag] waiting, so it retries at once.
+        async.elapse(const Duration(milliseconds: 2));
+        expect(channelsCreated, 2);
+
+        // That attempt goes the same way, and this one does wait: a peer that keeps accepting
+        // handshakes and answering nothing must not be retried every [pingMaxLag] forever.
+        async.elapse(const Duration(milliseconds: 249));
+        expect(channelsCreated, 2, reason: 'the second timeout waits out the backoff');
+
+        async.elapse(const Duration(milliseconds: 100));
+        expect(channelsCreated, 3);
+
+        socketClient.close();
+        async.flushTimers();
+      });
+    });
+
     test('a message sent while the socket waits out its backoff is queued, not lost', () {
-      var serverAnswers = true;
+      var offline = false;
       // Every message this client sends, ping excepted, whichever channel it goes out on: one
       // written to a channel that is already gone would show up here just the same.
       final sent = <dynamic>[];
       FakeWebSocketChannel? currentChannel;
       final fakeChannelFactory = FakeWebSocketChannelFactory((route) {
-        final channel = FakeWebSocketChannel(route)..shouldSendPong = serverAnswers;
+        if (offline) throw const SocketException('No internet');
+        final channel = FakeWebSocketChannel(route);
         channel.sentMessagesExceptPing.listen(sent.add);
         return currentChannel = channel;
       });
@@ -178,21 +212,21 @@ void main() {
         async.elapse(const Duration(milliseconds: 20));
         expect(socketClient.isConnected, isTrue);
 
-        // The peer stops answering: the ping goes unanswered and the client falls back to its
-        // reconnect backoff, which is no place to be writing messages.
-        serverAnswers = false;
+        // The network goes away under the socket: the ping goes unanswered, and the attempts that
+        // follow cannot get a channel either, so the client is left waiting out its backoff.
+        offline = true;
         currentChannel!.shouldSendPong = false;
-        async.elapse(const Duration(milliseconds: 300));
+        async.elapse(const Duration(seconds: 1));
         expect(socketClient.isFailing.value, isTrue);
         expect(socketClient.isConnected, isFalse);
 
         socketClient.send('test', {'foo': 'bar'});
-        async.elapse(const Duration(milliseconds: 10));
-        expect(sent, isEmpty, reason: 'the channel it would have gone out on is closed');
+        async.elapse(const Duration(milliseconds: 500));
+        expect(sent, isEmpty, reason: 'there is no channel to write it to');
 
-        // It goes out on the connection that replaces it instead.
-        serverAnswers = true;
-        async.elapse(const Duration(seconds: 1));
+        // It goes out on the connection that the network coming back makes possible.
+        offline = false;
+        async.elapse(const Duration(seconds: 2));
 
         expect(socketClient.isConnected, isTrue);
         expect(sent, [

--- a/test/network/socket_test.dart
+++ b/test/network/socket_test.dart
@@ -12,6 +12,7 @@ import 'package:lichess_mobile/src/model/common/socket.dart';
 import 'package:lichess_mobile/src/network/connectivity.dart';
 import 'package:lichess_mobile/src/network/http.dart';
 import 'package:lichess_mobile/src/network/socket.dart';
+import 'package:logging/logging.dart';
 import 'package:package_info_plus/package_info_plus.dart';
 
 import '../binding.dart';
@@ -110,6 +111,41 @@ void main() {
       expect(numConnectionAttempts, 2);
       expect(socketClient.nbConnectionAttempts, 2);
       expect(socketClient.nbConnectionSuccess, 1);
+
+      socketClient.close();
+    });
+
+    test('an unexpected connection failure is logged in full, a network one is not', () async {
+      var attempts = 0;
+      final fakeChannelFactory = FakeWebSocketChannelFactory((_) {
+        attempts++;
+        return switch (attempts) {
+          // What a device with no network looks like: routine, and not worth a log the user's
+          // crash reports would have to carry.
+          1 => throw const SocketException('Connection failed'),
+          // A bug in the connection setup, which no amount of retrying will fix: the logs are the
+          // only place it can be seen from production.
+          2 => throw StateError('boom'),
+          _ => FakeWebSocketChannel(defaultSocketUri),
+        };
+      });
+
+      final records = <LogRecord>[];
+      final subscription = Logger.root.onRecord
+          .where((record) => record.level >= Level.WARNING)
+          .listen(records.add);
+      addTearDown(subscription.cancel);
+
+      final socketClient = makeTestSocketClient(fakeChannelFactory: fakeChannelFactory);
+      socketClient.connect();
+
+      await socketClient.firstConnection;
+      expect(attempts, 3);
+
+      expect(records, hasLength(1), reason: 'only the unexpected failure is reported');
+      expect(records.single.level, Level.SEVERE);
+      expect(records.single.error, isStateError);
+      expect(records.single.stackTrace, isNotNull, reason: 'the stack trace is what points at it');
 
       socketClient.close();
     });

--- a/test/network/socket_test.dart
+++ b/test/network/socket_test.dart
@@ -1175,7 +1175,7 @@ void main() {
 
         // Everything that would bring the socket back in the foreground must leave it closed
         // here, and no timer left over from the connected socket may bring it back either.
-        pool.onDeviceOnline();
+        pool.onDeviceBackOnline();
         pool.onAuthChanged();
         async.elapse(const Duration(minutes: 10));
 

--- a/test/network/socket_test.dart
+++ b/test/network/socket_test.dart
@@ -158,6 +158,56 @@ void main() {
       socketClient.close();
     });
 
+    test('a connection the peer drops is failing at once', () {
+      FakeWebSocketChannel? channel;
+      final fakeChannelFactory = FakeWebSocketChannelFactory(
+        (route) => channel = FakeWebSocketChannel(route),
+      );
+
+      fakeAsync((async) {
+        final socketClient = makeTestSocketClient(fakeChannelFactory: fakeChannelFactory);
+        socketClient.connect();
+
+        async.elapse(const Duration(milliseconds: 20));
+        expect(socketClient.isConnected, isTrue);
+
+        // What a device losing its network under an open socket looks like: the channel is torn
+        // down, and there is nothing to wait for — least of all the pong timeout.
+        channel!.closeFromServer(const SocketException('Network is unreachable'));
+        async.elapse(const Duration(milliseconds: 1));
+
+        expect(socketClient.isFailing.value, isTrue);
+        expect(socketClient.isConnected, isFalse);
+
+        socketClient.close();
+        async.flushTimers();
+      });
+    });
+
+    test('a connection the peer closes cleanly is failing at once', () {
+      FakeWebSocketChannel? channel;
+      final fakeChannelFactory = FakeWebSocketChannelFactory(
+        (route) => channel = FakeWebSocketChannel(route),
+      );
+
+      fakeAsync((async) {
+        final socketClient = makeTestSocketClient(fakeChannelFactory: fakeChannelFactory);
+        socketClient.connect();
+
+        async.elapse(const Duration(milliseconds: 20));
+        expect(socketClient.isConnected, isTrue);
+
+        channel!.closeFromServer();
+        async.elapse(const Duration(milliseconds: 1));
+
+        expect(socketClient.isFailing.value, isTrue);
+        expect(socketClient.isConnected, isFalse);
+
+        socketClient.close();
+        async.flushTimers();
+      });
+    });
+
     test('a socket that opens but never answers a ping is failing', () {
       var serverAnswers = false;
       var channelsCreated = 0;
@@ -638,7 +688,7 @@ void main() {
     await testEventEmitted(socketClient, fakeChannel, pongMessage, [pongEvent]);
 
     // should not emit if ack
-    const ackMessage = '{"t":"n","d":10,"r":3}';
+    const ackMessage = '{"t":"ack","d":1}';
     await testEventEmitted(socketClient, fakeChannel, ackMessage, []);
 
     // should not emit if batch
@@ -1031,6 +1081,35 @@ void main() {
 
         async.flushTimers();
       });
+    });
+  });
+
+  group('socketPingProvider', () {
+    test('reports no lag as soon as the device is known to be offline', () async {
+      var offline = false;
+      final container = await makeContainer(overrides: offlineNetworkOverrides(() => offline));
+
+      await container.read(connectivityChangesProvider.future);
+
+      final client = container.read(socketPoolProvider).currentClient;
+      client.connect();
+      await client.firstConnection;
+      await Future<void>.delayed(kFakeWebSocketConnectionLag * 4);
+      await pumpEventQueue();
+
+      expect(container.read(socketPingProvider(null)).averageLag, isNot(Duration.zero));
+
+      // The network goes away. The socket has yet to notice — its next ping has not even been
+      // sent — but the check does, and the indicator must not go on showing a lag measured over a
+      // network that is no longer there.
+      offline = true;
+      FakeConnectivity.controller.add([ConnectivityResult.none]);
+      await pumpEventQueue();
+
+      expect(container.read(isDeviceOnlineProvider), isFalse);
+      expect(container.read(socketPingProvider(null)).averageLag, Duration.zero);
+
+      client.close();
     });
   });
 }

--- a/test/network/socket_test.dart
+++ b/test/network/socket_test.dart
@@ -976,21 +976,25 @@ void main() {
       pool.currentClient.close();
     });
 
-    test('does not reconnect the socket whose own pong brought the device back online', () async {
+    test('does not reconnect a socket that came back up before the check noticed', () async {
+      var offline = false;
       var channelsCreated = 0;
+      FakeWebSocketChannel? currentChannel;
       final container = await makeContainer(
         overrides: {
-          // Nothing the check probes can be reached, so the device is held offline; the socket is
-          // the only thing that works, as it is on a network that blocks the probe hosts.
           httpClientFactoryProvider: httpClientFactoryProvider.overrideWith(
             (ref) => FakeHttpClientFactory(
-              () => MockClient((request) => throw const SocketException('No internet')),
+              () => MockClient((request) async {
+                if (offline) throw const SocketException('No internet');
+                return http.Response('', 200);
+              }),
             ),
           ),
           webSocketChannelFactoryProvider: webSocketChannelFactoryProvider.overrideWithValue(
             FakeWebSocketChannelFactory((route) {
+              if (offline) throw const SocketException('No internet');
               channelsCreated++;
-              return createDefaultFakeWebSocketChannel(route);
+              return currentChannel = createDefaultFakeWebSocketChannel(route);
             }),
           ),
         },
@@ -998,18 +1002,32 @@ void main() {
 
       fakeAsync((async) {
         container.read(connectivityChangesProvider);
-        async.elapse(const Duration(seconds: 1));
-        expect(container.read(isDeviceOnlineProvider), isFalse);
-
         final pool = container.read(socketPoolProvider);
         pool.currentClient.connect();
         async.elapse(const Duration(seconds: 1));
-
-        // The pong cleared the offline status, and that transition reaches the pool like any
-        // other. Reconnecting here would tear down the connection that proved the network.
-        expect(container.read(isDeviceOnlineProvider), isTrue);
         expect(channelsCreated, 1);
+        expect(container.read(isDeviceOnlineProvider), isTrue);
+
+        // The network goes away, the plugin says so, and the socket loses its channel with it.
+        offline = true;
+        FakeConnectivity.controller.add([ConnectivityResult.none]);
+        currentChannel!.closeFromServer(const SocketException('No internet'));
+        async.elapse(const Duration(seconds: 5));
+        expect(container.read(isDeviceOnlineProvider), isFalse);
+        expect(pool.currentClient.isConnected, isFalse);
+
+        // The network comes back, and the socket's own retry gets there first.
+        offline = false;
+        async.elapse(const Duration(seconds: 10));
         expect(pool.currentClient.isConnected, isTrue);
+        final channelsWhenBack = channelsCreated;
+
+        // Only then does the check catch up. The socket it would reconnect has been up and
+        // answering since before this edge, so tearing it down would cost an event gap for nothing.
+        FakeConnectivity.controller.add([ConnectivityResult.wifi]);
+        async.elapse(const Duration(seconds: 1));
+        expect(container.read(isDeviceOnlineProvider), isTrue);
+        expect(channelsCreated, channelsWhenBack);
 
         pool.currentClient.close();
         async.flushTimers();
@@ -1187,87 +1205,6 @@ void main() {
         async.elapse(const Duration(seconds: 1));
         expect(attempts.length, 2);
         expect(pool.currentClient.isConnected, isTrue);
-
-        pool.currentClient.close();
-        async.flushTimers();
-      });
-    });
-
-    test(
-      'a socket that comes up with the lag the pool already holds still reports connected',
-      () async {
-        final container = await makeContainer();
-
-        fakeAsync((async) {
-          final pool = container.read(socketPoolProvider);
-          pool.open(defaultSocketUri);
-          async.elapse(const Duration(seconds: 1));
-          expect(pool.isConnected.value, isTrue);
-          final lag = pool.averageLag.value;
-
-          var lagChanges = 0;
-          pool.averageLag.addListener(() => lagChanges++);
-          var connectedEdges = 0;
-          pool.isConnected.addListener(() {
-            if (pool.isConnected.value) connectedEdges++;
-          });
-
-          // Another route, whose socket answers in exactly the time the first one took, so the lag
-          // the pool holds is never written to a different value.
-          pool.open(Uri(path: '/other/socket/v5'));
-          async.elapse(const Duration(seconds: 1));
-
-          expect(pool.averageLag.value, lag);
-          expect(lagChanges, 0, reason: 'nothing about the lag has changed');
-          expect(pool.isConnected.value, isTrue);
-          expect(connectedEdges, 1, reason: 'a socket coming up is heard even so');
-
-          pool.currentClient.close();
-          async.flushTimers();
-        });
-      },
-    );
-
-    test('takes on the connection state of the client it switches to', () async {
-      const flakyRoute = '/flaky/socket/v5';
-      var defaultRouteFails = false;
-      final container = await makeContainer(
-        overrides: {
-          webSocketChannelFactoryProvider: webSocketChannelFactoryProvider.overrideWithValue(
-            FakeWebSocketChannelFactory((route) {
-              if (route.path == flakyRoute || defaultRouteFails) {
-                throw const SocketException('No internet');
-              }
-              return createDefaultFakeWebSocketChannel(route);
-            }),
-          ),
-        },
-      );
-      final pool = container.read(socketPoolProvider);
-
-      var failingEdges = 0;
-      pool.isFailing.addListener(() {
-        if (pool.isFailing.value) failingEdges++;
-      });
-
-      fakeAsync((async) {
-        pool.open(Uri(path: flakyRoute));
-        async.elapse(const Duration(seconds: 1));
-        expect(pool.isFailing.value, isTrue);
-        expect(failingEdges, 1);
-
-        // Back to the default socket, which connects: the pool must not be left holding the
-        // failing state of the client it just closed.
-        pool.open(Uri(path: kDefaultSocketRoute));
-        async.elapse(const Duration(seconds: 1));
-        expect(pool.isFailing.value, isFalse);
-
-        // A failure on the new current client is then heard as the change it is.
-        defaultRouteFails = true;
-        pool.currentClient.connect();
-        async.elapse(const Duration(seconds: 1));
-        expect(pool.isFailing.value, isTrue);
-        expect(failingEdges, 2, reason: 'this failure must reach the listeners too');
 
         pool.currentClient.close();
         async.flushTimers();

--- a/test/network/socket_test.dart
+++ b/test/network/socket_test.dart
@@ -798,6 +798,52 @@ void main() {
       });
     });
 
+    test('takes on the connection state of the client it switches to', () async {
+      const flakyRoute = '/flaky/socket/v5';
+      var defaultRouteFails = false;
+      final container = await makeContainer(
+        overrides: {
+          webSocketChannelFactoryProvider: webSocketChannelFactoryProvider.overrideWithValue(
+            FakeWebSocketChannelFactory((route) {
+              if (route.path == flakyRoute || defaultRouteFails) {
+                throw const SocketException('No internet');
+              }
+              return createDefaultFakeWebSocketChannel(route);
+            }),
+          ),
+        },
+      );
+      final pool = container.read(socketPoolProvider);
+
+      var failingEdges = 0;
+      pool.isFailing.addListener(() {
+        if (pool.isFailing.value) failingEdges++;
+      });
+
+      fakeAsync((async) {
+        pool.open(Uri(path: flakyRoute));
+        async.elapse(const Duration(seconds: 1));
+        expect(pool.isFailing.value, isTrue);
+        expect(failingEdges, 1);
+
+        // Back to the default socket, which connects: the pool must not be left holding the
+        // failing state of the client it just closed.
+        pool.open(Uri(path: kDefaultSocketRoute));
+        async.elapse(const Duration(seconds: 1));
+        expect(pool.isFailing.value, isFalse);
+
+        // A failure on the new current client is then heard as the change it is.
+        defaultRouteFails = true;
+        pool.currentClient.connect();
+        async.elapse(const Duration(seconds: 1));
+        expect(pool.isFailing.value, isTrue);
+        expect(failingEdges, 2, reason: 'this failure must reach the listeners too');
+
+        pool.currentClient.close();
+        async.flushTimers();
+      });
+    });
+
     test('does not reopen the default socket in the background when a route goes idle', () async {
       const route = '/lobby/socket/v5';
       final attempts = <Uri>[];

--- a/test/network/socket_test.dart
+++ b/test/network/socket_test.dart
@@ -192,6 +192,46 @@ void main() {
       });
     });
 
+    test('a message sent after a connection that broke while opening is queued, not lost', () {
+      // Every message this client sends, ping excepted, whichever channel it goes out on: one
+      // written to the channel of the attempt that failed would show up here just the same.
+      final sent = <dynamic>[];
+      var nextChannelFailsItsPing = true;
+      final fakeChannelFactory = FakeWebSocketChannelFactory((route) {
+        final channel = FakeWebSocketChannel(route)..failNextWrite = nextChannelFailsItsPing;
+        nextChannelFailsItsPing = false;
+        channel.sentMessagesExceptPing.listen(sent.add);
+        return channel;
+      });
+
+      fakeAsync((async) {
+        // The handshake succeeds and the peer is gone by the first ping: the attempt fails with a
+        // channel of its own already in hand.
+        final socketClient = makeTestSocketClient(fakeChannelFactory: fakeChannelFactory);
+        socketClient.connect();
+        async.elapse(const Duration(milliseconds: 20));
+        expect(socketClient.isFailing.value, isTrue);
+        expect(socketClient.isConnected, isFalse);
+
+        socketClient.send('test', {'foo': 'bar'});
+        async.elapse(const Duration(milliseconds: 10));
+        expect(sent, isEmpty, reason: 'the channel of the failed attempt is gone');
+
+        // It goes out on the connection that the retry makes instead.
+        async.elapse(const Duration(seconds: 1));
+        expect(socketClient.isConnected, isTrue);
+        expect(sent, [
+          jsonEncode({
+            't': 'test',
+            'd': {'foo': 'bar'},
+          }),
+        ]);
+
+        socketClient.close();
+        async.flushTimers();
+      });
+    });
+
     test('a message sent while the socket waits out its backoff is queued, not lost', () {
       var offline = false;
       // Every message this client sends, ping excepted, whichever channel it goes out on: one

--- a/test/utils/fake_connectivity.dart
+++ b/test/utils/fake_connectivity.dart
@@ -1,6 +1,7 @@
 import 'dart:async';
 
 import 'package:connectivity_plus/connectivity_plus.dart';
+import 'package:flutter/services.dart';
 
 /// A fake implementation of [Connectivity] that always returns [ConnectivityResult.wifi].
 class FakeConnectivity implements Connectivity {
@@ -74,6 +75,30 @@ class SwitchableConnectivity implements Connectivity {
   Future<List<ConnectivityResult>> checkConnectivity() => shouldFail
       ? Future.error(StateError('the connectivity plugin failed'))
       : Future.value([ConnectivityResult.wifi]);
+
+  @override
+  Stream<List<ConnectivityResult>> get onConnectivityChanged => FakeConnectivity.controller.stream;
+}
+
+/// A fake [Connectivity] that fails the way the plugin really does, with a [PlatformException].
+///
+/// Riverpod retries a build that failed with an [Exception] — six times, per `lichessProviderRetry`
+/// — where it never retries an [Error]. Use this one, rather than [FailingConnectivity], for
+/// anything that has to go through that schedule.
+class PluginFailingConnectivity implements Connectivity {
+  /// Whether the next check fails. Set it to false to have the plugin recover.
+  bool shouldFail = true;
+
+  /// How many checks have been asked for, retries included.
+  int checks = 0;
+
+  @override
+  Future<List<ConnectivityResult>> checkConnectivity() {
+    checks++;
+    return shouldFail
+        ? Future.error(PlatformException(code: 'channel-error', message: 'Unable to establish'))
+        : Future.value([ConnectivityResult.wifi]);
+  }
 
   @override
   Stream<List<ConnectivityResult>> get onConnectivityChanged => FakeConnectivity.controller.stream;

--- a/test/utils/fake_connectivity.dart
+++ b/test/utils/fake_connectivity.dart
@@ -63,3 +63,18 @@ class PendingThenFailingConnectivity implements Connectivity {
   @override
   Stream<List<ConnectivityResult>> get onConnectivityChanged => FakeConnectivity.controller.stream;
 }
+
+/// A fake [Connectivity] whose check works until [shouldFail] is set, and fails from then on.
+///
+/// Lets a test have the plugin go wrong on a check that is not the first one.
+class SwitchableConnectivity implements Connectivity {
+  bool shouldFail = false;
+
+  @override
+  Future<List<ConnectivityResult>> checkConnectivity() => shouldFail
+      ? Future.error(StateError('the connectivity plugin failed'))
+      : Future.value([ConnectivityResult.wifi]);
+
+  @override
+  Stream<List<ConnectivityResult>> get onConnectivityChanged => FakeConnectivity.controller.stream;
+}

--- a/test/utils/fake_connectivity.dart
+++ b/test/utils/fake_connectivity.dart
@@ -29,3 +29,17 @@ class PendingConnectivity implements Connectivity {
   Stream<List<ConnectivityResult>> get onConnectivityChanged =>
       const Stream<List<ConnectivityResult>>.empty();
 }
+
+/// A fake implementation of [Connectivity] whose check always fails, to simulate the plugin
+/// itself going wrong.
+///
+/// It throws an [Error] rather than an [Exception] so that riverpod does not retry the build it
+/// makes fail: what is under test is the state that failure leaves behind.
+class FailingConnectivity implements Connectivity {
+  @override
+  Future<List<ConnectivityResult>> checkConnectivity() =>
+      Future.error(StateError('the connectivity plugin failed'));
+
+  @override
+  Stream<List<ConnectivityResult>> get onConnectivityChanged => FakeConnectivity.controller.stream;
+}

--- a/test/utils/fake_connectivity.dart
+++ b/test/utils/fake_connectivity.dart
@@ -43,3 +43,23 @@ class FailingConnectivity implements Connectivity {
   @override
   Stream<List<ConnectivityResult>> get onConnectivityChanged => FakeConnectivity.controller.stream;
 }
+
+/// A fake [Connectivity] whose check fails, but only once [failNow] is called.
+///
+/// Lets a test have a socket connect while the very first check is still running, and only then
+/// have the plugin go wrong.
+class PendingThenFailingConnectivity implements Connectivity {
+  final _failure = Completer<void>();
+
+  /// Makes the pending check fail.
+  void failNow() => _failure.complete();
+
+  @override
+  Future<List<ConnectivityResult>> checkConnectivity() async {
+    await _failure.future;
+    throw StateError('the connectivity plugin failed');
+  }
+
+  @override
+  Stream<List<ConnectivityResult>> get onConnectivityChanged => FakeConnectivity.controller.stream;
+}

--- a/test/utils/rate_limit_test.dart
+++ b/test/utils/rate_limit_test.dart
@@ -84,6 +84,60 @@ void main() {
       expect(called, 1);
     });
 
+    test('drops a call made within the delay when not trailing', () async {
+      final throttler = Throttler(const Duration(milliseconds: 100));
+      var called = 0;
+      throttler(() => called++);
+      await Future<void>.delayed(const Duration(milliseconds: 50));
+      throttler(() => called++);
+      await Future<void>.delayed(const Duration(milliseconds: 150));
+      expect(called, 1);
+    });
+
+    test('runs a trailing call once the delay expires', () async {
+      final throttler = Throttler(const Duration(milliseconds: 100), trailing: true);
+      var called = 0;
+      throttler(() => called++);
+      await Future<void>.delayed(const Duration(milliseconds: 50));
+      throttler(() => called++);
+      expect(called, 1, reason: 'the second call waits for the delay to expire');
+      await Future<void>.delayed(const Duration(milliseconds: 150));
+      expect(called, 2);
+    });
+
+    test('coalesces the calls made within the delay into a single trailing run', () async {
+      final throttler = Throttler(const Duration(milliseconds: 100), trailing: true);
+      final calls = <String>[];
+      throttler(() => calls.add('first'));
+      throttler(() => calls.add('second'));
+      throttler(() => calls.add('third'));
+      await Future<void>.delayed(const Duration(milliseconds: 300));
+      expect(calls, ['first', 'third'], reason: 'the last action of the window wins');
+    });
+
+    test('a trailing run opens a new delay of its own', () async {
+      final throttler = Throttler(const Duration(milliseconds: 100), trailing: true);
+      var called = 0;
+      throttler(() => called++);
+      throttler(() => called++);
+      await Future<void>.delayed(const Duration(milliseconds: 150));
+      expect(called, 2);
+      throttler(() => called++);
+      expect(called, 2, reason: 'the trailing run throttles what follows it');
+      await Future<void>.delayed(const Duration(milliseconds: 150));
+      expect(called, 3);
+    });
+
+    test('cancel drops a pending trailing call', () async {
+      final throttler = Throttler(const Duration(milliseconds: 100), trailing: true);
+      var called = 0;
+      throttler(() => called++);
+      throttler(() => called++);
+      throttler.cancel();
+      await Future<void>.delayed(const Duration(milliseconds: 150));
+      expect(called, 1);
+    });
+
     test('should call the callback multiple times if delay is passed', () async {
       final throttler = Throttler(const Duration(milliseconds: 100));
       var called = 0;

--- a/test/view/analysis/analysis_screen_test.dart
+++ b/test/view/analysis/analysis_screen_test.dart
@@ -797,10 +797,16 @@ void main() {
 
       expectSameLine(tester, ['1. e4', 'e5', '2. d4', 'exd4']);
 
+      // The full sequence: the app installs [AppLifecycleListener]s, which assert on a transition
+      // the platform cannot make.
+      tester.binding.handleAppLifecycleStateChanged(AppLifecycleState.inactive);
+      tester.binding.handleAppLifecycleStateChanged(AppLifecycleState.hidden);
       tester.binding.handleAppLifecycleStateChanged(AppLifecycleState.paused);
 
       liveGamePgn = 'e4 e5 Nf3 Nc6';
 
+      tester.binding.handleAppLifecycleStateChanged(AppLifecycleState.hidden);
+      tester.binding.handleAppLifecycleStateChanged(AppLifecycleState.inactive);
       tester.binding.handleAppLifecycleStateChanged(AppLifecycleState.resumed);
 
       // Wait for API call to refresh game and tree to be updated

--- a/test/view/auth/email_login_screen_test.dart
+++ b/test/view/auth/email_login_screen_test.dart
@@ -2,6 +2,7 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:http/testing.dart';
 import 'package:lichess_mobile/src/model/auth/auth_controller.dart';
+import 'package:lichess_mobile/src/network/connectivity.dart';
 import 'package:lichess_mobile/src/network/http.dart';
 import 'package:lichess_mobile/src/view/auth/email_login_screen.dart';
 import 'package:material_ui/material_ui.dart';
@@ -26,6 +27,10 @@ MockClientHandler happyPath({
   int autocompleteStatus = 200,
 }) {
   return (request) {
+    // The connectivity checks run on their own schedule and are not traffic this screen produced.
+    if (internetCheckUris.contains(request.url)) {
+      return mockResponse('', 200);
+    }
     recordUrl?.call(request.url);
     switch (request.url.path) {
       case '/api/player/autocomplete':
@@ -114,7 +119,10 @@ void main() {
       testWidgets(email.isEmpty ? '(empty)' : email, (tester) async {
         var requests = 0;
         final app = await makeApp(tester, (request) {
-          requests++;
+          // The connectivity checks are not traffic this screen produced.
+          if (!internetCheckUris.contains(request.url)) {
+            requests++;
+          }
           return mockResponse('', 204);
         });
         await tester.pumpWidget(app);
@@ -160,7 +168,10 @@ void main() {
   testWidgets('does not send a request without a username', (tester) async {
     var requests = 0;
     final app = await makeApp(tester, (request) {
-      requests++;
+      // The connectivity checks are not traffic this screen produced.
+      if (!internetCheckUris.contains(request.url)) {
+        requests++;
+      }
       return mockResponse('', 204);
     });
     await tester.pumpWidget(app);

--- a/test/view/offline_computer/offline_computer_game_screen_test.dart
+++ b/test/view/offline_computer/offline_computer_game_screen_test.dart
@@ -207,8 +207,8 @@ void main() {
       await tester.pump(kEngineEvalEmissionThrottleDelay * 2);
       expect(engine.stopCount, 0);
 
-      // The full sequence: [AppLifecycleListener] asserts on a transition the platform cannot
-      // make, and the socket pool now installs one.
+      // The full sequence: the app installs [AppLifecycleListener]s, which assert on a transition
+      // the platform cannot make.
       tester.binding.handleAppLifecycleStateChanged(AppLifecycleState.inactive);
       tester.binding.handleAppLifecycleStateChanged(AppLifecycleState.hidden);
       tester.binding.handleAppLifecycleStateChanged(AppLifecycleState.paused);


### PR DESCRIPTION
Assisted by Claude opus 5.

## Connectivity checks 
  - Overlapping checks are versioned: a slow check can no longer overwrite a fresher answer, and an older check finishing first cannot outdate a newer one. 
  - A failed check is treated as offline everywhere
  - Connectivity events are throttled with a trailing run, so an event arriving inside the window is no longer dropped for good.
  - Plugin failures on app resume are caught and logged instead of escaping as an unhandled async error.
  - The lifecycle state is applied immediately, separately from the check it triggers.

##  Socket reliability
  - channel.stream gets onError/onDone: a channel the OS tears down is now noticed at once rather than at the pong timeout, and stream errors are no longer uncaught.
  - Removed the redundant second ping at connect: a socket that opens and answers nothing is dropped after 9s, not 11.5s.
  - The first pong timeout reconnects immediately, matching the web client; only a continuing run of failures falls into the backoff.
  - Reconnect backoff: full speed for a 60s grace period, then doubling to a 60s ceiling
  - Messages sent while disconnected are queued and flushed on reconnect (ack ids preserved, no double registration).
  - The pool closes the socket after a spell in the background, reopens on foreground, reconnects on the online edge, and won't reopen a socket closed in the background.
  - send method now have a `noRetry` parameter to drop messages when there is no connection to write it to