### PR TITLE
Honor piece notation in opening explorer and tablebase

### DIFF
--- a/lib/src/view/explorer/opening_explorer_widgets.dart
+++ b/lib/src/view/explorer/opening_explorer_widgets.dart
@@ -2,6 +2,7 @@ import 'package:dartchess/dartchess.dart';
 import 'package:fast_immutable_collections/fast_immutable_collections.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:intl/intl.dart';
+import 'package:lichess_mobile/src/model/account/account_preferences.dart';
 import 'package:lichess_mobile/src/model/analysis/analysis_controller.dart';
 import 'package:lichess_mobile/src/model/common/chess.dart';
 import 'package:lichess_mobile/src/model/explorer/opening_explorer.dart';
@@ -109,6 +110,9 @@ class OpeningExplorerMoveTable extends ConsumerWidget {
       return loadingTable;
     }
 
+    final pieceNotation = ref
+        .watch(pieceNotationProvider)
+        .maybeWhen(data: (value) => value, orElse: () => defaultAccountPreferences.pieceNotation);
     final games = whiteWins + draws + blackWins;
 
     return Table(
@@ -154,7 +158,15 @@ class OpeningExplorerMoveTable extends ConsumerWidget {
             children: [
               TableRowInkWell(
                 onTap: () => onMoveSelected?.call(Move.parse(move.uci)!),
-                child: Padding(padding: kExplorerTableRowPadding, child: Text(move.san)),
+                child: Padding(
+                  padding: kExplorerTableRowPadding,
+                  child: Text(
+                    move.san,
+                    style: TextStyle(
+                      fontFamily: pieceNotation == PieceNotation.symbol ? 'ChessFont' : null,
+                    ),
+                  ),
+                ),
               ),
               TableRowInkWell(
                 onTap: () => onMoveSelected?.call(Move.parse(move.uci)!),

--- a/lib/src/view/explorer/tablebase_view.dart
+++ b/lib/src/view/explorer/tablebase_view.dart
@@ -1,5 +1,6 @@
 import 'package:dartchess/dartchess.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:lichess_mobile/src/model/account/account_preferences.dart';
 import 'package:lichess_mobile/src/model/common/chess.dart' show Variant;
 import 'package:lichess_mobile/src/model/explorer/tablebase.dart';
 import 'package:lichess_mobile/src/model/explorer/tablebase_repository.dart';
@@ -35,6 +36,12 @@ class TablebaseView extends ConsumerWidget {
           );
         }
 
+        final pieceNotation = ref
+            .watch(pieceNotationProvider)
+            .maybeWhen(
+              data: (value) => value,
+              orElse: () => defaultAccountPreferences.pieceNotation,
+            );
         final children = <Widget>[];
 
         void addMoveSection({
@@ -57,6 +64,7 @@ class TablebaseView extends ConsumerWidget {
                   color: index.isEven ? context.lichessTheme.rowEven : context.lichessTheme.rowOdd,
                   onMoveSelected: onMoveSelected,
                   isWinningForWhite: isWinningForWhite,
+                  pieceNotation: pieceNotation,
                 );
               }, growable: false),
             );
@@ -217,6 +225,7 @@ class _TablebaseMoveRow extends StatelessWidget {
     required this.move,
     required this.color,
     required this.isWinningForWhite,
+    required this.pieceNotation,
     this.onMoveSelected,
     super.key,
   });
@@ -224,6 +233,7 @@ class _TablebaseMoveRow extends StatelessWidget {
   final TablebaseMove move;
   final Color color;
   final bool? isWinningForWhite;
+  final PieceNotation pieceNotation;
   final void Function(Move)? onMoveSelected;
 
   @override
@@ -301,7 +311,13 @@ class _TablebaseMoveRow extends StatelessWidget {
         child: Row(
           children: [
             Expanded(
-              child: Text(move.san, style: const TextStyle(fontWeight: FontWeight.w500)),
+              child: Text(
+                move.san,
+                style: TextStyle(
+                  fontFamily: pieceNotation == PieceNotation.symbol ? 'ChessFont' : null,
+                  fontWeight: FontWeight.w500,
+                ),
+              ),
             ),
             metricsWidget,
           ],

--- a/test/view/explorer/explorer_view_test.dart
+++ b/test/view/explorer/explorer_view_test.dart
@@ -2,9 +2,11 @@ import 'dart:convert';
 
 import 'package:dartchess/dartchess.dart';
 import 'package:fast_immutable_collections/fast_immutable_collections.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:http/testing.dart';
 import 'package:lichess_mobile/src/constants.dart';
+import 'package:lichess_mobile/src/model/account/account_preferences.dart';
 import 'package:lichess_mobile/src/model/auth/auth_controller.dart';
 import 'package:lichess_mobile/src/model/common/id.dart';
 import 'package:lichess_mobile/src/model/explorer/opening_explorer.dart';
@@ -304,7 +306,68 @@ void main() {
     });
   });
 
+  group('TablebaseView', () {
+    for (final pieceNotation in PieceNotation.values) {
+      testWidgets('uses ${pieceNotation.name} piece notation', (tester) async {
+        final position = Chess.fromSetup(Setup.parseFen('4k3/8/4q3/4PR2/5P2/6NK/8/8 w - - 3 131'));
+
+        final app = await makeTestProviderScopeApp(
+          tester,
+          home: Scaffold(body: TablebaseView(position: position)),
+          authUser: authUser,
+          overrides: {
+            httpClientFactoryProvider: httpClientFactoryProvider.overrideWith((ref) {
+              return FakeHttpClientFactory(() => mockClient);
+            }),
+            pieceNotationProvider: pieceNotationProvider.overrideWithValue(
+              AsyncValue.data(pieceNotation),
+            ),
+          },
+        );
+        await tester.pumpWidget(app);
+        await tester.pump(const Duration(milliseconds: 350));
+
+        final moveText = tester.widget<Text>(find.text('Kh4'));
+        expect(
+          moveText.style?.fontFamily,
+          pieceNotation == PieceNotation.symbol ? 'ChessFont' : isNull,
+        );
+      });
+    }
+  });
+
   group('OpeningExplorerMoveTable', () {
+    for (final pieceNotation in PieceNotation.values) {
+      testWidgets('uses ${pieceNotation.name} piece notation', (tester) async {
+        final app = await makeTestProviderScopeApp(
+          tester,
+          home: Scaffold(
+            body: OpeningExplorerMoveTable(
+              moves: IList(const [
+                OpeningMove(uci: 'g1f3', san: 'Nf3', white: 50, draws: 10, black: 40),
+              ]),
+              whiteWins: 50,
+              draws: 10,
+              blackWins: 40,
+            ),
+          ),
+          overrides: {
+            pieceNotationProvider: pieceNotationProvider.overrideWithValue(
+              AsyncValue.data(pieceNotation),
+            ),
+          },
+        );
+        await tester.pumpWidget(app);
+        await tester.pump();
+
+        final moveText = tester.widget<Text>(find.text('Nf3'));
+        expect(
+          moveText.style?.fontFamily,
+          pieceNotation == PieceNotation.symbol ? 'ChessFont' : isNull,
+        );
+      });
+    }
+
     testWidgets('calls onMoveSelected with a DropMove when tapping a drop move row', (
       tester,
     ) async {


### PR DESCRIPTION
## Summary

- honor the account's piece-notation preference in opening-explorer move labels
- apply the same preference to tablebase move labels
- cover symbol and letter modes for both explorer surfaces with widget tests

Closes #2046.

## Visual verification

I reviewed both notation modes using these captures of the real Flutter widgets rendered from this branch. These are application screenshots, not AI-generated media.

### Opening explorer

| Symbols | Letters |
| --- | --- |
| <img src="https://raw.githubusercontent.com/philyawj/mobile/pr-assets-2046/.github/pr-assets/2046/opening-explorer-symbols.png" width="260" alt="Opening explorer using chess piece symbols"> | <img src="https://raw.githubusercontent.com/philyawj/mobile/pr-assets-2046/.github/pr-assets/2046/opening-explorer-letters.png" width="260" alt="Opening explorer using piece letters"> |

### Tablebase

| Symbols | Letters |
| --- | --- |
| <img src="https://raw.githubusercontent.com/philyawj/mobile/pr-assets-2046/.github/pr-assets/2046/tablebase-symbols.png" width="260" alt="Tablebase using chess piece symbols"> | <img src="https://raw.githubusercontent.com/philyawj/mobile/pr-assets-2046/.github/pr-assets/2046/tablebase-letters.png" width="260" alt="Tablebase using piece letters"> |

## Testing

- `flutter analyze`
- `flutter test test/view/explorer/explorer_view_test.dart` (13 tests)
- `flutter test` (1,482 tests)
- manually reviewed the rendered opening-explorer and tablebase output in symbol and letter modes

## AI assistance

OpenAI Codex was used to inspect the Top First Issues board, select this issue, implement the change, write tests, run validation, render the Flutter UI captures, and draft this pull-request description. I reviewed the code as it was produced, understand the change and how it uses the existing account-preference provider, and reviewed the fork draft before this upstream submission.
