### PR TITLE
Stop building the whole Watch tab on first paint

### DIFF
--- a/lib/src/view/broadcast/broadcast_carousel.dart
+++ b/lib/src/view/broadcast/broadcast_carousel.dart
@@ -70,10 +70,20 @@ class BroadcastCarousel extends StatefulWidget {
 class _BroadcastCarouselState extends State<BroadcastCarousel> {
   final _controller = CarouselController();
 
+  /// Offscreen cards each fire image decode + isolate color work on insert,
+  /// so only the first page is built synchronously. The rest is appended
+  /// after the first frame, while the scroll offset is still 0.
+  bool _showAll = false;
+
   @override
   void initState() {
     super.initState();
     watchTabInteraction.addListener(_onTabInteraction);
+    SchedulerBinding.instance.addPostFrameCallback((_) {
+      if (mounted) {
+        setState(() => _showAll = true);
+      }
+    });
   }
 
   @override
@@ -103,6 +113,10 @@ class _BroadcastCarouselState extends State<BroadcastCarousel> {
         final elementHeightFactor = flexWeights.length == 2 ? 0.75 : 0.6;
         final infoHeight = math.max(120, pictureHeight * elementHeightFactor);
         final elementHeight = pictureHeight + infoHeight;
+        // One full page plus a spare card; the rest arrives via _showAll.
+        final active = widget.broadcasts.active;
+        final initialCount = math.min(active.length, flexWeights.length + 2);
+        final visible = _showAll ? active : active.take(initialCount);
         return Padding(
           padding: const EdgeInsets.symmetric(horizontal: 8.0),
           child: ConstrainedBox(
@@ -121,7 +135,7 @@ class _BroadcastCarouselState extends State<BroadcastCarousel> {
                 if (widget._isLoading)
                   for (final _ in [1, 2, 3, 4, 5, 6, 7, 8, 9])
                     BroadcastCarouselItem.loading(worker: widget.worker, flexWeights: flexWeights),
-                for (final broadcast in widget.broadcasts.active)
+                for (final broadcast in visible)
                   BroadcastCarouselItem(
                     broadcast: broadcast,
                     worker: widget.worker,

--- a/lib/src/view/watch/watch_tab_screen.dart
+++ b/lib/src/view/watch/watch_tab_screen.dart
@@ -178,23 +178,25 @@ class _BodyState extends ConsumerState<_Body> {
         : ref.watch(liveStreamersProvider);
     final isTablet = isTabletOrLarger(context);
 
-    final content = [
-      if (_worker != null) _BroadcastWidget(broadcastList, _worker!),
+    final slivers = [
+      if (_worker != null) SliverToBoxAdapter(child: _BroadcastWidget(broadcastList, _worker!)),
       if (isTablet)
-        Row(
-          crossAxisAlignment: CrossAxisAlignment.start,
-          children: [
-            Expanded(child: _WatchTvWidget(featuredChannels)),
-            if (!isKidMode) Expanded(child: _StreamerWidget(streamers)),
-          ],
+        SliverToBoxAdapter(
+          child: Row(
+            crossAxisAlignment: CrossAxisAlignment.start,
+            children: [
+              Expanded(child: _WatchTvWidget(featuredChannels)),
+              if (!isKidMode) Expanded(child: _StreamerWidget(streamers)),
+            ],
+          ),
         )
       else ...[
-        _WatchTvWidget(featuredChannels),
-        if (!isKidMode) _StreamerWidget(streamers),
+        SliverToBoxAdapter(child: _WatchTvWidget(featuredChannels)),
+        if (!isKidMode) SliverToBoxAdapter(child: _StreamerWidget(streamers)),
       ],
     ];
 
-    return ListView(controller: watchScrollController, children: content);
+    return CustomScrollView(controller: watchScrollController, slivers: slivers);
   }
 }
 


### PR DESCRIPTION
Opening the Watch tab built every section up front: the full broadcast carousel, the TV list, and the streamer list. Each carousel card fires image decode plus isolate color work, so the tab did all of that before showing the first frame.

First, the tab body moves from ListView to CustomScrollView with one SliverToBoxAdapter per section, so each section lays out lazily. The pixels are identical and nothing else changes. Second, the carousel builds only the first page plus two spare cards synchronously and appends the rest after the first frame. The scroll offset is still 0 at that point, so appending cannot jump the scroll position.