### PR TITLE
Don't restart the move-expiration timer on unrelated rebuilds

### DIFF
--- a/lib/src/view/game/game_player.dart
+++ b/lib/src/view/game/game_player.dart
@@ -461,9 +461,11 @@ class _MoveExpirationState extends ConsumerState<MoveExpiration> {
   @override
   void didUpdateWidget(covariant MoveExpiration oldWidget) {
     super.didUpdateWidget(oldWidget);
-    _timer?.cancel();
-    timeLeft = widget.timeToMove;
-    _timer = startTimer();
+    if (oldWidget.timeToMove != widget.timeToMove) {
+      _timer?.cancel();
+      timeLeft = widget.timeToMove;
+      _timer = startTimer();
+    }
   }
 
   @override


### PR DESCRIPTION
The `MoveExpiration` countdown tore down and restarted its 1-second timer in `didUpdateWidget` no matter what changed. The game screen rebuilds constantly, so the timer kept getting cancelled and recreated, and `timeLeft` snapped back to the full value each time.

Now it only restarts when `timeToMove` actually changes.