### PR TITLE
Prevent accessing opening explorer in more tab for anon users

### DIFF
--- a/lib/src/view/more/more_tab_screen.dart
+++ b/lib/src/view/more/more_tab_screen.dart
@@ -22,6 +22,7 @@ import 'package:lichess_mobile/src/view/more/import_pgn_screen.dart';
 import 'package:lichess_mobile/src/view/relation/friend_screen.dart';
 import 'package:lichess_mobile/src/view/settings/settings_screen.dart';
 import 'package:lichess_mobile/src/view/user/player_screen.dart';
+import 'package:lichess_mobile/src/widgets/feedback.dart';
 import 'package:lichess_mobile/src/widgets/list.dart';
 import 'package:lichess_mobile/src/widgets/misc.dart';
 import 'package:lichess_mobile/src/widgets/platform.dart';
@@ -105,17 +106,24 @@ class _Body extends ConsumerWidget {
                     : null,
                 title: Text(context.l10n.openingExplorer),
                 enabled: isOnline,
-                onTap: () => Navigator.of(context, rootNavigator: true).push(
-                  OpeningExplorerScreen.buildRoute(
-                    const AnalysisOptions.pgn(
-                      id: StringId('standalone_opening_explorer'),
-                      orientation: Side.white,
-                      pgn: '',
-                      isComputerAnalysisAllowed: false,
-                      variant: Variant.standard,
+                onTap: () {
+                  if (authUser == null) {
+                    showSnackBar(context, context.l10n.youNeedAnAccountToDoThat);
+                    return;
+                  }
+
+                  Navigator.of(context, rootNavigator: true).push(
+                    OpeningExplorerScreen.buildRoute(
+                      const AnalysisOptions.pgn(
+                        id: StringId('standalone_opening_explorer'),
+                        orientation: Side.white,
+                        pgn: '',
+                        isComputerAnalysisAllowed: false,
+                        variant: Variant.standard,
+                      ),
                     ),
-                  ),
-                ),
+                  );
+                },
               ),
               ListTile(
                 leading: const Icon(Icons.edit_outlined),


### PR DESCRIPTION
This is a very simple change to prevent the app from building the **Opening explorer** page when the user is not logged in. When an anon user goes to the **Opening explorer** page their only real option is to back out of the page. Let's just give them a quick snackbar instead. When an anon user clicks **Opening explorer** they get a  snackbar  that uses the current existing message.


<img width="540" height="1137" alt="Screenshot_1" src="https://github.com/user-attachments/assets/052998a3-55f6-43f9-ac6b-a9d1cffc618e" />

No AI used.