### PR TITLE
fix: spelling and duplicate words

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -2,7 +2,7 @@ blank_issues_enabled: false
 contact_links:
   - name: Website
     url: https://github.com/lichess-org/lila/issues
-    about: Issues about the lichess website are tracked in a seperate repository.
+    about: Issues about the lichess website are tracked in a separate repository.
   - name: Old Mobile app
     url: https://github.com/lichess-org/lichobile/issues
     about: Issues for the old mobile app are tracked in a separate repository. Please check for duplicates first.

--- a/lib/src/model/engine/evaluation_mixin.dart
+++ b/lib/src/model/engine/evaluation_mixin.dart
@@ -56,7 +56,7 @@ mixin EvaluationMixinState<State extends EvaluationMixinState<State>> {
   /// Whether to always request a cloud evaluation, regardless of the current ply.
   bool get alwaysRequestCloudEval;
 
-  /// Whether the engine is in threat mode, i.e. pretending it's the the opposite side's turn.
+  /// Whether the engine is in threat mode, i.e. pretending it's the opposite side's turn.
   bool get engineInThreatMode;
 
   /// Whether the "show threat" feature can be used in the current position.

--- a/lib/src/model/game/game_controller.dart
+++ b/lib/src/model/game/game_controller.dart
@@ -223,7 +223,7 @@ class GameController extends AsyncNotifier<GameState> with ChatMixin<GameState> 
 
     _wasInBackground = true;
 
-    // real time games need the socket to stay connected otherwise lichess will think the player leaved
+    // real time games need the socket to stay connected otherwise lichess will think the player left
     // correspondence games can and should close the socket when the app is in background (because lichess won't send the push notification update when the player is still connected to the socket)
     if (state.requireValue.game.meta.speed == Speed.correspondence) {
       _socketClient.close();

--- a/lib/src/network/connectivity.dart
+++ b/lib/src/network/connectivity.dart
@@ -219,7 +219,7 @@ Future<bool> isOnline(Client client, {Duration timeout = const Duration(seconds:
 extension AsyncValueConnectivity on AsyncValue<ConnectivityStatus> {
   /// Switches between device's connectivity status.
   ///
-  /// Using this method assumes the the device is offline when the status is
+  /// Using this method assumes the device is offline when the status is
   /// not yet available (i.e. [AsyncValue.isLoading].
   /// If you want to handle the loading state separately, use
   /// [whenIsLoading] instead.

--- a/lib/src/network/http.dart
+++ b/lib/src/network/http.dart
@@ -332,7 +332,7 @@ Future<bool> downloadFiles(
     throw ArgumentError('expectedLengths must have the same length as urls.');
   }
 
-  // aggregrate progress of all files
+  // aggregate progress of all files
   final Map<Uri, int> fileLengths = {};
   final Map<Uri, int> fileReceived = {};
   final results = await Future.wait(

--- a/test/network/socket_test.dart
+++ b/test/network/socket_test.dart
@@ -194,7 +194,7 @@ void main() {
       // we expect another connection because it reconnects if not receiving pong
       await expectLater(socketClient.connectedStream, emits(null));
 
-      // check the the first connection was closed
+      // check the first connection was closed
       // no need to check the close code since it will alway be 1000 in our fake channel
       expect(channels[1]!.closeCode, isNotNull);
       expect(channels[2]!.closeCode, isNull);

--- a/test/view/engine/engine_button_test.dart
+++ b/test/view/engine/engine_button_test.dart
@@ -17,7 +17,7 @@ void main() {
   });
 
   testWidgets('Engine starts immediately after the request eval delay', (tester) async {
-    // loads a finished game, disable cloud eval because it is ususally not availabe in mid/end game
+    // loads a finished game, disable cloud eval because it is usually not available in mid/end game
     await makeEngineTestApp(tester, isCloudEvalEnabled: false, gameId: const GameId('xze7RH66'));
 
     expect(find.byType(CircularProgressIndicator), findsOne);


### PR DESCRIPTION
- seperate -> separate (config.yml)
- aggregrate -> aggregate (http.dart)
- leaved -> left (game_controller.dart)
- ususally/availabe -> usually/available (engine_button_test.dart)
- the the -> the (connectivity.dart, evaluation_mixin.dart, socket_test.dart)

Historical DB names puzzle_batchs intentionally untouched.