### PR TITLE
HttpNetworkImageWidget watching a client that never changes

### DIFF
--- a/lib/src/widgets/network_image.dart
+++ b/lib/src/widgets/network_image.dart
@@ -30,9 +30,10 @@ class HttpNetworkImageWidget extends ConsumerWidget {
       image: ResizeImage.resizeIfNeeded(
         cacheWidth,
         cacheHeight,
-        HttpNetworkImage(url, ref.watch(defaultClientProvider)),
+        HttpNetworkImage(url, ref.read(defaultClientProvider)),
       ),
       width: width,
+      height: height,
       fit: fit,
       errorBuilder: errorBuilder,
     );


### PR DESCRIPTION
I noticed `HttpNetworkImageWidget` was watching the HTTP client instead of just reading it. The client never really changes, so every avatar and image in the app sat subscribed to a provider for no reason. If that provider ever fired, all of them would rebuild at once and throw away their caches.
This switches it to `ref.read`. It also forwards the height param, which the widget accepted but silently dropped until now.