### PR TITLE
perf: puzzle screen select

### DIFF
--- a/lib/src/view/puzzle/puzzle_screen.dart
+++ b/lib/src/view/puzzle/puzzle_screen.dart
@@ -437,14 +437,10 @@ class _BodyState extends ConsumerState<_Body> {
   Widget build(BuildContext context) {
     final boardPreferences = ref.watch(boardPreferencesProvider);
     final ctrlProvider = puzzleControllerProvider(widget.initialPuzzleContext);
-    final puzzleState = ref.watch(ctrlProvider);
-    // Slice 1: isolate hint shapes and view-mode from whole-state watch.
+    // Slice 1+2+3: parent watches only slices; FeedbackWidget isolated below.
     final hintSquare = ref.watch(ctrlProvider.select((s) => s.hintSquare));
     final mode = ref.watch(ctrlProvider.select((s) => s.mode));
-    // Slice 2: narrow remaining hot fields. Parent still watches whole for
-    // FeedbackWidget; board/tree/bottom bar will use these selects.
     final pov = ref.watch(ctrlProvider.select((s) => s.pov));
-    final puzzle = ref.watch(ctrlProvider.select((s) => s.puzzle));
     final root = ref.watch(ctrlProvider.select((s) => s.root));
     final currentPath = ref.watch(ctrlProvider.select((s) => s.currentPath));
     final puzzleId = ref.watch(ctrlProvider.select((s) => s.puzzle.puzzle.id));
@@ -544,10 +540,16 @@ class _BodyState extends ConsumerState<_Body> {
                         mainAxisAlignment: MainAxisAlignment.spaceAround,
                         children: [
                           Center(
-                            child: PuzzleFeedbackWidget(
-                              puzzle: puzzle,
-                              state: puzzleState,
-                              onStreak: false,
+                            child: Consumer(
+                              builder: (context, ref, _) {
+                                final puzzle = ref.watch(ctrlProvider.select((s) => s.puzzle));
+                                final state = ref.watch(ctrlProvider);
+                                return PuzzleFeedbackWidget(
+                                  puzzle: puzzle,
+                                  state: state,
+                                  onStreak: false,
+                                );
+                              },
                             ),
                           ),
                           _PuzzleStatus(initialPuzzleContext: widget.initialPuzzleContext),
@@ -607,10 +609,16 @@ class _BodyState extends ConsumerState<_Body> {
                         horizontal: isTablet ? kTabletBoardTableSidePadding : 12.0,
                       ),
                       child: Center(
-                        child: PuzzleFeedbackWidget(
-                          puzzle: puzzle,
-                          state: puzzleState,
-                          onStreak: false,
+                        child: Consumer(
+                          builder: (context, ref, _) {
+                            final puzzle = ref.watch(ctrlProvider.select((s) => s.puzzle));
+                            final state = ref.watch(ctrlProvider);
+                            return PuzzleFeedbackWidget(
+                              puzzle: puzzle,
+                              state: state,
+                              onStreak: false,
+                            );
+                          },
                         ),
                       ),
                     ),

--- a/lib/src/view/puzzle/puzzle_screen.dart
+++ b/lib/src/view/puzzle/puzzle_screen.dart
@@ -438,6 +438,9 @@ class _BodyState extends ConsumerState<_Body> {
     final boardPreferences = ref.watch(boardPreferencesProvider);
     final ctrlProvider = puzzleControllerProvider(widget.initialPuzzleContext);
     final puzzleState = ref.watch(ctrlProvider);
+    // Slice 1: isolate hint shapes and view-mode from whole-state watch.
+    final hintSquare = ref.watch(ctrlProvider.select((s) => s.hintSquare));
+    final mode = ref.watch(ctrlProvider.select((s) => s.mode));
 
     // Warn the user when the server starts rate-limiting solve submissions.
     ref.listen(puzzleSolveLimiterProvider, (previous, next) {
@@ -475,13 +478,12 @@ class _BodyState extends ConsumerState<_Body> {
       }
     });
 
-    final shapes = puzzleState.hintSquare != null
-        ? <Shape>{Circle(color: ShapeColor.green.color, orig: puzzleState.hintSquare!)}
+    final shapes = hintSquare != null
+        ? <Shape>{Circle(color: ShapeColor.green.color, orig: hintSquare)}
         : const <Shape>{};
 
     final content = PopScope(
-      canPop:
-          Theme.of(context).platform != TargetPlatform.iOS || puzzleState.mode == PuzzleMode.view,
+      canPop: Theme.of(context).platform != TargetPlatform.iOS || mode == PuzzleMode.view,
       child: SafeArea(
         // view padding can change on Android when immersive mode is enabled, so to prevent any
         // board vertical shift, we set `maintainBottomViewPadding` to true.

--- a/lib/src/view/puzzle/puzzle_screen.dart
+++ b/lib/src/view/puzzle/puzzle_screen.dart
@@ -441,6 +441,13 @@ class _BodyState extends ConsumerState<_Body> {
     // Slice 1: isolate hint shapes and view-mode from whole-state watch.
     final hintSquare = ref.watch(ctrlProvider.select((s) => s.hintSquare));
     final mode = ref.watch(ctrlProvider.select((s) => s.mode));
+    // Slice 2: narrow remaining hot fields. Parent still watches whole for
+    // FeedbackWidget; board/tree/bottom bar will use these selects.
+    final pov = ref.watch(ctrlProvider.select((s) => s.pov));
+    final puzzle = ref.watch(ctrlProvider.select((s) => s.puzzle));
+    final root = ref.watch(ctrlProvider.select((s) => s.root));
+    final currentPath = ref.watch(ctrlProvider.select((s) => s.currentPath));
+    final puzzleId = ref.watch(ctrlProvider.select((s) => s.puzzle.puzzle.id));
 
     // Warn the user when the server starts rate-limiting solve submissions.
     ref.listen(puzzleSolveLimiterProvider, (previous, next) {
@@ -526,7 +533,7 @@ class _BodyState extends ConsumerState<_Body> {
                       onMove: (move, {viaDragAndDrop}) {
                         ref.read(ctrlProvider.notifier).onUserMove(move);
                       },
-                      orientation: _isBoardTurned ? puzzleState.pov.opposite : puzzleState.pov,
+                      orientation: _isBoardTurned ? pov.opposite : pov,
                       shapes: shapes,
                       settings: defaultSettings,
                     ),
@@ -538,7 +545,7 @@ class _BodyState extends ConsumerState<_Body> {
                         children: [
                           Center(
                             child: PuzzleFeedbackWidget(
-                              puzzle: puzzleState.puzzle,
+                              puzzle: puzzle,
                               state: puzzleState,
                               onStreak: false,
                             ),
@@ -555,8 +562,8 @@ class _BodyState extends ConsumerState<_Body> {
                                   child: Column(
                                     children: [
                                       DebouncedPgnTreeView(
-                                        root: puzzleState.root,
-                                        currentPath: puzzleState.currentPath,
+                                        root: root,
+                                        currentPath: currentPath,
                                         pgnRootComments: null,
                                         shouldShowComputerAnalysis: false,
                                         shouldShowComments: false,
@@ -574,7 +581,7 @@ class _BodyState extends ConsumerState<_Body> {
                             padding: const EdgeInsets.only(bottom: 16.0),
                             child: _BottomBar(
                               initialPuzzleContext: widget.initialPuzzleContext,
-                              puzzleId: puzzleState.puzzle.puzzle.id,
+                              puzzleId: puzzleId,
                               onFlipBoard: () => setState(() => _isBoardTurned = !_isBoardTurned),
                             ),
                           ),
@@ -601,7 +608,7 @@ class _BodyState extends ConsumerState<_Body> {
                       ),
                       child: Center(
                         child: PuzzleFeedbackWidget(
-                          puzzle: puzzleState.puzzle,
+                          puzzle: puzzle,
                           state: puzzleState,
                           onStreak: false,
                         ),
@@ -619,7 +626,7 @@ class _BodyState extends ConsumerState<_Body> {
                       onMove: (move, {viaDragAndDrop}) {
                         ref.read(ctrlProvider.notifier).onUserMove(move);
                       },
-                      orientation: _isBoardTurned ? puzzleState.pov.opposite : puzzleState.pov,
+                      orientation: _isBoardTurned ? pov.opposite : pov,
                       shapes: shapes,
                       settings: defaultSettings,
                     ),
@@ -634,7 +641,7 @@ class _BodyState extends ConsumerState<_Body> {
                   ),
                   _BottomBar(
                     initialPuzzleContext: widget.initialPuzzleContext,
-                    puzzleId: puzzleState.puzzle.puzzle.id,
+                    puzzleId: puzzleId,
                     onFlipBoard: () => setState(() => _isBoardTurned = !_isBoardTurned),
                   ),
                 ],
@@ -648,7 +655,7 @@ class _BodyState extends ConsumerState<_Body> {
     return Theme.of(context).platform == TargetPlatform.android
         ? AndroidGesturesExclusionWidget(
             boardKey: widget.boardKey,
-            shouldExcludeGesturesOnFocusGained: puzzleState.mode != PuzzleMode.view,
+            shouldExcludeGesturesOnFocusGained: mode != PuzzleMode.view,
             shouldSetImmersiveMode: boardPreferences.immersiveModeWhilePlaying ?? false,
             child: content,
           )

--- a/lib/src/view/puzzle/puzzle_screen.dart
+++ b/lib/src/view/puzzle/puzzle_screen.dart
@@ -437,7 +437,6 @@ class _BodyState extends ConsumerState<_Body> {
   Widget build(BuildContext context) {
     final boardPreferences = ref.watch(boardPreferencesProvider);
     final ctrlProvider = puzzleControllerProvider(widget.initialPuzzleContext);
-    // Slice 1+2+3: parent watches only slices; FeedbackWidget isolated below.
     final hintSquare = ref.watch(ctrlProvider.select((s) => s.hintSquare));
     final mode = ref.watch(ctrlProvider.select((s) => s.mode));
     final pov = ref.watch(ctrlProvider.select((s) => s.pov));


### PR DESCRIPTION
The puzzle screen was rebuilding its entire layout every time any part of the puzzle state changed, because the main body widget was watching the whole state object with nineteen fields. I changed it so the parent only watches the specific pieces it needs for the board, move list and puzzle ID, and left the slices for the hint arrow and view mode already isolated, then moved the feedback banner that needs the full state into its own small consumers so it rebuilds on its own. Now the board, the move tree and the bottom bar update only when their own data changes, and the rest of the screen no longer rebuilds for unrelated updates like the rating calculation.

Muse Spark 1.2 used with Opencode for this PR.