### PR TITLE
Stockfish 19

### DIFF
--- a/lib/src/model/engine/engine_failure.dart
+++ b/lib/src/model/engine/engine_failure.dart
@@ -46,7 +46,7 @@ class EngineFailure {
   /// A human-readable description of what went wrong, without the diagnostics.
   final String message;
 
-  /// A short name for the engine that failed: `sf16`, `variant`, `lc0`.
+  /// A short name for the engine that failed: `light`, `variant`, `lc0`.
   final String engine;
 
   /// The chess variant the engine was searching, when the failure was detected somewhere that

--- a/lib/src/model/engine/engine_slot.dart
+++ b/lib/src/model/engine/engine_slot.dart
@@ -5,10 +5,10 @@
 /// that resolve to the same slot are the same spec, so a slot can never be asked for two engines
 /// through the ordinary engine plumbing.
 enum EngineSlot {
-  /// Stockfish 16, with its NNUE network embedded in the binary.
-  sf16,
+  /// Stockfish with its small NNUE network embedded in the binary.
+  sfLight,
 
-  /// The latest Stockfish, whose networks are loaded from disk.
+  /// The latest Stockfish, whose network is loaded from disk.
   sfLatest,
 
   /// Fairy-Stockfish: chess variants, and negative skill levels.

--- a/lib/src/model/engine/engine_spec.dart
+++ b/lib/src/model/engine/engine_spec.dart
@@ -24,15 +24,14 @@ sealed class EngineSpec {
 /// A Stockfish engine, in one of the three flavors the app ships.
 @immutable
 final class StockfishSpec extends EngineSpec {
-  /// Stockfish 16, NNUE embedded in the binary.
-  const StockfishSpec.sf16()
-    : slot = EngineSlot.sf16,
-      flavor = StockfishFlavor.sf16,
-      bigNetPath = null,
-      smallNetPath = null;
+  /// Stockfish with a small NNUE network embedded in the binary.
+  const StockfishSpec.light()
+    : slot = EngineSlot.sfLight,
+      flavor = StockfishFlavor.light,
+      nnuePath = null;
 
-  /// The latest Stockfish, with its nets loaded from disk (see `StockfishNnueService`).
-  const StockfishSpec.latest({required String this.bigNetPath, required String this.smallNetPath})
+  /// The latest Stockfish, with its net loaded from disk (see `StockfishNnueService`).
+  const StockfishSpec.latest({required String this.nnuePath})
     : slot = EngineSlot.sfLatest,
       flavor = StockfishFlavor.latestNoNNUE;
 
@@ -40,8 +39,7 @@ final class StockfishSpec extends EngineSpec {
   const StockfishSpec.fairy()
     : slot = EngineSlot.fairy,
       flavor = StockfishFlavor.variant,
-      bigNetPath = null,
-      smallNetPath = null;
+      nnuePath = null;
 
   @override
   final EngineSlot slot;
@@ -52,22 +50,16 @@ final class StockfishSpec extends EngineSpec {
   @override
   String get label => flavor.name;
 
-  /// The big NNUE network, for [StockfishSpec.latest] only.
-  final String? bigNetPath;
-
-  /// The small NNUE network, for [StockfishSpec.latest] only.
-  final String? smallNetPath;
+  /// The NNUE network, for [StockfishSpec.latest] only.
+  final String? nnuePath;
 
   @override
   bool operator ==(Object other) =>
       identical(this, other) ||
-      other is StockfishSpec &&
-          other.slot == slot &&
-          other.bigNetPath == bigNetPath &&
-          other.smallNetPath == smallNetPath;
+      other is StockfishSpec && other.slot == slot && other.nnuePath == nnuePath;
 
   @override
-  int get hashCode => Object.hash(slot, bigNetPath, smallNetPath);
+  int get hashCode => Object.hash(slot, nnuePath);
 
   @override
   String toString() => 'StockfishSpec(${flavor.name})';

--- a/lib/src/model/engine/engine_transport.dart
+++ b/lib/src/model/engine/engine_transport.dart
@@ -75,8 +75,7 @@ class StockfishTransport implements EngineTransport {
 
     final stockfish = await Stockfish.create(
       flavor: spec.flavor,
-      bigNetPath: spec.bigNetPath,
-      smallNetPath: spec.smallNetPath,
+      nnuePath: spec.nnuePath,
       onStdout: (line) => transport == null ? buffered.add(line) : transport._receive(line),
     );
 

--- a/lib/src/model/engine/engine_utils.dart
+++ b/lib/src/model/engine/engine_utils.dart
@@ -134,6 +134,25 @@ Position threatModePosition(Position position) => position.copyWith(
 /// Variants supported by the official Stockfish engine. Every other variant needs Fairy-Stockfish.
 const officialStockfishVariants = {Variant.standard, Variant.chess960, Variant.fromPosition};
 
+/// Whether [position] holds material the official Stockfish will not accept.
+bool hasNonStandardMaterial(Position position) =>
+    !_isStandardMaterialSide(position.board, Side.white) ||
+    !_isStandardMaterialSide(position.board, Side.black);
+
+bool _isStandardMaterialSide(Board board, Side side) {
+  int count(Role role) => board.piecesOf(side, role).size;
+  final bishops = board.piecesOf(side, Role.bishop);
+  // Every piece beyond the ones a side starts with had to be promoted, and every promotion costs a
+  // pawn — so pawns and promotions together cannot exceed the eight pawns a side starts with.
+  final promoted =
+      max(count(Role.queen) - 1, 0) +
+      max(count(Role.rook) - 2, 0) +
+      max(count(Role.knight) - 2, 0) +
+      max(bishops.intersect(SquareSet.lightSquares).size - 1, 0) +
+      max(bishops.intersect(SquareSet.darkSquares).size - 1, 0);
+  return count(Role.pawn) + promoted <= 8;
+}
+
 extension FairyVariantExtension on Variant {
   /// The Fairy-Stockfish variant name, for the `UCI_Variant` option.
   String get fairy => switch (this) {

--- a/lib/src/model/engine/engine_utils.dart
+++ b/lib/src/model/engine/engine_utils.dart
@@ -5,6 +5,7 @@ import 'package:dartchess/dartchess.dart';
 import 'package:lichess_mobile/src/constants.dart';
 import 'package:lichess_mobile/src/model/common/chess.dart';
 import 'package:lichess_mobile/src/model/common/eval.dart';
+import 'package:lichess_mobile/src/model/engine/engine_spec.dart';
 import 'package:multistockfish/multistockfish.dart';
 
 /// Maximum number of CPU cores available for engine use.
@@ -15,30 +16,30 @@ int engineMaxMemoryFor(int physicalMemoryInMb) => (physicalMemoryInMb / 16).ceil
 
 const _nnueDownloadUrl = '$kLichessCDNHost/assets/lifat/nnue/';
 
-/// URL to download the latest big NNUE network.
-final bigNetUrl = Uri.parse('$_nnueDownloadUrl${Stockfish.latestBigNNUE}');
+/// URL to download the latest NNUE network.
+final nnueUrl = Uri.parse('$_nnueDownloadUrl${Stockfish.latestNNUE}');
 
-/// SHA256 hash (first 12 digits) of the latest big NNUE network.
-final bigNetHash = Stockfish.latestBigNNUE.substring(3, 15);
+/// SHA256 hash (first 12 digits) of the latest NNUE network.
+final nnueHash = Stockfish.latestNNUE.substring(3, 15);
 
-/// URL to download the latest small NNUE network.
-final smallNetUrl = Uri.parse('$_nnueDownloadUrl${Stockfish.latestSmallNNUE}');
-
-/// SHA256 hash (first 12 digits) of the latest small NNUE network.
-final smallNetHash = Stockfish.latestSmallNNUE.substring(3, 15);
-
-/// Approximate size in bytes of the big NNUE file (~109MB).
+/// Size in bytes of the NNUE file as it is served.
 ///
 /// Used as fallback for progress reporting when the server omits Content-Length.
-const bigNetExpectedSize = 109 * 1024 * 1024;
+const nnueExpectedSize = 73087040;
 
-/// Approximate size in bytes of the small NNUE file (~3.5MB).
+/// What the NNUE download costs, formatted as a human-readable string.
+const nnueDownloadSizeMB = '${nnueExpectedSize ~/ (1024 * 1024)}MB';
+
+/// The size of the net the latest Stockfish evaluates with, uncompressed.
 ///
-/// Used as fallback for progress reporting when the server omits Content-Length.
-const smallNetExpectedSize = 7 * 512 * 1024;
+/// Both Stockfish flavors the app ships are version 19 and report the same `id name`; the net they
+/// evaluate with is the whole of the difference, so its size is what names them apart to the user.
+/// Uncompressed on both sides, so that the two are compared like with like — the file this one is
+/// read from is smaller on disk, which is what [nnueDownloadSizeMB] says.
+const latestNetSizeMB = '94MB';
 
-/// Total expected NNUE download size formatted as a human-readable string (e.g. "113MB").
-const nnueTotalSizeMB = '${(bigNetExpectedSize + smallNetExpectedSize) ~/ (1024 * 1024)}MB';
+/// The size of the net built into the light Stockfish, uncompressed. See [latestNetSizeMB].
+const lightNetSizeMB = '1MB';
 
 /// Where the Maia networks that do not ship with the app are downloaded from.
 const _maiaDownloadUrl = '$kLichessCDNHost/assets/lifat/maia/';
@@ -94,18 +95,34 @@ ClientEval? pickBestClientEval({
   return eval;
 }
 
-/// Extracts a short label like "SF 16" from a UCI engine name like "Stockfish 16.1".
+/// Extracts a short label like "SF 19" from a UCI engine name like "Stockfish 19.1".
+///
+/// Pass the [spec] the name came from to have the light Stockfish labelled by its net, which is
+/// all that tells it apart from the full-net engine of the same version.
 ///
 /// Returns null if the engine name is null or doesn't match the expected pattern.
-String? engineShortLabel(String? engineName) {
+String? engineShortLabel(String? engineName, {EngineSpec? spec}) {
   if (engineName == null) return null;
   if (engineName.startsWith('Fairy-Stockfish')) {
     return 'Fairy SF';
   }
   final match = _sfVersionPattern.firstMatch(engineName);
   if (match == null) return null;
-  return 'SF ${match.group(1)}';
+  final label = 'SF ${match.group(1)}';
+  return isLightStockfish(spec) ? '$label $lightNetSizeMB' : label;
 }
+
+/// The engine name to show the user, which says which net a light Stockfish runs.
+String engineDisplayName(String? engineName, {EngineSpec? spec}) {
+  final name = engineName ?? 'Stockfish';
+  // The Fairy-Stockfish version is not the app's to advertise.
+  if (name.startsWith('Fairy-Stockfish')) return 'Fairy-Stockfish';
+  return isLightStockfish(spec) ? '$name ($lightNetSizeMB)' : name;
+}
+
+/// Whether [spec] is the Stockfish with the small net built in.
+bool isLightStockfish(EngineSpec? spec) =>
+    spec is StockfishSpec && spec.flavor == StockfishFlavor.light;
 
 /// The (fake) position to use in threat mode searches.
 Position threatModePosition(Position position) => position.copyWith(

--- a/lib/src/model/engine/evaluation_preferences.dart
+++ b/lib/src/model/engine/evaluation_preferences.dart
@@ -62,26 +62,24 @@ class EngineEvaluationPreferences extends Notifier<EngineEvaluationPrefState>
 }
 
 enum ChessEnginePref {
-  sf16,
+  /// Stockfish 19 with the small net embedded in the app, ready to evaluate right away.
+  sfLight,
+
+  /// Stockfish 19 with the full net, which has to be downloaded first.
   sfLatest;
 
   String get label => switch (this) {
-    ChessEnginePref.sf16 => 'Stockfish 16',
-    ChessEnginePref.sfLatest => 'Stockfish 18 ($nnueTotalSizeMB)',
+    ChessEnginePref.sfLight => 'Stockfish 19 ($lightNetSizeMB)',
+    ChessEnginePref.sfLatest => 'Stockfish 19 ($latestNetSizeMB)',
   };
 
   String get shortLabel => switch (this) {
-    ChessEnginePref.sf16 => 'SF 16',
-    ChessEnginePref.sfLatest => 'SF 18',
-  };
-
-  String get version => switch (this) {
-    ChessEnginePref.sf16 => '16',
-    ChessEnginePref.sfLatest => '18',
+    ChessEnginePref.sfLight => 'SF 19 $lightNetSizeMB',
+    ChessEnginePref.sfLatest => 'SF 19',
   };
 
   StockfishFlavor get flavor => switch (this) {
-    ChessEnginePref.sf16 => StockfishFlavor.sf16,
+    ChessEnginePref.sfLight => StockfishFlavor.light,
     ChessEnginePref.sfLatest => StockfishFlavor.latestNoNNUE,
   };
 }
@@ -101,7 +99,7 @@ sealed class EngineEvaluationPrefState with _$EngineEvaluationPrefState implemen
       toJson: _searchTimeToJson,
     )
     required Duration engineSearchTime,
-    @JsonKey(defaultValue: ChessEnginePref.sf16, unknownEnumValue: ChessEnginePref.sf16)
+    @JsonKey(defaultValue: ChessEnginePref.sfLight, unknownEnumValue: ChessEnginePref.sfLight)
     required ChessEnginePref enginePref,
   }) = _EngineEvaluationPrefState;
 
@@ -110,7 +108,7 @@ sealed class EngineEvaluationPrefState with _$EngineEvaluationPrefState implemen
     numEvalLines: 2,
     numEngineCores: 1,
     engineSearchTime: Duration(seconds: 4),
-    enginePref: ChessEnginePref.sf16,
+    enginePref: ChessEnginePref.sfLight,
   );
 
   factory EngineEvaluationPrefState.fromJson(Map<String, dynamic> json) {

--- a/lib/src/model/engine/position_evaluator.dart
+++ b/lib/src/model/engine/position_evaluator.dart
@@ -52,25 +52,26 @@ final positionEvaluatorProvider = NotifierProvider.autoDispose
       name: 'PositionEvaluatorProvider',
     );
 
-/// The flavor the evaluator will use for [variant].
+/// The flavor the evaluator will use for [variant], played from [position].
 ///
-/// The user's preference, except for the variants Stockfish does not know how to play, which only
-/// Fairy-Stockfish can evaluate. Read when the work starts rather than carried on it, so that
+/// The user's preference, except where only Fairy-Stockfish will do: the variants Stockfish does
+/// not know how to play, and the positions it refuses to accept the material of (see
+/// [hasNonStandardMaterial]). Read when the work starts rather than carried on it, so that
 /// changing the preference is picked up by the next evaluation wherever it comes from.
-StockfishFlavor evaluatorFlavorFor(Ref ref, Variant variant) =>
-    officialStockfishVariants.contains(variant)
+StockfishFlavor evaluatorFlavorFor(Ref ref, Variant variant, Position position) =>
+    officialStockfishVariants.contains(variant) && !hasNonStandardMaterial(position)
     ? ref.read(engineEvaluationPreferencesProvider).enginePref.flavor
     : StockfishFlavor.variant;
 
-/// The engine the evaluator will run [variant] on.
+/// The engine the evaluator will run [variant] on, played from [position].
 ///
 /// The slot rather than the [EngineSpec] because resolving a spec is asynchronous — it depends on
 /// whether the NNUE file is on disk — while the caller needs the answer now, in order to build a
 /// search request. What it is asked is whether some other role shares the evaluator's engine, and
 /// the slot settles that: the `latestNoNNUE` → `light` fallback can make this name the wrong
-/// Stockfish, but only a variant ever resolves to Fairy.
-EngineSlot evaluatorEngineSlotFor(Ref ref, Variant variant) =>
-    switch (evaluatorFlavorFor(ref, variant)) {
+/// Stockfish, but only a variant or an unplayable material ever resolves to Fairy.
+EngineSlot evaluatorEngineSlotFor(Ref ref, Variant variant, Position position) =>
+    switch (evaluatorFlavorFor(ref, variant, position)) {
       StockfishFlavor.variant => EngineSlot.fairy,
       StockfishFlavor.light => EngineSlot.sfLight,
       StockfishFlavor.latestNoNNUE => EngineSlot.sfLatest,
@@ -287,7 +288,7 @@ class PositionEvaluator extends Notifier<EngineEvaluationState> {
 
     _setEvalWork(work);
 
-    final flavor = _flavorFor(work.variant);
+    final flavor = _flavorFor(work);
 
     if (_engineFlavor == flavor) {
       // Already asking for the right engine. It may not be ready yet, in which case the work runs
@@ -433,8 +434,12 @@ class PositionEvaluator extends Notifier<EngineEvaluationState> {
     }
   }
 
-  /// The flavor to evaluate [variant] with.
-  StockfishFlavor _flavorFor(Variant variant) => evaluatorFlavorFor(ref, variant);
+  /// The flavor to evaluate [work] with.
+  ///
+  /// The material is read from the root of the tree rather than from the position being evaluated,
+  /// so that the engine cannot change under the user as pieces come off the board.
+  StockfishFlavor _flavorFor(EvalWork work) =>
+      evaluatorFlavorFor(ref, work.variant, work.initialPosition);
 
   /// Runs whatever work is current on the engine that has just become available.
   void _computeCurrentWork() {

--- a/lib/src/model/engine/position_evaluator.dart
+++ b/lib/src/model/engine/position_evaluator.dart
@@ -65,14 +65,14 @@ StockfishFlavor evaluatorFlavorFor(Ref ref, Variant variant) =>
 /// The engine the evaluator will run [variant] on.
 ///
 /// The slot rather than the [EngineSpec] because resolving a spec is asynchronous — it depends on
-/// whether the NNUE files are on disk — while the caller needs the answer now, in order to build a
+/// whether the NNUE file is on disk — while the caller needs the answer now, in order to build a
 /// search request. What it is asked is whether some other role shares the evaluator's engine, and
-/// the slot settles that: the `latestNoNNUE` → `sf16` fallback can make this name the wrong
+/// the slot settles that: the `latestNoNNUE` → `light` fallback can make this name the wrong
 /// Stockfish, but only a variant ever resolves to Fairy.
 EngineSlot evaluatorEngineSlotFor(Ref ref, Variant variant) =>
     switch (evaluatorFlavorFor(ref, variant)) {
       StockfishFlavor.variant => EngineSlot.fairy,
-      StockfishFlavor.sf16 => EngineSlot.sf16,
+      StockfishFlavor.light => EngineSlot.sfLight,
       StockfishFlavor.latestNoNNUE => EngineSlot.sfLatest,
     };
 
@@ -90,7 +90,13 @@ class PositionEvaluator extends Notifier<EngineEvaluationState> {
   final EvaluationContext context;
 
   /// What the UI sees before anything has been asked of the engine.
-  static const defaultState = (engine: null, eval: null, isComputing: false, currentWork: null);
+  static const defaultState = (
+    engine: null,
+    engineSpec: null,
+    eval: null,
+    isComputing: false,
+    currentWork: null,
+  );
 
   @override
   EngineEvaluationState build() {
@@ -115,13 +121,13 @@ class PositionEvaluator extends Notifier<EngineEvaluationState> {
 
   /// The flavor [_spec] was resolved from.
   ///
-  /// The *requested* flavor, not the effective one, so that a latestNoNNUE→sf16 fallback does not
+  /// The *requested* flavor, not the effective one, so that a latestNoNNUE→light fallback does not
   /// make every later latestNoNNUE request look like a change of engine. The variant is not part
   /// of this: it is a per-search option now, so two variants share one Fairy-Stockfish engine.
   StockfishFlavor? _engineFlavor;
 
   /// Set while the spec for a flavor is being resolved, which is async because it depends on
-  /// whether the NNUE files are on disk.
+  /// whether the NNUE file is on disk.
   bool _resolvingSpec = false;
 
   /// Whether the user has turned the engine off with [release].
@@ -411,23 +417,19 @@ class PositionEvaluator extends Notifier<EngineEvaluationState> {
     ),
   }.withContext(maxMemoryInMb: budget.maxMemoryInMb);
 
-  /// The spec for [flavor], falling back to SF 16 when the NNUE files are not on disk.
+  /// The spec for [flavor], falling back to the light engine when the NNUE file is not on disk.
   Future<EngineSpec> _resolveSpec(StockfishFlavor flavor) async {
     switch (flavor) {
       case StockfishFlavor.variant:
         return const StockfishSpec.fairy();
-      case StockfishFlavor.sf16:
-        return const StockfishSpec.sf16();
+      case StockfishFlavor.light:
+        return const StockfishSpec.light();
       case StockfishFlavor.latestNoNNUE:
-        if (await _nnueService.checkNNUEFiles()) {
-          final files = _nnueService.nnueFiles;
-          return StockfishSpec.latest(
-            bigNetPath: files.bigNet.path,
-            smallNetPath: files.smallNet.path,
-          );
+        if (await _nnueService.checkNNUEFile()) {
+          return StockfishSpec.latest(nnuePath: _nnueService.nnueFile.path);
         }
-        _logger.warning('NNUE files not found or corrupted. Falling back to SF16.');
-        return const StockfishSpec.sf16();
+        _logger.warning('NNUE file not found or corrupted. Falling back to the light engine.');
+        return const StockfishSpec.light();
     }
   }
 
@@ -661,6 +663,7 @@ class PositionEvaluator extends Notifier<EngineEvaluationState> {
     final current = state;
     final newState = (
       engine: engineFn != null ? engineFn() : current.engine,
+      engineSpec: _spec,
       eval: evalFn != null ? evalFn() : current.eval,
       isComputing: _engine?.isSearching.value ?? false,
       currentWork: workFn != null ? workFn() : current.currentWork,
@@ -692,6 +695,12 @@ typedef EngineEvaluationState = ({
   /// it is ready, and [AsyncError] when it could not start or has died. This is the whole of the
   /// engine's lifecycle as the UI sees it — there is no separate state machine to keep in step.
   AsyncValue<String?>? engine,
+
+  /// The engine the name came from, or null while there is none.
+  ///
+  /// What the name alone does not say: the two Stockfish flavors are the same version and report
+  /// the same `id name`, so only the spec tells the light one from the full-net one.
+  EngineSpec? engineSpec,
   LocalEval? eval,
 
   /// Whether the engine is searching right now.

--- a/lib/src/model/engine/weights_service.dart
+++ b/lib/src/model/engine/weights_service.dart
@@ -20,16 +20,14 @@ import 'package:multistockfish/multistockfish.dart';
 
 final _logger = Logger('EngineWeightsService');
 
-typedef NNUEFiles = ({File bigNet, File smallNet});
-
 /// A provider for [StockfishNnueService].
 final stockfishNnueServiceProvider = Provider<StockfishNnueService>((Ref ref) {
   return StockfishNnueService(ref);
 }, name: 'StockfishNnueServiceProvider');
 
-/// A service to manage NNUE files for the Stockfish engine.
+/// A service to manage the NNUE file for the Stockfish engine.
 ///
-/// This service handles downloading, checking, and deleting NNUE files.
+/// This service handles downloading, checking, and deleting the NNUE file.
 /// It can be overridden in tests to avoid file system access.
 class StockfishNnueService {
   StockfishNnueService(this._ref);
@@ -44,26 +42,23 @@ class StockfishNnueService {
 
   ValueListenable<double> get nnueDownloadProgress => _nnueDownloadProgress;
 
-  bool get isDownloadingNNUEFiles =>
+  bool get isDownloadingNNUEFile =>
       nnueDownloadProgress.value > 0.0 && nnueDownloadProgress.value < 1.0;
 
-  /// Get the NNUE files paths.
+  /// Get the NNUE file path.
   ///
   /// Throws an exception if the app support directory is not available.
-  NNUEFiles get nnueFiles {
+  File get nnueFile {
     final appSupportDirectory = _ref.read(preloadedDataProvider).requireValue.appSupportDirectory;
     if (appSupportDirectory == null) {
       throw Exception('App support directory is null.');
     }
 
-    final bigNetFile = File('${appSupportDirectory.path}/${Stockfish.latestBigNNUE}');
-    final smallNetFile = File('${appSupportDirectory.path}/${Stockfish.latestSmallNNUE}');
-
-    return (bigNet: bigNetFile, smallNet: smallNetFile);
+    return File('${appSupportDirectory.path}/${Stockfish.latestNNUE}');
   }
 
   Future<bool> hasOutdatedNNUEFiles() async {
-    if (await checkNNUEFiles()) {
+    if (await checkNNUEFile()) {
       return false;
     }
 
@@ -72,13 +67,10 @@ class StockfishNnueService {
       return false;
     }
 
-    final NNUEFiles files = nnueFiles;
+    final File file = nnueFile;
 
     await for (final entity in appSupportDirectory.list(followLinks: false)) {
-      if (entity is File &&
-          entity.path.endsWith('.nnue') &&
-          entity.path != files.bigNet.path &&
-          entity.path != files.smallNet.path) {
+      if (entity is File && entity.path.endsWith('.nnue') && entity.path != file.path) {
         return true;
       }
     }
@@ -87,8 +79,8 @@ class StockfishNnueService {
 
   /// Whether there is any NNUE file on disk, current or not, intact or not.
   ///
-  /// Useful to offer to reclaim the space taken by files the engine cannot use: the networks of a
-  /// previous Stockfish version, or a pair that did not survive its download.
+  /// Useful to offer to reclaim the space taken by files the engine cannot use: the network of a
+  /// previous Stockfish version, or one that did not survive its download.
   Future<bool> hasNNUEFilesOnDisk() async {
     final appSupportDirectory = _ref.read(preloadedDataProvider).requireValue.appSupportDirectory;
     if (appSupportDirectory == null) {
@@ -105,45 +97,40 @@ class StockfishNnueService {
     return false;
   }
 
-  /// Check the presence and integrity of the NNUE files.
+  /// Check the presence and integrity of the NNUE file.
   ///
-  /// Files that fail the checksum are deleted: they are useless to the engine, they take up more
-  /// than 100MB, and leaving them on disk makes the next download look like it has nothing to do.
-  Future<bool> checkNNUEFiles() async {
-    final NNUEFiles files;
+  /// A file that fails the checksum is deleted: it is useless to the engine, it takes up more
+  /// than 60MB, and leaving it on disk makes the next download look like it has nothing to do.
+  Future<bool> checkNNUEFile() async {
+    final File file;
     try {
-      files = nnueFiles;
+      file = nnueFile;
     } catch (e, st) {
-      _logger.warning('Error getting NNUE files:', e, st);
+      _logger.warning('Error getting the NNUE file:', e, st);
       return false;
     }
 
-    final (:bigNet, :smallNet) = files;
-
     try {
-      final found = await bigNet.exists() && await smallNet.exists();
-      if (found) {
-        _nnueSumCheckResult ??= await Isolate.run(() {
-          return _checksumMatches(bigNet.path, bigNetHash) &&
-              _checksumMatches(smallNet.path, smallNetHash);
-        });
+      if (await file.exists()) {
+        final path = file.path;
+        _nnueSumCheckResult ??= await Isolate.run(() => _checksumMatches(path, nnueHash));
 
         if (_nnueSumCheckResult == true) {
           return true;
         } else {
-          _logger.warning('NNUE files are corrupted, deleting them.');
+          _logger.warning('The NNUE file is corrupted, deleting it.');
           await deleteNNUEFiles();
         }
       }
 
       return false;
     } catch (e, st) {
-      _logger.warning('Error checking NNUE files:', e, st);
+      _logger.warning('Error checking the NNUE file:', e, st);
       return false;
     }
   }
 
-  Future<bool> downloadNNUEFiles({bool inBackground = true}) async {
+  Future<bool> downloadNNUEFile({bool inBackground = true}) async {
     if (_nnueOperationInProgress) {
       _logger.warning('NNUE download already in progress, ignoring request');
       return false;
@@ -152,29 +139,27 @@ class StockfishNnueService {
     _nnueOperationInProgress = true;
 
     try {
-      final NNUEFiles files;
+      final File file;
       try {
-        files = nnueFiles;
+        file = nnueFile;
       } catch (e, st) {
-        _logger.warning('Error getting NNUE files:', e, st);
+        _logger.warning('Error getting the NNUE file:', e, st);
         return false;
       }
-
-      final (:bigNet, :smallNet) = files;
 
       // delete any existing nnue files before downloading
       await deleteNNUEFiles();
 
       // The download only counts as a success if what landed on disk is what the engine needs:
       // a file that arrives truncated or garbled is deleted rather than kept and reported as
-      // downloaded, which would leave the engine falling back to SF16 with no way out.
+      // downloaded, which would leave the engine falling back to the light one with no way out.
       Future<bool> doDownload() async {
         final client = _ref.read(defaultClientProvider);
-        final downloaded = await downloadFiles(
+        final downloaded = await downloadFile(
           client,
-          [bigNetUrl, smallNetUrl],
-          [bigNet, smallNet],
-          expectedLengths: [bigNetExpectedSize, smallNetExpectedSize],
+          nnueUrl,
+          file,
+          expectedLength: nnueExpectedSize,
           onProgress: (received, length) {
             _nnueDownloadProgress.value = received / length;
           },
@@ -183,8 +168,8 @@ class StockfishNnueService {
           await deleteNNUEFiles();
           return false;
         }
-        // Deletes the files itself if they do not check out.
-        return await checkNNUEFiles();
+        // Deletes the file itself if it does not check out.
+        return await checkNNUEFile();
       }
 
       final connectivityResult = await _ref.read(connectivityPluginProvider).checkConnectivity();
@@ -201,7 +186,7 @@ class StockfishNnueService {
             builder: (context) {
               return AlertDialog.adaptive(
                 content: const Text(
-                  'Are you sure you want to download the NNUE files ($nnueTotalSizeMB)?',
+                  'Are you sure you want to download the NNUE file ($nnueDownloadSizeMB)?',
                 ),
                 actions: [
                   PlatformDialogAction(

--- a/lib/src/model/offline_computer/offline_computer_game_controller.dart
+++ b/lib/src/model/offline_computer/offline_computer_game_controller.dart
@@ -121,7 +121,8 @@ class OfflineComputerGameController extends Notifier<OfflineComputerGameState> {
   bool get _sharesOneEngine {
     if (!state.game.casual && !state.game.practiceMode) return false;
     final variant = state.game.meta.variant;
-    return state.game.opponentSpec.engineSpec.slot == evaluatorEngineSlotFor(ref, variant);
+    return state.game.opponentSpec.engineSpec.slot ==
+        evaluatorEngineSlotFor(ref, variant, state.game.initialPosition);
   }
 
   /// The cores the evaluator asks for. The table it gets is the engine's own, settled when the

--- a/lib/src/view/engine/engine_button.dart
+++ b/lib/src/view/engine/engine_button.dart
@@ -33,7 +33,7 @@ class _EngineButtonState extends ConsumerState<EngineButton> {
   @override
   Widget build(BuildContext context) {
     final prefs = ref.watch(engineEvaluationPreferencesProvider);
-    final (:engine, eval: localEval, :isComputing, currentWork: _) = ref.watch(
+    final (:engine, :engineSpec, eval: localEval, :isComputing, currentWork: _) = ref.watch(
       engineEvaluationProvider(widget.filters),
     );
     final eval = pickBestClientEval(localEval: localEval, savedEval: widget.savedEval);
@@ -136,7 +136,7 @@ class _EngineButtonState extends ConsumerState<EngineButton> {
         Positioned(
           bottom: -6,
           child: Text(
-            engineShortLabel(engine?.value) ?? prefs.enginePref.shortLabel,
+            engineShortLabel(engine?.value, spec: engineSpec) ?? prefs.enginePref.shortLabel,
             style: TextStyle(
               fontSize: 10,
               fontWeight: FontWeight.w700,
@@ -282,7 +282,7 @@ class _EnginePopup extends ConsumerWidget {
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
-    final (:engine, currentWork: work, eval: evalStateEval, :isComputing) = ref.watch(
+    final (:engine, :engineSpec, currentWork: work, eval: evalStateEval, :isComputing) = ref.watch(
       engineEvaluationProvider(filters),
     );
     final bool canGoDeeper =
@@ -307,16 +307,12 @@ class _EnginePopup extends ConsumerWidget {
 
     final knps = isComputing ? ', ${evalStateEval?.knps.round()}kn/s' : '';
 
-    // remove Fairy-Stockfish version from engine name
-    final engineName = engine?.value;
-    final fixedEngineName = engineName != null && engineName.startsWith('Fairy-Stockfish')
-        ? 'Fairy-Stockfish'
-        : engineName ?? 'Stockfish';
+    final displayName = engineDisplayName(engine?.value, spec: engineSpec);
 
     return ListTile(
       contentPadding: const EdgeInsets.only(left: 16.0),
       leading: Image.asset('assets/images/stockfish/icon.webp', width: 44, height: 44),
-      title: Text(fixedEngineName),
+      title: Text(displayName),
       subtitle: currentEval != null ? Text(context.l10n.depthX('${currentEval.depth}$knps')) : null,
       trailing: canGoDeeper
           ? IconButton(

--- a/lib/src/view/home/home_tab_screen.dart
+++ b/lib/src/view/home/home_tab_screen.dart
@@ -1092,7 +1092,7 @@ class _NNUEFilesOutdatedTipState extends ConsumerState<_NNUEFilesOutdatedTip> {
     }
 
     final nnueService = ref.watch(stockfishNnueServiceProvider);
-    if (nnueService.isDownloadingNNUEFiles) {
+    if (nnueService.isDownloadingNNUEFile) {
       return const SizedBox.shrink();
     }
 
@@ -1122,7 +1122,7 @@ class _NNUEFilesOutdatedTipState extends ConsumerState<_NNUEFilesOutdatedTip> {
                 const Flexible(
                   child: Text(
                     // TODO l10n
-                    'New Stockfish version available! Go to the settings to download the updated NNUE files.',
+                    'New Stockfish version available! Go to the settings to download the updated NNUE file.',
                   ),
                 ),
               ],

--- a/lib/src/view/settings/engine_settings_screen.dart
+++ b/lib/src/view/settings/engine_settings_screen.dart
@@ -28,14 +28,14 @@ class EngineSettingsScreen extends ConsumerStatefulWidget {
 }
 
 class _EngineSettingsScreenState extends ConsumerState<EngineSettingsScreen> {
-  /// null = loading, true = has files with checked integrity, false = doesn't have files
-  bool? _hasVerifiedNNUEFiles;
+  /// null = loading, true = has the file with checked integrity, false = doesn't have it
+  bool? _hasVerifiedNNUEFile;
 
-  /// Whether there are NNUE files on disk the engine cannot use: the networks of a previous
-  /// Stockfish version, or a pair that did not survive its download.
+  /// Whether there are NNUE files on disk the engine cannot use: the network of a previous
+  /// Stockfish version, or one that did not survive its download.
   bool _hasUnusableNNUEFiles = false;
 
-  Future<bool>? _downloadNNUEFilesFuture;
+  Future<bool>? _downloadNNUEFileFuture;
 
   late final ValueListenable<double> _downloadProgress;
 
@@ -50,29 +50,29 @@ class _EngineSettingsScreenState extends ConsumerState<EngineSettingsScreen> {
 
   Future<void> _checkFiles() async {
     final nnueService = ref.read(stockfishNnueServiceProvider);
-    // Deletes the files itself if they are corrupted, so whatever is left over afterwards is
+    // Deletes the file itself if it is corrupted, so whatever is left over afterwards is
     // either usable or from another Stockfish version.
-    final good = await nnueService.checkNNUEFiles();
+    final good = await nnueService.checkNNUEFile();
     final leftOver = !good && await nnueService.hasNNUEFilesOnDisk();
     if (!mounted) return;
     setState(() {
-      _hasVerifiedNNUEFiles = good;
+      _hasVerifiedNNUEFile = good;
       _hasUnusableNNUEFiles = leftOver;
     });
   }
 
   void _startDownload() {
-    final future = ref.read(stockfishNnueServiceProvider).downloadNNUEFiles(inBackground: false);
+    final future = ref.read(stockfishNnueServiceProvider).downloadNNUEFile(inBackground: false);
     future.then((downloaded) {
       if (mounted && downloaded) {
         setState(() {
-          _hasVerifiedNNUEFiles = true;
+          _hasVerifiedNNUEFile = true;
           _hasUnusableNNUEFiles = false;
         });
       }
     });
     setState(() {
-      _downloadNNUEFilesFuture = future;
+      _downloadNNUEFileFuture = future;
     });
   }
 
@@ -84,7 +84,7 @@ class _EngineSettingsScreenState extends ConsumerState<EngineSettingsScreen> {
       appBar: PlatformAppBar(title: const Text('Chess engine')),
       body: ListView(
         children: [
-          if (_hasVerifiedNNUEFiles == null)
+          if (_hasVerifiedNNUEFile == null)
             Shimmer(
               child: ShimmerLoading(isLoading: true, child: ListSection.loading(itemsNumber: 2)),
             )
@@ -103,20 +103,20 @@ class _EngineSettingsScreenState extends ConsumerState<EngineSettingsScreen> {
                       onSelectedItemChanged: (ChessEnginePref? value) {
                         ref
                             .read(engineEvaluationPreferencesProvider.notifier)
-                            .setEvaluationFunction(value ?? ChessEnginePref.sf16);
-                        if (value == ChessEnginePref.sfLatest && _hasVerifiedNNUEFiles == false) {
+                            .setEvaluationFunction(value ?? ChessEnginePref.sfLight);
+                        if (value == ChessEnginePref.sfLatest && _hasVerifiedNNUEFile == false) {
                           _startDownload();
                         }
                       },
                     );
                   },
                 ),
-                if (prefs.enginePref == ChessEnginePref.sfLatest && _hasVerifiedNNUEFiles == false)
+                if (prefs.enginePref == ChessEnginePref.sfLatest && _hasVerifiedNNUEFile == false)
                   LoadingButtonBuilder(
-                    initialFuture: _downloadNNUEFilesFuture,
+                    initialFuture: _downloadNNUEFileFuture,
                     fetchData: () => ref
                         .read(stockfishNnueServiceProvider)
-                        .downloadNNUEFiles(inBackground: false),
+                        .downloadNNUEFile(inBackground: false),
                     builder: (context, isLoading, fetchData) {
                       return ListTile(
                         trailing: isLoading
@@ -130,14 +130,14 @@ class _EngineSettingsScreenState extends ConsumerState<EngineSettingsScreen> {
                                 },
                               )
                             : const Icon(Icons.download),
-                        title: Text(isLoading ? 'Downloading NNUE files' : 'Download NNUE files'),
-                        subtitle: const Text(nnueTotalSizeMB),
+                        title: Text(isLoading ? 'Downloading NNUE file' : 'Download NNUE file'),
+                        subtitle: const Text(nnueDownloadSizeMB),
                         enabled: !isLoading,
                         onTap: () async {
                           final downloaded = await fetchData();
                           if (context.mounted && downloaded) {
                             setState(() {
-                              _hasVerifiedNNUEFiles = true;
+                              _hasVerifiedNNUEFile = true;
                               _hasUnusableNNUEFiles = false;
                             });
                           }
@@ -146,18 +146,18 @@ class _EngineSettingsScreenState extends ConsumerState<EngineSettingsScreen> {
                     },
                   )
                 else if (prefs.enginePref == ChessEnginePref.sfLatest &&
-                    _hasVerifiedNNUEFiles == true)
+                    _hasVerifiedNNUEFile == true)
                   ListTile(
                     trailing: const Icon(Icons.check),
-                    title: const Text('NNUE files downloaded'),
-                    subtitle: const Text('$nnueTotalSizeMB (tap to delete)'),
+                    title: const Text('NNUE file downloaded'),
+                    subtitle: const Text('$nnueDownloadSizeMB (tap to delete)'),
                     onTap: () async {
                       final isOk = await showAdaptiveDialog<bool>(
                         context: context,
                         barrierDismissible: true,
                         builder: (context) {
                           return AlertDialog.adaptive(
-                            content: const Text('Do you want to delete the NNUE files?'),
+                            content: const Text('Do you want to delete the NNUE file?'),
                             actions: [
                               PlatformDialogAction(
                                 child: const Text('OK'),
@@ -179,13 +179,13 @@ class _EngineSettingsScreenState extends ConsumerState<EngineSettingsScreen> {
                         await ref.read(stockfishNnueServiceProvider).deleteNNUEFiles();
                         if (!mounted) return;
                         setState(() {
-                          _hasVerifiedNNUEFiles = false;
+                          _hasVerifiedNNUEFile = false;
                           _hasUnusableNNUEFiles = false;
                         });
                       }
                     },
                   ),
-                if (_hasVerifiedNNUEFiles == false && _hasUnusableNNUEFiles)
+                if (_hasVerifiedNNUEFile == false && _hasUnusableNNUEFiles)
                   ListTile(
                     trailing: const Icon(Icons.delete),
                     title: const Text('Delete unusable NNUE files'),

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -1107,8 +1107,8 @@ packages:
     dependency: "direct main"
     description:
       path: "pkgs/multistockfish"
-      ref: "50b1c4f6c53ad76429bfdfb118f9ebc8c8d2848a"
-      resolved-ref: "50b1c4f6c53ad76429bfdfb118f9ebc8c8d2848a"
+      ref: "896c3884921ae1d775fcd3088ddcd1559fb87308"
+      resolved-ref: "896c3884921ae1d775fcd3088ddcd1559fb87308"
       url: "https://github.com/lichess-org/dart-multistockfish.git"
     source: git
     version: "0.6.0"
@@ -1116,26 +1116,26 @@ packages:
     dependency: "direct overridden"
     description:
       path: "pkgs/multistockfish_chess"
-      ref: "50b1c4f6c53ad76429bfdfb118f9ebc8c8d2848a"
-      resolved-ref: "50b1c4f6c53ad76429bfdfb118f9ebc8c8d2848a"
+      ref: "896c3884921ae1d775fcd3088ddcd1559fb87308"
+      resolved-ref: "896c3884921ae1d775fcd3088ddcd1559fb87308"
       url: "https://github.com/lichess-org/dart-multistockfish.git"
     source: git
     version: "0.6.0"
-  multistockfish_sf16:
+  multistockfish_light:
     dependency: "direct overridden"
     description:
-      path: "pkgs/multistockfish_sf16"
-      ref: "50b1c4f6c53ad76429bfdfb118f9ebc8c8d2848a"
-      resolved-ref: "50b1c4f6c53ad76429bfdfb118f9ebc8c8d2848a"
+      path: "pkgs/multistockfish_light"
+      ref: "896c3884921ae1d775fcd3088ddcd1559fb87308"
+      resolved-ref: "896c3884921ae1d775fcd3088ddcd1559fb87308"
       url: "https://github.com/lichess-org/dart-multistockfish.git"
     source: git
-    version: "0.4.0"
+    version: "0.1.0"
   multistockfish_variant:
     dependency: "direct overridden"
     description:
       path: "pkgs/multistockfish_variant"
-      ref: "50b1c4f6c53ad76429bfdfb118f9ebc8c8d2848a"
-      resolved-ref: "50b1c4f6c53ad76429bfdfb118f9ebc8c8d2848a"
+      ref: "896c3884921ae1d775fcd3088ddcd1559fb87308"
+      resolved-ref: "896c3884921ae1d775fcd3088ddcd1559fb87308"
       url: "https://github.com/lichess-org/dart-multistockfish.git"
     source: git
     version: "0.4.0"

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -69,7 +69,7 @@ dependencies:
   multistockfish:
     git:
       url: https://github.com/lichess-org/dart-multistockfish.git
-      ref: 50b1c4f6c53ad76429bfdfb118f9ebc8c8d2848a
+      ref: 896c3884921ae1d775fcd3088ddcd1559fb87308
       path: pkgs/multistockfish
   package_info_plus: ^10.2.1
   path: ^1.9.1
@@ -115,17 +115,17 @@ dependency_overrides:
   multistockfish_chess:
     git:
       url: https://github.com/lichess-org/dart-multistockfish.git
-      ref: 50b1c4f6c53ad76429bfdfb118f9ebc8c8d2848a
+      ref: 896c3884921ae1d775fcd3088ddcd1559fb87308
       path: pkgs/multistockfish_chess
-  multistockfish_sf16:
+  multistockfish_light:
     git:
       url: https://github.com/lichess-org/dart-multistockfish.git
-      ref: 50b1c4f6c53ad76429bfdfb118f9ebc8c8d2848a
-      path: pkgs/multistockfish_sf16
+      ref: 896c3884921ae1d775fcd3088ddcd1559fb87308
+      path: pkgs/multistockfish_light
   multistockfish_variant:
     git:
       url: https://github.com/lichess-org/dart-multistockfish.git
-      ref: 50b1c4f6c53ad76429bfdfb118f9ebc8c8d2848a
+      ref: 896c3884921ae1d775fcd3088ddcd1559fb87308
       path: pkgs/multistockfish_variant
 
 flutter:

--- a/test/model/engine/engine_factory_test.dart
+++ b/test/model/engine/engine_factory_test.dart
@@ -30,24 +30,24 @@ void main() {
       final engine = FakeEngine();
       final factory = factoryFor(engine);
 
-      final started = await factory.create(const StockfishSpec.sf16());
+      final started = await factory.create(const StockfishSpec.light());
       addTearDown(started.dispose);
       await pumpEventQueue();
 
-      expect(started.spec, const StockfishSpec.sf16());
-      expect(started.name.value, 'Stockfish 16');
+      expect(started.spec, const StockfishSpec.light());
+      expect(started.name.value, 'Stockfish 19');
     });
 
     test('a create waits for the engine it replaces to finish exiting', () async {
       final engine = FakeEngine(quitDelay: const Duration(milliseconds: 50));
       final factory = factoryFor(engine);
 
-      final first = await factory.create(const StockfishSpec.sf16());
+      final first = await factory.create(const StockfishSpec.light());
 
       // Let go of it without waiting: this is what a provider being disposed looks like.
       unawaited(first.dispose());
 
-      final second = await factory.create(const StockfishSpec.sf16());
+      final second = await factory.create(const StockfishSpec.light());
       addTearDown(second.dispose);
 
       // The native library only frees the slot once the engine has actually exited, so the second
@@ -61,11 +61,11 @@ void main() {
     test('two live engines on one slot are a programming error, not a restart', () async {
       final factory = factoryFor(FakeEngine());
 
-      final live = await factory.create(const StockfishSpec.sf16());
+      final live = await factory.create(const StockfishSpec.light());
       addTearDown(live.dispose);
 
       await expectLater(
-        factory.create(const StockfishSpec.sf16()),
+        factory.create(const StockfishSpec.light()),
         throwsA(
           isA<EngineCreationException>().having(
             (e) => e.failure.error,
@@ -80,7 +80,7 @@ void main() {
       final factory = factoryFor(ThrowingStartEngine());
 
       await expectLater(
-        factory.create(const StockfishSpec.sf16()),
+        factory.create(const StockfishSpec.light()),
         throwsA(
           isA<EngineCreationException>().having(
             (e) => e.failure.kind,
@@ -95,7 +95,7 @@ void main() {
       final factory = factoryFor(ErrorEngine());
 
       await expectLater(
-        factory.create(const StockfishSpec.sf16()),
+        factory.create(const StockfishSpec.light()),
         throwsA(
           isA<EngineCreationException>().having(
             (e) => e.failure.kind,
@@ -112,7 +112,7 @@ void main() {
       fakeAsync((async) {
         Object? error;
         factory
-            .create(const StockfishSpec.sf16())
+            .create(const StockfishSpec.light())
             .then<void>((_) {}, onError: (Object e) => error = e);
 
         async.elapse(kEngineCreateTimeout - const Duration(seconds: 1));
@@ -134,7 +134,7 @@ void main() {
       fakeAsync((async) {
         Object? error;
         factory
-            .create(const StockfishSpec.sf16())
+            .create(const StockfishSpec.light())
             .then<void>((_) {}, onError: (Object e) => error = e);
 
         async.elapse(kEngineCreateTimeout + const Duration(seconds: 1));
@@ -155,13 +155,13 @@ void main() {
       final engine = FakeEngine(startDelay: const Duration(milliseconds: 50));
       final factory = factoryFor(engine);
 
-      final firstRequest = factory.create(const StockfishSpec.sf16());
+      final firstRequest = factory.create(const StockfishSpec.light());
 
       // Listened to straight away: this one is expected to fail, and an error nobody is waiting
       // for yet would surface as an unhandled async error instead.
       Object? secondError;
       final secondRequest = factory
-          .create(const StockfishSpec.sf16())
+          .create(const StockfishSpec.light())
           .then<Engine?>(
             (engine) => engine,
             onError: (Object e) {
@@ -187,13 +187,13 @@ void main() {
       final engine = FakeEngine();
       final factory = factoryFor(engine);
 
-      final sf16 = await factory.create(const StockfishSpec.sf16());
-      addTearDown(sf16.dispose);
+      final light = await factory.create(const StockfishSpec.light());
+      addTearDown(light.dispose);
       final fairy = await factory.create(const StockfishSpec.fairy());
       addTearDown(fairy.dispose);
 
       expect(engine.quitCount, 0);
-      expect(sf16.spec, isNot(fairy.spec));
+      expect(light.spec, isNot(fairy.spec));
     });
 
     test('an LC0 engine and a Stockfish engine are live at once, each with its '
@@ -206,7 +206,7 @@ void main() {
       final engine = ThrottleTestEngine();
       final factory = factoryFor(engine);
 
-      final stockfish = await factory.create(const StockfishSpec.sf16());
+      final stockfish = await factory.create(const StockfishSpec.light());
       addTearDown(stockfish.dispose);
       final lc0 = await factory.create(const Lc0Spec());
       addTearDown(lc0.dispose);
@@ -216,7 +216,7 @@ void main() {
       expect(engine.quitCount, 0, reason: 'neither is quit to make room');
 
       // Each engine read its own handshake, from its own session.
-      expect(stockfish.name.value, 'Stockfish 16');
+      expect(stockfish.name.value, 'Stockfish 19');
       expect(lc0.name.value, 'Lc0 v0.32.1');
 
       // And each search is answered by the engine it was given to.

--- a/test/model/engine/engine_providers_test.dart
+++ b/test/model/engine/engine_providers_test.dart
@@ -17,7 +17,7 @@ void main() {
       addTearDown(container.dispose);
 
       final subscription = container.listen<AsyncValue<Engine>>(
-        engineProvider(const StockfishSpec.sf16()),
+        engineProvider(const StockfishSpec.light()),
         (_, _) {},
       );
 
@@ -42,10 +42,10 @@ void main() {
       addTearDown(container.dispose);
 
       final subscription = container.listen<AsyncValue<Engine>>(
-        engineProvider(const StockfishSpec.sf16()),
+        engineProvider(const StockfishSpec.light()),
         (_, _) {},
       );
-      await container.read(engineProvider(const StockfishSpec.sf16()).future);
+      await container.read(engineProvider(const StockfishSpec.light()).future);
       subscription.close();
 
       await pumpEventQueue();
@@ -63,10 +63,10 @@ void main() {
       addTearDown(container.dispose);
 
       final subscription = container.listen<AsyncValue<Engine>>(
-        engineProvider(const StockfishSpec.sf16()),
+        engineProvider(const StockfishSpec.light()),
         (_, _) {},
       );
-      await container.read(engineProvider(const StockfishSpec.sf16()).future);
+      await container.read(engineProvider(const StockfishSpec.light()).future);
 
       // Watched for longer than the window: a timer started when the engine was built would have
       // fired by now, and the engine would be quit the moment its last watcher went away.
@@ -91,10 +91,10 @@ void main() {
       addTearDown(container.dispose);
 
       final subscription = container.listen<AsyncValue<Engine>>(
-        engineProvider(const StockfishSpec.sf16()),
+        engineProvider(const StockfishSpec.light()),
         (_, _) {},
       );
-      await container.read(engineProvider(const StockfishSpec.sf16()).future);
+      await container.read(engineProvider(const StockfishSpec.light()).future);
       subscription.close();
       await pumpEventQueue();
       expect(fakeEngine.isRunning, isTrue, reason: 'still inside its dispose window');

--- a/test/model/engine/engine_test.dart
+++ b/test/model/engine/engine_test.dart
@@ -45,7 +45,7 @@ void main() {
       final engine = Engine(transport);
       await pumpEventQueue();
 
-      expect(engine.name.value, 'Stockfish 16.1');
+      expect(engine.name.value, 'Stockfish 19');
       addTearDown(engine.dispose);
     });
 
@@ -146,7 +146,7 @@ void main() {
     test('an option is reset even when the engine declared no defaults', () async {
       // A handshake with no `option` lines is what the plugin's own fakes produce, and what an
       // engine that answers `uciok` without listing its options would look like.
-      final transport = FakeTransport(startupLines: const ['id name Stockfish 16.1', 'uciok']);
+      final transport = FakeTransport(startupLines: const ['id name Stockfish 19', 'uciok']);
       final engine = Engine(transport);
       addTearDown(engine.dispose);
       await pumpEventQueue();
@@ -426,7 +426,7 @@ void main() {
       final search = await startSearch(engine, transport, makeRequest());
 
       transport.die(
-        const EngineFailure(kind: EngineFailureKind.runtime, message: 'boom', engine: 'sf16'),
+        const EngineFailure(kind: EngineFailureKind.runtime, message: 'boom', engine: 'light'),
       );
       await pumpEventQueue();
 

--- a/test/model/engine/engine_utils_test.dart
+++ b/test/model/engine/engine_utils_test.dart
@@ -1,0 +1,65 @@
+import 'package:dartchess/dartchess.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:lichess_mobile/src/model/engine/engine_utils.dart';
+
+Position position(String fen) => Chess.fromSetup(Setup.parseFen(fen));
+
+void main() {
+  group('hasNonStandardMaterial', () {
+    test('the initial position is standard material', () {
+      expect(hasNonStandardMaterial(Chess.initial), isFalse);
+    });
+
+    test('a promoted piece paid for with a pawn is standard material', () {
+      // Eight white pieces beyond the king, one of them a second queen that came from a promotion.
+      expect(hasNonStandardMaterial(position('4k3/8/8/8/8/8/PPPPPPP1/QQ2K3 w - - 0 1')), isFalse);
+    });
+
+    test('a third knight with no pawn spent on it is standard material', () {
+      // A knight can be promoted to, and with no pawns left there is a promotion to account for it.
+      expect(hasNonStandardMaterial(position('nnnk4/8/8/8/8/8/8/4KNNN w - - 0 1')), isFalse);
+    });
+
+    test('a third knight beside a full set of pawns is not standard material', () {
+      expect(
+        hasNonStandardMaterial(position('nnnk4/pppppppp/8/8/8/8/PPPPPPPP/4KNNN w - - 0 1')),
+        isTrue,
+      );
+    });
+
+    test('a promotion too many for the pawns left is not standard material', () {
+      // Eight pawns and a second queen: the queen had nothing to be promoted from.
+      expect(hasNonStandardMaterial(position('4k3/8/8/8/8/8/PPPPPPPP/QQ2K3 w - - 0 1')), isTrue);
+    });
+
+    test('two bishops on the same colour count as a promotion', () {
+      // Light-squared bishops on f1 and h3, so one of them is promoted, and eight pawns to pay
+      // for it are one too many.
+      expect(hasNonStandardMaterial(position('4k3/8/8/8/8/7B/PPPPPPPP/4KB2 w - - 0 1')), isTrue);
+    });
+
+    test('a bishop pair on opposite colours is standard material', () {
+      expect(hasNonStandardMaterial(position('4k3/8/8/8/8/8/PPPPPPPP/2B1KB2 w - - 0 1')), isFalse);
+    });
+
+    test('material is judged for both sides', () {
+      expect(hasNonStandardMaterial(position('qqqqk3/pppppppp/8/8/8/8/8/4K3 w - - 0 1')), isTrue);
+    });
+  });
+
+  group('engineShortLabel', () {
+    test('reads the version from the engine name', () {
+      expect(engineShortLabel('Stockfish 19'), 'SF 19');
+      expect(engineShortLabel('Stockfish 19.1'), 'SF 19');
+    });
+
+    test('names Fairy-Stockfish without its version', () {
+      expect(engineShortLabel('Fairy-Stockfish 14.0.1'), 'Fairy SF');
+    });
+
+    test('returns null for a name it cannot read', () {
+      expect(engineShortLabel(null), isNull);
+      expect(engineShortLabel('Lc0 v0.32.1'), isNull);
+    });
+  });
+}

--- a/test/model/engine/fake_engine.dart
+++ b/test/model/engine/fake_engine.dart
@@ -27,9 +27,11 @@ Rule ruleFromUciVariant(String uciVariant) => switch (uciVariant) {
   _ => throw ArgumentError('Unexpected uci variant: $uciVariant'),
 };
 
+/// Both Stockfish flavors report the same name, as the real binaries do: which one is running is
+/// read from the spec, not from the name.
 String _engineNameFor(EngineSpec spec) => switch (spec) {
-  StockfishSpec(flavor: StockfishFlavor.sf16) => 'Stockfish 16',
-  StockfishSpec(flavor: StockfishFlavor.latestNoNNUE) => 'Stockfish 18',
+  StockfishSpec(flavor: StockfishFlavor.light) => 'Stockfish 19',
+  StockfishSpec(flavor: StockfishFlavor.latestNoNNUE) => 'Stockfish 19',
   StockfishSpec(flavor: StockfishFlavor.variant) => 'Fairy-Stockfish',
   Lc0Spec() => 'Lc0 v0.32.1',
 };

--- a/test/model/engine/fake_stockfish_nnue_service.dart
+++ b/test/model/engine/fake_stockfish_nnue_service.dart
@@ -6,9 +6,9 @@ import 'package:lichess_mobile/src/model/engine/weights_service.dart';
 /// A fake implementation of [StockfishNnueService] for testing.
 ///
 /// This implementation:
-/// - Always returns true for [checkNNUEFiles] (NNUE files are available)
-/// - Returns dummy file paths for [nnueFiles] (not used by FakeStockfish)
-/// - Returns false for [downloadNNUEFiles]
+/// - Always returns true for [checkNNUEFile] (the NNUE file is available)
+/// - Returns a dummy file path for [nnueFile] (not used by FakeStockfish)
+/// - Returns false for [downloadNNUEFile]
 /// - Does nothing for [deleteNNUEFiles]
 class FakeStockfishNnueService implements StockfishNnueService {
   FakeStockfishNnueService();
@@ -19,16 +19,16 @@ class FakeStockfishNnueService implements StockfishNnueService {
   ValueListenable<double> get nnueDownloadProgress => _nnueDownloadProgress;
 
   @override
-  bool get isDownloadingNNUEFiles => false;
+  bool get isDownloadingNNUEFile => false;
 
   @override
-  NNUEFiles get nnueFiles {
-    // Return dummy file paths - these won't be accessed by FakeStockfish
-    return (bigNet: File('/tmp/fake_big.nnue'), smallNet: File('/tmp/fake_small.nnue'));
+  File get nnueFile {
+    // Return a dummy file path - it won't be accessed by FakeStockfish
+    return File('/tmp/fake_net.nnue');
   }
 
   @override
-  Future<bool> checkNNUEFiles() async {
+  Future<bool> checkNNUEFile() async {
     return true;
   }
 
@@ -43,7 +43,7 @@ class FakeStockfishNnueService implements StockfishNnueService {
   }
 
   @override
-  Future<bool> downloadNNUEFiles({bool inBackground = true}) async {
+  Future<bool> downloadNNUEFile({bool inBackground = true}) async {
     return false;
   }
 
@@ -53,9 +53,9 @@ class FakeStockfishNnueService implements StockfishNnueService {
   }
 }
 
-/// A fake [StockfishNnueService] that simulates missing/unavailable NNUE files.
+/// A fake [StockfishNnueService] that simulates a missing/unavailable NNUE file.
 ///
-/// - Always returns false for [checkNNUEFiles]
+/// - Always returns false for [checkNNUEFile]
 /// - Always returns true for [hasOutdatedNNUEFiles]
 /// - All other behaviour is identical to [FakeStockfishNnueService]
 class FakeStockfishNnueServiceUnavailable implements StockfishNnueService {
@@ -67,15 +67,15 @@ class FakeStockfishNnueServiceUnavailable implements StockfishNnueService {
   ValueListenable<double> get nnueDownloadProgress => _nnueDownloadProgress;
 
   @override
-  bool get isDownloadingNNUEFiles => false;
+  bool get isDownloadingNNUEFile => false;
 
   @override
-  NNUEFiles get nnueFiles {
-    return (bigNet: File('/tmp/fake_big.nnue'), smallNet: File('/tmp/fake_small.nnue'));
+  File get nnueFile {
+    return File('/tmp/fake_net.nnue');
   }
 
   @override
-  Future<bool> checkNNUEFiles() async {
+  Future<bool> checkNNUEFile() async {
     return false;
   }
 
@@ -90,7 +90,7 @@ class FakeStockfishNnueServiceUnavailable implements StockfishNnueService {
   }
 
   @override
-  Future<bool> downloadNNUEFiles({bool inBackground = true}) async {
+  Future<bool> downloadNNUEFile({bool inBackground = true}) async {
     return false;
   }
 

--- a/test/model/engine/fake_transport.dart
+++ b/test/model/engine/fake_transport.dart
@@ -36,10 +36,10 @@ const kFakeLc0OptionDeclarations = [
 /// the lines in and the lines out.
 class FakeTransport implements EngineTransport {
   FakeTransport({
-    this.spec = const StockfishSpec.sf16(),
+    this.spec = const StockfishSpec.light(),
     List<String> startupLines = const [
-      'Stockfish 16.1 by the Stockfish developers',
-      'id name Stockfish 16.1',
+      'Stockfish 19 by the Stockfish developers',
+      'id name Stockfish 19',
       ...kFakeOptionDeclarations,
       'uciok',
     ],

--- a/test/model/engine/position_evaluator_test.dart
+++ b/test/model/engine/position_evaluator_test.dart
@@ -806,6 +806,22 @@ void main() {
       expect(service.state.spec, const StockfishSpec.light());
     });
 
+    test('Falls back to Fairy-Stockfish on material Stockfish will not accept', () async {
+      final container = await makeContainer();
+      final service = readEvaluator(container);
+
+      // Three knights a side beside a full set of pawns: legal to set up, but not material a
+      // standard game could produce, and Stockfish 19 exits rather than evaluate it.
+      final position = Chess.fromSetup(
+        Setup.parseFen('nnnk4/pppppppp/8/8/8/8/PPPPPPPP/4KNNN w - - 0 1'),
+      );
+
+      final stream = service.evaluate(makeWork(initialPosition: position));
+      expect(stream, isNotNull);
+      await stream!.first;
+      expect(service.state.spec, const StockfishSpec.fairy());
+    });
+
     test('Falls back to Fairy-Stockfish for the variants Stockfish cannot play', () async {
       final container = await makeContainer();
       // Even asked for the latest Stockfish, an atomic game can only be evaluated by Fairy.

--- a/test/model/engine/position_evaluator_test.dart
+++ b/test/model/engine/position_evaluator_test.dart
@@ -8,6 +8,7 @@ import 'package:lichess_mobile/src/model/common/id.dart';
 import 'package:lichess_mobile/src/model/common/uci.dart';
 import 'package:lichess_mobile/src/model/engine/engine_factory.dart';
 import 'package:lichess_mobile/src/model/engine/engine_providers.dart';
+import 'package:lichess_mobile/src/model/engine/engine_spec.dart';
 import 'package:lichess_mobile/src/model/engine/evaluation_context.dart';
 import 'package:lichess_mobile/src/model/engine/evaluation_preferences.dart';
 import 'package:lichess_mobile/src/model/engine/position_evaluator.dart';
@@ -33,6 +34,9 @@ enum EngineLifecycle { initial, loading, idle, computing, error }
 extension EngineEvaluationStateTest on EngineEvaluationState {
   /// The engine's `id name`, once it has one.
   String? get engineName => engine?.value;
+
+  /// Which engine the name came from: the two Stockfish flavors share a name.
+  EngineSpec? get spec => engineSpec;
 
   EngineLifecycle get lifecycle => switch (engine) {
     null => EngineLifecycle.initial,
@@ -754,12 +758,12 @@ void main() {
     });
 
     test(
-      'latestNoNNUE falling back to sf16 does not cause restart on subsequent latestNoNNUE requests',
+      'latestNoNNUE falling back to light does not cause restart on subsequent latestNoNNUE requests',
       () async {
         final delayedStockfish = FakeEngine();
         fakeEngine = delayedStockfish;
 
-        // NNUE files are unavailable: latestNoNNUE will fall back to sf16
+        // The NNUE file is unavailable: latestNoNNUE will fall back to the light engine
         final container = await makeContainer(
           overrides: {
             stockfishNnueServiceProvider: stockfishNnueServiceProvider.overrideWithValue(
@@ -775,7 +779,7 @@ void main() {
 
         expect(delayedStockfish.startCount, 1);
 
-        // A second request with latestNoNNUE should reuse the running sf16 engine.
+        // A second request with latestNoNNUE should reuse the running light engine.
         final work2 = makeWork(path: UciPath.fromId(UciCharPair.fromUci('e2e4')));
         final stream2 = service.evaluate(work2);
         await stream2!.first;
@@ -784,7 +788,7 @@ void main() {
           delayedStockfish.startCount,
           1,
           reason:
-              'Engine must not restart when latestNoNNUE already fell back to sf16 '
+              'Engine must not restart when latestNoNNUE already fell back to the light engine '
               'and a new latestNoNNUE request arrives',
         );
       },
@@ -799,7 +803,7 @@ void main() {
       final stream = service.evaluate(makeWork(variant: Variant.chess960));
       expect(stream, isNotNull);
       await stream!.first;
-      expect(service.state.engineName, 'Stockfish 16');
+      expect(service.state.spec, const StockfishSpec.light());
     });
 
     test('Falls back to Fairy-Stockfish for the variants Stockfish cannot play', () async {
@@ -1148,7 +1152,7 @@ void main() {
       expect(stream1, isNotNull);
       await stream1!.first;
 
-      expect(service.state.engineName, 'Stockfish 16');
+      expect(service.state.spec, const StockfishSpec.light());
 
       service.release();
       await pumpEventQueue();
@@ -1160,7 +1164,10 @@ void main() {
       expect(stream2, isNotNull);
       await stream2!.first;
 
-      expect(service.state.engineName, 'Stockfish 18');
+      expect(
+        service.state.spec,
+        isA<StockfishSpec>().having((s) => s.nnuePath, 'nnuePath', isNotNull),
+      );
     });
   });
 
@@ -1514,8 +1521,8 @@ void main() {
         service.evaluate(work);
         async.elapse(const Duration(seconds: 2));
 
-        // Notifier should have the first engine name
-        expect(latestState?.engineName, 'Stockfish 16');
+        // Notifier should have the first engine
+        expect(latestState?.spec, const StockfishSpec.light());
 
         // Let go of the engine, then ask for a different one.
         service.release();
@@ -1527,11 +1534,11 @@ void main() {
         service.evaluate(work);
         async.elapse(const Duration(seconds: 2));
 
-        // Notifier should have the updated engine name
+        // Notifier should have the updated engine
         expect(
-          latestState?.engineName,
-          'Stockfish 18',
-          reason: 'engineEvaluationProvider should surface the new engine name after a restart',
+          latestState?.spec,
+          isA<StockfishSpec>().having((s) => s.nnuePath, 'nnuePath', isNotNull),
+          reason: 'engineEvaluationProvider should surface the new engine after a restart',
         );
       });
     });

--- a/test/model/engine/stockfish_nnue_service_test.dart
+++ b/test/model/engine/stockfish_nnue_service_test.dart
@@ -73,8 +73,8 @@ Future<ProviderContainer> makeNnueTestContainer({
 
 void main() {
   group('StockfishNnueService', () {
-    group('nnueFiles', () {
-      test('returns correct file paths when appSupportDirectory is available', () async {
+    group('nnueFile', () {
+      test('returns the correct file path when appSupportDirectory is available', () async {
         final tempDir = await Directory.systemTemp.createTemp('nnue_test_');
         addTearDown(() => tempDir.delete(recursive: true));
 
@@ -82,10 +82,8 @@ void main() {
         addTearDown(container.dispose);
 
         final service = container.read(stockfishNnueServiceProvider);
-        final files = service.nnueFiles;
 
-        expect(files.bigNet.path, '${tempDir.path}/${Stockfish.latestBigNNUE}');
-        expect(files.smallNet.path, '${tempDir.path}/${Stockfish.latestSmallNNUE}');
+        expect(service.nnueFile.path, '${tempDir.path}/${Stockfish.latestNNUE}');
       });
 
       test('throws exception when appSupportDirectory is null', () async {
@@ -94,22 +92,22 @@ void main() {
 
         final service = container.read(stockfishNnueServiceProvider);
 
-        expect(() => service.nnueFiles, throwsException);
+        expect(() => service.nnueFile, throwsException);
       });
     });
 
-    group('checkNNUEFiles', () {
+    group('checkNNUEFile', () {
       test('returns false when appSupportDirectory is null', () async {
         final container = await makeNnueTestContainer(appSupportDirectory: null);
         addTearDown(container.dispose);
 
         final service = container.read(stockfishNnueServiceProvider);
-        final result = await service.checkNNUEFiles();
+        final result = await service.checkNNUEFile();
 
         expect(result, isFalse);
       });
 
-      test('returns false when files do not exist', () async {
+      test('returns false when the file does not exist', () async {
         final tempDir = await Directory.systemTemp.createTemp('nnue_test_');
         addTearDown(() => tempDir.delete(recursive: true));
 
@@ -117,64 +115,42 @@ void main() {
         addTearDown(container.dispose);
 
         final service = container.read(stockfishNnueServiceProvider);
-        final result = await service.checkNNUEFiles();
+        final result = await service.checkNNUEFile();
 
         expect(result, isFalse);
       });
 
-      test('returns false when only one file exists', () async {
+      test('returns false when the file exists but its checksum does not match', () async {
         final tempDir = await Directory.systemTemp.createTemp('nnue_test_');
         addTearDown(() => tempDir.delete(recursive: true));
 
-        // Create only the big net file
-        final bigNetFile = File('${tempDir.path}/${Stockfish.latestBigNNUE}');
-        await bigNetFile.writeAsBytes([1, 2, 3]);
+        // Create a file with invalid content
+        final netFile = File('${tempDir.path}/${Stockfish.latestNNUE}');
+        await netFile.writeAsBytes([1, 2, 3]);
 
         final container = await makeNnueTestContainer(appSupportDirectory: tempDir);
         addTearDown(container.dispose);
 
         final service = container.read(stockfishNnueServiceProvider);
-        final result = await service.checkNNUEFiles();
+        final result = await service.checkNNUEFile();
 
         expect(result, isFalse);
       });
 
-      test('returns false when files exist but checksums do not match', () async {
+      test('deletes the file when its checksum does not match', () async {
         final tempDir = await Directory.systemTemp.createTemp('nnue_test_');
         addTearDown(() => tempDir.delete(recursive: true));
 
-        // Create files with invalid content
-        final bigNetFile = File('${tempDir.path}/${Stockfish.latestBigNNUE}');
-        final smallNetFile = File('${tempDir.path}/${Stockfish.latestSmallNNUE}');
-        await bigNetFile.writeAsBytes([1, 2, 3]);
-        await smallNetFile.writeAsBytes([4, 5, 6]);
+        final netFile = File('${tempDir.path}/${Stockfish.latestNNUE}');
+        await netFile.writeAsBytes([1, 2, 3]);
 
         final container = await makeNnueTestContainer(appSupportDirectory: tempDir);
         addTearDown(container.dispose);
 
         final service = container.read(stockfishNnueServiceProvider);
-        final result = await service.checkNNUEFiles();
+        await service.checkNNUEFile();
 
-        expect(result, isFalse);
-      });
-
-      test('deletes the files when the checksums do not match', () async {
-        final tempDir = await Directory.systemTemp.createTemp('nnue_test_');
-        addTearDown(() => tempDir.delete(recursive: true));
-
-        final bigNetFile = File('${tempDir.path}/${Stockfish.latestBigNNUE}');
-        final smallNetFile = File('${tempDir.path}/${Stockfish.latestSmallNNUE}');
-        await bigNetFile.writeAsBytes([1, 2, 3]);
-        await smallNetFile.writeAsBytes([4, 5, 6]);
-
-        final container = await makeNnueTestContainer(appSupportDirectory: tempDir);
-        addTearDown(container.dispose);
-
-        final service = container.read(stockfishNnueServiceProvider);
-        await service.checkNNUEFiles();
-
-        expect(await bigNetFile.exists(), isFalse);
-        expect(await smallNetFile.exists(), isFalse);
+        expect(await netFile.exists(), isFalse);
       });
     });
 
@@ -239,13 +215,13 @@ void main() {
       });
     });
 
-    group('downloadNNUEFiles', () {
+    group('downloadNNUEFile', () {
       test('returns false when appSupportDirectory is null', () async {
         final container = await makeNnueTestContainer(appSupportDirectory: null);
         addTearDown(container.dispose);
 
         final service = container.read(stockfishNnueServiceProvider);
-        final result = await service.downloadNNUEFiles(inBackground: true);
+        final result = await service.downloadNNUEFile(inBackground: true);
 
         expect(result, isFalse);
       });
@@ -270,10 +246,10 @@ void main() {
         final service = container.read(stockfishNnueServiceProvider);
 
         // Start first download
-        final firstDownload = service.downloadNNUEFiles(inBackground: true);
+        final firstDownload = service.downloadNNUEFile(inBackground: true);
 
         // Immediately start second download while first is in progress
-        final secondDownload = service.downloadNNUEFiles(inBackground: true);
+        final secondDownload = service.downloadNNUEFile(inBackground: true);
 
         final results = await Future.wait([firstDownload, secondDownload]);
 
@@ -293,7 +269,7 @@ void main() {
 
         final service = container.read(stockfishNnueServiceProvider);
 
-        expect(() => service.downloadNNUEFiles(inBackground: true), throwsException);
+        expect(() => service.downloadNNUEFile(inBackground: true), throwsException);
       });
 
       test('allows sequential downloads after previous one completes', () async {
@@ -316,16 +292,16 @@ void main() {
         final service = container.read(stockfishNnueServiceProvider);
 
         // First download
-        await service.downloadNNUEFiles(inBackground: true);
+        await service.downloadNNUEFile(inBackground: true);
 
         // Second download after first completes
-        await service.downloadNNUEFiles(inBackground: true);
+        await service.downloadNNUEFile(inBackground: true);
 
-        // Both downloads should have been allowed (4 requests = 2 files x 2 downloads)
-        expect(downloadCount, 4);
+        // Both downloads should have been allowed
+        expect(downloadCount, 2);
       });
 
-      test('returns false and keeps nothing when the downloaded files are corrupted', () async {
+      test('returns false and keeps nothing when the downloaded file is corrupted', () async {
         final tempDir = await Directory.systemTemp.createTemp('nnue_test_');
         addTearDown(() => tempDir.delete(recursive: true));
 
@@ -339,11 +315,10 @@ void main() {
         addTearDown(container.dispose);
 
         final service = container.read(stockfishNnueServiceProvider);
-        final result = await service.downloadNNUEFiles(inBackground: true);
+        final result = await service.downloadNNUEFile(inBackground: true);
 
         expect(result, isFalse);
-        expect(await service.nnueFiles.bigNet.exists(), isFalse);
-        expect(await service.nnueFiles.smallNet.exists(), isFalse);
+        expect(await service.nnueFile.exists(), isFalse);
       });
 
       test('returns false and keeps nothing when a download fails', () async {
@@ -360,22 +335,21 @@ void main() {
         addTearDown(container.dispose);
 
         final service = container.read(stockfishNnueServiceProvider);
-        final result = await service.downloadNNUEFiles(inBackground: true);
+        final result = await service.downloadNNUEFile(inBackground: true);
 
         expect(result, isFalse);
-        expect(await service.nnueFiles.bigNet.exists(), isFalse);
-        expect(await service.nnueFiles.smallNet.exists(), isFalse);
+        expect(await service.nnueFile.exists(), isFalse);
       });
     });
 
-    group('isDownloadingNNUEFiles', () {
+    group('isDownloadingNNUEFile', () {
       test('returns false when progress is 0', () async {
         final container = await makeNnueTestContainer(appSupportDirectory: null);
         addTearDown(container.dispose);
 
         final service = container.read(stockfishNnueServiceProvider);
 
-        expect(service.isDownloadingNNUEFiles, isFalse);
+        expect(service.isDownloadingNNUEFile, isFalse);
       });
 
       test('returns false when progress is 1', () async {
@@ -384,9 +358,9 @@ void main() {
 
         final service = container.read(stockfishNnueServiceProvider);
         // We can't easily set progress to 1 without downloading, but we can verify the logic
-        // Progress starts at 0, so isDownloadingNNUEFiles should be false
+        // Progress starts at 0, so isDownloadingNNUEFile should be false
         expect(service.nnueDownloadProgress.value, 0.0);
-        expect(service.isDownloadingNNUEFiles, isFalse);
+        expect(service.isDownloadingNNUEFile, isFalse);
       });
     });
   });

--- a/test/view/home/home_tab_screen_test.dart
+++ b/test/view/home/home_tab_screen_test.dart
@@ -505,7 +505,7 @@ void main() {
 
     group('NNUE files missing tip', () {
       const nnueFilesMissingTip =
-          'New Stockfish version available! Go to the settings to download the updated NNUE files.';
+          'New Stockfish version available! Go to the settings to download the updated NNUE file.';
       testWidgets('Shown if engine pref is latest sf and NNUE files are missing', (tester) async {
         final app = await makeTestProviderScope(
           tester,
@@ -560,7 +560,7 @@ void main() {
         expect(find.text(nnueFilesMissingTip), findsNothing);
       });
 
-      testWidgets('Not shown if engine pref is sf16', (tester) async {
+      testWidgets('Not shown if engine pref is sfLight', (tester) async {
         final app = await makeTestProviderScope(
           tester,
           overrides: {
@@ -572,7 +572,7 @@ void main() {
           defaultPreferences: {
             PrefCategory.engineEvaluation.storageKey: jsonEncode(
               EngineEvaluationPrefState.defaults
-                  .copyWith(enginePref: ChessEnginePref.sf16)
+                  .copyWith(enginePref: ChessEnginePref.sfLight)
                   .toJson(),
             ),
           },

--- a/test/view/offline_computer/offline_computer_game_screen_test.dart
+++ b/test/view/offline_computer/offline_computer_game_screen_test.dart
@@ -157,8 +157,8 @@ void main() {
 
       expect(engine.sessions.map((session) => session.spec.label).toSet(), {
         'variant',
-        'sf16',
-      }, reason: 'the opponent plays on Fairy while the hints are computed on Stockfish 16');
+        'light',
+      }, reason: 'the opponent plays on Fairy while the hints are computed on the light Stockfish');
       expect(
         engine.quitCount,
         0,


### PR DESCRIPTION
Assisted with Claude opus 5.

* Upgrade latest Stockfish to version 19
* Replace SF16 with a light SF19 (1MB)
* Add a fallback to Fairy SF for positions that hold non standard material 