### PR TITLE
perf(db): use COUNT(*) in GameStorage.count

### DIFF
--- a/lib/src/model/game/game_storage.dart
+++ b/lib/src/model/game/game_storage.dart
@@ -23,12 +23,11 @@ class GameStorage {
   final Database _db;
 
   Future<int> count({UserId? userId}) async {
-    final list = await _db.query(
-      kGameStorageTable,
-      where: 'userId = ?',
-      whereArgs: [userId ?? kStorageAnonId],
+    final result = await _db.rawQuery(
+      'SELECT COUNT(*) as cnt FROM $kGameStorageTable WHERE userId = ?',
+      [userId ?? kStorageAnonId],
     );
-    return list.length;
+    return Sqflite.firstIntValue(result) ?? 0;
   }
 
   Future<IList<StoredGame>> page({


### PR DESCRIPTION
Replace full table query + Dart list.length with SELECT COUNT(*). Avoids loading all row data (including large JSON blobs) into memory just to count rows. O(n) allocations -> O(1).

Muse Spark 1.2 used with Opencode for this PR.

