### PR TITLE
Allow board editor analysis with more than 32 pieces

### DIFF
--- a/lib/src/view/board_editor/board_editor_screen.dart
+++ b/lib/src/view/board_editor/board_editor_screen.dart
@@ -417,10 +417,8 @@ class _BottomBar extends ConsumerWidget {
         BottomBarButton(
           key: const Key('analysis-board-button'),
           label: context.l10n.analysis,
-          onTap:
-              editorState.pgn != null &&
-                  // 1 condition (of many) where stockfish segfaults
-                  (pieceCount > 0 && (pieceCount <= 32 || editorState.variant == Variant.horde))
+          // The evaluator uses Fairy-Stockfish for nonstandard material.
+          onTap: editorState.pgn != null && pieceCount > 0
               ? () {
                   Navigator.of(context).push(
                     AnalysisScreen.buildRoute(

--- a/test/model/engine/engine_utils_test.dart
+++ b/test/model/engine/engine_utils_test.dart
@@ -10,6 +10,20 @@ void main() {
       expect(hasNonStandardMaterial(Chess.initial), isFalse);
     });
 
+    test('more than 32 pieces is not standard material', () {
+      expect(
+        hasNonStandardMaterial(
+          position('rnbqkbnr/pppppppp/8/8/8/4N3/PPPPPPPP/RNBQKBNR w KQkq - 0 1'),
+        ),
+        isTrue,
+      );
+    });
+
+    test('more than eight pawns on either side is not standard material', () {
+      expect(hasNonStandardMaterial(position('4k3/8/8/8/8/P7/PPPPPPPP/4K3 w - - 0 1')), isTrue);
+      expect(hasNonStandardMaterial(position('4k3/pppppppp/p7/8/8/8/8/4K3 w - - 0 1')), isTrue);
+    });
+
     test('a promoted piece paid for with a pawn is standard material', () {
       // Eight white pieces beyond the king, one of them a second queen that came from a promotion.
       expect(hasNonStandardMaterial(position('4k3/8/8/8/8/8/PPPPPPP1/QQ2K3 w - - 0 1')), isFalse);

--- a/test/model/engine/position_evaluator_test.dart
+++ b/test/model/engine/position_evaluator_test.dart
@@ -822,6 +822,19 @@ void main() {
       expect(service.state.spec, const StockfishSpec.fairy());
     });
 
+    test('Falls back to Fairy-Stockfish with ten pawns per side', () async {
+      final container = await makeContainer();
+      final service = readEvaluator(container);
+      final position = Chess.fromSetup(
+        Setup.parseFen('rnbqkbnr/pppppppp/4p3/3p4/8/5PP1/PPPPPPPP/RNBQKBNR w KQkq - 0 1'),
+      );
+
+      final stream = service.evaluate(makeWork(initialPosition: position));
+      expect(stream, isNotNull);
+      await stream!.first;
+      expect(service.state.spec, const StockfishSpec.fairy());
+    });
+
     test('Falls back to Fairy-Stockfish for the variants Stockfish cannot play', () async {
       final container = await makeContainer();
       // Even asked for the latest Stockfish, an atomic game can only be evaluated by Fairy.

--- a/test/view/board_editor/board_editor_screen_test.dart
+++ b/test/view/board_editor/board_editor_screen_test.dart
@@ -6,10 +6,14 @@ import 'package:flutter_test/flutter_test.dart';
 import 'package:lichess_mobile/src/model/board_editor/board_editor_controller.dart';
 import 'package:lichess_mobile/src/model/common/chess.dart';
 import 'package:lichess_mobile/src/model/common/chess960.dart';
+import 'package:lichess_mobile/src/model/engine/engine_spec.dart';
+import 'package:lichess_mobile/src/view/analysis/analysis_screen.dart';
 import 'package:lichess_mobile/src/view/board_editor/board_editor_screen.dart';
 import 'package:lichess_mobile/src/widgets/bottom_bar.dart';
 import 'package:material_ui/material_ui.dart';
 
+import '../../model/engine/fake_engine.dart';
+import '../../test_helpers.dart' show getBoardPieces;
 import '../../test_provider_scope.dart';
 
 void _mockClipboard(String text) {
@@ -319,6 +323,32 @@ void main() {
         // Obtained by playing the moves above on lichess.org/editor
         '1nbqkbnr/pppppppp/r7/8/3PP3/8/PPP2PPP/RNQ1KBNR w KQk - 0 1',
       );
+    });
+
+    testWidgets('Analysis opens with Fairy-Stockfish after adding a 33rd piece', (tester) async {
+      fakeEngine = FakeEngine();
+      addTearDown(() => fakeEngine = FakeEngine());
+      final app = await makeTestProviderScopeApp(tester, home: const BoardEditorScreen());
+      await tester.pumpWidget(app);
+
+      await tester.tap(find.byKey(const Key('piece-button-white-knight')));
+      await tester.pump();
+      await tapSquare(tester, 'e3');
+
+      const fen = 'rnbqkbnr/pppppppp/8/8/8/4N3/PPPPPPPP/RNBQKBNR w KQkq - 0 1';
+      expect(tester.widget<ChessboardEditor>(find.byType(ChessboardEditor)).pieces, readFen(fen));
+      expect(
+        tester.widget<BottomBarButton>(find.byKey(const Key('analysis-board-button'))).onTap,
+        isNotNull,
+      );
+
+      await tester.tap(find.byKey(const Key('analysis-board-button')));
+      await tester.pumpAndSettle();
+
+      expect(find.byType(AnalysisScreen), findsOneWidget);
+      expect(getBoardPieces(tester), readFen(fen));
+      expect(fakeEngine.spec, const StockfishSpec.fairy());
+      expect(fakeEngine.position?.fen, fen);
     });
 
     testWidgets('illegal position cannot be analyzed', (tester) async {


### PR DESCRIPTION
#3653 added a fallback to fairy-stockfish

Remove the old analysis material limit. Keep position validity and nonempty-board checks.

Add an editor navigation regression tests for:
- An extra knight
- 33 pieces
- Nine pawns on either side.

AI assistance: OpenAI Codex implemented the change and tests.

Resolves #3322

Showing fairy stockfish fallback running for a position with an extra knight:
[Screen_recording_20260909_180100.webm](https://github.com/user-attachments/assets/ca67dc52-b7ba-43b6-847c-0a9d41d45f4e)
