### PR TITLE
Hide tournament pairing status before start

### DIFF
--- a/lib/src/view/tournament/tournament_screen.dart
+++ b/lib/src/view/tournament/tournament_screen.dart
@@ -160,6 +160,11 @@ class _Body extends ConsumerWidget {
   Widget build(BuildContext context, WidgetRef ref) {
     final authUser = ref.watch(authControllerProvider);
     final timeLeft = state.tournament.timeToStart ?? state.tournament.timeToFinish;
+    final showPairingStatus =
+        authUser != null &&
+        state.joined &&
+        state.tournament.isStarted == true &&
+        state.tournament.isFinished != true;
 
     final standingWidgets = [
       if (state.tournament.teamStanding != null) ...[
@@ -178,7 +183,7 @@ class _Body extends ConsumerWidget {
         _FeaturedGame(state.tournament.featuredGame!),
     ];
 
-    final bottomSheetSpacer = (authUser != null && state.joined)
+    final bottomSheetSpacer = showPairingStatus
         ? const SizedBox(height: 35)
         : const SizedBox.shrink();
 
@@ -272,7 +277,7 @@ class _Body extends ConsumerWidget {
             );
           },
         ),
-        bottomSheet: authUser != null && state.joined && state.tournament.isFinished != true
+        bottomSheet: showPairingStatus
             ? Material(
                 child: Container(
                   height: 35,

--- a/test/view/tournament/tournament_screen_test.dart
+++ b/test/view/tournament/tournament_screen_test.dart
@@ -87,6 +87,7 @@ String makeTournamentJson({
   required int nbPlayers,
   String? verdictsJson,
   TournamentMe? me,
+  bool isStarted = true,
   bool isPrivate = false,
   String featuredGameJson = '',
 }) {
@@ -113,8 +114,8 @@ String makeTournamentJson({
   "nbPlayers": $nbPlayers,
   ${meToJson(me)}
   "duels": [ ],
-  "secondsToFinish": 2744,
-  "isStarted": true,
+  "${isStarted ? 'secondsToFinish' : 'secondsToStart'}": 2744,
+  "isStarted": $isStarted,
   $featuredGameJson
   "standing": {
     "page": 1,
@@ -546,6 +547,50 @@ void main() {
       await tester.pump();
       expect(find.text('11-12 / 12'), findsOneWidget);
     });
+
+    for (final isStarted in [false, true]) {
+      testWidgets('${isStarted ? 'Shows' : 'Hides'} pairing status for a joined '
+          '${isStarted ? 'started' : 'scheduled'} tournament', (WidgetTester tester) async {
+        final mockClient = MockClient((request) {
+          if (request.url.path == '/api/tournament/82QbxlJb') {
+            return mockResponse(
+              makeTournamentJson(
+                standings: makeTestPlayers(10),
+                nbPlayers: 11,
+                me: (gameId: null, pauseDelay: null, rank: 11, withdraw: null),
+                isStarted: isStarted,
+              ),
+              200,
+            );
+          }
+          return mockResponse('', 404);
+        });
+
+        const name = 'tom-anders';
+        final authUser = AuthUser(
+          user: LightUser(id: UserId.fromUserName(name), name: name),
+          token: 'test-token',
+        );
+
+        final app = await makeTestProviderScopeApp(
+          tester,
+          home: const TournamentScreen(id: TournamentId('82QbxlJb')),
+          authUser: authUser,
+          overrides: {
+            lichessClientProvider: lichessClientProvider.overrideWith((ref) {
+              return LichessClient(mockClient, ref);
+            }),
+          },
+        );
+        await tester.pumpWidget(app);
+        await tester.pump();
+
+        expect(
+          find.text('Stand by $name, pairing players, get ready!'),
+          isStarted ? findsOneWidget : findsNothing,
+        );
+      });
+    }
 
     testWidgets('Cannot join tournament if not logged in', (WidgetTester tester) async {
       final mockClient = MockClient((request) {


### PR DESCRIPTION
## Summary

- hide the tournament pairing status before a joined tournament starts
- only reserve layout space for the status while it is displayed
- add widget tests covering joined scheduled and started tournaments

Fixes #3629

## Screenshots

| Joined scheduled tournament | Joined started tournament |
| --- | --- |
| <img src="https://raw.githubusercontent.com/philyawj/mobile/pr-assets-3629/.github/pr-assets/3629/tournament-scheduled.png" width="300" alt="Joined scheduled tournament with no pairing status banner"> | <img src="https://raw.githubusercontent.com/philyawj/mobile/pr-assets-3629/.github/pr-assets/3629/tournament-started.png" width="300" alt="Joined started tournament with the pairing status banner visible"> |

These are deterministic Flutter UI renders, not AI-generated images.

## Testing

- `flutter analyze`
- `flutter test test/view/tournament/tournament_screen_test.dart`
- `flutter test` (1,480 tests passed)

## AI usage

OpenAI Codex generated the initial implementation, regression tests, commit message, temporary screenshot harness, and PR description. I reviewed the code and resulting behavior, confirmed that I understand the change and that it satisfies the issue, and directed the final PR contents.
