### PR TITLE
Sort and search friends list

### DIFF
--- a/lib/src/model/user/user.dart
+++ b/lib/src/model/user/user.dart
@@ -1,10 +1,12 @@
 import 'package:deep_pick/deep_pick.dart';
 import 'package:fast_immutable_collections/fast_immutable_collections.dart';
 import 'package:freezed_annotation/freezed_annotation.dart';
+import 'package:lichess_mobile/src/constants.dart';
 import 'package:lichess_mobile/src/model/common/id.dart';
 import 'package:lichess_mobile/src/model/common/perf.dart';
 import 'package:lichess_mobile/src/model/user/profile.dart';
 import 'package:lichess_mobile/src/utils/json.dart';
+import 'package:material_ui/material_ui.dart';
 
 part 'user.freezed.dart';
 part 'user.g.dart';
@@ -482,4 +484,31 @@ sealed class Crosstable with _$Crosstable {
       return CrosstableMatchup.fromPick(matchupPick.required());
     }),
   );
+}
+
+extension DisplayRating on IMap<Perf, UserPerf> {
+  Perf? get _displayPerfs {
+    List<Perf> userPerfs = Perf.values
+        .where((element) {
+          final p = this[element];
+          return p != null && p.numberOfGamesOrRuns > 0 && p.ratingDeviation < kClueLessDeviation;
+        })
+        .toList(growable: false);
+
+    if (userPerfs.isEmpty) return null;
+
+    userPerfs.sort(
+      (p1, p2) => this[p1]!.numberOfGamesOrRuns.compareTo(this[p2]!.numberOfGamesOrRuns),
+    );
+    userPerfs = userPerfs.reversed.toList();
+    return userPerfs.first;
+  }
+
+  String? get displayRating {
+    final perf = _displayPerfs;
+    if (perf == null) return null;
+    return this[perf]?.rating.toString() ?? '?';
+  }
+
+  IconData? get displayRatingIcon => _displayPerfs?.icon;
 }

--- a/lib/src/view/relation/friend_screen.dart
+++ b/lib/src/view/relation/friend_screen.dart
@@ -9,6 +9,7 @@ import 'package:lichess_mobile/src/model/user/user.dart';
 import 'package:lichess_mobile/src/styles/styles.dart';
 import 'package:lichess_mobile/src/utils/l10n_context.dart';
 import 'package:lichess_mobile/src/utils/navigation.dart';
+import 'package:lichess_mobile/src/view/user/search_screen.dart';
 import 'package:lichess_mobile/src/view/user/user_context_menu.dart';
 import 'package:lichess_mobile/src/view/user/user_or_profile_screen.dart';
 import 'package:lichess_mobile/src/view/watch/tv_screen.dart';
@@ -79,6 +80,20 @@ class _FriendScreenState extends ConsumerState<FriendScreen> with TickerProvider
     final onlineFriendsCount = ref.watch(onlineFriendsProvider.select((v) => v.value?.length ?? 0));
     final followingCount = ref.watch(followingProvider.select((v) => v.value?.length ?? 0));
 
+    final searchButton = SemanticIconButton(
+      icon: const Icon(Icons.search),
+      onPressed: () {
+        Navigator.of(context).push(
+          SearchScreen.buildRoute(
+            onUserTap: (user) {
+              Navigator.of(context).push(UserOrProfileScreen.buildRoute(user));
+            },
+          ),
+        );
+      },
+      semanticsLabel: context.l10n.searchSearch,
+    );
+
     final sortButton = SemanticIconButton(
       icon: const Icon(Icons.sort),
       // TODO: translate
@@ -119,7 +134,7 @@ class _FriendScreenState extends ConsumerState<FriendScreen> with TickerProvider
     return PlatformScaffold(
       appBar: PlatformAppBar(
         title: Text(context.l10n.friends),
-        actions: [sortButton],
+        actions: [searchButton, sortButton],
         bottom: TabBar(
           controller: _tabController,
           tabs: <Widget>[

--- a/lib/src/view/relation/friend_screen.dart
+++ b/lib/src/view/relation/friend_screen.dart
@@ -2,6 +2,7 @@ import 'package:fast_immutable_collections/fast_immutable_collections.dart';
 import 'package:flutter/gestures.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_slidable/flutter_slidable.dart';
+import 'package:lichess_mobile/l10n/l10n.dart';
 import 'package:lichess_mobile/src/model/relation/online_friends.dart';
 import 'package:lichess_mobile/src/model/relation/relation_repository.dart';
 import 'package:lichess_mobile/src/model/user/user.dart';
@@ -11,13 +12,36 @@ import 'package:lichess_mobile/src/utils/navigation.dart';
 import 'package:lichess_mobile/src/view/user/user_context_menu.dart';
 import 'package:lichess_mobile/src/view/user/user_or_profile_screen.dart';
 import 'package:lichess_mobile/src/view/watch/tv_screen.dart';
+import 'package:lichess_mobile/src/widgets/adaptive_bottom_sheet.dart';
+import 'package:lichess_mobile/src/widgets/buttons.dart';
 import 'package:lichess_mobile/src/widgets/feedback.dart';
+import 'package:lichess_mobile/src/widgets/filter.dart';
 import 'package:lichess_mobile/src/widgets/list.dart';
 import 'package:lichess_mobile/src/widgets/platform.dart';
 import 'package:lichess_mobile/src/widgets/shimmer.dart';
 import 'package:lichess_mobile/src/widgets/user.dart';
 import 'package:lichess_mobile/src/widgets/user_list_tile.dart';
 import 'package:material_ui/material_ui.dart';
+
+enum _FriendSortType {
+  alphabetical,
+  ratingDesc,
+  ratingAsc,
+  lastOnline;
+
+  String l10n(AppLocalizations l10n) {
+    switch (this) {
+      case _FriendSortType.alphabetical:
+        return l10n.studyAlphabetical;
+      case ratingDesc:
+        return 'Rating Descending';
+      case _FriendSortType.ratingAsc:
+        return 'Rating Ascending';
+      case _FriendSortType.lastOnline:
+        return 'Last Seen';
+    }
+  }
+}
 
 final followingProvider = FutureProvider.autoDispose<IList<User>>((ref) {
   return ref.read(relationRepositoryProvider).getAllFollowing();
@@ -36,6 +60,7 @@ class FriendScreen extends ConsumerStatefulWidget {
 
 class _FriendScreenState extends ConsumerState<FriendScreen> with TickerProviderStateMixin {
   late final TabController _tabController;
+  _FriendSortType sortType = _FriendSortType.ratingDesc;
 
   @override
   void initState() {
@@ -54,9 +79,47 @@ class _FriendScreenState extends ConsumerState<FriendScreen> with TickerProvider
     final onlineFriendsCount = ref.watch(onlineFriendsProvider.select((v) => v.value?.length ?? 0));
     final followingCount = ref.watch(followingProvider.select((v) => v.value?.length ?? 0));
 
+    final sortButton = SemanticIconButton(
+      icon: const Icon(Icons.sort),
+      // TODO: translate
+      semanticsLabel: 'Sort friends',
+      onPressed: () => showModalBottomSheet<void>(
+        context: context,
+        isScrollControlled: true,
+        constraints: BoxConstraints(minHeight: MediaQuery.heightOf(context) * 0.4),
+        builder: (_) => StatefulBuilder(
+          builder: (context, setLocalState) {
+            return BottomSheetScrollableContainer(
+              padding: const EdgeInsets.all(16.0),
+              children: [
+                const SizedBox(height: 16.0),
+                Text('Sort by', style: Theme.of(context).textTheme.bodyLarge),
+                const SizedBox(height: 16.0),
+                Filter<_FriendSortType>(
+                  filterType: FilterType.singleChoice,
+                  choices: _FriendSortType.values,
+                  choiceSelected: (choice) => sortType == choice,
+                  choiceLabel: (category) => Text(category.l10n(context.l10n)),
+                  onSelected: (value, selected) {
+                    if (_tabController.index == 0) {
+                      _tabController.animateTo(1, duration: kTabScrollDuration);
+                    }
+                    setLocalState(() => sortType = value);
+                    setState(() => sortType = value);
+                  },
+                ),
+                const SizedBox(height: 16.0),
+              ],
+            );
+          },
+        ),
+      ),
+    );
+
     return PlatformScaffold(
       appBar: PlatformAppBar(
         title: Text(context.l10n.friends),
+        actions: [sortButton],
         bottom: TabBar(
           controller: _tabController,
           tabs: <Widget>[
@@ -65,7 +128,10 @@ class _FriendScreenState extends ConsumerState<FriendScreen> with TickerProvider
           ],
         ),
       ),
-      body: TabBarView(controller: _tabController, children: const [_Online(), _Following()]),
+      body: TabBarView(
+        controller: _tabController,
+        children: [const _Online(), _Following(sortType)],
+      ),
     );
   }
 }
@@ -169,7 +235,8 @@ class _Online extends ConsumerWidget {
 }
 
 class _Following extends ConsumerWidget {
-  const _Following();
+  const _Following(this.sortType);
+  final _FriendSortType sortType;
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
@@ -177,7 +244,28 @@ class _Following extends ConsumerWidget {
 
     switch (following) {
       case AsyncData(:final value):
-        IList<User> following = value;
+        IList<User> following = switch (sortType) {
+          _FriendSortType.alphabetical => value.sort(
+            (a, b) => a.username.toLowerCase().compareTo(b.username.toLowerCase()),
+          ),
+          _FriendSortType.ratingDesc =>
+            value
+                .sort(
+                  (a, b) => (int.tryParse(a.perfs.displayRating ?? '0') ?? 0).compareTo(
+                    int.tryParse(b.perfs.displayRating ?? '0') ?? 0,
+                  ),
+                )
+                .reversed,
+          _FriendSortType.ratingAsc => value.sort(
+            (a, b) => (int.tryParse(a.perfs.displayRating ?? '0') ?? 0).compareTo(
+              int.tryParse(b.perfs.displayRating ?? '0') ?? 0,
+            ),
+          ),
+          _FriendSortType.lastOnline =>
+            value
+                .sort((a, b) => (a.seenAt ?? DateTime(1970)).compareTo(b.seenAt ?? DateTime(1970)))
+                .reversed,
+        };
         return StatefulBuilder(
           builder: (BuildContext context, StateSetter setState) {
             if (following.isEmpty) {

--- a/lib/src/view/user/user_profile.dart
+++ b/lib/src/view/user/user_profile.dart
@@ -160,7 +160,10 @@ class Location extends StatelessWidget {
   Widget build(BuildContext context) {
     return Row(
       children: [
-        if (profile.location != null) ...[Text(profile.location!), const SizedBox(width: 5)],
+        if (profile.location != null) ...[
+          Flexible(flex: 2, child: Text(profile.location!)),
+          const SizedBox(width: 5),
+        ],
         if (profile.country != null) ...[
           HttpNetworkImageWidget(
             lichessFlagSrc(profile.country!),
@@ -168,7 +171,8 @@ class Location extends StatelessWidget {
           ),
           const SizedBox(width: 5),
         ],
-        if (countries[profile.country] != null) Text(countries[profile.country]!),
+        if (countries[profile.country] != null)
+          Expanded(flex: 3, child: Text(countries[profile.country]!)),
       ],
     );
   }

--- a/lib/src/widgets/user_list_tile.dart
+++ b/lib/src/widgets/user_list_tile.dart
@@ -1,5 +1,4 @@
 import 'package:fast_immutable_collections/fast_immutable_collections.dart';
-import 'package:lichess_mobile/src/constants.dart';
 import 'package:lichess_mobile/src/model/common/id.dart';
 import 'package:lichess_mobile/src/model/common/perf.dart';
 import 'package:lichess_mobile/src/model/user/user.dart';
@@ -64,22 +63,9 @@ class _UserRating extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    List<Perf> userPerfs = Perf.values
-        .where((element) {
-          final p = perfs[element];
-          return p != null && p.numberOfGamesOrRuns > 0 && p.ratingDeviation < kClueLessDeviation;
-        })
-        .toList(growable: false);
-
-    if (userPerfs.isEmpty) return const SizedBox.shrink();
-
-    userPerfs.sort(
-      (p1, p2) => perfs[p1]!.numberOfGamesOrRuns.compareTo(perfs[p2]!.numberOfGamesOrRuns),
-    );
-    userPerfs = userPerfs.reversed.toList();
-
-    final rating = perfs[userPerfs.first]?.rating.toString() ?? '?';
-    final icon = userPerfs.first.icon;
+    final rating = perfs.displayRating;
+    if (rating == null) return const SizedBox.shrink();
+    final icon = perfs.displayRatingIcon;
 
     return Row(
       mainAxisSize: MainAxisSize.min,


### PR DESCRIPTION
This pr adds sort and search features to the friends list screen. It also fixes a text overflow in the user profile screen. The broadcast list screen was used as a reference for the sort and search implementation.

Fixes #3586

**Changes made:**
- `model/user/user.dart`: Added an extension to the user perfs map to pick the user's highest rating from his most played game mode

- `widgets/user_list_tile.dart`: This is where the logic mentioned above used to live. By moving it to an extension, it can be reused across the app easily

- `view/relation/friend_screen.dart`: Added sort and search functionality to the friend list. Sort simply rearranges the list items, while search reuses `view/user/search_screen.dart`.

- `view/user/user_profile.dart`: Fixed a text overflow in `UserProfileWidget`. Screenshots below

**Tests performed:**
- flutter test
- flutter analyze
- Manually tested the new features - debug build on an Android device, API level 31

https://github.com/user-attachments/assets/8be54c57-7988-4f3f-a2f0-59b1060821da

https://github.com/user-attachments/assets/2ead354a-e910-4b2b-b896-d678be761bf4

<img width="284" height="507" alt="User Profile - Before" src="https://github.com/user-attachments/assets/118bd634-237d-4a24-b638-8879ef1d6128" />

<img width="284" height="507" alt="User Profile - After" src="https://github.com/user-attachments/assets/ded90b5c-4e02-49e8-8b36-12fa5134a88c" />




