### PR TITLE
Index game history paging on (userId, lastModified)

### DIFF
--- a/lib/src/db/database.dart
+++ b/lib/src/db/database.dart
@@ -91,6 +91,7 @@ Future<Database> openAppDatabase(DatabaseFactory dbFactory, String path) {
         _createCorrespondenceGameTableV1(batch);
         _createChatReadMessagesTableV1(batch);
         _createGameTableV2(batch);
+        _createGameTableIndexesV6(batch);
         _createHttpLogTableV4(batch);
         _createAppLogTableV5(batch);
         await batch.commit();
@@ -99,7 +100,6 @@ Future<Database> openAppDatabase(DatabaseFactory dbFactory, String path) {
         final batch = db.batch();
         if (oldVersion == 1) {
           _createGameTableV2(batch);
-          _createGameTableIndexesV6(batch);
         }
         if (oldVersion < 3) {
           _updatePuzzleBatchTableToV3(batch);

--- a/lib/src/db/database.dart
+++ b/lib/src/db/database.dart
@@ -63,7 +63,7 @@ Future<Database> openAppDatabase(DatabaseFactory dbFactory, String path) {
   return dbFactory.openDatabase(
     path,
     options: OpenDatabaseOptions(
-      version: 5,
+      version: 6,
       onConfigure: (db) async {
         final version = await _getDatabaseVersion(db);
         _logger.info('SQLite version: $version');
@@ -99,6 +99,7 @@ Future<Database> openAppDatabase(DatabaseFactory dbFactory, String path) {
         final batch = db.batch();
         if (oldVersion == 1) {
           _createGameTableV2(batch);
+          _createGameTableIndexesV6(batch);
         }
         if (oldVersion < 3) {
           _updatePuzzleBatchTableToV3(batch);
@@ -108,6 +109,9 @@ Future<Database> openAppDatabase(DatabaseFactory dbFactory, String path) {
         }
         if (oldVersion < 5) {
           _createAppLogTableV5(batch);
+        }
+        if (oldVersion < 6) {
+          _createGameTableIndexesV6(batch);
         }
         await batch.commit();
       },
@@ -182,6 +186,13 @@ void _createGameTableV2(Batch batch) {
     data TEXT NOT NULL,
     PRIMARY KEY (gameId)
   )
+    ''');
+}
+
+void _createGameTableIndexesV6(Batch batch) {
+  batch.execute('''
+    CREATE INDEX IF NOT EXISTS idx_game_user_lastModified
+    ON game(userId, lastModified DESC)
     ''');
 }
 

--- a/test/db/database_test.dart
+++ b/test/db/database_test.dart
@@ -1,0 +1,25 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:lichess_mobile/src/db/database.dart';
+import 'package:sqflite_common_ffi/sqflite_ffi.dart';
+
+void main() {
+  group('App database v6', () {
+    test('game table has composite index covering history paging', () async {
+      final db = await openAppDatabase(databaseFactoryFfi, inMemoryDatabasePath);
+      addTearDown(db.close);
+
+      final indexes = await db.rawQuery(
+        "SELECT name FROM sqlite_master WHERE type = 'index' AND tbl_name = 'game'",
+      );
+      expect(indexes.map((row) => row['name']), contains('idx_game_user_lastModified'));
+
+      final plan = await db.rawQuery(
+        'EXPLAIN QUERY PLAN SELECT * FROM game WHERE userId = ? ORDER BY lastModified DESC LIMIT 20',
+        ['**anonymous**'],
+      );
+      final detail = plan.map((row) => row['detail']! as String).join(' ');
+      expect(detail, contains('idx_game_user_lastModified'));
+      expect(detail, isNot(contains('SCAN')));
+    });
+  });
+}


### PR DESCRIPTION
Every game-history page load ran `WHERE userId = ? ORDER BY lastModified DESC LIMIT 20` against the `game `table, whose only index is the `gameId` primary key. I confirmed with `EXPLAIN QUERY PLAN` that each page does a full table scan plus a temp b-tree sort, on a table holding 90 days of games.

This adds `idx_game_user_lastModified ON game(userId, lastModified DESC)` as a v6 migration, wired into both `onCreate` and `onUpgrade`. The same plan check now shows an index search with no sort step.

Two commits: the migration, plus a test asserting the index exists and covers the paging query.