### PR TITLE
refactor(engine): defer NNUE cleanup and protect in-flight Maia network downloads from checksum deletion

### DIFF
--- a/lib/src/model/engine/weights_service.dart
+++ b/lib/src/model/engine/weights_service.dart
@@ -147,13 +147,13 @@ class StockfishNnueService {
         return false;
       }
 
-      // delete any existing nnue files before downloading
-      await deleteNNUEFiles();
-
       // The download only counts as a success if what landed on disk is what the engine needs:
       // a file that arrives truncated or garbled is deleted rather than kept and reported as
       // downloaded, which would leave the engine falling back to the light one with no way out.
       Future<bool> doDownload() async {
+        // delete any existing nnue files before downloading
+        await deleteNNUEFiles();
+
         final client = _ref.read(defaultClientProvider);
         final downloaded = await downloadFile(
           client,
@@ -290,6 +290,7 @@ class MaiaWeightsService {
   /// always produce it, without a network connection.
   Future<bool> isAvailable(MaiaRating rating) async {
     if (rating.isBundled) return true;
+    if (_inFlight.containsKey(rating)) return false;
     return await _checkFile(rating);
   }
 
@@ -390,7 +391,10 @@ class MaiaWeightsService {
     final claimed = <String>{};
     for (final rating in MaiaRating.values) {
       // A bundled rating always claims its file, whether or not it has been written out yet.
-      if (rating.isBundled || await isAvailable(rating)) claimed.add(weightsFile(rating).path);
+      // An in-flight download also claims its file so it is not reported as unusable while downloading.
+      if (rating.isBundled || _inFlight.containsKey(rating) || await isAvailable(rating)) {
+        claimed.add(weightsFile(rating).path);
+      }
     }
 
     // Listed after the checks above, which delete the corrupted files they find: what is left is

--- a/test/model/engine/weights_service_test.dart
+++ b/test/model/engine/weights_service_test.dart
@@ -1,3 +1,4 @@
+import 'dart:async';
 import 'dart:io';
 
 import 'package:device_info_plus/device_info_plus.dart';
@@ -196,6 +197,41 @@ void main() {
       expect(await file.exists(), isFalse);
     });
 
+    test('isAvailable returns false and does not delete file during in-flight download', () async {
+      final dir = await makeTempDir();
+      final downloadCompleter = Completer<void>();
+      final fileWrittenCompleter = Completer<void>();
+
+      final container = makeWeightsContainer(
+        appSupportDirectory: dir,
+        mockClient: MockClient((_) async {
+          final file = File('${dir.path}/maia/maia-1700.pb.gz');
+          await file.parent.create(recursive: true);
+          await file.writeAsBytes([1, 2, 3, 4, 5]);
+
+          if (!fileWrittenCompleter.isCompleted) {
+            fileWrittenCompleter.complete();
+          }
+
+          await downloadCompleter.future;
+          return http.Response('test content', 200);
+        }),
+      );
+      final service = container.read(maiaWeightsServiceProvider);
+
+      final downloadFuture = service.download(MaiaRating.maia1700);
+
+      await fileWrittenCompleter.future;
+
+      final file = service.weightsFile(MaiaRating.maia1700);
+      expect(await file.exists(), isTrue);
+      expect(await service.isAvailable(MaiaRating.maia1700), isFalse);
+      expect(await file.exists(), isTrue);
+
+      downloadCompleter.complete();
+      await downloadFuture;
+    });
+
     test('a corrupted bundled network is replaced by the one in the asset bundle', () async {
       final dir = await makeTempDir();
       final container = makeWeightsContainer(appSupportDirectory: dir);
@@ -241,6 +277,38 @@ void main() {
       expect(await stray.exists(), isFalse);
       expect(await File(path).exists(), isTrue);
       expect(await service.unusableWeights(), (count: 0, bytes: 0));
+    });
+
+    test('unusableWeights does not report in-flight download as unusable', () async {
+      final dir = await makeTempDir();
+      final downloadCompleter = Completer<void>();
+      final fileWrittenCompleter = Completer<void>();
+
+      final container = makeWeightsContainer(
+        appSupportDirectory: dir,
+        mockClient: MockClient((_) async {
+          final file = File('${dir.path}/maia/maia-1700.pb.gz');
+          await file.parent.create(recursive: true);
+          await file.writeAsBytes([1, 2, 3, 4, 5]);
+
+          if (!fileWrittenCompleter.isCompleted) {
+            fileWrittenCompleter.complete();
+          }
+
+          await downloadCompleter.future;
+          return http.Response('test content', 200);
+        }),
+      );
+      final service = container.read(maiaWeightsServiceProvider);
+
+      final downloadFuture = service.download(MaiaRating.maia1700);
+
+      await fileWrittenCompleter.future;
+
+      expect(await service.unusableWeights(), (count: 0, bytes: 0));
+
+      downloadCompleter.complete();
+      await downloadFuture;
     });
 
     test('reports rather than throws when there is nowhere to put a network', () async {


### PR DESCRIPTION
Fixes an issue where inspecting Maia network availability or calculating unusable file sizes while a download is in progress causes `MaiaWeightsService` to fail checksum verification and delete the active download file mid-stream.

Also, Refactors `StockfishNnueService.downloadNNUEFile()` to defer deleting existing NNUE files until inside `doDownload()`, right after connectivity check and user confirmation.

## Problem & Scenarios
When downloading a Maia network (e.g. `maia-1800.pb.gz`), `downloadFile()` streams HTTP chunks directly into `weightsFile(rating)`. While a download is in progress:

1. **Active Download Deletion**: If `availableRatings()` or `isAvailable()` is called (e.g. user opens Engine Settings or re-opens the Opponent Picker sheet while downloading), `_checkFile()` inspects the partially downloaded file on disk. The SHA-256 checksum fails, causing `_checkFile()` to log a false corruption warning and delete the file out from under the active HTTP stream.
2. **False Positive in Unusable Files**: Because `isAvailable()` returns `false` during an active download, `_unusableFiles()` does not mark the in-flight file path as claimed. As a result, `unusableWeights()` classifies the actively downloading file as an "unusable file" and `deleteUnusableWeights()` deletes it.

## Fix
- **`MaiaWeightsService.isAvailable()`**: Added a check for `_inFlight.containsKey(rating)`. If a rating is currently downloading, `isAvailable()` returns `false` early without attempting SHA-256 verification or deleting the file.
- **`MaiaWeightsService._unusableFiles()`**: Included `_inFlight.containsKey(rating)` when building `claimed` paths, ensuring active downloads are never classified or reported as unusable files.

## Refactoring
Refactors `StockfishNnueService.downloadNNUEFile()` to defer deleting existing NNUE files until inside `doDownload()`, right after connectivity check and user confirmation. It ensures that delete operations do not occur if pre-download network checks fail or if a user cancels the confirmation dialog. The service API remains robust and free of side effects if called by future features or background tasks.

Note: Gemini AI agent has been used as assistance and validation tool with manual code review and guidance.