### PR TITLE
Memoize per-tile perf sort in user list rows

### DIFF
--- a/lib/src/widgets/user_list_tile.dart
+++ b/lib/src/widgets/user_list_tile.dart
@@ -64,19 +64,9 @@ class _UserRating extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    List<Perf> userPerfs = Perf.values
-        .where((element) {
-          final p = perfs[element];
-          return p != null && p.numberOfGamesOrRuns > 0 && p.ratingDeviation < kClueLessDeviation;
-        })
-        .toList(growable: false);
+    final userPerfs = _sortedUserPerfs(perfs);
 
     if (userPerfs.isEmpty) return const SizedBox.shrink();
-
-    userPerfs.sort(
-      (p1, p2) => perfs[p1]!.numberOfGamesOrRuns.compareTo(perfs[p2]!.numberOfGamesOrRuns),
-    );
-    userPerfs = userPerfs.reversed.toList();
 
     final rating = perfs[userPerfs.first]?.rating.toString() ?? '?';
     final icon = userPerfs.first.icon;
@@ -86,4 +76,25 @@ class _UserRating extends StatelessWidget {
       children: [Icon(icon, size: 16), const SizedBox(width: 5), Text(rating)],
     );
   }
+}
+
+/// Perfs with enough rated games, sorted by game count descending.
+///
+/// This runs in every row of every scrolling user list (leaderboards, search,
+/// teams), so the filter + sort is memoized per map instance. [IMap] is
+/// immutable, so instance identity implies value identity and the cached list
+/// stays valid as long as the map is alive.
+final _sortedPerfsCache = Expando<List<Perf>>('sortedUserPerfs');
+
+List<Perf> _sortedUserPerfs(IMap<Perf, UserPerf> perfs) {
+  return _sortedPerfsCache[perfs] ??=
+      Perf.values
+          .where((element) {
+            final p = perfs[element];
+            return p != null && p.numberOfGamesOrRuns > 0 && p.ratingDeviation < kClueLessDeviation;
+          })
+          .toList(growable: false)
+        ..sort(
+          (p1, p2) => perfs[p2]!.numberOfGamesOrRuns.compareTo(perfs[p1]!.numberOfGamesOrRuns),
+        );
 }


### PR DESCRIPTION
Every user list row filtered `Perf.values` and sorted by game count on each build. Leaderboards render dozens of these per scroll frame, so scrolling paid for the same sort over and over.

`_UserRating` now reads the sorted list from a per-map `Expando` cache instead. `IMap` is immutable, so the cached order stays valid as long as the map is alive. The filter is untouched, and the descending comparator matches the old ascending-then-reversed order exactly in a better way.